### PR TITLE
Dependency tracking between nodes is too coarse grained

### DIFF
--- a/engine/runtime-instrument-common/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
+++ b/engine/runtime-instrument-common/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
@@ -221,6 +221,27 @@ class ChangesetBuilderTest
       )
     }
 
+    "multiline remove node" in {
+      val code =
+        """x ->
+          |    y = foo 5
+          |    z = foo 7
+          |    y + x""".stripMargin.linesIterator.mkString("\n")
+      val edit = TextEdit(Range(Position(2, 4), Position(3, 4)), "")
+
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[Function.Lambda]
+
+      val secondLine = ir.body.children()(1).asInstanceOf[Expression.Binding]
+      val zName      = secondLine.name
+
+      invalidated(ir, code, edit) should contain theSameElementsAs Seq(
+        zName.getId
+      )
+    }
+
     "multiline insert line 1" in {
       val code =
         """x ->
@@ -434,6 +455,7 @@ class ChangesetBuilderTest
         atCode
       )
     }
+
   }
 
   def findIR(ir: IR, uuid: String): IR = {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #11237 

Changelog:
- update: implement special case for a line removal when calculating the changeset

### Important Notes

Note that the graph is still re-calculated when the node is re-added (by pressing `ctrl-z`). The reason is that the engine processes edits on the textual level and there is not enough information to do similar workarounds. The issue becomes irrelevant when we switch to the direct tree manipulation in Ydoc.

https://github.com/user-attachments/assets/c85afde8-6386-44df-82b5-6fb0cca5205b



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.