### PR TITLE
Enable SQLServer Sort Feature and associated tests

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -225,7 +225,7 @@ type Redshift_Dialect
         False
 
     ## PRIVATE
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         base_gen.default_generate_column self expr name
 
     ## PRIVATE

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -225,8 +225,8 @@ type Redshift_Dialect
         False
 
     ## PRIVATE
-    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column self expr name
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        base_gen.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -225,6 +225,10 @@ type Redshift_Dialect
         False
 
     ## PRIVATE
+    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        Base_Generator.default_generate_column
+
+    ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument
     ensure_query_has_no_holes self jdbc:JDBC_Connection raw_sql:Text =
         jdbc.ensure_query_has_no_holes raw_sql

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -226,7 +226,7 @@ type Redshift_Dialect
 
     ## PRIVATE
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column
+        Base_Generator.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -271,8 +271,8 @@ type Dialect
 
     ## PRIVATE
        Generates a column for the given expression for use in the SELECT clause. 
-       Used for databases where the expression sytanx is different in the SELECT clause 
-       to the synatx in the WHERE clause
+       Used for databases where the expression syntax is different in the SELECT clause 
+       to the syntax in the WHERE clause
     generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         _ = [base_gen, expr, name]
         Unimplemented.throw "This is an interface only."

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -273,7 +273,7 @@ type Dialect
        Generates a column for the given expression for use in the SELECT clause. 
        Used for databases where the expression sytanx is different in the SELECT clause 
        to the synatx in the WHERE clause
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         _ = [base_gen, expr, name]
         Unimplemented.throw "This is an interface only."
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -269,6 +269,10 @@ type Dialect
         _ = [base_table, key_columns, resolved_aggregates, problem_builder]
         Unimplemented.throw "This is an interface only."
 
+    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        _ = [expr, name]
+         Unimplemented.throw "This is an interface only."
+
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument
     ensure_query_has_no_holes jdbc:JDBC_Connection raw_sql:Text =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -273,8 +273,8 @@ type Dialect
        Generates a column for the given expression for use in the SELECT clause. 
        Used for databases where the expression sytanx is different in the SELECT clause 
        to the synatx in the WHERE clause
-    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        _ = [expr, name]
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        _ = [base_gen, expr, name]
         Unimplemented.throw "This is an interface only."
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -271,7 +271,7 @@ type Dialect
 
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         _ = [expr, name]
-         Unimplemented.throw "This is an interface only."
+        Unimplemented.throw "This is an interface only."
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -269,6 +269,10 @@ type Dialect
         _ = [base_table, key_columns, resolved_aggregates, problem_builder]
         Unimplemented.throw "This is an interface only."
 
+    ## PRIVATE
+       Generates a column for the given expression for use in the SELECT clause. 
+       Used for databases where the expression sytanx is different in the SELECT clause 
+       to the synatx in the WHERE clause
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         _ = [expr, name]
         Unimplemented.throw "This is an interface only."

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
@@ -161,6 +161,12 @@ type SQL_Generator
         base_expression ++ collation ++ order_suffix ++ nulls_suffix
 
     ## PRIVATE
+    generate_column self dialect expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        x = self.generate_expression dialect expr
+        y = alias dialect name
+        x ++ y
+
+    ## PRIVATE
         Generates SQL code corresponding to a SELECT statement.
 
         Arguments:
@@ -169,11 +175,10 @@ type SQL_Generator
     generate_select_query_sql : Dialect -> Vector (Pair Text SQL_Expression) -> Context -> SQL_Builder
     generate_select_query_sql self dialect columns ctx =
         gen_exprs exprs = exprs.map (self.generate_expression dialect)
-        gen_column pair = (self.generate_expression dialect pair.second) ++ alias dialect pair.first
 
         generated_columns = case columns of
             Nothing -> SQL_Builder.code "*"
-            _ -> SQL_Builder.join ", " (columns.map gen_column)
+            _ -> SQL_Builder.join ", " (columns.map (c-> dialect.generate_column self expr=c.second name=c.first))
 
         from_part = self.generate_from_part dialect ctx.from_spec
         where_part = (SQL_Builder.join " AND " (gen_exprs ctx.where_filters)) . prefix_if_present " WHERE "

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
@@ -161,10 +161,8 @@ type SQL_Generator
         base_expression ++ collation ++ order_suffix ++ nulls_suffix
 
     ## PRIVATE
-    generate_column self dialect expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        x = self.generate_expression dialect expr
-        y = alias dialect name
-        x ++ y
+    default_generate_column self dialect expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        self.generate_expression dialect expr ++ alias dialect name
 
     ## PRIVATE
         Generates SQL code corresponding to a SELECT statement.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
@@ -176,7 +176,7 @@ type SQL_Generator
 
         generated_columns = case columns of
             Nothing -> SQL_Builder.code "*"
-            _ -> SQL_Builder.join ", " (columns.map (c-> dialect.generate_column self expr=c.second name=c.first))
+            _ -> SQL_Builder.join ", " (columns.map (c-> dialect.generate_column_for_select self expr=c.second name=c.first))
 
         from_part = self.generate_from_part dialect ctx.from_spec
         where_part = (SQL_Builder.join " AND " (gen_exprs ctx.where_filters)) . prefix_if_present " WHERE "

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/IR/Context.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/IR/Context.enso
@@ -108,14 +108,12 @@ type Context
        takes precedence, but if any orderings were already present they are also
        taken into account to break ties within the new ordering.
 
-       In practice this means, that the old orderings are preserved, but the new
-       ones are added to the beginning of the list so that they take precedence.
-
        Arguments:
        - new_orders: The new ordering clauses to add to the query.
     add_orders : Vector Order_Descriptor -> Context
     add_orders self new_orders =
