### PR TITLE
Expand and improve `pretty` for core data types, vector and table.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -78,14 +78,23 @@ type Any
     to_text : Text
     to_text self = @Builtin_Method "Any.to_text"
 
-    ## ICON convert
-       Generic conversion of an arbitrary Enso value to a corresponding human-readable
-       representation.
+    ## GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
 
        > Example
-         Getting a human-readable representation of the number 7.
+         Getting the Enso code of the number 7.
 
-             7.to_text
+             7.pretty
+             ## Returns a Text
+                7
+
+       > Example
+         Getting the Enso code of the text Hello World!.
+
+             "Hello World!".pretty
+             ## Returns a Text
+                'Hello World!'
     pretty : Text
     pretty self = @Builtin_Method "Any.pretty"
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -795,6 +795,13 @@ type Array
     to_display_text : Text
     to_display_text self = self.short_display_text max_entries=40
 
+    ## PRIVATE
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+    pretty : Text
+    pretty self = self.map .pretty . join ", " "[" "]"
+
     ## ICON column_add
        Combines all the elements of a non-empty array using a binary operation.
        If the array is empty, it returns `if_empty`.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
@@ -574,6 +574,23 @@ type Range
         step = if self.step.abs == 1 then "" else " by " + self.step.to_display_text
         start + step + "]"
 
+    ## PRIVATE
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the range 1 until 29.
+
+             1.up_to 29 . pretty
+             ## Returns a Text
+                Range.new 1 29
+    pretty : Text
+    pretty self =
+        start = self.start.pretty
+        end = self.end.pretty
+        "Range.new " + start + " " + end + (if self.step.abs == 1 then "" else " " + self.step.pretty)
+
 ## PRIVATE
 throw_zero_step_error = Error.throw (Illegal_State.Error "A range with step = 0 is ill-formed.")
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
@@ -1,5 +1,4 @@
 import project.Any.Any
-import project.Any.Any
 import project.Data.Array_Proxy.Array_Proxy
 import project.Data.Filter_Condition.Filter_Condition
 import project.Data.Numbers.Integer

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
@@ -1,4 +1,5 @@
 import project.Any.Any
+import project.Any.Any
 import project.Data.Array_Proxy.Array_Proxy
 import project.Data.Filter_Condition.Filter_Condition
 import project.Data.Numbers.Integer
@@ -589,7 +590,7 @@ type Range
     pretty self =
         start = self.start.pretty
         end = self.end.pretty
-        "Range.new " + start + " " + end + (if self.step.abs == 1 then "" else " " + self.step.pretty)
+        "Range.new " + start + " " + end + (if self.step.abs == 1 then "" else " step=" + self.step.abs.pretty)
 
 ## PRIVATE
 throw_zero_step_error = Error.throw (Illegal_State.Error "A range with step = 0 is ill-formed.")

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -830,9 +830,18 @@ type Date
         format.format_date self
 
     ## PRIVATE
-       Convert to a Enso code representation of this Date.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the date 29-October-2024.
+
+             (Date.new 2024 10 29).pretty
+             ## Returns a Text
+                Date.new 2024 10 29
     pretty : Text
-    pretty self = "(Date.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text + ")"
+    pretty self = "Date.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text
 
     ## PRIVATE
        Gets the default drop down option for Date.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -26,7 +26,8 @@ import project.Panic.Panic
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
 from project.Data.Time.Date_Time import ensure_in_epoch
-from project.Metadata import Display, Widget
+from project.Metadata import Display, make_single_choice, Widget
+from project.Metadata.Choice import Option
 from project.Widget_Helpers import make_date_format_selector
 
 polyglot java import java.lang.ArithmeticException
@@ -335,7 +336,7 @@ type Date
        Arguments:
        - period: the period to add to self.
     next : Date_Period -> Date
-    next self period=Date_Period.Day = self + period.to_period
+    next self period:Date_Period=..Day = self + period.to_period
 
     ## GROUP DateTime
        ICON time
@@ -347,7 +348,7 @@ type Date
        Arguments:
        - period: the period to add to self.
     previous : Date_Period -> Date
-    previous self period=Date_Period.Day = self - period.to_period
+    previous self period:Date_Period=..Day = self - period.to_period
 
     ## GROUP DateTime
        ICON time
@@ -492,6 +493,8 @@ type Date
              from Standard.Base import Date, Time_Of_Day, Time_Zone
 
              example_to_time = Date.new 2020 2 3 . to_date_time Time_Of_Day.new Time_Zone.utc
+    @time_of_day (Time_Of_Day.default_widget include_now=False)
+    @zone Time_Zone.default_widget
     to_date_time : Time_Of_Day -> Time_Zone -> Date_Time
     to_date_time self (time_of_day=Time_Of_Day.new) (zone=Time_Zone.system) =
         Time_Utils.make_zoned_date_time self time_of_day zone
@@ -830,6 +833,13 @@ type Date
        Convert to a Enso code representation of this Date.
     pretty : Text
     pretty self = "(Date.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text + ")"
+
+    ## PRIVATE
+       Gets the default drop down option for Date.
+    default_widget : Boolean -> Widget
+    default_widget (include_today:Boolean=False) =
+        options = [Option "<Fixed Date>" "Date.new"] + (if include_today then [Option "<Today>" "Date.today"] else [])
+        Widget.Single_Choice values=options display=Display.When_Modified
 
 ## PRIVATE
 week_days_between start end =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
@@ -116,7 +116,7 @@ type Date_Range
     pretty self =
         start = self.start.pretty
         end = self.end.pretty
-        "Date_Range.new " + start + " " + end + (if self.step == (Period.new days=1) then "" else " " + self.step.pretty)
+        "Date_Range.new (" + start + ") (" + end + (if self.step == (Period.new days=1) then ")" else ") (" + self.step.pretty + ")")
 
     ## PRIVATE
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
@@ -101,9 +101,22 @@ type Date_Range
         start + step + "]"
 
     ## PRIVATE
