### PR TITLE
Experiment in GUI Styling

### DIFF
--- a/app/gui/src/project-view/assets/base.css
+++ b/app/gui/src/project-view/assets/base.css
@@ -21,9 +21,10 @@
   --color-frame-selected-bg: rgb(255 255 255 / 0.7);
   --color-widget-slight: rgb(255 255 255 / 0.06);
   --color-widget: rgb(255 255 255 / 0.12);
-  --color-widget-focus: rgb(255 255 255 / 0.25);
+  --color-widget-unfocus: rgb(255 255 255 / 0.6);
+  --color-widget-focus: rgb(255 255 255 / 1);
   --color-widget-selected: rgb(255 255 255 / 0.58);
-  --color-widget-selection: rgba(255 255 255 / 0.2);
+  --color-widget-selection: rgba(0 0 0 / 0.2);
   --color-port-connected: rgb(255 255 255 / 0.15);
 
   /* colors for specific icons */

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -105,17 +105,6 @@ const rootStyle = computed(() => {
   isolation: isolate;
 }
 
-.iconPort::before {
-  content: '';
-  position: absolute;
-  top: calc(var(--port-padding) - var(--component-editor-padding));
-  width: var(--port-edge-width);
-  height: calc(var(--component-editor-padding) - var(--port-padding) + var(--icon-height) / 2);
-  transform: translate(-50%, 0);
-  background-color: var(--node-color-port);
-  z-index: -1;
-}
-
 .nodeIcon {
   color: white;
   width: var(--icon-height);

--- a/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
@@ -79,7 +79,7 @@ const targetPos = computed<Vec2 | undefined>(() => {
   } else if (mouseAnchorPos.value != null) {
     return mouseAnchorPos.value
   } else if ('anchor' in props.edge && props.edge.anchor.type === 'fixed') {
-    return props.edge.anchor.scenePos
+    return props.edge.anchor.scenePos.add(new Vec2(0, -(selfArgumentArrowHeight + selfArgumentArrowYOffset)))
   } else {
     return undefined
   }

--- a/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
@@ -140,8 +140,8 @@ const sourceMask = computed<NodeMask | undefined>(() => {
 
 const edgeColor = computed(() =>
   'color' in props.edge ? props.edge.color
-  : targetNode.value ? graph.db.getNodeColorStyle(targetNode.value)
   : sourceNode.value ? graph.db.getNodeColorStyle(sourceNode.value)
+  : targetNode.value ? graph.db.getNodeColorStyle(targetNode.value)
   : undefined,
 )
 
@@ -510,13 +510,7 @@ const backwardEdgeArrowTransform = computed<string | undefined>(() => {
 })
 
 const targetIsSelfArgument = computed(() => {
-  if ('targetIsSelfArgument' in props.edge && props.edge?.targetIsSelfArgument) return true
-  if (!targetExpr.value) return
-  const nodeId = graph.getPortNodeId(targetExpr.value)
-  if (!nodeId) return
-  const primarySubject = graph.db.nodeIdToNode.get(nodeId)?.primarySubject
-  if (!primarySubject) return
-  return targetExpr.value === primarySubject
+  return true
 })
 
 const selfArgumentArrowHeight = 9

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -534,7 +534,7 @@ function recomputeOnce() {
     <div
       ref="contentNode"
       :class="{ content: true, dragged: isDragged, selected: selected, singleSelected: isOnlyOneSelected }"
-      :style="{ padding: CONTENT_PADDING_PX, color: (selected ? 'var(--node-color-primary)' : 'white') }"
+      :style="{ padding: CONTENT_PADDING_PX }"
       v-on="dragPointer.events"
       @click="handleNodeClick"
     >
@@ -547,6 +547,7 @@ function recomputeOnce() {
         :potentialSelfArgumentId="potentialSelfArgumentId"
         :conditionalPorts="props.node.conditionalPorts"
         :extended="isOnlyOneSelected"
+        :singleSelected="isOnlyOneSelected"
         @openFullMenu="openFullMenu"
       />
     </div>
@@ -564,7 +565,7 @@ function recomputeOnce() {
       :type="visibleMessage.type"
     />
     <svg class="bgPaths">
-      <rect class="bgFill" :style="{fillOpacity: (selected ? 0.2 : 1)}" />
+      <rect :class="{bgFill:true, selected:selected}" />
       <GraphNodeOutputPorts
         v-if="props.node.type !== 'output'"
         :nodeId="nodeId"
@@ -605,6 +606,10 @@ function recomputeOnce() {
   transition: fill 0.2s ease;
 }
 
+.bgFill.selected {
+  fill: color-mix(in oklab, var(--node-color-primary) 30%, white 70%);
+}
+
 .GraphNode {
   position: absolute;
   border-radius: var(--node-border-radius);
@@ -633,6 +638,7 @@ function recomputeOnce() {
   top: 0;
   left: 0;
   border-radius: var(--node-border-radius);
+  color: white;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -640,6 +646,10 @@ function recomputeOnce() {
   z-index: 24;
   transition: outline 0.2s ease;
   outline: 0px solid transparent;
+}
+
+.content.selected {
+  color: color-mix(in oklab, var(--node-color-primary) 80%, black 20%)
 }
 
 .binding {

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -44,10 +44,6 @@ const CONTENT_PADDING = 4
 const CONTENT_PADDING_PX = `${CONTENT_PADDING}px`
 const MENU_CLOSE_TIMEOUT_MS = 300
 
-const contentNodeStyle = {
-  padding: CONTENT_PADDING_PX,
-}
-
 const props = defineProps<{
   node: Node
   edited: boolean
@@ -537,8 +533,8 @@ function recomputeOnce() {
     />
     <div
       ref="contentNode"
-      :class="{ content: true, dragged: isDragged }"
-      :style="contentNodeStyle"
+      :class="{ content: true, dragged: isDragged, selected: selected, singleSelected: isOnlyOneSelected }"
+      :style="{ padding: CONTENT_PADDING_PX, color: (selected ? 'var(--node-color-primary)' : 'white') }"
       v-on="dragPointer.events"
       @click="handleNodeClick"
     >
@@ -568,7 +564,7 @@ function recomputeOnce() {
       :type="visibleMessage.type"
     />
     <svg class="bgPaths">
-      <rect class="bgFill" />
+      <rect class="bgFill" :style="{fillOpacity: (selected ? 0.2 : 1)}" />
       <GraphNodeOutputPorts
         v-if="props.node.type !== 'output'"
         :nodeId="nodeId"

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeSelection.vue
@@ -46,7 +46,7 @@ const rootStyle = computed(() => {
   contain: strict;
   inset: calc(0px - var(--selected-node-border-width));
   width: calc(var(--selected-node-border-width) * 2 + var(--node-size-x));
-  height: calc(var(--selected-node-border-width) + var(--node-size-y) / 2);
+  height: calc(var(--selected-node-border-width) + var(--node-base-height) / 2);
   border-radius: 0;
   border-top-left-radius: calc(var(--node-border-radius) * 2 + var(--selected-node-border-width));
   border-top-right-radius: calc(var(--node-border-radius) * 2 + var(--selected-node-border-width));

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeSelection.vue
@@ -46,21 +46,22 @@ const rootStyle = computed(() => {
   contain: strict;
   inset: calc(0px - var(--selected-node-border-width));
   width: calc(var(--selected-node-border-width) * 2 + var(--node-size-x));
-  height: calc(var(--selected-node-border-width) * 2 + var(--node-size-y));
-  border-radius: calc(var(--node-border-radius) + var(--selected-node-border-width));
+  height: calc(var(--selected-node-border-width) + var(--node-size-y) / 2);
+  border-radius: 0;
+  border-top-left-radius: calc(var(--node-border-radius) * 2 + var(--selected-node-border-width));
+  border-top-right-radius: calc(var(--node-border-radius) * 2 + var(--selected-node-border-width));
+  border-bottom-left-radius: calc(var(--node-border-radius));
+  border-bottom-right-radius: calc(var(--node-border-radius));
 
   &:before {
     position: absolute;
     content: '';
-    opacity: 0.2;
+    opacity: 0;
     display: block;
     inset: var(--selected-node-border-width);
-    box-shadow: 0 0 0 calc(0px - var(--node-border-radius)) var(--selection-color);
-    border-radius: var(--node-border-radius);
 
     transition:
-      box-shadow 0.2s ease-in-out,
-      opacity 0.2s ease-in-out;
+      box-shadow 0.2s ease-in-out;
   }
 }
 
@@ -68,7 +69,7 @@ const rootStyle = computed(() => {
   box-shadow: 0 0 0 var(--selected-node-border-width) var(--selection-color);
 }
 
-.GraphNodeSelection:not(.selected):hover::before {
+.GraphNodeSelection:hover::before {
   opacity: 0.3;
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization.vue
@@ -278,8 +278,13 @@ customElements.define(ensoVisualizationHost, defineCustomElement(VisualizationHo
   position: absolute;
   border-radius: var(--radius-default);
   background: var(--color-visualization-bg);
+  opacity: 0.9;
   /** Prevent drawing on top of other UI elements (e.g. dropdown widgets). */
   isolation: isolate;
+}
+
+.selected .GraphVisualization {
+  opacity: 1;
 }
 
 .VisualizationPanel {

--- a/app/gui/src/project-view/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui/src/project-view/components/GraphEditor/NodeWidgetTree.vue
@@ -125,8 +125,6 @@ export const ICON_WIDTH = 16
 
 <style scoped>
 .NodeWidgetTree {
-  color: white;
-
   outline: none;
   min-height: var(--node-port-height);
   display: flex;

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetArgumentName.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetArgumentName.vue
@@ -70,6 +70,6 @@ export const ArgumentNameShownKey: unique symbol = Symbol.for('WidgetInput:Argum
 
 .placeholder,
 .name {
-  color: rgb(255 255 255 / 0.5);
+  opacity: 0.6;
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -113,7 +113,7 @@ export const widgetDefinition = defineWidget(
 }
 
 .name {
-  color: rgb(255 255 255 / 0.5);
+  opacity: 0.5;
   margin-right: var(--widget-token-pad-unit);
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetGroup.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetGroup.vue
@@ -47,7 +47,7 @@ export const widgetDefinition = defineWidget(
 }
 
 .token {
-  color: rgb(255 255 255 / 0.33);
+  opacity: 0.33;
   user-select: none;
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
@@ -215,6 +215,7 @@ export const widgetDefinition = defineWidget(
 
 .WidgetPort.connected {
   background-color: var(--node-color-port);
+  color: white;
 }
 
 .GraphEditor.draggingEdge .WidgetPort {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
@@ -250,15 +250,4 @@ export const widgetDefinition = defineWidget(
   }
 }
 
-.WidgetPort.isTarget:not(.isSelfArgument):after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  left: 50%;
-  width: 4px;
-  height: 5px;
-  transform: translate(-50%, 0);
-  background-color: var(--node-color-port);
-  z-index: -1;
-}
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -471,7 +471,8 @@ declare module '@/providers/widgetRegistry' {
         <SizeTransition height :duration="100">
           <DropdownWidget
             v-if="dropDownInteraction.isActive() && activity == null"
-            color="var(--node-color-primary)"
+            backgroundColor="color-mix(in oklab, var(--node-color-primary) 30%, white 70%)"
+            color="color-mix(in oklab, var(--node-color-primary) 80%, black 20%)"
             :entries="entries"
             @clickEntry="onClick"
           />

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -463,8 +463,8 @@ declare module '@/providers/widgetRegistry' {
     @pointerout="isHovered = false"
   >
     <NodeWidget :input="innerWidgetInput" />
-    <Teleport v-if="showArrow" defer :disabled="!arrowLocation" :to="arrowLocation">
-      <SvgIcon name="arrow_right_head_only" class="arrow widgetOutOfLayout" />
+    <Teleport defer :disabled="!arrowLocation" :to="arrowLocation">
+      <SvgIcon name="arrow_right_head_only" :class="{arrow:true, widgetOutOfLayout:true, shown:isHovered}" />
     </Teleport>
     <Teleport v-if="tree.nodeElement" :to="tree.nodeElement">
       <div ref="dropdownElement" :style="floatingStyles" class="widgetOutOfLayout floatingElement">
@@ -512,9 +512,17 @@ svg.arrow {
   left: 50%;
   transform: translateX(-50%) rotate(90deg) scale(0.7);
   transform-origin: center;
-  opacity: 0.5;
+  opacity: 0;
   /* Prevent the parent from receiving a pointerout event if the mouse is over the arrow, which causes flickering. */
   pointer-events: none;
+}
+
+.singleSelected svg.arrow {
+  opacity: 0.5;
+}
+
+svg.arrow.shown {
+  opacity: 0.5;
 }
 
 .activityElement {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
@@ -137,4 +137,14 @@ export const widgetDefinition = defineWidget(
     background: var(--color-widget-selection);
   }
 }
+
+.singleSelected .WidgetText {
+  background: var(--color-widget-unfocus);
+  &:has(> :focus) {
+    background: var(--color-widget-focus);
+  }
+  &:deep(::selection) {
+    background: var(--color-widget-selection);
+  }
+}
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetToken.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetToken.vue
@@ -28,12 +28,12 @@ export const widgetDefinition = defineWidget(
   display: inline-block;
   vertical-align: middle;
   white-space: pre;
-  color: rgb(255 255 255 / 0.33);
+  opacity: 0.33;
 
   &.Ident,
   &.TextSection,
   &.Digits {
-    color: white;
+    opacity: 1;
   }
 
   &.TextSection,

--- a/app/gui/src/project-view/components/widgets/DropdownWidget.vue
+++ b/app/gui/src/project-view/components/widgets/DropdownWidget.vue
@@ -10,7 +10,7 @@ enum SortDirection {
   descending = 'descending',
 }
 
-const props = defineProps<{ color: string; entries: Entry[] }>()
+const props = defineProps<{ backgroundColor: string, color: string, entries: Entry[] }>()
 const emit = defineEmits<{ clickEntry: [entry: Entry, keepOpen: boolean] }>()
 
 const sortDirection = ref<SortDirection>(SortDirection.none)
@@ -56,7 +56,8 @@ const enableSortButton = ref(false)
 
 const styleVars = computed(() => {
   return {
-    '--dropdown-bg': props.color,
+    '--dropdown-bg': props.backgroundColor,
+    '--dropdown-fg': props.color,
     // Slightly shift the top border of drawn dropdown away from node's top border by a fraction of
     // a pixel, to prevent it from poking through and disturbing node's siluette.
     '--extend-margin': `${0.2 / (graphNavigator?.scale ?? 1)}px`,
@@ -111,6 +112,7 @@ export interface DropdownEntry {
   margin-top: calc(0px - var(--dropdown-extend));
   padding-top: var(--dropdown-extend);
   background-color: var(--dropdown-bg);
+  color: var(--dropdown-fg);
   border-radius: calc(var(--item-height) / 2 + var(--dropdown-padding));
 
   &:before {
@@ -130,7 +132,6 @@ export interface DropdownEntry {
   min-height: 16px;
   max-height: calc(var(--visible-items) * var(--item-height) + 2 * var(--dropdown-padding));
   list-style-type: none;
-  color: var(--color-text-light);
   scrollbar-width: thin;
   padding: var(--dropdown-padding);
   position: relative;
@@ -146,16 +147,12 @@ export interface DropdownEntry {
   overflow: hidden;
 
   &:hover {
-    background-color: color-mix(in oklab, var(--color-port-connected) 50%, transparent 50%);
+    background-color: color-mix(in oklab, var(--dropdown-bg) 50%, white 50%);
     span {
       --text-scroll-max: calc(var(--dropdown-max-width) - 28px);
       will-change: transform;
       animation: 6s 1s infinite text-scroll;
     }
-  }
-
-  &:not(.selected):hover {
-    color: white;
   }
 
   &.selected {

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -134,6 +134,16 @@ const rootNode = ref<HTMLElement>()
 
 const cssPropsToCopy = ['--node-color-primary', '--node-color-port', '--node-border-radius']
 
+function onClickDelete(event: PointerEvent , index: number) {
+  if (
+    !(event.target instanceof HTMLElement && event.target.previousElementSibling instanceof HTMLElement)
+  )
+    return
+
+  const modelValue = props.modelValue.filter((_, i) => i !== index)
+  emit('update:modelValue', modelValue)
+}
+
 function onDragStart(event: DragEvent, index: number) {
   if (
     !(event.target instanceof HTMLElement && event.target.nextElementSibling instanceof HTMLElement)
@@ -394,8 +404,9 @@ function addItem() {
                 draggable="true"
                 @dragstart="onDragStart($event, entry.index)"
                 @dragend="onDragEnd"
-              ></div>
+              >‖</div>
               <slot :item="entry.item"></slot>
+              <div class="handle" style="cursor: pointer;" @click.stop="onClickDelete($event, entry.index)">×</div>
             </li>
             <li
               v-show="entry.index != props.modelValue.length - 1"
@@ -514,65 +525,27 @@ div {
 }
 
 .handle {
-  position: absolute;
-  display: block;
-  left: -6px;
+  display: none;
+  background-color: 0 0 0 0;
   height: calc(100% - 12px);
-  width: 2px;
-  box-shadow:
-    2px 0 0 transparent,
-    -2px 0 0 transparent;
-  transition: box-shadow 0.2s ease;
-  pointer-events: none;
+  width: 6px;
   cursor: grab;
 
   &:before {
-    content: '';
-    opacity: 0;
-    transition: opacity 0.2s ease;
-    position: absolute;
-    display: block;
-    left: -8px;
-    right: -16px;
-    top: -3px;
-    bottom: -3px;
+    opacity: 0.6;
     border-radius: var(--node-border-radius) 0 0 var(--node-border-radius);
-    background-color: var(--node-color-primary);
-    z-index: -1;
   }
 }
 
-.item:hover {
-  z-index: 0;
+.singleSelected .handle {
+  display: block;
 }
 
 .item:hover .handle {
-  box-shadow:
-    2px 0 0 rgb(255 255 255 / 0.5),
-    -2px 0 0 rgb(255 255 255 / 0.5);
-
-  &:hover {
-    box-shadow:
-      2px 0 0 rgb(255 255 255 / 0.8),
-      -2px 0 0 rgb(255 255 255 / 0.8);
-  }
-
-  background: var(--node-color-primary);
   pointer-events: all;
 
   &:before {
-    opacity: 0.5;
-  }
-
-  &:after {
-    content: '';
-    position: absolute;
-    display: block;
-    left: -1px;
-    right: -4px;
-    top: -3px;
-    bottom: -3px;
-    z-index: 1;
+    opacity: 1;
   }
 }
 

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -134,7 +134,7 @@ const rootNode = ref<HTMLElement>()
 
 const cssPropsToCopy = ['--node-color-primary', '--node-color-port', '--node-border-radius']
 
-function onClickDelete(event: PointerEvent , index: number) {
+function onClickDelete(event: MouseEvent , index: number) {
   if (
     !(event.target instanceof HTMLElement && event.target.previousElementSibling instanceof HTMLElement)
   )

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -425,7 +425,7 @@ function addItem() {
           </template>
         </template>
       </TransitionGroup>
-      <SvgIcon class="item-button" name="vector_add" @click.stop="addItem" />
+      <SvgIcon class="item-button" name="vector_add" @click.stop="addItem"/>
       <span class="token widgetApplyPadding">]</span>
     </div>
     <div
@@ -561,6 +561,7 @@ div {
   transition-property: opacity;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
+  cursor: pointer;
   display: none;
   margin-left: 4px;
   transition: margin 0.2s ease-in-out;

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -496,7 +496,7 @@ div {
 }
 
 .token {
-  color: rgb(255 255 255 / 0.33);
+  opacity: 0.50;
   user-select: none;
 }
 
@@ -588,12 +588,17 @@ div {
   transition-property: opacity;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
-  opacity: 0.5;
+  display: none;
   margin-left: 4px;
   transition: margin 0.2s ease-in-out;
   .items:empty + & {
     margin: 0 2px;
   }
+}
+
+.singleSelected .add-item {
+  display: block;
+  opacity: 0.6;
 }
 
 .add-item:hover {

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -406,7 +406,7 @@ function addItem() {
                 @dragend="onDragEnd"
               >‖</div>
               <slot :item="entry.item"></slot>
-              <div class="handle" style="cursor: pointer;" @click.stop="onClickDelete($event, entry.index)">×</div>
+              <SvgIcon class="item-button" name="close" @click.stop="onClickDelete($event, entry.index)" />
             </li>
             <li
               v-show="entry.index != props.modelValue.length - 1"
@@ -425,7 +425,7 @@ function addItem() {
           </template>
         </template>
       </TransitionGroup>
-      <SvgIcon class="add-item" name="vector_add" @click.stop="addItem" />
+      <SvgIcon class="item-button" name="vector_add" @click.stop="addItem" />
       <span class="token widgetApplyPadding">]</span>
     </div>
     <div
@@ -557,7 +557,7 @@ div {
   display: none;
 }
 
-.add-item {
+.item-button {
   transition-property: opacity;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
@@ -569,12 +569,12 @@ div {
   }
 }
 
-.singleSelected .add-item {
+.singleSelected .item-button {
   display: block;
   opacity: 0.6;
 }
 
-.add-item:hover {
+.item-button:hover {
   opacity: 1;
 }
 

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -134,12 +134,7 @@ const rootNode = ref<HTMLElement>()
 
 const cssPropsToCopy = ['--node-color-primary', '--node-color-port', '--node-border-radius']
 
-function onClickDelete(event: MouseEvent , index: number) {
-  if (
-    !(event.target instanceof HTMLElement && event.target.previousElementSibling instanceof HTMLElement)
-  )
-    return
-
+function onClickDelete(index: number) {
   const modelValue = props.modelValue.filter((_, i) => i !== index)
   emit('update:modelValue', modelValue)
 }
@@ -406,7 +401,7 @@ function addItem() {
                 @dragend="onDragEnd"
               >‖</div>
               <slot :item="entry.item"></slot>
-              <SvgIcon class="item-button" name="close" @click.stop="onClickDelete($event, entry.index)" />
+              <SvgIcon class="item-button" name="close" @click.stop="()=> onClickDelete(entry.index)" />
             </li>
             <li
               v-show="entry.index != props.modelValue.length - 1"

--- a/app/gui/src/project-view/components/widgets/NumericInputWidget.vue
+++ b/app/gui/src/project-view/components/widgets/NumericInputWidget.vue
@@ -164,16 +164,22 @@ defineExpose({
   }
 }
 
-.NumericInputWidget.slider {
+.singleSelected .NumericInputWidget {
+  background: var(--color-widget-unfocus);
+  &:has(> :focus) {
+    background: var(--color-widget-focus);
+  }
+}
+
+.singleSelected .NumericInputWidget.slider {
   &:focus {
     /* Color will be blended with background defined below. */
-    background-color: var(--color-widget);
+    background-color: var(--color-widget-focus);
   }
   background: linear-gradient(
     to right,
-    var(--color-widget-focus) 0 calc(var(--slider-width) - 1px),
-    var(--color-widget-slight) calc(var(--slider-width) - 1px) var(--slider-width),
-    var(--color-widget) var(--slider-width) 100%
+    var(--color-widget-focus) 0 calc(var(--slider-width)),
+    var(--color-widget-unfocus) var(--slider-width) 100%
   );
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

- Invert the colours of selected components.
- Only show the halo for hovering over components.
- Only show the halo on the top half of a component.
- Show the visual cues for editing vectors and dropdowns when selecting a single component.
- Vector editor to always show grab handle and also add a delete button.
- Higher contrast for text / numeric input widgets to make them more prominent when editing.
- Slight opacity in the visualization panel if not selected, so you can see things behind this.
- The colour of the edges is from the source, not the target.
- Edges going into components end as arrows.
- When adding a new component, an arrow should point at the new component (not a connected line).

**Not Implemented:**
- Red highlight on parameters when a missing value error.
- Drop down indicator next to viz selector should be a lot clearer.
- Right click to open the menu,
- Copy component(s) in the menu.
- If a default value Numeric/Text widget should be italic not bold.
- Connections from the selected nodes should be in the lighter node.
- @AdRiley to give a halo design.
- Default cursor on the icon.

**To Prototype:** 
- Remove halo.
- Components are read-only if not selected
- Allowing moving around without a halo, by clicking anywhere in the node.
- Potentially later ability to enable widgets by holding down a key.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
