### PR TITLE
Ensure EnsoMultiValue returns some Meta.type_of

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/TypeOfNode.java
@@ -15,6 +15,7 @@ import org.enso.interpreter.node.expression.builtin.meta.AtomWithAHoleNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
+import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.DataflowError;
@@ -74,6 +75,16 @@ public abstract class TypeOfNode extends Node {
     return withoutWarning.execute(value.getValue());
   }
 
+  static boolean isWithType(Object value, TypesLibrary types, InteropLibrary iop) {
+    if (value instanceof EnsoMultiValue) {
+      return true;
+    }
+    if (iop.isNumber(value)) {
+      return false;
+    }
+    return types.hasType(value);
+  }
+
   static boolean isWithoutType(Object value, TypesLibrary types) {
     if (value instanceof EnsoObject) {
       return false;
@@ -94,7 +105,7 @@ public abstract class TypeOfNode extends Node {
     return delegate.execute(type, value);
   }
 
-  @Specialization(guards = {"types.hasType(value)", "!interop.isNumber(value)"})
+  @Specialization(guards = {"isWithType(value, types, interop)"})
   Object doType(
       Object value,
       @Shared("interop") @CachedLibrary(limit = "3") InteropLibrary interop,

--- a/test/Base_Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Meta_Spec.enso
@@ -52,6 +52,21 @@ type Sum_Type
     Variant_A x
     Variant_B y
 
+type R
+    private V a:Text i:Integer
+
+    as_text self = self:Text
+    as_int_text self =
+        r = (self : Integer & Text)
+        r
+    as_text_int self =
+        r = (self : Text & Integer)
+        r
+    as_int self = self:Integer
+
+Text.from (that:R) = that.a
+Integer.from (that:R) = that.i
+
 add_specs suite_builder =
     suite_builder.group "Meta-Value Manipulation" group_builder->
         group_builder.specify "should allow manipulating unresolved symbols" <|
@@ -208,6 +223,24 @@ add_specs suite_builder =
             e_tpe = Meta.type_of e
             e_tpe . should_equal_type IOException
             e_tpe . should_not_equal_type JException
+
+        group_builder.specify "multi_value_as_text" <|
+            v = R.V "hi" 3 . as_text
+            Meta.type_of v . should_equal Text
+
+        group_builder.specify "multi_value_as_int" <|
+            v = R.V "hi" 3 . as_int
+            Meta.type_of v . should_equal Integer
+
+        group_builder.specify "multi_value_as_text_int" <|
+            v = R.V "hi" 3 . as_text_int
+            Meta.type_of v . should_equal Text
+            v.is_a Text . should_be_true
+
+        group_builder.specify "multi_value_as_int_text" <|
+            v = R.V "hi" 3 . as_int_text
+            Meta.type_of v . should_equal Integer
+            v.is_a Integer . should_be_true
 
         group_builder.specify "constructors of Boolean" <|
             typ = Boolean


### PR DESCRIPTION
### Pull Request Description

Discovered when discussing #11366 - sometimes (when also representing a number) a _multi value_ panics on computing `Meta.type_of`.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