-       Convert to a human-readable representation.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the date range 10-September-2024 until
+         29-October-2024.
+
+             (Date.new 2024 09 10).up_to (Date.new 2024 10 29) . pretty
+             ## Returns a Text
+                Date_Range.new (Date.new 2024 09 10) (Date.new 2024 10 29)
     pretty : Text
-    pretty self = self.to_text
+    pretty self =
+        start = self.start.pretty
+        end = self.end.pretty
+        "Date_Range.new " + start + " " + end + (if self.period == Date_Period.Day then "" else " " + self.period.pretty)
 
     ## PRIVATE
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
@@ -116,7 +116,7 @@ type Date_Range
     pretty self =
         start = self.start.pretty
         end = self.end.pretty
-        "Date_Range.new " + start + " " + end + (if self.period == Date_Period.Day then "" else " " + self.period.pretty)
+        "Date_Range.new " + start + " " + end + (if self.step == (Period.new days=1) then "" else " " + self.step.pretty)
 
     ## PRIVATE
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -838,16 +838,18 @@ type Date_Time
     ## PRIVATE
        Convert to a Enso code representation of this Time_Of_Day.
     pretty : Text
-    pretty self = "(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text
-        + (if self.hour == 0 then "" else " hour="+self.hour.to_text)
-        + (if self.minute == 0 then "" else " minute="+self.minute.to_text)
-        + (if self.second == 0 then "" else " second="+self.second.to_text)
-        + (if self.millisecond == 0 then "" else " millisecond="+self.millisecond.to_text)
-        + (if self.microsecond == 0 then "" else " microsecond="+self.microsecond.to_text)
-        + (if self.nanosecond == 0 then "" else " nanosecond="+self.nanosecond.to_text)
-        + (if self.zone == Time_Zone.system then "" else " zone="+self.zone.pretty)
-        + ")"
-
+    pretty self =
+        parts = Vector.build builder->
+            builder.append "(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text"
+            if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
+            if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
+            if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)
+            if self.millisecond != 0 then builder.append ((if builder.length!=4 then " millisecond=" else " ") + self.millisecond.to_text)
+            if self.microsecond != 0 then builder.append ((if builder.length!=5 then " microsecond=" else " ") + self.microsecond.to_text)
+            if self.nanosecond != 0 then builder.append ((if builder.length!=6 then " nanosecond=" else " ") + self.nanosecond.to_text)
+            if self.zone != Time_Zone.system then builder.append ((if builder.length!=7 then " zone=" else " ") + self.zone.pretty)
+            builder.append ")"
+        parts.join ""
 
     ## PRIVATE
        Convert to a JavaScript Object representing a Date_Time.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -840,7 +840,7 @@ type Date_Time
     pretty : Text
     pretty self =
         parts = Vector.build builder->
-            builder.append "(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text
+            builder.append ("(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text)
             if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
             if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
             if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -856,7 +856,7 @@ type Date_Time
             if self.millisecond != 0 then builder.append ((if builder.length!=4 then " millisecond=" else " ") + self.millisecond.to_text)
             if self.microsecond != 0 then builder.append ((if builder.length!=5 then " microsecond=" else " ") + self.microsecond.to_text)
             if self.nanosecond != 0 then builder.append ((if builder.length!=6 then " nanosecond=" else " ") + self.nanosecond.to_text)
-            if self.zone != Time_Zone.system then builder.append ((if builder.length!=7 then " zone=" else " ") + self.zone.pretty)
+            if self.zone != Time_Zone.system then builder.append ((if builder.length!=7 then " zone=(" else " (") + self.zone.pretty + ")")
         parts.join ""
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -840,7 +840,7 @@ type Date_Time
     pretty : Text
     pretty self =
         parts = Vector.build builder->
-            builder.append "(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text"
+            builder.append "(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text
             if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
             if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
             if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -836,11 +836,20 @@ type Date_Time
         self.format "yyyy-MM-dd "+time_format+zone_format
 
     ## PRIVATE
-       Convert to a Enso code representation of this Time_Of_Day.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the date 29-October-2024 12:34.
+
+             (Date_Time.new 2024 10 29 12 34).pretty
+             ## Returns a Text
+                Date_Time.new 2024 10 29 12 34
     pretty : Text
     pretty self =
         parts = Vector.build builder->
-            builder.append ("(Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text)
+            builder.append ("Date_Time.new " + self.year.to_text + " " + self.month.to_text + " " + self.day.to_text)
             if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
             if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
             if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)
@@ -848,7 +857,6 @@ type Date_Time
             if self.microsecond != 0 then builder.append ((if builder.length!=5 then " microsecond=" else " ") + self.microsecond.to_text)
             if self.nanosecond != 0 then builder.append ((if builder.length!=6 then " nanosecond=" else " ") + self.nanosecond.to_text)
             if self.zone != Time_Zone.system then builder.append ((if builder.length!=7 then " zone=" else " ") + self.zone.pretty)
-            builder.append ")"
         parts.join ""
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
@@ -209,6 +209,26 @@ type Period
             if self.days==0 . not then builder.append ["days", self.days]
         JS_Object.from_pairs v
 
+    ## PRIVATE
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the period 1 month and 2 days.
+
+             (Period.new months=1 days=2).pretty
+             ## Returns a Text
+                Time_Of_Day.new 12 34 millisecond=500
+    pretty : Text
+    pretty self =
+        parts = Vector.build builder->
+            builder.append "Period.new"
+            if self.years != 0 then builder.append ((if builder.length!=1 then " years=" else " ") + self.years.to_text)
+            if self.months != 0 then builder.append ((if builder.length!=2 then " months=" else " ") + self.months.to_text)
+            if self.days != 0 then builder.append ((if builder.length!=3 then " days=" else " ") + self.days.to_text)
+        parts.join ""
+
 ## PRIVATE
 catch_java_exceptions operation ~action =
     handle_arithmetic_exception caught_panic =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -494,18 +494,26 @@ type Time_Of_Day
         format.format_time self
 
     ## PRIVATE
-       Convert to a Enso code representation of this Time_Of_Day.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+
+       > Example
+         Getting the Enso code of the time 12:34:00.5
+
+             (Time_Of_Day.new 12 34 0 500).pretty
+             ## Returns a Text
+                Time_Of_Day.new 12 34 millisecond=500
     pretty : Text
     pretty self =
         parts = Vector.build builder->
-            builder.append "(Time_Of_Day.new"
+            builder.append "Time_Of_Day.new"
             if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
             if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
             if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)
             if self.millisecond != 0 then builder.append ((if builder.length!=4 then " millisecond=" else " ") + self.millisecond.to_text)
             if self.microsecond != 0 then builder.append ((if builder.length!=5 then " microsecond=" else " ") + self.microsecond.to_text)
             if self.nanosecond != 0 then builder.append ((if builder.length!=6 then " nanosecond=" else " ") + self.nanosecond.to_text)
