### PR TITLE
Fix Meta.get_qualified_type_name when run as single file

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
@@ -1,5 +1,8 @@
 package org.enso.interpreter.caches;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -29,9 +32,13 @@ public class HelloWorldCacheTest {
     // the second run must read Hello_World from its .ir file!
     var secondMsgs = executeOnce(helloWorld);
     assertTrue("Contains hello world:\n" + secondMsgs, secondMsgs.contains("Hello World"));
-    assertTrue(
+    assertThat(
         "Properly deserialized:\n" + secondMsgs,
-        secondMsgs.contains("Deserializing module Hello_World from IR file: true"));
+        secondMsgs,
+        allOf(
+            containsString("Deserializing module"),
+            containsString("Hello_World"),
+            containsString("from IR file: true")));
   }
 
   private static String executeOnce(File src) throws Exception {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/QualifiedNameTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/QualifiedNameTest.java
@@ -1,0 +1,37 @@
+package org.enso.interpreter.test.meta;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import org.enso.test.utils.ProjectUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class QualifiedNameTest {
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private static final String mainModSrc =
+      """
+      from Standard.Base import all
+
+      type My_Type
+          Value x
+
+      main =
+          obj = My_Type.Value 42
+          Meta.get_qualified_type_name obj
+      """;
+
+  @Test
+  public void qualifiedTypeNameWorks_WhenRunningSingleFile() throws IOException {
+    var projDir = temporaryFolder.newFolder().toPath();
+    ProjectUtils.createProject("Proj", mainModSrc, projDir);
+    ProjectUtils.testProjectRun(
+        projDir,
+        (res) -> {
+          assertThat(res.asString(), is("local.Proj.Main.My_Type"));
+        });
+  }
+}

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/refactoring/IRUtilsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/refactoring/IRUtilsTest.scala
@@ -22,23 +22,19 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
     .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
     .asHostObject[EnsoContext]()
 
+  private val moduleName = QualifiedName.simpleName("Test")
+
   implicit private class PreprocessModule(code: String) {
 
-    private val Module = QualifiedName(List("Unnamed"), "Test")
-
-    def preprocessModule(name: QualifiedName): Module = {
+    def preprocessModule(): Module = {
       val module = new runtime.Module(
-        name,
+        moduleName,
         null,
         code.stripMargin.linesIterator.mkString("\n")
       )
       langCtx.getCompiler.run(module.asCompilerModule())
       module.getIr
     }
-
-    def preprocessModule: Module =
-      preprocessModule(Module)
-
   }
 
   private def findUsagesOfLiteral(
@@ -86,7 +82,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule
+      val module    = code.preprocessModule()
       val operator1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfLiteral(module, operator1)
 
@@ -111,7 +107,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule
+      val module    = code.preprocessModule()
       val operator1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfLiteral(module, operator1)
 
@@ -136,7 +132,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule
+      val module    = code.preprocessModule()
       val operator1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfLiteral(module, operator1)
 
@@ -148,8 +144,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
     }
 
     "find usages of a static method call in main body" in {
-      val uuid1      = new UUID(0, 1)
-      val moduleName = QualifiedName(List("Unnamed"), "Test")
+      val uuid1 = new UUID(0, 1)
       val code =
         s"""function1 x = x + 1
            |
@@ -164,7 +159,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule(moduleName)
+      val module    = code.preprocessModule()
       val function1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfModuleMethod(moduleName, module, function1)
 
@@ -176,8 +171,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
     }
 
     "find usages of a static call in lambda" in {
-      val uuid1      = new UUID(0, 1)
-      val moduleName = QualifiedName(List("Unnamed"), "Test")
+      val uuid1 = new UUID(0, 1)
       val code =
         s"""function1 x = x
            |
@@ -192,7 +186,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule(moduleName)
+      val module    = code.preprocessModule()
       val function1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfModuleMethod(moduleName, module, function1)
 
@@ -204,8 +198,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
     }
 
     "find usages of a static method call in presence of an instance method" in {
-      val uuid1      = new UUID(0, 1)
-      val moduleName = QualifiedName(List("Unnamed"), "Test")
+      val uuid1 = new UUID(0, 1)
       val code =
         s"""function1 x = x
            |
@@ -220,7 +213,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule(moduleName)
+      val module    = code.preprocessModule()
       val function1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfModuleMethod(moduleName, module, function1)
 
@@ -232,8 +225,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
     }
 
     "find usages of a static method call in presence of a type method" in {
-      val uuid1      = new UUID(0, 1)
-      val moduleName = QualifiedName(List("Unnamed"), "Test")
+      val uuid1 = new UUID(0, 1)
       val code =
         s"""function1 x = x
            |
@@ -251,7 +243,7 @@ class IRUtilsTest extends AnyWordSpecLike with Matchers with OptionValues {
            |[]
            |""".stripMargin
 
-      val module    = code.preprocessModule(moduleName)
+      val module    = code.preprocessModule()
       val operator1 = IRUtils.findByExternalId(module, uuid1).get
       val usages    = findUsagesOfModuleMethod(moduleName, module, operator1)
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
@@ -58,7 +58,7 @@ class ImportExportTest
     .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
     .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
     .option(RuntimeOptions.STRICT_ERRORS, "false")
-    .logHandler(System.err)
+    .logHandler(out)
     .option(
       RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
       Paths

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
@@ -1,5 +1,6 @@
 package org.enso.compiler.test.semantic
 
+import com.oracle.truffle.api.TruffleFile
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{Module, ProcessingPass, Warning}
 import org.enso.compiler.core.ir.expression.errors
@@ -11,17 +12,18 @@ import org.enso.interpreter.runtime
 import org.enso.interpreter.runtime.EnsoContext
 import org.enso.persist.Persistance
 import org.enso.pkg.QualifiedName
+import org.enso.pkg.Package
 import org.enso.common.LanguageInfo
-import org.enso.common.MethodNames
 import org.enso.compiler.phase.exports.Node
 import org.enso.common.RuntimeOptions
+import org.enso.test.utils.{ContextUtils, ProjectUtils}
 import org.graalvm.polyglot.{Context, Engine}
-import org.scalatest.BeforeAndAfter
+import org.scalatest.{BeforeAndAfter}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import java.io.ByteArrayOutputStream
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 import java.util.logging.Level
 import java.io.IOException
 
@@ -35,12 +37,17 @@ class ImportExportTest
     with BeforeAndAfter {
   private val out = new ByteArrayOutputStream()
 
+  private val namespace   = "local"
+  private val packageName = "My_Package"
+  private val packageQualifiedName =
+    QualifiedName.fromString(namespace + "." + packageName)
+
   private val engine = Engine
     .newBuilder("enso")
     .allowExperimentalOptions(true)
     .build()
 
-  private val ctx = Context
+  private val ctxBldr = Context
     .newBuilder(LanguageInfo.ID)
     .engine(engine)
     .allowExperimentalOptions(true)
@@ -60,23 +67,34 @@ class ImportExportTest
         .getAbsolutePath
     )
     .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-    .build()
 
-  private val langCtx: EnsoContext = ctx
-    .getBindings(LanguageInfo.ID)
-    .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
-    .asHostObject[EnsoContext]()
+  private var ctx: Context              = _
+  private var langCtx: EnsoContext      = _
+  private var tmpDir: Path              = _
+  private var pkg: Package[TruffleFile] = _
 
-  private val namespace   = "my_pkg"
-  private val packageName = "My_Package"
-  private val packageQualifiedName =
-    QualifiedName.fromString(namespace + "." + packageName)
+  before {
+    // Create temp dir with skeleton project structure. In the tests, we will create
+    // synthetic modules that will be part of this project.
+    tmpDir = Files.createTempDirectory("enso-test")
+    ProjectUtils.createProject(packageName, "main = 42", tmpDir)
+    ctxBldr.option(RuntimeOptions.PROJECT_ROOT, tmpDir.toAbsolutePath.toString)
+    ctx     = ctxBldr.build()
+    langCtx = ContextUtils.leakContext(ctx)
+    langCtx.getPackageRepository.getMainProjectPackage shouldBe defined
+    pkg = langCtx.getPackageRepository.getMainProjectPackage.get
+    ctx.enter()
+  }
 
-  langCtx.getPackageRepository.registerSyntheticPackage(namespace, packageName)
+  after {
+    ctx.leave()
+    out.reset()
+    ProjectUtils.deleteRecursively(tmpDir)
+  }
 
   implicit private class CreateModule(moduleCode: String) {
     def createModule(moduleName: QualifiedName): runtime.Module = {
-      val module = new runtime.Module(moduleName, null, moduleCode)
+      val module = new runtime.Module(moduleName, pkg, moduleCode)
       langCtx.getPackageRepository.registerModuleCreatedInRuntime(
         module.asCompilerModule()
       )
@@ -112,15 +130,6 @@ class ImportExportTest
     sortedCompilerModules.map(
       org.enso.interpreter.runtime.Module.fromCompilerModule
     )
-  }
-
-  before {
-    ctx.enter()
-  }
-
-  after {
-    ctx.leave()
-    out.reset()
   }
 
   "Import resolution with just two modules" should {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -168,9 +168,19 @@ public final class Module implements EnsoObject {
       return;
     }
     if (pkg != null && name.isSimple()) {
-      throw new IllegalArgumentException("Simple module name must not be in a package");
+      throw new IllegalArgumentException(
+          "Simple module name must not be in a package, i.e., trying to initialize a module in a"
+              + " package '"
+              + pkg.libraryName().toString()
+              + "' with a simple name '"
+              + name
+              + "'");
     } else if (pkg == null && !name.isSimple()) {
-      throw new IllegalArgumentException("Qualified module name must be in a package");
+      throw new IllegalArgumentException(
+          "Qualified module name must be in a package, i.e., trying to initialize "
+              + "a module with a qualified name '"
+              + name
+              + "' without a package");
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -87,6 +87,7 @@ public final class Module implements EnsoObject {
    * @param sourceFile the module's source file.
    */
   public Module(QualifiedName name, Package<TruffleFile> pkg, TruffleFile sourceFile) {
+    ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(sourceFile);
     this.name = name;
     this.scopeBuilder = new ModuleScope.Builder(this);
@@ -105,6 +106,7 @@ public final class Module implements EnsoObject {
    * @param literalSource the module's source.
    */
   public Module(QualifiedName name, Package<TruffleFile> pkg, String literalSource) {
+    ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(Rope.apply(literalSource));
     this.name = name;
     this.scopeBuilder = new ModuleScope.Builder(this);
@@ -124,6 +126,7 @@ public final class Module implements EnsoObject {
    * @param literalSource the module's source.
    */
   public Module(QualifiedName name, Package<TruffleFile> pkg, Rope literalSource) {
+    ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(literalSource);
     this.name = name;
     this.scopeBuilder = new ModuleScope.Builder(this);
@@ -143,6 +146,7 @@ public final class Module implements EnsoObject {
    */
   private Module(
       QualifiedName name, Package<TruffleFile> pkg, boolean synthetic, Rope literalSource) {
+    ensureConsistentName(name, pkg);
     this.sources =
         literalSource == null ? ModuleSources.NONE : ModuleSources.NONE.newWith(literalSource);
     this.name = name;
@@ -156,6 +160,17 @@ public final class Module implements EnsoObject {
       scopeBuilder.build();
     } else {
       this.compilationStage = CompilationStage.AFTER_CODEGEN;
+    }
+  }
+
+  private void ensureConsistentName(QualifiedName name, Package<TruffleFile> pkg) {
+    if (name.toString().equals(Builtins.MODULE_NAME)) {
+      return;
+    }
+    if (pkg != null && name.isSimple()) {
+      throw new IllegalArgumentException("Simple module name must not be in a package");
+    } else if (pkg == null && !name.isSimple()) {
+      throw new IllegalArgumentException("Qualified module name must be in a package");
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.enso.common.MethodNames;
 import org.enso.compiler.PackageRepository;
+import org.enso.editions.LibraryName;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
@@ -151,7 +152,15 @@ public final class TopLevelScope implements EnsoObject {
           Types.extractArguments(arguments, String.class, String.class);
       QualifiedName qualName = QualifiedName.fromString(args.getFirst());
       File location = new File(args.getSecond());
-      Module module = new Module(qualName, null, context.getTruffleFile(location));
+      var libName = LibraryName.fromModuleName(qualName.toString());
+      Package<TruffleFile> pkg = null;
+      if (libName.isDefined()) {
+        var pkgOpt = context.getPackageRepository().getPackageForLibraryJava(libName.get());
+        if (pkgOpt.isPresent()) {
+          pkg = pkgOpt.get();
+        }
+      }
+      Module module = new Module(qualName, pkg, context.getTruffleFile(location));
       scope.packageRepository.registerModuleCreatedInRuntime(module.asCompilerModule());
       return module;
     }

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/QualifiedName.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/QualifiedName.scala
@@ -49,6 +49,12 @@ case class QualifiedName(path: List[String], item: String) {
     path.asJava
   }
 
+  /** Returns true if this a simple name, not a fully qualified name.
+    */
+  def isSimple(): Boolean = {
+    path.isEmpty
+  }
+
   def fullPath(): List[String] = path :+ item
 }
 

--- a/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
@@ -27,7 +27,7 @@ add_specs suite_builder = suite_builder.group "Meta-Value Inspection" group_buil
         y = My_Type.Value 1 2 3
         Meta.get_qualified_type_name x . should_equal "Standard.Base.Data.Numbers.Integer"
         Meta.get_simple_type_name x . should_equal "Integer"
-        Meta.get_qualified_type_name y . should_end_with "Meta_Location_Spec.My_Type"
+        Meta.get_qualified_type_name y . should_equal "enso_dev.Base_Tests.Semantic.Meta_Location_Spec.My_Type"
         Meta.get_simple_type_name y . should_equal "My_Type"
 
     group_builder.specify "should allow access to package names" <|


### PR DESCRIPTION
Fixes #10228

### Pull Request Description

`Meta.get_qualified_type_name` correctly returns fully qualified type name when running a single file from a project with `enso --run Proj/src/Main.enso`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