-        Context.Value self.from_spec self.where_filters new_orders+self.orders self.groups self.limit self.extensions
+        deduped_orders = new_orders+self.orders . distinct .expression
+        Context.Value self.from_spec self.where_filters deduped_orders self.groups self.limit self.extensions
 
     ## PRIVATE
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -326,7 +326,7 @@ type Postgres_Dialect
         False
 
     ## PRIVATE
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         base_gen.default_generate_column self expr name
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -327,7 +327,7 @@ type Postgres_Dialect
 
     ## PRIVATE
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column
+        Base_Generator.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -326,8 +326,8 @@ type Postgres_Dialect
         False
 
     ## PRIVATE
-    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column self expr name
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        base_gen.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -326,6 +326,10 @@ type Postgres_Dialect
         False
 
     ## PRIVATE
+    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        Base_Generator.default_generate_column
+
+    ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument
     ensure_query_has_no_holes self jdbc:JDBC_Connection raw_sql:Text =
         jdbc.ensure_query_has_no_holes raw_sql

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -329,8 +329,8 @@ type SQLite_Dialect
         False
 
     ## PRIVATE
-    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column self expr name
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        base_gen.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -329,7 +329,7 @@ type SQLite_Dialect
         False
 
     ## PRIVATE
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         base_gen.default_generate_column self expr name
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -329,6 +329,10 @@ type SQLite_Dialect
         False
 
     ## PRIVATE
+    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        Base_Generator.default_generate_column
+
+    ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument
     ensure_query_has_no_holes self jdbc:JDBC_Connection raw_sql:Text =
         jdbc.ensure_query_has_no_holes raw_sql

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -330,7 +330,7 @@ type SQLite_Dialect
 
     ## PRIVATE
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column
+        Base_Generator.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -312,6 +312,17 @@ type SQLServer_Dialect
     ## PRIVATE
        Returns a pair of a SQL_Builder for the given expression and a vector of columns
        that have been used in the expression and need to be checked for nulls.
+       SQL Server needs special handling commpared to ther databases as it does not have a
+       boolean data type.
+       This means that you can write
+         SELECT * FROM MyTable WHERE [Column1] > [Column2]
+       but you cannot write
+         SELECT [Column1] > [Column2] FROM MyTable
+       to write the second query you need to write
+         SELECT CASE WHEN [Column1] IS NULL OR [Column2] IS NULL WHEN [Column1] > [Column2] THEN 1 ELSE 0 END FROM MyTable
+       The below function collects all of the fields which are needed to be checked for nulls returning them in a vector
+       as the second element of the pair.
+       The first element of the pair is the SQL_Builder for the expression.
     generate_expression self base_gen expr = case expr of
         SQL_Expression.Column _ _ ->
             wrapped_name = base_gen.generate_expression self expr

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -320,7 +320,7 @@ type SQLServer_Dialect
             wrapped = case value of
                 Nothing -> SQL_Builder.code "NULL"
                 _ -> SQL_Builder.interpolation value
-            pair (wrapped) [wrapped]
+            pair wrapped [wrapped]
         SQL_Expression.Literal value -> 
             wrapped = SQL_Builder.code value
             pair wrapped [wrapped]
@@ -356,14 +356,15 @@ type SQLServer_Dialect
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of
             SQL_Expression.Operation _ _ _ ->
-                null_check = _generate_null_check_sql_builder expr_null_checks_pair.second
-                SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
+                null_check = if expr_null_checks_pair.second.length == 0 then "" else
+                    SQL_Builder.code "WHEN " ++ _generate_null_check_sql_builder expr_null_checks_pair.second ++ " THEN NULL "
+                SQL_Builder.code "CASE " ++ null_check ++ "WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
             _ -> base_expr
         built_expr ++ Base_Generator.alias self name
 
 ## PRIVATE
 private _generate_null_check_sql_builder null_checks:Vector -> SQL_Builder =
-    (null_checks.map it->(it.paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
+    (null_checks.map it->(it.paren ++ " IS NULL ")) . reduce acc-> i-> acc ++ "OR " ++ i
 
 ## PRIVATE
 make_dialect_operations =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -228,6 +228,7 @@ type SQLServer_Dialect
         case feature of
             Feature.Select_Columns -> True
             Feature.Sort -> True
+            Feature.Filter -> True
             _ -> False
 
     ## PRIVATE
@@ -302,6 +303,58 @@ type SQLServer_Dialect
            We can skip this check and still get a decent error message
         if raw_sql.contains "#" . not then
             jdbc.ensure_query_has_no_holes raw_sql
+
+    generate_expression self dialect expr = case expr.first of
+        SQL_Expression.Column origin name ->
+            r = dialect.wrap_identifier origin ++ '.' ++ dialect.wrap_identifier name
+            pair r expr.second+[r]
+        SQL_Expression.Constant value -> SQL_Builder.interpolation value
+        SQL_Expression.Literal value -> SQL_Builder.code value
+        SQL_Expression.Text_Literal value ->
+            escaped = value.replace "'" "''"
+            SQL_Builder.code ("'" + escaped + "'")
+        SQL_Expression.Operation kind arguments metadata ->
+            op = dialect.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
+            parsed_args = arguments.map (c -> self.generate_expression dialect (pair c []))
+            parsed_args2 = parsed_args.map .first
+            result = op parsed_args2
+            null_checks = parsed_args.map .second
+            # If the function expects more arguments, we pass the metadata as the last argument.
+            r = case result of
+                _ : Function -> result metadata
+                _ -> result
+            pair r null_checks
+        SQL_Expression.Let _ binder bindee body ->
+            wrapped_binder = dialect.wrap_identifier binder
+            bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression dialect bindee).paren ++ " AS " ++ "x"
+
+            body_sql_builder = self.let_bindings_ref.with_modification (h-> h.insert binder) <|
+                self.generate_expression dialect body
+
+            body_exp = SQL_Builder.code "SELECT " ++ body_sql_builder ++ " FROM " ++ wrapped_binder
+            (SQL_Builder.code "WITH " ++ wrapped_binder  ++ " AS " ++ bindee_exp.paren ++ " " ++ body_exp).paren
+        SQL_Expression.Let_Ref _ binder standalone_expression ->
+            binding_state = self.let_bindings_ref.get
+            case binding_state.contains binder of
+                True ->
+                    wrapped_binder = dialect.wrap_identifier binder
+                    wrapped_binder ++ "." ++ "x"
+                False ->
+                    self.generate_expression dialect standalone_expression
+        query : Query -> self.generate_sub_query dialect query
+        descriptor : Order_Descriptor -> self.generate_order dialect descriptor
+
+
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        it = pair expr []
+        x = self.generate_expression self it
+        IO.println (x.second.at 0 . at 0)
+        null_check = (x.second.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
+        
+        x1 = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ x.first ++ " THEN 1 ELSE 0 END")
+        IO.println x1.build
+        y = Base_Generator.alias self name
+        x1 ++ y
 
 ## PRIVATE
 make_dialect_operations =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -335,23 +335,6 @@ type SQLServer_Dialect
                 _ : Function -> result metadata
                 _ -> result
             pair r null_checks
-        SQL_Expression.Let _ binder bindee body ->
-            wrapped_binder = self.wrap_identifier binder
-            bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression base_gen bindee).paren ++ " AS " ++ "x"
-
-            body_sql_builder = self.let_bindings_ref.with_modification (h-> h.insert binder) <|
-                self.generate_expression base_gen body
-
-            body_exp = SQL_Builder.code "SELECT " ++ body_sql_builder ++ " FROM " ++ wrapped_binder
-            (SQL_Builder.code "WITH " ++ wrapped_binder  ++ " AS " ++ bindee_exp.paren ++ " " ++ body_exp).paren
-        SQL_Expression.Let_Ref _ binder standalone_expression ->
-            binding_state = self.let_bindings_ref.get
-            case binding_state.contains binder of
-                True ->
-                    wrapped_binder = self.wrap_identifier binder
-                    wrapped_binder ++ "." ++ "x"
-                False ->
-                    self.generate_expression base_gen standalone_expression
         query : Query -> pair (base_gen.generate_sub_query self query) []
         descriptor : Order_Descriptor -> pair (base_gen.generate_order self descriptor) []
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -310,6 +310,8 @@ type SQLServer_Dialect
             jdbc.ensure_query_has_no_holes raw_sql
 
     ## PRIVATE