-            builder.append ")"
         parts.join ""
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -11,6 +11,7 @@ import project.Data.Time.Duration.Duration
 import project.Data.Time.Period.Period
 import project.Data.Time.Time_Period.Time_Period
 import project.Data.Time.Time_Zone.Time_Zone
+import project.Data.Vector.Vector
 import project.Error.Error
 import project.Errors.Common.Type_Error
 import project.Errors.Illegal_Argument.Illegal_Argument
@@ -20,7 +21,8 @@ import project.Nothing.Nothing
 import project.Panic.Panic
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
-from project.Metadata import Display, Widget
+from project.Metadata import Display, make_single_choice, Widget
+from project.Metadata.Choice import Option
 from project.Widget_Helpers import make_time_format_selector
 
 polyglot java import java.lang.Exception as JException
@@ -494,14 +496,24 @@ type Time_Of_Day
     ## PRIVATE
        Convert to a Enso code representation of this Time_Of_Day.
     pretty : Text
-    pretty self = "(Time_Of_Day.new"
-        + (if self.hour == 0 then "" else " hour="+self.hour.to_text)
-        + (if self.minute == 0 then "" else " minute="+self.minute.to_text)
-        + (if self.second == 0 then "" else " second="+self.second.to_text)
-        + (if self.millisecond == 0 then "" else " millisecond="+self.millisecond.to_text)
-        + (if self.microsecond == 0 then "" else " microsecond="+self.microsecond.to_text)
-        + (if self.nanosecond == 0 then "" else " nanosecond="+self.nanosecond.to_text)
-        + ")"
+    pretty self =
+        parts = Vector.build builder->
+            builder.append "(Time_Of_Day.new"
+            if self.hour != 0 then builder.append ((if builder.length!=1 then " hour=" else " ") + self.hour.to_text)
+            if self.minute != 0 then builder.append ((if builder.length!=2 then " minute=" else " ") + self.minute.to_text)
+            if self.second != 0 then builder.append ((if builder.length!=3 then " second=" else " ") + self.second.to_text)
+            if self.millisecond != 0 then builder.append ((if builder.length!=4 then " millisecond=" else " ") + self.millisecond.to_text)
+            if self.microsecond != 0 then builder.append ((if builder.length!=5 then " microsecond=" else " ") + self.microsecond.to_text)
+            if self.nanosecond != 0 then builder.append ((if builder.length!=6 then " nanosecond=" else " ") + self.nanosecond.to_text)
+            builder.append ")"
+        parts.join ""
+
+    ## PRIVATE
+       Gets the default drop down option for Time_Of_Day.
+    default_widget : Boolean -> Widget
+    default_widget (include_now:Boolean=False) =
+        options = [Option "<Fixed Time>" "Time_Of_Day.new"] + (if include_now then [Option "<Now>" "Time_Of_Day.now"] else [])
+        Widget.Single_Choice values=options display=Display.When_Modified
 
 ## PRIVATE
 Time_Of_Day.from (that:JS_Object) =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
@@ -214,10 +214,11 @@ type Time_Zone
     zone_names = Time_Utils.getZoneNames
 
     ## PRIVATE
-       Convert to a Enso code representation of this Time_Of_Day.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
     pretty : Text
-    pretty self = "(Time_Zone.parse '" + self.zone_id + "')"
-
+    pretty self = "Time_Zone.parse " + self.zone_id.pretty
 
 ## PRIVATE
 Time_Zone.from (that:JS_Object) =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -878,6 +878,14 @@ type Vector a
     short_display_text self (max_entries : Integer = 10) =
         Array_Like_Helpers.short_display_text self max_entries
 
+    ## PRIVATE
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
+    pretty : Text
+    pretty self = self.map .pretty . join ", " "[" "]"
+
+
     ## ALIAS append, concatenate, union
        GROUP Operators
        ICON union

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -530,6 +530,7 @@ type Enso_File
         "Enso_File "+self.path
 
     ## PRIVATE
+       Converts the file descriptor to a JSON object.
     to_js_object : JS_Object
     to_js_object self =
         JS_Object.from_pairs [["type", "Enso_File"], ["constructor", "new"], ["path", self.path.to_text]]

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -177,7 +177,7 @@ type Enso_Secret
     ## PRIVATE
        Convert to a Enso code representation of this Enso_Secret.
     pretty : Text
-    pretty self = "(Enso_Secret.get " + self.path.pretty + ")"
+    pretty self = "(Enso_Secret.get " + self.path.to_text.pretty + ")"
 
 ## PRIVATE
 type Enso_Secret_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -175,9 +175,11 @@ type Enso_Secret
         JS_Object.from_pairs [["type", "Enso_Secret"], ["constructor", "get"], ["path", self.path.to_text]]
 
     ## PRIVATE
-       Convert to a Enso code representation of this Enso_Secret.
+       GROUP convert
+       ICON enso_logo
+       Convert the value to a corresponding Enso code representation.
     pretty : Text
