### PR TITLE
Skeletal PanicExceptionTest and more logging when AssertionError happens

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
@@ -1,0 +1,59 @@
+package org.enso.interpreter.node.expression.builtin.error;
+
+import static org.junit.Assert.assertEquals;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
+import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.test.utils.ContextUtils;
+import org.enso.test.utils.TestRootNode;
+import org.graalvm.polyglot.Context;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PanicExceptionTest {
+
+  private static final InteropLibrary interop = InteropLibrary.getUncached();
+
+  private static Context context;
+  private static CatchPanicNode catchPanicNode;
+  private static HostValueToEnsoNode hostValueToEnsoNode;
+  private static TestRootNode testRootNode;
+
+  @BeforeClass
+  public static void initContextAndData() {
+    context = ContextUtils.createDefaultContext();
+    ContextUtils.executeInContext(
+        context,
+        () -> {
+          catchPanicNode = CatchPanicNode.build();
+          hostValueToEnsoNode = HostValueToEnsoNode.build();
+          testRootNode = new TestRootNode();
+          testRootNode.insertChildren(catchPanicNode, hostValueToEnsoNode);
+          return null;
+        });
+  }
+
+  @AfterClass
+  public static void disposeContext() {
+    context.close();
+    context = null;
+  }
+
+  @Test
+  public void panicExceptionMessageForAssertionError() throws Exception {
+    ContextUtils.executeInContext(
+        context,
+        () -> {
+          var text = Text.create("Some text for the exception");
+          var thrown = new java.lang.AssertionError(text.toString());
+          var ex = new PanicException(text, thrown, null);
+          assertEquals(text.toString(), ex.getMessage());
+          var msg = InteropLibrary.getUncached().getExceptionMessage(ex);
+          assertEquals(text, msg);
+          return null;
+        });
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -285,4 +285,21 @@ public final class Text implements EnsoObject {
     }
     return result;
   }
+
+  @Override
+  public int hashCode() {
+    int hash = 7 * toString().hashCode();
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof Text other) {
+      return this.toString().equals(other.toString());
+    }
+    return false;
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -23,6 +23,7 @@ import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.data.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.state.State;
@@ -87,7 +88,19 @@ public final class PanicException extends AbstractTruffleException implements En
       var info = library.getExceptionMessage(this);
       msg = library.asString(info);
     } catch (StackOverflowError | AssertionError | UnsupportedMessageException e) {
-      logger().atError().log("Cannot compute message for " + payload, e);
+      var l = logger();
+      l.atError().log("Cannot compute message for " + payload, e);
+      l.error("Exception location: " + getLocation());
+      if (getLocation() != null) {
+        l.error("  location source: " + getLocation().getEncapsulatingSourceSection());
+        l.error("  location class: " + getLocation().getClass().getName());
+        l.error("  location string: " + getLocation());
+      }
+      l.error("  payload class: " + payload.getClass().getName());
+      if (payload instanceof Atom atom) {
+        l.error("  payload cons: " + atom.getConstructor());
+        l.error("  payload type: " + atom.getConstructor().getType());
+      }
       msg = TypeToDisplayTextNode.getUncached().execute(payload);
     }
     cacheMessage = msg;


### PR DESCRIPTION
### Pull Request Description

Closes #11127 by adding more logging when `AssertionError` happens. Plus adding skeletal `PanicExceptionTest` that asserts `getMessage()` works as expected under regular constellations.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