+       Returns a pair of a SQL_Builder for the given expression and a vector of columns
+       that have been used in the expression and need to be checked for nulls.
     generate_expression self base_gen expr = case expr of
         SQL_Expression.Column _ _ ->
             wrapped_name = base_gen.generate_expression self expr
@@ -332,6 +334,9 @@ type SQLServer_Dialect
             null_checks = parsed_args_and_null_checks.map .second  . flatten
 
             expr_result = case kind of
+                ## In the case that we actually want to check for null then we need to generate the null
+                   check sql for all the columns that have been used up to this point and that 
+                   becomes the expression.
                 "IS_NULL" -> _generate_null_check_sql_builder null_checks
                 _ -> 
                     result = op parsed_args
@@ -339,10 +344,8 @@ type SQLServer_Dialect
                     case result of
                         _ : Function -> result metadata
                         _ -> result
+            null_checks_result = if kind == "IS_NULL" then [] else null_checks
 
-            null_checks_result = case kind of
-                "IS_NULL" -> []
-                _ -> null_checks
             
             pair expr_result null_checks_result
         query : Query -> pair (base_gen.generate_sub_query self query) []

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -305,8 +305,8 @@ type SQLServer_Dialect
             jdbc.ensure_query_has_no_holes raw_sql
 
     generate_expression self base_gen expr_null_checks_pair = case expr_null_checks_pair.first of
-        SQL_Expression.Column origin name ->
-            wrapped_name = self.wrap_identifier origin ++ '.' ++ self.wrap_identifier name
+        SQL_Expression.Column _ _ ->
+            wrapped_name = base_gen.generate_expression self expr_null_checks_pair.first
             pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
         SQL_Expression.Constant value -> SQL_Builder.interpolation value
         SQL_Expression.Literal value -> SQL_Builder.code value

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -329,13 +329,22 @@ type SQLServer_Dialect
             op = self.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
             parsed_args_and_null_checks = arguments.map (c -> self.generate_expression base_gen c)
             parsed_args = parsed_args_and_null_checks.map .first
-            result = op parsed_args
-            null_checks = parsed_args_and_null_checks.map .second
-            # If the function expects more arguments, we pass the metadata as the last argument.
-            r = case result of
-                _ : Function -> result metadata
-                _ -> result
-            pair r null_checks
+            null_checks = parsed_args_and_null_checks.map .second  . flatten
+
+            expr_result = case kind of
+                "IS_NULL" -> _generate_null_check_sql_builder null_checks
+                _ -> 
+                    result = op parsed_args
+                    # If the function expects more arguments, we pass the metadata as the last argument.
+                    case result of
+                        _ : Function -> result metadata
+                        _ -> result
+
+            null_checks_result = case kind of
+                "IS_NULL" -> []
+                _ -> null_checks
+            
+            pair expr_result null_checks_result
         query : Query -> pair (base_gen.generate_sub_query self query) []
 
     ## PRIVATE
@@ -344,14 +353,14 @@ type SQLServer_Dialect
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of
             SQL_Expression.Operation kind _ _ ->
