### PR TITLE
Batch refetches for different `listDirectory` queries

### DIFF
--- a/app/gui/src/dashboard/layouts/AssetsTable.tsx
+++ b/app/gui/src/dashboard/layouts/AssetsTable.tsx
@@ -20,6 +20,7 @@ import {
   queryOptions,
   useMutation,
   useQueries,
+  useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query'
@@ -465,24 +466,11 @@ export default function AssetsTable(props: AssetsTableProps) {
               }
             },
 
-            refetchInterval:
-              enableAssetsTableBackgroundRefresh ? assetsTableBackgroundRefreshInterval : false,
-            refetchOnMount: 'always',
-            refetchIntervalInBackground: false,
-            refetchOnWindowFocus: true,
-
             enabled: !hidden,
             meta: { persist: false },
           }),
         ),
-      [
-        hidden,
-        backend,
-        category,
-        expandedDirectoryIds,
-        assetsTableBackgroundRefreshInterval,
-        enableAssetsTableBackgroundRefresh,
-      ],
+      [hidden, backend, category, expandedDirectoryIds],
     ),
     combine: (results) => {
       const rootQuery = results[expandedDirectoryIds.indexOf(rootDirectory.id)]
@@ -507,6 +495,20 @@ export default function AssetsTable(props: AssetsTableProps) {
         ),
       }
     },
+  })
+
+  // We use a different query to refetch the directory data in the background.
+  // This reduces the amount of rerenders by batching them together, so they happen less often.
+  useQuery({
+    queryKey: [backend.type, 'refetchListDirectory'],
+    queryFn: () => queryClient.refetchQueries({ queryKey: [backend.type, 'listDirectory'] }),
+    refetchInterval:
+      enableAssetsTableBackgroundRefresh ? assetsTableBackgroundRefreshInterval : false,
+    refetchOnMount: 'always',
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    enabled: !hidden,
+    meta: { persist: false },
   })
 
   /** Return type of the query function for the listDirectory query. */


### PR DESCRIPTION
### Pull Request Description

This PR moves invalidation of the `listDirectory` queries into a separate `useQuery` to sync mutliple invalidations into a single one

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