-    pretty self = "(Enso_Secret.get " + self.path.to_text.pretty + ")"
+    pretty self = "Enso_Secret.get " + self.path.to_text.pretty
 
 ## PRIVATE
 type Enso_Secret_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -31,7 +31,19 @@ polyglot java import org.enso.base.enso_cloud.HideableValue.SecretValue
 ## A reference to a secret stored in the Enso Cloud.
 type Enso_Secret
     ## PRIVATE
-    Value name:Text id:Text path:Enso_Path
+    private Value internal_name:Text id:Text internal_path:Enso_Path
+
+    ## GROUP Metadata
+         ICON metadata
+         The name of the secret.
+    name : Text
+    name self = self.internal_name
+
+    ## GROUP Metadata
+       ICON metadata
+       The path of the secret.
+    path : Enso_Path
+    path self = self.internal_path
 
     ## GROUP Output
        ICON edit
@@ -145,6 +157,27 @@ type Enso_Secret
             response.if_not_error <|
                 EnsoSecretHelper.deleteSecretFromCache self.id
                 self
+
+    ## PRIVATE
+       Returns a text representation of the secret.
+    to_text : Text
+    to_text self = "Enso_Secret " + self.path.to_text
+
+    ## PRIVATE
+       Returns a display text representation of the secret.
+    to_display_text : Text
+    to_display_text self = "Enso_Secret {" + self.name + "}"
+
+    ## PRIVATE
+       Converts the secret to a JSON object.
+    to_js_object : JS_Object
+    to_js_object self =
+        JS_Object.from_pairs [["type", "Enso_Secret"], ["constructor", "get"], ["path", self.path.to_text]]
+
+    ## PRIVATE
+       Convert to a Enso code representation of this Enso_Secret.
+    pretty : Text
+    pretty self = "(Enso_Secret.get " + self.path.pretty + ")"
 
 ## PRIVATE
 type Enso_Secret_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -42,8 +42,8 @@ type Enso_Secret
     ## GROUP Metadata
        ICON metadata
        The path of the secret.
-    path : Enso_Path
-    path self = self.internal_path
+    path : Text
+    path self = self.internal_path.to_text
 
     ## GROUP Output
        ICON edit

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -322,20 +322,20 @@ type Request_Error
 
 ## PRIVATE
    Access the HTTP's timeout (for testing purposes).
-get_timeout : HTTP -> Duration
-get_timeout http:HTTP = http.timeout
+_get_timeout : HTTP -> Duration
+_get_timeout http:HTTP = http.timeout
 
 ## PRIVATE
    Access the HTTP's follow_redirects (for testing purposes).
-get_follow_redirects : HTTP -> Boolean
-get_follow_redirects http:HTTP = http.follow_redirects
+_get_follow_redirects : HTTP -> Boolean
+_get_follow_redirects http:HTTP = http.follow_redirects
 
 ## PRIVATE
    Access the HTTP's proxy (for testing purposes).
-get_proxy : HTTP -> Proxy
-get_proxy http:HTTP = http.proxy
+_get_proxy : HTTP -> Proxy
+_get_proxy http:HTTP = http.proxy
 
 ## PRIVATE
     Access the HTTP's version (for testing purposes).
-get_version : HTTP -> HTTP_Version
-get_version http:HTTP = http.version
+_get_version : HTTP -> HTTP_Version
+_get_version http:HTTP = http.version

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response.enso
@@ -193,7 +193,7 @@ type Response
 
              example_write =
                 Data.fetch Examples.geo_data_url . write Examples.scratch_file
-    @path (Widget.Text_Input display=Display.Always)
+    @file (Widget.Text_Input display=Display.Always)
     write : Writable_File -> Existing_File_Behavior -> File
     write self file:Writable_File on_existing_file=Existing_File_Behavior.Backup =
         self.body.write file on_existing_file

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response_Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response_Body.enso
@@ -180,7 +180,7 @@ type Response_Body
 
              example_write =
                 Examples.get_geo_data.write Examples.scratch_file
-    @path (Widget.Text_Input display=Display.Always)
+    @file (Widget.Text_Input display=Display.Always)
     write : Writable_File -> Existing_File_Behavior -> File
     write self file:Writable_File on_existing_file=Existing_File_Behavior.Backup =
         self.with_stream body_stream->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -232,7 +232,7 @@ type Bytes
 type JSON_Format
     ## PRIVATE
        Resolve an unresolved constructor to the actual type.
-    resolve : Function -> Bytes | Nothing
+    resolve : Function -> JSON_Format | Nothing
     resolve constructor =
         _ = constructor
         Nothing

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2589,6 +2589,13 @@ type Column
         data = Statistic.running self.to_vector statistic
         Column.from_vector name data
 
+    ## PRIVATE
+    pretty : Text
+    pretty self =
+        name = self.name.pretty
+        data = self.to_vector.map .pretty . join ", "
+        "(Column.from_vector " + name + " [" + data + "])"
+
 ## PRIVATE
 
    Folds the vectorized operation over the provided column and values. When more

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2594,7 +2594,7 @@ type Column
     pretty self =
         name = self.name.pretty
         data = self.to_vector.map .pretty . join ", "
-        "(Column.from_vector " + name + " [" + data + "])"
+        "Column.from_vector " + name + " [" + data + "]"
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2593,7 +2593,7 @@ type Column
     pretty : Text
     pretty self =
         name = self.name.pretty
-        data = self.to_vector.map .pretty . join ", "
+        data = self.to_vector.pretty
         "Column.from_vector " + name + " [" + data + "]"
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2594,7 +2594,7 @@ type Column
     pretty self =
         name = self.name.pretty
         data = self.to_vector.pretty
-        "Column.from_vector " + name + " [" + data + "]"
+        "Column.from_vector " + name + " " + data
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -3739,6 +3739,12 @@ type Table
                     if merged_columns.is_empty then problem_builder_for_unification.raise_no_output_columns_with_cause else
                         Table.new merged_columns
 
