### PR TITLE
Open enso devtools on call of toggleDevtools()

### DIFF
--- a/app/gui/src/dashboard/App.tsx
+++ b/app/gui/src/dashboard/App.tsx
@@ -519,13 +519,11 @@ function AppRouter(props: AppRouterProps) {
                     <LocalBackendPathSynchronizer />
                     <VersionChecker />
                     {routes}
-                    {detect.IS_DEV_MODE && (
-                      <suspense.Suspense>
-                        <errorBoundary.ErrorBoundary>
-                          <devtools.EnsoDevtools />
-                        </errorBoundary.ErrorBoundary>
-                      </suspense.Suspense>
-                    )}
+                    <suspense.Suspense>
+                      <errorBoundary.ErrorBoundary>
+                        <devtools.EnsoDevtools />
+                      </errorBoundary.ErrorBoundary>
+                    </suspense.Suspense>
                   </errorBoundary.ErrorBoundary>
                 </DriveProvider>
               </InputBindingsProvider>

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtools.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtools.tsx
@@ -24,6 +24,7 @@ import {
   useEnableVersionChecker,
   usePaywallDevtools,
   useSetEnableVersionChecker,
+  useShowDevtools,
 } from './EnsoDevtoolsProvider'
 
 import * as ariaComponents from '#/components/AriaComponents'
@@ -54,6 +55,9 @@ export function EnsoDevtools() {
   const { authQueryKey, session } = authProvider.useAuth()
   const queryClient = reactQuery.useQueryClient()
   const { getFeature } = billing.usePaywallFeatures()
+
+  const showDevtools = useShowDevtools()
+
   const { features, setFeature } = usePaywallDevtools()
   const enableVersionChecker = useEnableVersionChecker()
   const setEnableVersionChecker = useSetEnableVersionChecker()
@@ -65,6 +69,10 @@ export function EnsoDevtools() {
 
   const featureFlags = useFeatureFlags()
   const setFeatureFlags = useSetFeatureFlags()
+
+  if (!showDevtools) {
+    return null
+  }
 
   return (
     <Portal>

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
@@ -3,6 +3,7 @@
  * This file provides a zustand store that contains the state of the Enso devtools.
  */
 import type { PaywallFeatureName } from '#/hooks/billing'
+import { IS_DEV_MODE } from 'enso-common/src/detect'
 import * as React from 'react'
 import * as zustand from 'zustand'
 
@@ -27,12 +28,12 @@ interface EnsoDevtoolsStore {
 }
 
 export const ensoDevtoolsStore = zustand.createStore<EnsoDevtoolsStore>((set) => ({
-  showDevtools: false,
+  showDevtools: IS_DEV_MODE,
   setShowDevtools: (showDevtools) => {
     set({ showDevtools })
   },
   toggleDevtools: () => {
-    set((state) => ({ showDevtools: !state.showDevtools }))
+    set(({ showDevtools }) => ({ showDevtools: !showDevtools }))
   },
   showVersionChecker: false,
   paywallFeatures: {

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
@@ -3,6 +3,7 @@
  * This file provides a zustand store that contains the state of the Enso devtools.
  */
 import type { PaywallFeatureName } from '#/hooks/billing'
+import * as React from 'react'
 import * as zustand from 'zustand'
 
 /** Configuration for a paywall feature. */
@@ -16,13 +17,23 @@ export interface PaywallDevtoolsFeatureConfiguration {
 
 /** The state of this zustand store. */
 interface EnsoDevtoolsStore {
+  readonly showDevtools: boolean
+  readonly setShowDevtools: (showDevtools: boolean) => void
+  readonly toggleDevtools: () => void
   readonly showVersionChecker: boolean | null
   readonly paywallFeatures: Record<PaywallFeatureName, PaywallDevtoolsFeatureConfiguration>
   readonly setPaywallFeature: (feature: PaywallFeatureName, isForceEnabled: boolean | null) => void
   readonly setEnableVersionChecker: (showVersionChecker: boolean | null) => void
 }
 
-const ensoDevtoolsStore = zustand.createStore<EnsoDevtoolsStore>((set) => ({
+export const ensoDevtoolsStore = zustand.createStore<EnsoDevtoolsStore>((set) => ({
+  showDevtools: false,
+  setShowDevtools: (showDevtools) => {
+    set({ showDevtools })
+  },
+  toggleDevtools: () => {
+    set((state) => ({ showDevtools: !state.showDevtools }))
+  },
   showVersionChecker: false,
   paywallFeatures: {
     share: { isForceEnabled: null },
@@ -66,4 +77,24 @@ export function usePaywallDevtools() {
     features: state.paywallFeatures,
     setFeature: state.setPaywallFeature,
   }))
+}
+
+/** A hook that provides access to the show devtools state. */
+export function useShowDevtools() {
+  return zustand.useStore(ensoDevtoolsStore, (state) => state.showDevtools)
+}
+
+// =================================
+// === DevtoolsProvider ===
+// =================================
+
+/**
+ * Provide the Enso devtools to the app.
+ */
+export function DevtoolsProvider(props: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    window.toggleDevtools = ensoDevtoolsStore.getState().toggleDevtools
+  }, [])
+
+  return <>{props.children}</>
 }

--- a/app/gui/src/dashboard/components/Devtools/ReactQueryDevtools.tsx
+++ b/app/gui/src/dashboard/components/Devtools/ReactQueryDevtools.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import * as reactQuery from '@tanstack/react-query'
 import * as reactQueryDevtools from '@tanstack/react-query-devtools'
 import * as errorBoundary from 'react-error-boundary'
+import { useShowDevtools } from './EnsoDevtoolsProvider'
 
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import('@tanstack/react-query-devtools/build/modern/production.js').then((d) => ({
@@ -13,18 +14,12 @@ const ReactQueryDevtoolsProduction = React.lazy(() =>
 
 /** Show the React Query Devtools and provide the ability to show them in production. */
 export function ReactQueryDevtools() {
-  const [showDevtools, setShowDevtools] = React.useState(false)
+  const showDevtools = useShowDevtools()
   // It is safer to pass the client directly to the devtools
   // since there might be a chance that we have multiple versions of `react-query`,
   // in case we forget to update the devtools, npm messes up the versions,
   // or there are hoisting issues.
   const client = reactQuery.useQueryClient()
-
-  React.useEffect(() => {
-    window.toggleDevtools = () => {
-      setShowDevtools((old) => !old)
-    }
-  }, [])
 
   return (
     <errorBoundary.ErrorBoundary

--- a/app/gui/src/dashboard/index.tsx
+++ b/app/gui/src/dashboard/index.tsx
@@ -21,7 +21,7 @@ import LoggerProvider, { type Logger } from '#/providers/LoggerProvider'
 
 import LoadingScreen from '#/pages/authentication/LoadingScreen'
 
-import { ReactQueryDevtools } from '#/components/Devtools'
+import { DevtoolsProvider, ReactQueryDevtools } from '#/components/Devtools'
 import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { OfflineNotificationManager } from '#/components/OfflineNotificationManager'
 import { Suspense } from '#/components/Suspense'
@@ -113,21 +113,23 @@ export function run(props: DashboardProps) {
     reactDOM.createRoot(root).render(
       <React.StrictMode>
         <QueryClientProvider client={queryClient}>
-          <ErrorBoundary>
-            <Suspense fallback={<LoadingScreen />}>
-              <OfflineNotificationManager>
-                <LoggerProvider logger={logger}>
-                  <HttpClientProvider httpClient={httpClient}>
-                    <UIProviders locale="en-US" portalRoot={portalRoot}>
-                      <App {...props} supportsDeepLinks={actuallySupportsDeepLinks} />
-                    </UIProviders>
-                  </HttpClientProvider>
-                </LoggerProvider>
-              </OfflineNotificationManager>
-            </Suspense>
-          </ErrorBoundary>
+          <DevtoolsProvider>
+            <ErrorBoundary>
+              <Suspense fallback={<LoadingScreen />}>
+                <OfflineNotificationManager>
+                  <LoggerProvider logger={logger}>
+                    <HttpClientProvider httpClient={httpClient}>
+                      <UIProviders locale="en-US" portalRoot={portalRoot}>
+                        <App {...props} supportsDeepLinks={actuallySupportsDeepLinks} />
+                      </UIProviders>
+                    </HttpClientProvider>
+                  </LoggerProvider>
+                </OfflineNotificationManager>
+              </Suspense>
+            </ErrorBoundary>
 
-          <ReactQueryDevtools />
+            <ReactQueryDevtools />
+          </DevtoolsProvider>
         </QueryClientProvider>
       </React.StrictMode>,
     )


### PR DESCRIPTION
### Pull Request Description

This PR changes the behavior of `toggleDevtools()` function and shows `ensoDevtools` with `tanstack` devtools

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
