### PR TITLE
More robust enso4igv when "find in projects" invoked

### DIFF
--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
@@ -71,7 +71,11 @@ final class EnsoRootProject implements Project {
 
     @Override
     public Node findPath(Node node, Object o) {
-      return org.openide.nodes.NodeOp.findChild(node, (String) o);
+      if (o instanceof String path) {
+        return org.openide.nodes.NodeOp.findChild(node, path);
+      } else {
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Check if the provided argument is really a string. Shields against:
```
java.lang.ClassCastException: class org.netbeans.modules.masterfs.filebasedfs.fileobjects.FileObj cannot be cast to class java.lang.String (org.netbeans.modules.masterfs.filebasedfs.fileobjects.FileObj is in unnamed module of loader org.netbeans.StandardModule$OneModuleClassLoader @2415a13c; java.lang.String is in module java.base of loader 'bootstrap')
        at org.enso.tools.enso4igv.EnsoRootProject$LogicalView.findPath(EnsoRootProject.java:74)
        at org.netbeans.modules.project.ui.ProjectsRootNode.findNode(ProjectsRootNode.java:185)
        at org.netbeans.modules.project.ui.ProjectTab$2.run(ProjectTab.java:552)
        at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
        at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
Caused: org.openide.util.RequestProcessor$SlowItem
```
looks like the `findPath` argument doesn't have to be `String` as previously (and too optimistically) expected by the code.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