+    ## PRIVATE
+    pretty : Text
+    pretty self =
+        data = self.columns.map c->("[" + c.name.pretty + ", [" + (c.to_vector.map .pretty . join ", ") + "]]") . join ", "
+        "(Table.new [" + data + "])"
+
 ## PRIVATE
    A helper to create a new table consisting of slices of the original table.
 slice_ranges table ranges =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -3743,7 +3743,7 @@ type Table
     pretty : Text
     pretty self =
         data = self.columns.map c->("[" + c.name.pretty + ", [" + (c.to_vector.map .pretty . join ", ") + "]]") . join ", "
-        "(Table.new [" + data + "])"
+        "Table.new [" + data + "]"
 
 ## PRIVATE
    A helper to create a new table consisting of slices of the original table.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -3742,7 +3742,7 @@ type Table
     ## PRIVATE
     pretty : Text
     pretty self =
-        data = self.columns.map c->("[" + c.name.pretty + ", [" + (c.to_vector.map .pretty . join ", ") + "]]") . join ", "
+        data = self.columns.map c->("[" + c.name.pretty + ", " + c.to_vector.pretty + "]") . join ", "
         "Table.new [" + data + "]"
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -1,5 +1,7 @@
 from Standard.Base import all
+import Standard.Base.Metadata.Widget
 import Standard.Base.Errors.Common.Not_Invokable
+from Standard.Base.Logging import all
 from Standard.Base.Meta import Instrumentor
 
 from Standard.Table import all
@@ -20,7 +22,11 @@ get_widget_json value call_name argument_names uuids="{}" =
             uuid:Text -> Instrumentor.uuid uuid
             _ -> Nothing
 