-                null_checks = expr_null_checks_pair.second . flatten
-                null_check = (null_checks.map it->(it.paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
-                case kind of
-                    ## TODO move deeper
-                    "IS_NULL" -> SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN 1 ELSE 0 END"
-                    _ -> SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
+                null_check = _generate_null_check_sql_builder expr_null_checks_pair.second
+                SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
             _ -> base_expr
         built_expr ++ Base_Generator.alias self name
+
+## PRIVATE
+private _generate_null_check_sql_builder null_checks:Vector -> SQL_Builder =
+    (null_checks.map it->(it.paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
 
 ## PRIVATE
 make_dialect_operations =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -309,6 +309,7 @@ type SQLServer_Dialect
         if raw_sql.contains "#" . not then
             jdbc.ensure_query_has_no_holes raw_sql
 
+    ## PRIVATE
     generate_expression self base_gen expr = case expr of
         SQL_Expression.Column _ _ ->
             wrapped_name = base_gen.generate_expression self expr
@@ -321,15 +322,15 @@ type SQLServer_Dialect
         SQL_Expression.Literal value -> 
             wrapped = SQL_Builder.code value
             pair wrapped [wrapped]
-        SQL_Expression.Text_Literal value ->
-            escaped = value.replace "'" "''"
-            pair (SQL_Builder.code ("'" + escaped + "'")) []
+        SQL_Expression.Text_Literal _ ->
+            wrapped_literal = base_gen.generate_expression self expr
+            pair wrapped_literal []
         SQL_Expression.Operation kind arguments metadata ->
             op = self.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
-            parsed_args = arguments.map (c -> self.generate_expression base_gen c)
-            parsed_args2 = parsed_args.map .first
-            result = op parsed_args2
-            null_checks = parsed_args.map .second
+            parsed_args_and_null_checks = arguments.map (c -> self.generate_expression base_gen c)
+            parsed_args = parsed_args_and_null_checks.map .first
+            result = op parsed_args
+            null_checks = parsed_args_and_null_checks.map .second
             # If the function expects more arguments, we pass the metadata as the last argument.
             r = case result of
                 _ : Function -> result metadata
@@ -337,6 +338,7 @@ type SQLServer_Dialect
             pair r null_checks
         query : Query -> pair (base_gen.generate_sub_query self query) []
 
+    ## PRIVATE
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         expr_null_checks_pair = self.generate_expression base_gen expr
         base_expr = expr_null_checks_pair.first

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -307,11 +307,15 @@ type SQLServer_Dialect
         SQL_Expression.Column _ _ ->
             wrapped_name = base_gen.generate_expression self expr_null_checks_pair.first
             pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
-        SQL_Expression.Constant value -> SQL_Builder.interpolation value
-        SQL_Expression.Literal value -> SQL_Builder.code value
+        SQL_Expression.Constant value -> 
+            wrapped = SQL_Builder.interpolation value
+            pair (wrapped) [wrapped]
+        SQL_Expression.Literal value -> 
+            wrapped = SQL_Builder.code value
+            pair wrapped [wrapped]
         SQL_Expression.Text_Literal value ->
             escaped = value.replace "'" "''"
-            SQL_Builder.code ("'" + escaped + "'")
+            pair (SQL_Builder.code ("'" + escaped + "'")) []
         SQL_Expression.Operation kind arguments metadata ->
             op = self.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
             parsed_args = arguments.map (c -> self.generate_expression base_gen (pair c []))
@@ -347,10 +351,10 @@ type SQLServer_Dialect
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         expr_null_checks_pair = self.generate_expression base_gen (pair expr [])
         base_expr = expr_null_checks_pair.first
-        null_checks = expr_null_checks_pair.second
         built_expr = case expr of
             SQL_Expression.Operation _ _ _ ->
-                null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
+                null_checks = expr_null_checks_pair.second . flatten
+                null_check = (null_checks.map it->(it.paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
                 SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
             _ -> base_expr
         built_expr ++ Base_Generator.alias self name

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -308,7 +308,9 @@ type SQLServer_Dialect
             wrapped_name = base_gen.generate_expression self expr_null_checks_pair.first
             pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
         SQL_Expression.Constant value -> 
-            wrapped = SQL_Builder.interpolation value
+            wrapped = case value of
+                Nothing -> SQL_Builder.code "NULL"
+                _ -> SQL_Builder.interpolation value
             pair (wrapped) [wrapped]
         SQL_Expression.Literal value -> 
             wrapped = SQL_Builder.code value

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -227,6 +227,7 @@ type SQLServer_Dialect
     is_feature_supported self feature:Feature -> Boolean =
         case feature of
             Feature.Select_Columns -> True
+            Feature.Sort -> True
             _ -> False
 
     ## PRIVATE

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -355,7 +355,7 @@ type SQLServer_Dialect
         expr_null_checks_pair = self.generate_expression base_gen expr
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of
-            SQL_Expression.Operation kind _ _ ->
+            SQL_Expression.Operation _ _ _ ->
                 null_check = _generate_null_check_sql_builder expr_null_checks_pair.second
                 SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
             _ -> base_expr

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -304,10 +304,10 @@ type SQLServer_Dialect
         if raw_sql.contains "#" . not then
             jdbc.ensure_query_has_no_holes raw_sql
 
-    generate_expression self dialect expr = case expr.first of
+    generate_expression self dialect expr_null_checks_pair = case expr_null_checks_pair.first of
         SQL_Expression.Column origin name ->
-            r = dialect.wrap_identifier origin ++ '.' ++ dialect.wrap_identifier name
-            pair r expr.second+[r]
+            wrapped_name = dialect.wrap_identifier origin ++ '.' ++ dialect.wrap_identifier name
+            pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
         SQL_Expression.Constant value -> SQL_Builder.interpolation value
         SQL_Expression.Literal value -> SQL_Builder.code value
         SQL_Expression.Text_Literal value ->

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -328,7 +328,7 @@ type SQLServer_Dialect
             r = case result of
                 _ : Function -> result metadata
                 _ -> result
-            pair r null_checks
+            if (kind == "IS_IN" && arguments.length == 1) then (pair (SQL_Builder.code "1=0") []) else (pair r null_checks)
         SQL_Expression.Let _ binder bindee body ->
             wrapped_binder = self.wrap_identifier binder
             bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression base_gen bindee).paren ++ " AS " ++ "x"
@@ -346,8 +346,8 @@ type SQLServer_Dialect
                     wrapped_binder ++ "." ++ "x"
                 False ->
                     self.generate_expression base_gen standalone_expression
-        query : Query -> self.generate_sub_query self query
-        descriptor : Order_Descriptor -> self.generate_order self descriptor
+        query : Query -> pair (base_gen.generate_sub_query self query) []
+        descriptor : Order_Descriptor -> pair (base_gen.generate_order self descriptor) []
 
 
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -309,10 +309,10 @@ type SQLServer_Dialect
         if raw_sql.contains "#" . not then
             jdbc.ensure_query_has_no_holes raw_sql
 
-    generate_expression self base_gen expr_null_checks_pair = case expr_null_checks_pair.first of
+    generate_expression self base_gen expr = case expr of
         SQL_Expression.Column _ _ ->
-            wrapped_name = base_gen.generate_expression self expr_null_checks_pair.first
-            pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
+            wrapped_name = base_gen.generate_expression self expr
+            pair wrapped_name [wrapped_name]
         SQL_Expression.Constant value -> 
             wrapped = case value of
                 Nothing -> SQL_Builder.code "NULL"
@@ -326,7 +326,7 @@ type SQLServer_Dialect
             pair (SQL_Builder.code ("'" + escaped + "'")) []
         SQL_Expression.Operation kind arguments metadata ->
             op = self.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
-            parsed_args = arguments.map (c -> self.generate_expression base_gen (pair c []))
+            parsed_args = arguments.map (c -> self.generate_expression base_gen c)
             parsed_args2 = parsed_args.map .first
             result = op parsed_args2
             null_checks = parsed_args.map .second
@@ -336,11 +336,9 @@ type SQLServer_Dialect
                 _ -> result
             pair r null_checks
         query : Query -> pair (base_gen.generate_sub_query self query) []
-        descriptor : Order_Descriptor -> pair (base_gen.generate_order self descriptor) []
-
 
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        expr_null_checks_pair = self.generate_expression base_gen (pair expr [])
+        expr_null_checks_pair = self.generate_expression base_gen expr
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of
             SQL_Expression.Operation kind _ _ ->

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -348,8 +348,11 @@ type SQLServer_Dialect
         expr_null_checks_pair = self.generate_expression base_gen (pair expr [])
         base_expr = expr_null_checks_pair.first
         null_checks = expr_null_checks_pair.second
-        null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
-        built_expr = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END")
+        built_expr = case expr of
+            SQL_Expression.Operation _ _ _ ->
+                null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
+                SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
+            _ -> base_expr
         built_expr ++ Base_Generator.alias self name
 
 ## PRIVATE

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -350,9 +350,8 @@ type SQLServer_Dialect
         base_expr = expr_null_checks_pair.first
         null_checks = expr_null_checks_pair.second
         null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
-        x1 = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END")
-        y = Base_Generator.alias self name
-        x1 ++ y
+        built_expr = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END")
+        built_expr ++ Base_Generator.alias self name
 
 ## PRIVATE
 make_dialect_operations =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -228,7 +228,6 @@ type SQLServer_Dialect
         case feature of
             Feature.Select_Columns -> True
             Feature.Sort -> True
-            Feature.Filter -> True
             _ -> False
 
     ## PRIVATE

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -103,6 +103,12 @@ type SQLServer_Dialect
         Base_Generator.wrap_in_quotes identifier
 
     ## PRIVATE
+       Generates a SQL expression for a table literal.
+    make_table_literal : Vector (Vector Text) -> Vector Text -> Text -> SQL_Builder
+    make_table_literal self vecs column_names as_name =
+        Base_Generator.default_make_table_literal self.wrap_identifier vecs column_names as_name
+
+    ## PRIVATE
        Prepares an ordering descriptor.
 
        One of the purposes of this method is to verify if the expected ordering
@@ -328,7 +334,7 @@ type SQLServer_Dialect
             r = case result of
                 _ : Function -> result metadata
                 _ -> result
-            if (kind == "IS_IN" && arguments.length == 1) then (pair (SQL_Builder.code "1=0") []) else (pair r null_checks)
+            pair r null_checks
         SQL_Expression.Let _ binder bindee body ->
             wrapped_binder = self.wrap_identifier binder
             bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression base_gen bindee).paren ++ " AS " ++ "x"
@@ -354,10 +360,13 @@ type SQLServer_Dialect
         expr_null_checks_pair = self.generate_expression base_gen (pair expr [])
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of
-            SQL_Expression.Operation _ _ _ ->
+            SQL_Expression.Operation kind _ _ ->
                 null_checks = expr_null_checks_pair.second . flatten
                 null_check = (null_checks.map it->(it.paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
-                SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
+                case kind of
+                    ## TODO move deeper
+                    "IS_NULL" -> SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN 1 ELSE 0 END"
+                    _ -> SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END"
             _ -> base_expr
         built_expr ++ Base_Generator.alias self name
 
@@ -367,7 +376,7 @@ make_dialect_operations =
     text = [starts_with, contains, ends_with, agg_shortest, agg_longest, make_case_sensitive, ["REPLACE", replace], left, right]+concat_ops+cases+trim_ops
     counts = [agg_count_is_null, agg_count_empty, agg_count_not_empty, ["COUNT_DISTINCT", agg_count_distinct], ["COUNT_DISTINCT_INCLUDE_NULL", agg_count_distinct_include_null]]
     arith_extensions = [is_nan, is_inf, is_finite, floating_point_div, mod_op, decimal_div, decimal_mod, ["ROW_MIN", Base_Generator.make_function "LEAST"], ["ROW_MAX", Base_Generator.make_function "GREATEST"]]
-    bool = [bool_or]
+    bool = [bool_or, bool_not]
     eq = lift_binary_op "==" make_equals
     compare = [eq]
 
@@ -378,7 +387,8 @@ make_dialect_operations =
     special_overrides = [is_null]
     other = [["RUNTIME_ERROR", make_runtime_error_op]]
     my_mappings = text + counts + stats + first_last_aggregators + arith_extensions + bool + compare + date_ops + special_overrides + other
-    Base_Generator.base_dialect_operations . extend_with my_mappings
+    base = Base_Generator.base_dialect_operations . extend_with my_mappings
+    Base_Generator.Dialect_Operations.Value (base.operations_dict.remove "IS_IN")
 
 ## PRIVATE
 is_null = Base_Generator.lift_unary_op "IS_NULL" arg->
@@ -558,6 +568,10 @@ is_finite = Base_Generator.lift_unary_op "IS_FINITE" arg->
 ## PRIVATE
 bool_or = Base_Generator.lift_unary_op "BOOL_OR" arg->
     SQL_Builder.code "bool_or(" ++ arg ++ ")"
+
+## PRIVATE
+bool_not = Base_Generator.lift_unary_op "NOT" arg->
+    SQL_Builder.code "(" ++ arg ++ ")=0"
 
 ## PRIVATE
 floating_point_div = Base_Generator.lift_binary_op "/" x-> y->

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -346,13 +346,11 @@ type SQLServer_Dialect
 
 
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        it = pair expr []
-        x = self.generate_expression self it
-        IO.println (x.second.at 0 . at 0)
-        null_check = (x.second.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
-        
-        x1 = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ x.first ++ " THEN 1 ELSE 0 END")
-        IO.println x1.build
+        expr_null_checks_pair = self.generate_expression self (pair expr [])
+        base_expr = expr_null_checks_pair.first
+        null_checks = expr_null_checks_pair.second
+        null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i
+        x1 = (SQL_Builder.code "CASE WHEN " ++ null_check ++ " THEN NULL WHEN " ++ base_expr ++ " THEN 1 ELSE 0 END")
         y = Base_Generator.alias self name
         x1 ++ y
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -304,9 +304,9 @@ type SQLServer_Dialect
         if raw_sql.contains "#" . not then
             jdbc.ensure_query_has_no_holes raw_sql
 
-    generate_expression self dialect expr_null_checks_pair = case expr_null_checks_pair.first of
+    generate_expression self base_gen expr_null_checks_pair = case expr_null_checks_pair.first of
         SQL_Expression.Column origin name ->
-            wrapped_name = dialect.wrap_identifier origin ++ '.' ++ dialect.wrap_identifier name
+            wrapped_name = self.wrap_identifier origin ++ '.' ++ self.wrap_identifier name
             pair wrapped_name expr_null_checks_pair.second+[wrapped_name]
         SQL_Expression.Constant value -> SQL_Builder.interpolation value
         SQL_Expression.Literal value -> SQL_Builder.code value
@@ -314,8 +314,8 @@ type SQLServer_Dialect
             escaped = value.replace "'" "''"
             SQL_Builder.code ("'" + escaped + "'")
         SQL_Expression.Operation kind arguments metadata ->
-            op = dialect.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
-            parsed_args = arguments.map (c -> self.generate_expression dialect (pair c []))
+            op = self.dialect_operations.operations_dict.get kind (Error.throw <| Unsupported_Database_Operation.Error kind)
+            parsed_args = arguments.map (c -> self.generate_expression base_gen (pair c []))
             parsed_args2 = parsed_args.map .first
             result = op parsed_args2
             null_checks = parsed_args.map .second
@@ -325,11 +325,11 @@ type SQLServer_Dialect
                 _ -> result
             pair r null_checks
         SQL_Expression.Let _ binder bindee body ->
-            wrapped_binder = dialect.wrap_identifier binder
-            bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression dialect bindee).paren ++ " AS " ++ "x"
+            wrapped_binder = self.wrap_identifier binder
+            bindee_exp = SQL_Builder.code "SELECT " ++ (self.generate_expression base_gen bindee).paren ++ " AS " ++ "x"
 
             body_sql_builder = self.let_bindings_ref.with_modification (h-> h.insert binder) <|
-                self.generate_expression dialect body
+                self.generate_expression base_gen body
 
             body_exp = SQL_Builder.code "SELECT " ++ body_sql_builder ++ " FROM " ++ wrapped_binder
             (SQL_Builder.code "WITH " ++ wrapped_binder  ++ " AS " ++ bindee_exp.paren ++ " " ++ body_exp).paren
@@ -337,16 +337,16 @@ type SQLServer_Dialect
             binding_state = self.let_bindings_ref.get
             case binding_state.contains binder of
                 True ->
-                    wrapped_binder = dialect.wrap_identifier binder
+                    wrapped_binder = self.wrap_identifier binder
                     wrapped_binder ++ "." ++ "x"
                 False ->
-                    self.generate_expression dialect standalone_expression
-        query : Query -> self.generate_sub_query dialect query
-        descriptor : Order_Descriptor -> self.generate_order dialect descriptor
+                    self.generate_expression base_gen standalone_expression
+        query : Query -> self.generate_sub_query self query
+        descriptor : Order_Descriptor -> self.generate_order self descriptor
 
 
     generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        expr_null_checks_pair = self.generate_expression self (pair expr [])
+        expr_null_checks_pair = self.generate_expression base_gen (pair expr [])
         base_expr = expr_null_checks_pair.first
         null_checks = expr_null_checks_pair.second
         null_check = (null_checks.map it->((it.at 0).paren ++ " IS NULL ")) . fold (SQL_Builder.code "1=0 ") acc-> i-> acc ++ "OR " ++ i

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -351,7 +351,7 @@ type SQLServer_Dialect
         query : Query -> pair (base_gen.generate_sub_query self query) []
 
     ## PRIVATE
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         expr_null_checks_pair = self.generate_expression base_gen expr
         base_expr = expr_null_checks_pair.first
         built_expr = case expr of

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -159,7 +159,7 @@ on_unknown_type sql_type =
 ## PRIVATE
    Maps operation names to functions that infer its result type.
 operations_dict : Dictionary Text (Vector -> SQL_Type)
-operations_dict = Dictionary.from_vector [["IS_NULL", const (SQL_Type.Value Types.BIT "BIT")],["==", const (SQL_Type.Value Types.BIT "BIT")]]
+operations_dict = Dictionary.from_vector [["IS_NULL", const (SQL_Type.Value Types.BIT "BIT")],["==", const (SQL_Type.Value Types.BIT "BIT")],["NOT", const (SQL_Type.Value Types.BIT "BIT")]]
 
 ## PRIVATE
    This is the maximum size that JDBC driver reports for 'unbounded' types in

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -108,7 +108,7 @@ type SQLServer_Type_Mapping
 
     ## PRIVATE
        The SQLServer_Type_Mapping always relies on the return type determined by
-       the database backend.
+       the database backend except for boolean types.
     infer_return_type : (SQL_Expression -> SQL_Type_Reference) -> Text -> Vector -> SQL_Expression -> SQL_Type_Reference
     infer_return_type infer_from_database_callback op_name arguments expression =
         case operations_dict.contains_key op_name of

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -159,7 +159,7 @@ on_unknown_type sql_type =
 ## PRIVATE
    Maps operation names to functions that infer its result type.
 operations_dict : Dictionary Text (Vector -> SQL_Type)
-operations_dict = Dictionary.from_vector [["IS_NULL", const (SQL_Type.Value Types.BIT "BIT")],["==", const (SQL_Type.Value Types.BIT "BIT")],["NOT", const (SQL_Type.Value Types.BIT "BIT")]]
+operations_dict = Dictionary.from_vector [["IS_NULL", const (SQL_Type.Value Types.BIT "BIT")],["==", const (SQL_Type.Value Types.BIT "BIT")],["NOT", const (SQL_Type.Value Types.BIT "BIT")],["BETWEEN", const (SQL_Type.Value Types.BIT "BIT")]]
 
 ## PRIVATE
    This is the maximum size that JDBC driver reports for 'unbounded' types in

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -309,8 +309,8 @@ type Snowflake_Dialect
         _                      -> False
 
     ## PRIVATE
-    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column self expr name
+    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        base_gen.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -309,6 +309,10 @@ type Snowflake_Dialect
         _                      -> False
 
     ## PRIVATE
+    generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+        Base_Generator.default_generate_column
+
+    ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument
     ensure_query_has_no_holes self jdbc:JDBC_Connection raw_sql:Text =
         jdbc.ensure_query_has_no_holes raw_sql

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -310,7 +310,7 @@ type Snowflake_Dialect
 
     ## PRIVATE
     generate_column self expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
-        Base_Generator.default_generate_column
+        Base_Generator.default_generate_column self expr name
 
     ## PRIVATE
     ensure_query_has_no_holes : JDBC_Connection -> Text -> Nothing ! Illegal_Argument

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -309,7 +309,7 @@ type Snowflake_Dialect
         _                      -> False
 
     ## PRIVATE
-    generate_column self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
+    generate_column_for_select self base_gen expr:(SQL_Expression | Order_Descriptor | Query) name:Text -> SQL_Builder =
         base_gen.default_generate_column self expr name
 
     ## PRIVATE

--- a/test/AWS_Tests/src/Redshift_Spec.enso
+++ b/test/AWS_Tests/src/Redshift_Spec.enso
@@ -85,9 +85,10 @@ add_database_specs suite_builder create_connection_fn =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     is_feature_supported_fn feature:Feature = default_connection.get.dialect.is_feature_supported feature
+    is_operation_supported_fn operation:Text = default_connection.get.dialect.is_operation_supported operation
     flagged_fn = default_connection.get.dialect.flagged
 
-    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
 
     Common_Spec.add_specs suite_builder prefix create_connection_fn default_connection setup
     add_redshift_specific_specs suite_builder create_connection_fn setup

--- a/test/Microsoft_Tests/src/SQLServer_Spec.enso
+++ b/test/Microsoft_Tests/src/SQLServer_Spec.enso
@@ -207,9 +207,10 @@ add_sqlserver_specs suite_builder create_connection_fn =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     is_feature_supported_fn feature:Feature = default_connection.get.dialect.is_feature_supported feature
+    is_operation_supported_fn operation:Text = default_connection.get.dialect.is_operation_supported operation
     flagged_fn = default_connection.get.dialect.flagged
 
-    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
 
     Common_Spec.add_specs suite_builder prefix create_connection_fn default_connection setup
     Common_Table_Operations.Main.add_specs suite_builder setup

--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -547,9 +547,10 @@ add_snowflake_specs suite_builder create_connection_fn db_name =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     is_feature_supported_fn feature:Feature = default_connection.get.dialect.is_feature_supported feature
+    is_operation_supported_fn operation:Text = default_connection.get.dialect.is_operation_supported operation
     flagged_fn = default_connection.get.dialect.flagged
 
-    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_integer_type=is_snowflake_integer is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_integer_type=is_snowflake_integer is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
 
     Common_Spec.add_specs suite_builder prefix create_connection_fn default_connection setup
     snowflake_specific_spec suite_builder default_connection db_name setup

--- a/test/Table_Tests/src/Common_Table_Operations/Add_Row_Number_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Add_Row_Number_Spec.enso
@@ -30,7 +30,7 @@ type Data
         self.connection.close
 
 add_specs suite_builder setup =
-    if setup.is_feature_supported Feature.Filter then (add_row_number_specs suite_builder setup) else
+    if setup.is_feature_supported Feature.Add_Row_Number then (add_row_number_specs suite_builder setup) else
         suite_builder.group setup.prefix+"Table.add_row_number" group_builder->
             group_builder.specify "add_row_number should report unsupported" <|
                 table_builder = setup.light_table_builder

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -73,7 +73,7 @@ type Test_Setup
          boolean indicating if the feature is supported by the backend.
        - flagged: A function that takes a `Dialect_Flag` and returns a boolean indicating if the 
          flag is set for the backend.
-    Config prefix table_fn empty_table_fn (table_builder : (Vector Any -> (Any|Nothing)) -> Any) materialize is_database test_selection aggregate_test_selection create_connection_func light_table_builder is_integer_type=(.is_integer) is_feature_supported flagged
+    Config prefix table_fn empty_table_fn (table_builder : (Vector Any -> (Any|Nothing)) -> Any) materialize is_database test_selection aggregate_test_selection create_connection_func light_table_builder is_integer_type=(.is_integer) is_feature_supported flagged is_operation_supported
 
     ## Specifies if the given Table backend supports custom Enso types.
 

--- a/test/Table_Tests/src/Common_Table_Operations/Nothing_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Nothing_Spec.enso
@@ -131,7 +131,7 @@ add_nothing_specs suite_builder setup =
             table = setup.light_table_builder [["x", [True, False, Nothing]]]
             table.at "x" . not . to_vector . should_equal [False, True, Nothing]
 
-    suite_builder.group prefix+"(Nothing_Spec) is_in" group_builder->
+    if setup.is_operation_supported "IS_IN" then suite_builder.group prefix+"(Nothing_Spec) is_in" group_builder->
         values_with_nothing.map triple->
             value = triple.at 0
             other_value = triple.at 1
@@ -176,7 +176,7 @@ add_nothing_specs suite_builder setup =
                     table = table_builder_typed [["x", [value, Nothing]], ["y", [other_value, Nothing]], ["z", [value, other_value]], ["n", [Nothing, Nothing]]] value_type
                     table.at "x" . is_in [] . to_vector . should_equal [False, False]
 
-    if setup.test_selection.run_advanced_edge_case_tests then suite_builder.group prefix+"(Nothing_Spec) is_in: Boolean+Nothing edge cases" group_builder->
+    if setup.test_selection.run_advanced_edge_case_tests && setup.is_operation_supported "IS_IN" then suite_builder.group prefix+"(Nothing_Spec) is_in: Boolean+Nothing edge cases" group_builder->
         make_containing_values had_null had_true had_false =
             null_maybe = if had_null then [Nothing] else []
             true_maybe = if had_true then [True] else []
@@ -222,7 +222,7 @@ add_nothing_specs suite_builder setup =
 
                     c.to_vector . should_equal [output]
 
-                group_builder.specify "Boolean is_in: edge cases (Column), "+negation_desc+" "+cs.to_text <|
+                if setup.is_feature_supported Feature.Distinct then group_builder.specify "Boolean is_in: edge cases (Column), "+negation_desc+" "+cs.to_text <|
                     input_column = transform_input (Vector.fill containing_values.length input)
                     t = table_builder_typed [["input", input_column], ["containing", transform_argument containing_values]] Value_Type.Boolean
                     expected_output = if input_column.is_empty then [] else [output]
@@ -232,7 +232,7 @@ add_nothing_specs suite_builder setup =
                     c.to_vector . length . should_equal input_column.length
                     c.to_vector.distinct . should_equal expected_output
 
-    suite_builder.group prefix+"(Nothing_Spec) distinct" group_builder->
+    if setup.is_feature_supported Feature.Distinct then suite_builder.group prefix+"(Nothing_Spec) distinct" group_builder->
         values_without_nothing.map triple->
             value = triple.at 0
             other_value = triple.at 1

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -737,9 +737,10 @@ add_postgres_specs suite_builder create_connection_fn db_name =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     is_feature_supported_fn feature:Feature = default_connection.get.dialect.is_feature_supported feature
+    is_operation_supported_fn operation:Text = default_connection.get.dialect.is_operation_supported operation
     flagged_fn = default_connection.get.dialect.flagged
 
-    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
 
     Common_Spec.add_specs suite_builder prefix create_connection_fn default_connection setup
     postgres_specific_spec suite_builder create_connection_fn db_name setup

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -352,9 +352,10 @@ sqlite_spec suite_builder prefix create_connection_func persistent_connector =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     is_feature_supported_fn feature:Feature = default_connection.get.dialect.is_feature_supported feature
+    is_operation_supported_fn operation:Text = default_connection.get.dialect.is_operation_supported operation
     flagged_fn = default_connection.get.dialect.flagged
 
-    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_func light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_func light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
     
     Common_Spec.add_specs suite_builder prefix create_connection_func default_connection setup
     sqlite_specific_spec suite_builder prefix create_connection_func setup

--- a/test/Table_Tests/src/In_Memory/Common_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Common_Spec.enso
@@ -37,11 +37,13 @@ in_memory_setup =
         Dummy_Connection.Value
     is_feature_supported_fn _ =
         True
+    is_operation_supported_fn _ =
+        True
     flagged_fn flag:Dialect_Flag =
         case flag of
             Dialect_Flag.Supports_Case_Sensitive_Columns -> True
 
-    Common_Table_Operations.Main.Test_Setup.Config "[In-Memory] " agg_table_fn empty_table_fn table_builder materialize is_database=False test_selection=selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_func light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn
+    Common_Table_Operations.Main.Test_Setup.Config "[In-Memory] " agg_table_fn empty_table_fn table_builder materialize is_database=False test_selection=selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_func light_table_builder=light_table_builder is_feature_supported=is_feature_supported_fn flagged=flagged_fn is_operation_supported=is_operation_supported_fn
 
 add_specs suite_builder =
     Common_Table_Operations.Main.add_specs suite_builder in_memory_setup


### PR DESCRIPTION
### Pull Request Description

Enables Sort Feature Flag and the corresponding tests.

Takes SQLServer test suite from 92 to 265 passing tests

### Important Notes

The boolean and null handling for SQLServer is very different to different database which has introduced more duplication than I would have liked. But I am hesitant to exposed the other dialects to the additional complication required by SQLServer.

Summary of the issue that got us here

So imagine you have this table
INSERT INTO MyTable2 (Column1, Column2)
VALUES 
    (10, 20),
    (30, 30),
    (50, null);
In SQLServer you can write select * from MyTable2 where [Column2] > 25
Like normal
But you can't write select [Column2] > 25 from MyTable2
Mainly because SQLServer doesn't have a boolean data type on tables.
For boolean you use bit
So to write that query we have to wrap it in a case statement
select CASE WHEN [Column2] > 25 THEN 1 ELSE 0 END from MyTable2
Which works but for the NULL handling. This always resolves to 1 or 0 and never NULL
So we have to add an extra case for NULL handling.
Which looks like this select CASE WHEN [Column2] IS NULL THEN NULL WHEN [Column2] > 25 THEN 1 ELSE 0 END from MyTable2
But the null check is painful as it isn't just the expression it is all the columns that are used in that expression.
Hence the painful code which I have ended up with. And I think will still have problems as I get to more complex expressions.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
  - https://github.com/enso-org/enso/actions/runs/11514615425