-    read_annotation argument =
+    log_panic argument err =
+        Widget.log_message "Failed for "+argument+": "+err.payload.to_display_text ..Warning
+        Nothing
+
+    read_annotation argument = Panic.catch Any handler=(log_panic argument) <|
         annotation = Warning.clear <| Meta.get_annotation value call_name argument
         return_target err = err.payload.target
         Panic.catch Not_Invokable handler=return_target

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
@@ -47,7 +47,7 @@ public abstract class AnyPrettyNode extends Node {
 
   @CompilerDirectives.TruffleBoundary
   private Text consName(AtomConstructor constructor) {
-    return Text.create(constructor.getDisplayName());
+    return Text.create(constructor.getType().getName() + "." + constructor.getName());
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/test/Base_Tests/src/Data/Array_Spec.enso
+++ b/test/Base_Tests/src/Data/Array_Spec.enso
@@ -49,6 +49,14 @@ add_specs suite_builder =
             make_enso_array [] . reduce (+) . should_fail_with (Empty_Error.Error Array)
             make_enso_array [] . reduce (+) 0 . should_equal 0
 
+        group_builder.specify "should have a well-defined debug-printing method" <|
+            ## Enso arrays should be coded as Vectors when Enso code is generated.
+            make_enso_array [] . pretty . should_equal "[]"
+            make_enso_array [1,2,3] . pretty . should_equal "[1, 2, 3]"
+            make_enso_array [Nothing] . pretty . should_equal "[Nothing]"
+            make_enso_array [True, False, 'a'] . pretty . should_equal "[True, False, 'a']"
+            make_enso_array [Date.new 2022 1 1] . pretty . should_equal "[Date.new 2022 1 1]"
+
     suite_builder.group "Compare functionality with Vector" group_builder->
         group_builder.specify "compare methods" <|
             vector_methods = Meta.meta Vector . methods . sort

--- a/test/Base_Tests/src/Data/Range_Spec.enso
+++ b/test/Base_Tests/src/Data/Range_Spec.enso
@@ -565,7 +565,7 @@ add_specs suite_builder = suite_builder.group "Range" group_builder->
         range_2 = 0.up_to 10 . with_step 2
         range_3 = 20.down_to 0 . with_step 3
 
-        range.to_text . should_equal "(Between 1 10 1)"
+        range.to_text . should_equal "(Between 1 100 1)"
         range_2.to_text . should_equal "(Between 0 10 2)"
         range_3.to_text . should_equal "(Between 20 0 -3)"
 

--- a/test/Base_Tests/src/Data/Range_Spec.enso
+++ b/test/Base_Tests/src/Data/Range_Spec.enso
@@ -573,7 +573,7 @@ add_specs suite_builder = suite_builder.group "Range" group_builder->
         range_2.to_display_text . should_equal "[0 .. 10 by 2]"
         range_3.to_display_text . should_equal "[20 .. 0 by -3]"
 
-        range.pretty . should_equal "Range.new 1 10"
+        range.pretty . should_equal "Range.new 1 100"
         range_2.pretty . should_equal "Range.new 0 10 step=2"
         range_3.pretty . should_equal "Range.new 20 0 step=3"
         Debug.eval range_3.pretty . should_equal range_3

--- a/test/Base_Tests/src/Data/Range_Spec.enso
+++ b/test/Base_Tests/src/Data/Range_Spec.enso
@@ -7,6 +7,7 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Common.Unsupported_Argument_Types
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -558,6 +559,24 @@ add_specs suite_builder = suite_builder.group "Range" group_builder->
         invalid_range . all _->True . should_fail_with Illegal_State
         invalid_range . find _->True . should_fail_with Illegal_State
         invalid_range . contains 0 . should_fail_with Illegal_State
+
+    group_builder.specify "should define friendly text representations" <|
+        range = 1.up_to 100
+        range_2 = 0.up_to 10 . with_step 2
+        range_3 = 20.down_to 0 . with_step 3
+
+        range.to_text . should_equal "(Between 1 10 1)"
+        range_2.to_text . should_equal "(Between 0 10 2)"
+        range_3.to_text . should_equal "(Between 20 0 -3)"
+
+        range.to_display_text . should_equal "[1 .. 10]"
+        range_2.to_display_text . should_equal "[0 .. 10 by 2]"
+        range_3.to_display_text . should_equal "[20 .. 0 by -3]"
+
+        range.pretty . should_equal "Range.new 1 10"
+        range_2.pretty . should_equal "Range.new 0 10 step=2"
+        range_3.pretty . should_equal "Range.new 20 0 step=3"
+        Debug.eval range_3.pretty . should_equal range_3
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Base_Tests/src/Data/Range_Spec.enso
+++ b/test/Base_Tests/src/Data/Range_Spec.enso
@@ -569,7 +569,7 @@ add_specs suite_builder = suite_builder.group "Range" group_builder->
         range_2.to_text . should_equal "(Between 0 10 2)"
         range_3.to_text . should_equal "(Between 20 0 -3)"
 
-        range.to_display_text . should_equal "[1 .. 10]"
+        range.to_display_text . should_equal "[1 .. 100]"
         range_2.to_display_text . should_equal "[0 .. 10 by 2]"
         range_3.to_display_text . should_equal "[20 .. 0 by -3]"
 

--- a/test/Base_Tests/src/Data/Time/Date_Range_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Range_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Empty_Error.Empty_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -194,8 +195,11 @@ add_specs suite_builder =
             r1.to_text . should_equal '(Date_Range from 2020-02-28 up to 2020-03-02)'
             r2.to_text . should_equal '(Date_Range from 2020-03-20 down to 2020-02-29 by 7D)'
 
-            r1.pretty . should_equal r1.to_text
-            r2.pretty . should_equal r2.to_text
+            r1.pretty . should_equal 'Date_Range.new (Date.new 2020 2 28) (Date.new 2020 3 2)'
+            (Debug.eval r1.pretty) . should_equal r1
+
+            r2.pretty . should_equal 'Date_Range.new (Date.new 2020 3 20) (Date.new 2020 2 29) (Period.new days=7)'
+            (Debug.eval r2.pretty) . should_equal r2
 
             r1.to_display_text . should_equal '[2020-02-28 .. 2020-03-02]'
             r2.to_display_text . should_equal '[2020-03-20 .. 2020-02-29 by -7D]'

--- a/test/Base_Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Spec.enso
@@ -96,6 +96,10 @@ spec_with suite_builder name create_new_date parse_date pending=Nothing =
             datetime.date . should_equal date
             datetime.time_of_day . should_equal time
 
+        group_builder.specify "should convert to Enso code" <|
+            date = create_new_date 2001 12 21
+            date.pretty . should_equal "Date.new 2001 12 21"
+
         group_builder.specify "should convert to Json" <|
             date = create_new_date 2001 12 21
             date.to_json.should_equal <|

--- a/test/Base_Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Time_Error.Time_Error
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -99,6 +100,7 @@ spec_with suite_builder name create_new_date parse_date pending=Nothing =
         group_builder.specify "should convert to Enso code" <|
             date = create_new_date 2001 12 21
             date.pretty . should_equal "Date.new 2001 12 21"
+            Debug.eval date.pretty . should_equal date
 
         group_builder.specify "should convert to Json" <|
             date = create_new_date 2001 12 21

--- a/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
@@ -124,9 +124,10 @@ spec_with suite_builder name create_new_datetime parse_datetime nanoseconds_loss
             create_new_datetime 1970 . pretty . should_equal "Date_Time.new 1970 1 1"
             create_new_datetime 1923 9 24 . pretty . should_equal "Date_Time.new 1923 9 24"
             create_new_datetime 1923 9 24 12 20 44 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 44"
-            create_new_datetime 1923 9 24 12 20 nanosecond=500000000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 millisecond=500"
-            create_new_datetime 1923 9 24 12 20 nanosecond=500000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 microsecond=500"
-            create_new_datetime 1923 9 24 12 20 nanosecond=500 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 nanosecond=500"
+            if nanoseconds_loss_in_precision.not then
+                create_new_datetime 1923 9 24 12 20 nanosecond=500000000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 millisecond=500"
+                create_new_datetime 1923 9 24 12 20 nanosecond=500000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 microsecond=500"
+                create_new_datetime 1923 9 24 12 20 nanosecond=500 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 nanosecond=500"
 
             date_time = create_new_datetime 1970 12 21 11 23 45 nanosecond=123456789 zone=Time_Zone.utc
             Debug.eval date_time.pretty . should_equal date_time

--- a/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Time_Error.Time_Error
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -118,6 +119,17 @@ spec_with suite_builder name create_new_datetime parse_datetime nanoseconds_loss
         group_builder.specify "should format using default pattern" <|
             text = create_new_datetime 1970 (zone = Time_Zone.utc) . to_text
             text . should_equal "1970-01-01 00:00:00Z[UTC]"
+
+        group_builder.specify "should convert to Enso code" <|
+            create_new_datetime 1970 . pretty . should_equal "Date_Time.new 1970 1 1"
+            create_new_datetime 1923 9 24 . pretty . should_equal "Date_Time.new 1923 9 24"
+            create_new_datetime 1923 9 24 12 20 44 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 44"
+            create_new_datetime 1923 9 24 12 20 nanosecond=500000000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 millisecond=500"
+            create_new_datetime 1923 9 24 12 20 nanosecond=500000 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 microsecond=500"
+            create_new_datetime 1923 9 24 12 20 nanosecond=500 . pretty . should_equal "Date_Time.new 1923 9 24 12 20 nanosecond=500"
+
+            date_time = create_new_datetime 1970 12 21 11 23 45 nanosecond=123456789 zone=Time_Zone.utc
+            Debug.eval date_time.pretty . should_equal date_time
 
         group_builder.specify "should convert to Json" <|
             time = create_new_datetime 1970 12 21 (zone = Time_Zone.utc)

--- a/test/Base_Tests/src/Data/Time/Day_Of_Week_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Day_Of_Week_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -10,6 +11,10 @@ add_specs suite_builder =
             Day_Of_Week.Wednesday.to_integer . should_equal 4
             Day_Of_Week.Friday.to_integer . should_equal 6
             Day_Of_Week.Saturday.to_integer . should_equal 7
+
+        group_builder.specify "should be able to convert to Enso code" <|
+            Day_Of_Week.Sunday.pretty . should_equal "Day_Of_Week.Sunday"
+            Debug.eval Day_Of_Week.Wednesday.pretty . should_equal Day_Of_Week.Wednesday
 
         group_builder.specify "should be able to convert from an Integer" <|
             Day_Of_Week.from 1 . should_equal Day_Of_Week.Sunday

--- a/test/Base_Tests/src/Data/Time/Period_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Period_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -49,6 +50,18 @@ add_specs suite_builder =
             Period.new months=18 . to_display_text . should_equal "1Y 6M"
             Period.new years=2 days=3 . to_display_text . should_equal "2Y 0M 3D"
             Period.new days=18 . to_display_text . should_equal "18D"
+
+        group_builder.specify "should render to Enso code" <|
+            Period.new . pretty . should_equal "Period.new"
+            Period.new years=2 . pretty . should_equal "Period.new 2"
+            Period.new months=24 . pretty . should_equal "Period.new months=24"
+            Period.new months=4 . pretty . should_equal "Period.new months=4"
+            Period.new years=1 months=6 . pretty . should_equal "Period.new 1 6"
+            Period.new years=2 days=3 . pretty . should_equal "Period.new 2 days=3"
+            Period.new days=18 . pretty . should_equal "Period.new days=18"
+
+            period = Period.new years=2 days=3
+            Debug.eval period.pretty . should_equal period
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Base_Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -3,6 +3,7 @@ import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Time_Error.Time_Error
+import Standard.Base.Runtime.Debug
 
 from Standard.Test import all
 
@@ -64,6 +65,9 @@ specWith suite_builder name create_new_time parse_time nanoseconds_loss_in_preci
             create_new_time 12 20 0 500000000 . pretty . should_equal "Time_Of_Day.new 12 20 millisecond=500"
             create_new_time 12 20 0 500000 . pretty . should_equal "Time_Of_Day.new 12 20 microsecond=500"
             if nanoseconds_loss_in_precision.not then create_new_time 12 20 0 500 . pretty . should_equal "Time_Of_Day.new 12 20 nanosecond=500"
+
+            time = create_new_time 12 20 0 500000
+            Debug.eval time.pretty . should_equal time
 
         group_builder.specify "should convert to Json" <|
             time = create_new_time 1 2 3

--- a/test/Base_Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -58,6 +58,13 @@ specWith suite_builder name create_new_time parse_time nanoseconds_loss_in_preci
             text = create_new_time 12 20 44 . to_text
             text . should_equal "12:20:44"
 
+        group_builder.specify "should convert to Enso code" <|
+            create_new_time 12 20 . pretty . should_equal "Time_Of_Day.new 12 20"
+            create_new_time 12 20 44 . pretty . should_equal "Time_Of_Day.new 12 20 44"
+            create_new_time 12 20 0 500000000 . pretty . should_equal "Time_Of_Day.new 12 20 millisecond=500"
+            create_new_time 12 20 0 500000 . pretty . should_equal "Time_Of_Day.new 12 20 microsecond=500"
+            if nanoseconds_loss_in_precision.not then create_new_time 12 20 0 500 . pretty . should_equal "Time_Of_Day.new 12 20 nanosecond=500"
+
         group_builder.specify "should convert to Json" <|
             time = create_new_time 1 2 3
             time.to_json.should_equal <|

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -12,6 +12,7 @@ import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Unimplemented.Unimplemented
+import Standard.Base.Runtime.Debug
 import Standard.Base.Runtime.Ref.Ref
 import Standard.Base.Runtime.State
 from Standard.Base.Panic import Wrapped_Dataflow_Error
@@ -1243,6 +1244,11 @@ add_specs suite_builder =
             [Nothing].pretty.should_equal "[Nothing]"
             [True, False, 'a'].pretty . should_equal "[True, False, 'a']"
             [Foo.Value True].pretty . should_equal "[(Foo.Value True)]"
+            [Date.new 2022 1 1].pretty . should_equal "[Date.new 2022 1 1]"
+
+            mixed = [1, 2, 'a', (Foo.Value True), Date.new 2022 1 1, Nothing]
+            mixed.pretty . should_equal "[1, 2, 'a', (Foo.Value True), Date.new 2022 1 1, Nothing]"
+            Debug.eval (mixed.pretty) . should_equal [1, 2, 'a', Foo.Value True, Date.new 2022 1 1, Nothing]
 
     type_spec suite_builder "Use Vector as vectors" identity
     type_spec suite_builder "Use Array as vectors" (v -> v.to_array)

--- a/test/Base_Tests/src/Network/Http_Spec.enso
+++ b/test/Base_Tests/src/Network/Http_Spec.enso
@@ -10,7 +10,7 @@ import Standard.Base.Network.HTTP.Request_Body.Request_Body
 import Standard.Base.Network.HTTP.Request_Error
 import Standard.Base.Network.Proxy.Proxy
 import Standard.Base.Runtime.Context
-from Standard.Base.Network.HTTP import _resolve_headers, get_follow_redirects, get_proxy, get_timeout, get_version
+from Standard.Base.Network.HTTP import _resolve_headers, _get_follow_redirects, _get_proxy, _get_timeout, _get_version
 
 from Standard.Test import all
 from Standard.Test.Execution_Context_Helpers import run_with_and_without_output
@@ -65,11 +65,11 @@ add_specs suite_builder =
     suite_builder.group "HTTP client" pending=pending_has_url group_builder->
         group_builder.specify "should create HTTP client with timeout setting" <|
             http = HTTP.new (timeout = (Duration.new seconds=30))
-            (get_timeout http).should_equal (Duration.new seconds=30)
+            (_get_timeout http).should_equal (Duration.new seconds=30)
 
         group_builder.specify "should create HTTP client with follow_redirects setting" <|
             http = HTTP.new (follow_redirects = False)
-            (get_follow_redirects http).should_equal False
+            (_get_follow_redirects http).should_equal False
 
             Test.with_retries <|
                 r = http.request (Request.new HTTP_Method.Get base_url_with_slash+"test_redirect")
@@ -80,12 +80,12 @@ add_specs suite_builder =
         group_builder.specify "should create HTTP client with proxy setting" <|
             proxy_setting = Proxy.Address "example.com" 80
             http = HTTP.new (proxy = proxy_setting)
-            (get_proxy http).should_equal proxy_setting
+            (_get_proxy http).should_equal proxy_setting
 
         group_builder.specify "should create HTTP client with version setting" <|
             version_setting = HTTP_Version.HTTP_2
             http = HTTP.new (version = version_setting)
-            (get_version http).should_equal version_setting
+            (_get_version http).should_equal version_setting
 
     url_get = base_url_with_slash.if_not_nothing <| base_url_with_slash + "get"
     suite_builder.group "fetch" pending=pending_has_url group_builder->

--- a/test/Table_Tests/src/In_Memory/Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Runtime.Debug
 
 import project.Util
 
@@ -256,6 +257,20 @@ add_specs suite_builder =
 
             r2 = Column.from_vector "X" [] (Value_Type.Char size=0 variable_length=True)
             r2.should_fail_with Illegal_Argument
+
+        group_builder.specify "should be able to serialize to Enso code" <|
+            c1 = Column.from_vector "X" [1, 2] Value_Type.Float
+            c1.pretty . should_equal 'Column.from_vector \'X\' [1.0, 2.0]'
+            Debug.eval c1.pretty . should_equal c1
+
+            c2 = Column.from_vector "X" ["a", 42]
+            c2.pretty . should_equal 'Column.from_vector \'X\' [\'a\', 42]'
+
+            c3 = Column.from_vector "X" ["aaa", "bbb"]
+            c3.pretty . should_equal 'Column.from_vector \'X\' [\'aaa\', \'bbb\']'
+
+            c4 = Column.from_vector "X" [Time_Of_Day.new 10 11 12, Time_Of_Day.new 11 30]
+            c4.pretty . should_equal 'Column.from_vector \'X\' [Time_Of_Day.new 10 11 12, Time_Of_Day.new 11 30]'
 
     suite_builder.group "Rounding" group_builder->
         group_builder.specify "should be able to round a column of decimals" <|

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Runtime.Debug
 
 from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Blank_Selector, Value_Type
 from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Equality, Invalid_Value_Type, Row_Count_Mismatch
@@ -87,6 +88,23 @@ add_specs suite_builder =
             r2.row_count . should_equal 0
             r2.at "foo" . to_vector . should_equal []
             r2.at "bar" . to_vector . should_equal []
+
+        group_builder.specify "should allow creating Enso code from a Table" <|
+            r = Table.new [["foo", [1, 2, 3]], ["bar", [False, True, False]]]
+            r.pretty . should_equal "Table.new [['foo', [1, 2, 3]], ['bar', [False, True, False]]]"
+            Debug.eval r.pretty . should_equal r
+
+            r2 = Table.new [["foo", []], ["bar", []]]
+            r2.pretty . should_equal "Table.new [['foo', []], ['bar', []]]"
+            Debug.eval r2.pretty . should_equal r2
+
+            r3 = Table.new [["date", [Date.new 2022 8 27, Date.new 1999 1 1]], ["time", [Time_Of_Day.new 18, Time_Of_Day.new 1 2 34]]]
+            r3.pretty . should_equal "Table.new [['date', [Date.new 2022 8 27, Date.new 1999 1 1]], ['time', [Time_Of_Day.new 18, Time_Of_Day.new 1 2 34]]]"
+            Debug.eval r3.pretty . should_equal r3
+
+            r4 = Table.new [["foo", [1, 2, 3]], ["bar", [False, True, False]], ["date", [Date.new 2022 8 27, Date.new 1999 1 1, Date.new 2012 1 23]], ["time", [Time_Of_Day.new 18, Time_Of_Day.new 1 2 34, Time_Of_Day.new 12 0]]]
+            r4.pretty . should_equal "Table.new [['foo', [1, 2, 3]], ['bar', [False, True, False]], ['date', [Date.new 2022 8 27, Date.new 1999 1 1, Date.new 2012 1 23]], ['time', [Time_Of_Day.new 18, Time_Of_Day.new 1 2 34, Time_Of_Day.new 12]]]"
+            Debug.eval r4.pretty . should_equal r4
 
         group_builder.specify "should handle error scenarios gracefully" <|
             Table.new [["X", [1,2,3]], ["Y", [4]]] . should_fail_with Illegal_Argument


### PR DESCRIPTION
### Pull Request Description

- ✅ Alter default `Any.pretty` so constructor is prefixed with type name (as needed now).
![image](https://github.com/user-attachments/assets/72d5ff2f-b567-47e2-becf-2e4acd4d089d)
- ✅ Tests for `pretty` on `Date`.
- `pretty` for ✅ `Date_Time` and ✅ `Time_Of_Day` improved to not have as much noise.
- `pretty` for ✅ `Period`, ✅ `Date_Range` and ✅ `Range`.
- Added custom `pretty` for ✅ `Vector` and ✅ `Array` as built-in method doesn't call through to overrides.
- Added custom `pretty` for ✅ `Column` and ✅ `Table`.
- Bug fix for `pretty` in `Time_Zone` so calls through to `pretty` of the zone_id to ensure safely escaped.
- Initial `default_widget` for `Date` and `Time_Of_Day`.
- Improve widget for `Date.to_date_time`.
![image](https://github.com/user-attachments/assets/18bc1d88-8ea9-42d0-8a9c-bc873e5d6835)
- `to_text`, `to_display_text` and `pretty` for `Enso_Secret`
![image](https://github.com/user-attachments/assets/d850c109-d1af-4b6f-a450-013c4d137805)
- private constructor for `Enso_Secret` as can't be correctly built directly.
- Use `_` for the testing methods in `HTTP` to clarify they shouldn't be used in general code.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
