### PR TITLE
Use GraphBuilder to construct an alias Graph

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
@@ -1,0 +1,108 @@
+package org.enso.compiler.pass.analyse.alias.graph;
+
+/**
+ * Builder of {@link Graph}. Separates the concerns of building a graph of local symbol definitions
+ * and their usages from the actual querying of those symbols.
+ */
+public final class GraphBuilder {
+  private final Graph graph;
+  private final Graph.Scope scope;
+
+  private GraphBuilder(Graph graph, Graph.Scope scope) {
+    this.graph = graph;
+    this.scope = scope;
+  }
+
+  /**
+   * Creates new empty builder.
+   *
+   * @return empty builder
+   */
+  public static GraphBuilder create() {
+    var topLevel = Graph$.MODULE$.create();
+    return create(topLevel, topLevel.rootScope());
+  }
+
+  /**
+   * Creates a builder for given graph and scope.
+   *
+   * @param g the graph
+   * @param s its scope
+   * @return builder operating on the graph {@code g} starting at scope {@code s}
+   */
+  public static GraphBuilder create(Graph g, Graph.Scope s) {
+    return new GraphBuilder(g, s);
+  }
+
+  /**
+   * Creates a child scope and returns a builder for it.
+   *
+   * @return new builder for newly created scope, but the same graph
+   */
+  public GraphBuilder addChild() {
+    return new GraphBuilder(graph, scope.addChild());
+  }
+
+  /**
+   * Adds occurrence to current scope.
+   *
+   * @return this builder with modified scope
+   */
+  public GraphBuilder add(GraphOccurrence occ) {
+    this.scope.add(occ);
+    return this;
+  }
+
+  /**
+   * Adds definition to current scope.
+   *
+   * @return this builder with modified scope
+   */
+  public GraphBuilder addDefinition(GraphOccurrence.Def def) {
+    this.scope.addDefinition(def);
+    return this;
+  }
+
+  /**
+   * Finds definition ID of provided symbol.
+   *
+   * @param name the name of the symbol
+   * @return -1 if not such symbol found, otherwise ID of the symbol
+   */
+  public int findDef(String name) {
+    var first = this.scope.occurrences().values().find(occ -> occ.symbol().equals(name));
+    return first.nonEmpty() ? first.get().id() : -1;
+  }
+
+  /** Creates new definition for */
+  public GraphOccurrence.Def newDef(
+      String symbol, java.util.UUID identifier, scala.Option<java.util.UUID> externalId) {
+    return newDef(symbol, identifier, externalId, false);
+  }
+
+  public GraphOccurrence.Def newDef(
+      String symbol,
+      java.util.UUID identifier,
+      scala.Option<java.util.UUID> externalId,
+      boolean suspended) {
+    return new GraphOccurrence.Def(graph.nextId(), symbol, identifier, externalId, suspended);
+  }
+
+  /** Factory method to create new [GraphOccurrence.Use]. */
+  public GraphOccurrence.Use newUse(
+      String symbol, java.util.UUID identifier, scala.Option<java.util.UUID> externalId) {
+    return new GraphOccurrence.Use(graph.nextId(), symbol, identifier, externalId);
+  }
+
+  public void resolveLocalUsage(GraphOccurrence.Use use) {
+    graph.resolveLocalUsage(use);
+  }
+
+  public Graph toGraph() {
+    return graph;
+  }
+
+  public Graph.Scope toScope() {
+    return scope;
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
@@ -71,7 +71,11 @@ public final class GraphBuilder {
    */
   public int findDef(String name) {
     var first = this.scope.occurrences().values().find(occ -> occ.symbol().equals(name));
-    return first.nonEmpty() ? first.get().id() : -1;
+    if (first.nonEmpty() && first.get() instanceof GraphOccurrence.Def def) {
+      return def.id();
+    } else {
+      return -1;
+    }
   }
 
   /** Creates new definition for */

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
@@ -6,6 +6,7 @@ import org.enso.compiler.pass.analyse.FrameVariableNames
 import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.alias.graph.{
   GraphOccurrence,
+  GraphBuilder,
   Graph => AliasGraph
 }
 
@@ -92,7 +93,9 @@ class LocalScope(
     *
     * @return a child of this scope
     */
-  def createChild(): LocalScope = createChild(() => scope.addChild())
+  def createChild(): LocalScope = createChild(() => {
+    GraphBuilder.create(null, scope).addChild().toScope()
+  })
 
   /** Creates a child using a known aliasing scope.
     *

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -309,7 +309,7 @@ case object AliasAnalysis extends IRPass {
             ).updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.RootScope(builder.toGraph())
+                alias.AliasMetadata.RootScope(graph.toGraph())
               )
             )
           })

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -29,8 +29,7 @@ import org.enso.compiler.core.ir.{
 import org.enso.compiler.core.{CompilerError, IR}
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.IRProcessingPass
-import org.enso.compiler.pass.analyse.alias.graph.Graph
-import org.enso.compiler.pass.analyse.alias.graph.GraphOccurrence
+import org.enso.compiler.pass.analyse.alias.graph.GraphBuilder
 import org.enso.compiler.pass.analyse.alias.graph.Graph.Scope
 import org.enso.compiler.pass.desugar._
 import org.enso.compiler.pass.lint.UnusedBindings
@@ -140,7 +139,7 @@ case object AliasAnalysis extends IRPass {
             val mapping = mutable.Map(localScope.scope -> scope)
             ag.deepCopy(mapping)
           }
-        val result = analyseExpression(ir, graph, scope)
+        val result = analyseExpression(ir, GraphBuilder.create(graph, scope))
 
         result
       }
@@ -232,7 +231,7 @@ case object AliasAnalysis extends IRPass {
   def analyseModuleDefinition(
     ir: Definition
   ): Definition = {
-    val topLevelGraph = new Graph
+    val builder = GraphBuilder.create()
 
     ir match {
       case m: definition.Method.Conversion =>
@@ -241,14 +240,13 @@ case object AliasAnalysis extends IRPass {
             m.copy(
               body = analyseExpression(
                 m.body,
-                topLevelGraph,
-                topLevelGraph.rootScope,
+                builder,
                 lambdaReuseScope = true
               )
             ).updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.RootScope(topLevelGraph)
+                alias.AliasMetadata.RootScope(builder.toGraph())
               )
             )
           case _ =>
@@ -262,14 +260,13 @@ case object AliasAnalysis extends IRPass {
             m.copy(
               body = analyseExpression(
                 m.body,
-                topLevelGraph,
-                topLevelGraph.rootScope,
+                builder,
                 lambdaReuseScope = true
               )
             ).updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.RootScope(topLevelGraph)
+                alias.AliasMetadata.RootScope(builder.toGraph())
               )
             )
           case _ =>
@@ -285,39 +282,42 @@ case object AliasAnalysis extends IRPass {
         t.copy(
           params = analyseArgumentDefs(
             t.params,
-            topLevelGraph,
-            topLevelGraph.rootScope
+            builder
           ),
           members = t.members.map(d => {
-            val graph = new Graph
+            val graph = GraphBuilder.create()
             d.copy(
               arguments = analyseArgumentDefs(
                 d.arguments,
-                graph,
-                graph.rootScope
+                graph
               ),
               annotations = d.annotations.map { ann =>
                 ann
                   .copy(
                     expression = analyseExpression(
                       ann.expression,
-                      topLevelGraph,
-                      topLevelGraph.rootScope
+                      builder
                     )
                   )
                   .updateMetadata(
                     new MetadataPair(
                       this,
-                      alias.AliasMetadata.RootScope(topLevelGraph)
+                      alias.AliasMetadata.RootScope(builder.toGraph())
                     )
                   )
               }
             ).updateMetadata(
-              new MetadataPair(this, alias.AliasMetadata.RootScope(graph))
+              new MetadataPair(
+                this,
+                alias.AliasMetadata.RootScope(builder.toGraph())
+              )
             )
           })
         ).updateMetadata(
-          new MetadataPair(this, alias.AliasMetadata.RootScope(topLevelGraph))
+          new MetadataPair(
+            this,
+            alias.AliasMetadata.RootScope(builder.toGraph())
+          )
         )
       case _: Definition.SugaredType =>
         throw new CompilerError(
@@ -343,12 +343,14 @@ case object AliasAnalysis extends IRPass {
           .copy(expression =
             analyseExpression(
               ann.expression,
-              topLevelGraph,
-              topLevelGraph.rootScope
+              builder
             )
           )
           .updateMetadata(
-            new MetadataPair(this, alias.AliasMetadata.RootScope(topLevelGraph))
+            new MetadataPair(
+              this,
+              alias.AliasMetadata.RootScope(builder.toGraph())
+            )
           )
       case err: Error => err
     }
@@ -363,99 +365,90 @@ case object AliasAnalysis extends IRPass {
     * information. Please see the pass header documentation for more details.
     *
     * @param expression       the expression to perform alias analysis on
-    * @param graph            the aliasing graph in which the analysis is being performed
-    * @param parentScope      the parent scope for this expression
+    * @param builder          the scope builder
     * @param lambdaReuseScope whether to reuse the parent scope for a lambda
     *                         instead of creating a new scope
     * @return `expression`, potentially with aliasing information attached
     */
   private def analyseExpression(
     expression: Expression,
-    graph: Graph,
-    parentScope: Scope,
+    builder: GraphBuilder,
     lambdaReuseScope: Boolean = false
   ): Expression = {
     expression match {
       case fn: Function =>
-        analyseFunction(fn, graph, parentScope, lambdaReuseScope)
+        analyseFunction(fn, builder, lambdaReuseScope)
       case name: Name =>
         analyseName(
           name,
           isInPatternContext                = false,
           isConstructorNameInPatternContext = false,
-          graph,
-          parentScope
+          builder
         )
-      case cse: Case => analyseCase(cse, graph, parentScope)
+      case cse: Case => analyseCase(cse, builder)
       case block: Expression.Block =>
         val currentScope =
-          if (!block.suspended) parentScope else parentScope.addChild()
+          if (!block.suspended) builder else builder.addChild()
 
         block
           .copy(
             expressions = block.expressions.map((expression: Expression) =>
               analyseExpression(
                 expression,
-                graph,
                 currentScope
               )
             ),
             returnValue = analyseExpression(
               block.returnValue,
-              graph,
               currentScope
             )
           )
           .updateMetadata(
             new MetadataPair(
               this,
-              alias.AliasMetadata.ChildScope(graph, currentScope)
+              new alias.AliasMetadata.ChildScope(currentScope)
             )
           )
       case binding @ Expression.Binding(name, expression, _, _) =>
-        if (
-          !parentScope.hasSymbolOccurrenceAs[GraphOccurrence.Def](name.name)
-        ) {
+        if (builder.findDef(name.name) == -1) {
           val isSuspended = expression match {
             case Expression.Block(_, _, _, isSuspended, _) => isSuspended
             case _                                         => false
           }
-          val occurrence = graph.newDef(
+          val occurrence = builder.newDef(
             name.name,
             binding.getId(),
             binding.getExternalId,
             isSuspended
           )
 
-          parentScope.add(occurrence)
-          parentScope.addDefinition(occurrence)
+          builder.add(occurrence)
+          builder.addDefinition(occurrence)
 
           binding
             .copy(
               expression = analyseExpression(
                 expression,
-                graph,
-                parentScope
+                builder
               )
             )
             .updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.Occurrence(graph, occurrence.id)
+                alias.AliasMetadata.Occurrence(builder.toGraph(), occurrence.id)
               )
             )
         } else {
           errors.Redefined.Binding(binding)
         }
       case app: Application =>
-        analyseApplication(app, graph, parentScope)
-      case tpe: Type => analyseType(tpe, graph, parentScope)
+        analyseApplication(app, builder)
+      case tpe: Type => analyseType(tpe, builder)
       case x =>
         x.mapExpressions((expression: Expression) =>
           analyseExpression(
             expression,
-            graph,
-            parentScope
+            builder
           )
         )
     }
@@ -464,48 +457,46 @@ case object AliasAnalysis extends IRPass {
   /** Performs alias analysis on a type-related expression.
     *
     * @param value       the ir to analyse
-    * @param graph       the graph in which the analysis is taking place
-    * @param parentScope the parent scope in which `value` occurs
+    * @param builder       the graph builder
     * @return `value`, annotated with aliasing information
     */
   def analyseType(
     value: Type,
-    graph: Graph,
-    parentScope: Scope
+    builder: GraphBuilder
   ): Type = {
     value match {
       case member @ `type`.Set.Member(label, memberType, value, _, _) =>
         val memberTypeScope = memberType match {
-          case _: Literal => parentScope
-          case _          => parentScope.addChild()
+          case _: Literal => builder
+          case _          => builder.addChild()
         }
 
         val valueScope = value match {
-          case _: Literal => parentScope
-          case _          => parentScope.addChild()
+          case _: Literal => builder
+          case _          => builder.addChild()
         }
 
-        val definition = graph.newDef(
+        val definition = builder.newDef(
           label.name,
           label.getId,
           label.getExternalId
         )
-        parentScope.add(definition)
-        parentScope.addDefinition(definition)
+        builder.add(definition)
+        builder.addDefinition(definition)
 
         member
           .copy(
-            memberType = analyseExpression(memberType, graph, memberTypeScope),
-            value      = analyseExpression(value, graph, valueScope)
+            memberType = analyseExpression(memberType, memberTypeScope),
+            value      = analyseExpression(value, valueScope)
           )
           .updateMetadata(
             new MetadataPair(
               this,
-              alias.AliasMetadata.Occurrence(graph, definition.id)
+              alias.AliasMetadata.Occurrence(builder.toGraph(), definition.id)
             )
           )
       case x =>
-        x.mapExpressions(analyseExpression(_, graph, parentScope))
+        x.mapExpressions(analyseExpression(_, builder))
     }
   }
 
@@ -520,15 +511,12 @@ case object AliasAnalysis extends IRPass {
     * the argument's scope).
     *
     * @param args  the list of arguments to perform analysis on
-    * @param graph the graph in which the analysis is taking place
-    * @param scope the scope of the function for which `args` are being
-    *              defined
+    * @param builder the graph builder
     * @return `args`, potentially
     */
   private def analyseArgumentDefs(
     args: List[DefinitionArgument],
-    graph: Graph,
-    scope: Scope
+    builder: GraphBuilder
   ): List[DefinitionArgument] = {
     args.map {
       case arg @ DefinitionArgument.Specified(
@@ -541,22 +529,21 @@ case object AliasAnalysis extends IRPass {
           ) =>
         // Synthetic `self` must not be added to the scope, but it has to be added as a
         // definition for frame index metadata
-        val definition = graph.newDef(
+        val definition = builder.newDef(
           selfName.name,
           arg.getId(),
           arg.getExternalId
         )
-        scope.addDefinition(definition)
+        builder.addDefinition(definition)
         arg
           .updateMetadata(
             new MetadataPair(
               this,
-              alias.AliasMetadata.Occurrence(graph, definition.id)
+              alias.AliasMetadata.Occurrence(builder.toGraph(), definition.id)
             )
           )
           .copy(
-            ascribedType =
-              arg.ascribedType.map(analyseExpression(_, graph, scope))
+            ascribedType = arg.ascribedType.map(analyseExpression(_, builder))
           )
 
       case arg @ DefinitionArgument.Specified(
@@ -568,41 +555,35 @@ case object AliasAnalysis extends IRPass {
             _
           ) =>
         val nameOccursInScope =
-          scope.hasSymbolOccurrenceAs[GraphOccurrence.Def](
+          builder.findDef(
             name.name
           )
-        if (!nameOccursInScope) {
-          val argScope = if (suspended) scope.addChild() else scope
+        if (nameOccursInScope == -1) {
+          val argScope = if (suspended) builder.addChild() else builder
           val newDefault =
-            value.map((ir: Expression) =>
-              analyseExpression(ir, graph, argScope)
-            )
+            value.map((ir: Expression) => analyseExpression(ir, argScope))
 
-          val definition = graph.newDef(
+          val definition = builder.newDef(
             name.name,
             arg.getId(),
             arg.getExternalId,
             suspended
           )
-          scope.add(definition)
-          scope.addDefinition(definition)
+          builder.add(definition)
+          builder.addDefinition(definition)
 
           arg
             .copy(
               defaultValue = newDefault,
-              ascribedType =
-                arg.ascribedType.map(analyseExpression(_, graph, scope))
+              ascribedType = arg.ascribedType.map(analyseExpression(_, builder))
             )
             .updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.Occurrence(graph, definition.id)
+                alias.AliasMetadata.Occurrence(builder.toGraph(), definition.id)
               )
             )
         } else {
-          val f = scope.occurrences.values.collectFirst {
-            case x if x.symbol == name.name => x
-          }
           arg
             .copy(
               ascribedType = Some(Redefined.Arg(name, arg.identifiedLocation))
@@ -610,7 +591,8 @@ case object AliasAnalysis extends IRPass {
             .updateMetadata(
               new MetadataPair(
                 this,
-                alias.AliasMetadata.Occurrence(graph, f.get.id)
+                alias.AliasMetadata
+                  .Occurrence(builder.toGraph(), nameOccursInScope)
               )
             )
         }
@@ -626,29 +608,28 @@ case object AliasAnalysis extends IRPass {
     */
   def analyseApplication(
     application: Application,
-    graph: Graph,
-    scope: Graph.Scope
+    builder: GraphBuilder
   ): Application = {
     application match {
       case app: Application.Prefix =>
         app.copy(
-          function  = analyseExpression(app.function, graph, scope),
-          arguments = analyseCallArguments(app.arguments, graph, scope)
+          function  = analyseExpression(app.function, builder),
+          arguments = analyseCallArguments(app.arguments, builder)
         )
       case app: Application.Force =>
-        app.copy(target = analyseExpression(app.target, graph, scope))
+        app.copy(target = analyseExpression(app.target, builder))
       case app: Application.Sequence =>
-        app.copy(items = app.items.map(analyseExpression(_, graph, scope)))
+        app.copy(items = app.items.map(analyseExpression(_, builder)))
       case tSet: Application.Typeset =>
-        val newScope = scope.addChild()
+        val newScope = builder.addChild()
         tSet
           .copy(expression =
-            tSet.expression.map(analyseExpression(_, graph, newScope))
+            tSet.expression.map(analyseExpression(_, newScope))
           )
           .updateMetadata(
             new MetadataPair(
               this,
-              alias.AliasMetadata.ChildScope(graph, newScope)
+              new alias.AliasMetadata.ChildScope(newScope)
             )
           )
       case _: Operator.Binary =>
@@ -665,26 +646,24 @@ case object AliasAnalysis extends IRPass {
   /** Performs alias analysis on function call arguments.
     *
     * @param args        the list of arguments to analyse
-    * @param graph       the graph in which the analysis is taking place
-    * @param parentScope the scope in which the arguments are defined
+    * @param builder     the graph builder
     * @return `args`, with aliasing information attached to each argument
     */
   private def analyseCallArguments(
     args: List[CallArgument],
-    graph: Graph,
-    parentScope: Graph.Scope
+    builder: GraphBuilder
   ): List[CallArgument] = {
     args.map { case arg @ CallArgument.Specified(_, expr, _, _) =>
       val currentScope = expr match {
-        case _: Literal => parentScope
-        case _          => parentScope.addChild()
+        case _: Literal => builder
+        case _          => builder.addChild()
       }
       arg
-        .copy(value = analyseExpression(expr, graph, currentScope))
+        .copy(value = analyseExpression(expr, currentScope))
         .updateMetadata(
           new MetadataPair(
             this,
-            alias.AliasMetadata.ChildScope(graph, currentScope)
+            new alias.AliasMetadata.ChildScope(currentScope)
           )
         )
     }
@@ -693,37 +672,34 @@ case object AliasAnalysis extends IRPass {
   /** Performs alias analysis on a function definition.
     *
     * @param function         the function to analyse
-    * @param graph            the graph in which the analysis is taking place
-    * @param parentScope      the scope in which the function is declared
+    * @param builder            the graph builder
     * @param lambdaReuseScope whether or not the lambda should reuse the parent
     *                         scope or allocate a child of it
     * @return `function`, with alias analysis information attached
     */
   def analyseFunction(
     function: Function,
-    graph: Graph,
-    parentScope: Scope,
+    builder: GraphBuilder,
     lambdaReuseScope: Boolean = false
   ): Function = {
     val currentScope =
-      if (lambdaReuseScope) parentScope else parentScope.addChild()
+      if (lambdaReuseScope) builder else builder.addChild()
 
     function match {
       case lambda: Function.Lambda =>
         lambda
           .copy(
-            arguments =
-              analyseArgumentDefs(lambda.arguments, graph, currentScope),
+            arguments = analyseArgumentDefs(lambda.arguments, currentScope),
             body = analyseExpression(
               lambda.body,
-              graph,
               currentScope
             )
           )
           .updateMetadata(
             new MetadataPair(
               this,
-              alias.AliasMetadata.ChildScope(graph, currentScope)
+              alias.AliasMetadata
+                .ChildScope(currentScope.toGraph(), currentScope.toScope())
             )
           )
       case _: Function.Binding =>
@@ -740,44 +716,42 @@ case object AliasAnalysis extends IRPass {
     *                           pattern context
     * @param isConstructorNameInPatternContext whether or not the name is
     *                           constructor name occurring in a pattern context
-    * @param graph the graph in which the analysis is taking place
-    * @param parentScope the scope in which `name` is declared
+    * @param builder the graph builder
     * @return `name`, with alias analysis information attached
     */
   def analyseName(
     name: Name,
     isInPatternContext: Boolean,
     isConstructorNameInPatternContext: Boolean,
-    graph: Graph,
-    parentScope: Scope
+    builder: GraphBuilder
   ): Name = {
     val occurrenceId =
       if (isInPatternContext && !isConstructorNameInPatternContext) {
-        val definition = graph.newDef(
+        val definition = builder.newDef(
           name.name,
           name.getId,
           name.getExternalId
         )
-        parentScope.add(definition)
-        parentScope.addDefinition(definition)
+        builder.add(definition)
+        builder.addDefinition(definition)
         definition.id
       } else {
         val occurrence =
-          graph.newUse(
+          builder.newUse(
             name.name,
             name.getId,
             name.getExternalId
           )
-        parentScope.add(occurrence)
+        builder.add(occurrence)
         if (!isConstructorNameInPatternContext && !name.isMethod) {
-          graph.resolveLocalUsage(occurrence)
+          builder.resolveLocalUsage(occurrence)
         }
         occurrence.id
       }
     name.updateMetadata(
       new MetadataPair(
         this,
-        alias.AliasMetadata.Occurrence(graph, occurrenceId)
+        alias.AliasMetadata.Occurrence(builder.toGraph(), occurrenceId)
       )
     )
   }
@@ -791,17 +765,14 @@ case object AliasAnalysis extends IRPass {
     */
   def analyseCase(
     ir: Case,
-    graph: Graph,
-    parentScope: Scope
+    builder: GraphBuilder
   ): Case = {
     ir match {
       case caseExpr: Case.Expr =>
         caseExpr
           .copy(
-            scrutinee =
-              analyseExpression(caseExpr.scrutinee, graph, parentScope),
-            branches =
-              caseExpr.branches.map(analyseCaseBranch(_, graph, parentScope))
+            scrutinee = analyseExpression(caseExpr.scrutinee, builder),
+            branches  = caseExpr.branches.map(analyseCaseBranch(_, builder))
           )
       case _: Case.Branch =>
         throw new CompilerError("Case branch in `analyseCase`.")
@@ -811,30 +782,27 @@ case object AliasAnalysis extends IRPass {
   /** Performs alias analysis on a case branch.
     *
     * @param branch the case branch to analyse
-    * @param graph the graph in which the analysis is taking place
-    * @param parentScope the scope in which the case branch occurs
+    * @param builder the graph builder
     * @return `branch`, possibly with alias analysis information attached
     */
   def analyseCaseBranch(
     branch: Case.Branch,
-    graph: Graph,
-    parentScope: Scope
+    builder: GraphBuilder
   ): Case.Branch = {
-    val currentScope = parentScope.addChild()
+    val currentScope = builder.addChild()
 
     branch
       .copy(
-        pattern = analysePattern(branch.pattern, graph, currentScope),
+        pattern = analysePattern(branch.pattern, currentScope),
         expression = analyseExpression(
           branch.expression,
-          graph,
           currentScope
         )
       )
       .updateMetadata(
         new MetadataPair(
           this,
-          alias.AliasMetadata.ChildScope(graph, currentScope)
+          new alias.AliasMetadata.ChildScope(currentScope)
         )
       )
   }
@@ -842,14 +810,12 @@ case object AliasAnalysis extends IRPass {
   /** Performs alias analysis on a pattern.
     *
     * @param pattern the pattern to analyse
-    * @param graph the graph in which the analysis is taking place
-    * @param parentScope the scope in which the case branch occurs
+    * @param builder the graph builder
     * @return `pattern`, possibly with alias analysis information attached
     */
   def analysePattern(
     pattern: Pattern,
-    graph: Graph,
-    parentScope: Scope
+    builder: GraphBuilder
   ): Pattern = {
     pattern match {
       case named: Pattern.Name =>
@@ -858,8 +824,7 @@ case object AliasAnalysis extends IRPass {
             named.name,
             isInPatternContext                = true,
             isConstructorNameInPatternContext = false,
-            graph,
-            parentScope
+            builder
           )
         )
       case cons: Pattern.Constructor =>
@@ -875,10 +840,9 @@ case object AliasAnalysis extends IRPass {
             cons.constructor,
             isInPatternContext                = true,
             isConstructorNameInPatternContext = true,
-            graph,
-            parentScope
+            builder
           ),
-          fields = cons.fields.map(analysePattern(_, graph, parentScope))
+          fields = cons.fields.map(analysePattern(_, builder))
         )
       case literalPattern: Pattern.Literal =>
         literalPattern
@@ -888,15 +852,13 @@ case object AliasAnalysis extends IRPass {
             typePattern.name,
             isInPatternContext                = true,
             isConstructorNameInPatternContext = false,
-            graph,
-            parentScope
+            builder
           ),
           tpe = analyseName(
             typePattern.tpe,
             isInPatternContext                = false,
             isConstructorNameInPatternContext = false,
-            graph,
-            parentScope
+            builder
           )
         )
       case _: Pattern.Documentation =>

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/AliasMetadata.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/AliasMetadata.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.pass.analyse.alias
 
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.alias.graph.Graph
+import org.enso.compiler.pass.analyse.alias.graph.GraphBuilder
 
 /** Information about the aliasing state for a given IR node. */
 sealed trait AliasMetadata extends IRPass.IRMetadata {
@@ -45,6 +46,10 @@ object AliasMetadata {
     override val graph: Graph,
     scope: Graph.Scope
   ) extends Scope {
+    def this(b: GraphBuilder) = {
+      this(b.toGraph(), b.toScope())
+    }
+
     override val metadataName: String = "AliasMetadata.ChildScope"
 
     /** @inheritdoc */

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
@@ -404,7 +404,7 @@ object Graph {
       *
       * @return a scope that is a child of `this`
       */
-    final def addChild(): Scope = {
+    private[graph] def addChild(): Scope = {
       val scope = new Scope()
       scope._parent = this
       _childScopes ::= scope
@@ -416,7 +416,7 @@ object Graph {
       *
       * @param occurrence the occurrence to add
       */
-    final def add(occurrence: GraphOccurrence): Unit = {
+    private[graph] def add(occurrence: GraphOccurrence): Unit = {
       if (occurrences.contains(occurrence.id)) {
         throw new CompilerError(
           s"Multiple occurrences found for ID ${occurrence.id}."
@@ -431,7 +431,7 @@ object Graph {
       *
       * @param definition The definition to add.
       */
-    final def addDefinition(definition: GraphOccurrence.Def): Unit = {
+    private[graph] def addDefinition(definition: GraphOccurrence.Def): Unit = {
       _allDefinitions = allDefinitions ++ List(definition)
     }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
@@ -80,34 +80,13 @@ sealed class Graph(
     *
     * @return a unique identifier for this graph
     */
-  private def nextId(): Graph.Id = {
+  private[graph] def nextId(): Graph.Id = {
     val nextId = _nextIdCounter
     if (nextId < 0) {
       throw new IllegalStateException("Cannot emit new IDs. Frozen!")
     }
     _nextIdCounter += 1
     nextId
-  }
-
-  /** Factory method to create new [GraphOccurrence.Def].
-    */
-  final def newDef(
-    symbol: String,
-    identifier: java.util.UUID,
-    externalId: Option[java.util.UUID],
-    suspended: Boolean = false
-  ): GraphOccurrence.Def = {
-    new GraphOccurrence.Def(nextId(), symbol, identifier, externalId, suspended)
-  }
-
-  /** Factory method to create new [GraphOccurrence.Use].
-    */
-  final def newUse(
-    symbol: String,
-    identifier: java.util.UUID,
-    externalId: Option[java.util.UUID]
-  ): GraphOccurrence.Use = {
-    new GraphOccurrence.Use(nextId(), symbol, identifier, externalId)
   }
 
   /** Resolves any links for the given usage of a symbol, assuming the symbol
@@ -324,6 +303,9 @@ sealed class Graph(
   }
 }
 object Graph {
+
+  /** Creates new empty, graph */
+  private[graph] def create(): Graph = new Graph()
 
   /** The type of symbols on the graph. */
   type Symbol = String

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/pass/analyse/test/AliasAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/pass/analyse/test/AliasAnalysisTest.scala
@@ -18,7 +18,11 @@ import org.enso.compiler.pass.PassConfiguration._
 import org.enso.compiler.pass.analyse.AliasAnalysis
 import org.enso.compiler.pass.analyse.alias.graph.Graph.Link
 import org.enso.compiler.pass.analyse.alias.AliasMetadata
-import org.enso.compiler.pass.analyse.alias.graph.{Graph, GraphOccurrence}
+import org.enso.compiler.pass.analyse.alias.graph.{
+  Graph,
+  GraphBuilder,
+  GraphOccurrence
+}
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
 import org.enso.compiler.test.CompilerTest
 
@@ -84,7 +88,7 @@ class AliasAnalysisTest extends CompilerTest {
   // === The Tests ============================================================
 
   "The analysis scope" should {
-    val graph = new Graph()
+    val builder = GraphBuilder.create()
 
     val flatScope = new Graph.Scope()
 
@@ -94,19 +98,19 @@ class AliasAnalysisTest extends CompilerTest {
     val childOfChild        = child1.addChild()
     val childOfChildOfChild = childOfChild.addChild()
 
-    val aDef   = graph.newDef("a", genId, None)
+    val aDef   = builder.newDef("a", genId, None)
     val aDefId = aDef.id
 
-    val bDef   = graph.newDef("b", genId, None)
+    val bDef   = builder.newDef("b", genId, None)
     val bDefId = bDef.id
 
-    val aUse   = graph.newUse("a", genId, None)
+    val aUse   = builder.newUse("a", genId, None)
     val aUseId = aUse.id
 
-    val bUse   = graph.newUse("b", genId, None)
+    val bUse   = builder.newUse("b", genId, None)
     val bUseId = bUse.id
 
-    val cUse   = graph.newUse("c", genId, None)
+    val cUse   = builder.newUse("c", genId, None)
     val cUseId = cUse.id
 
     // Add occurrences to the scopes
@@ -227,23 +231,24 @@ class AliasAnalysisTest extends CompilerTest {
   }
 
   "The Aliasing graph" should {
-    val graph = new Graph()
+    val builder = GraphBuilder.create()
+    val graph   = builder.toGraph()
 
-    val rootScope  = graph.rootScope
+    val rootScope  = builder.toScope()
     val childScope = rootScope.addChild()
 
-    val aDef   = graph.newDef("a", genId, None)
+    val aDef   = builder.newDef("a", genId, None)
     val aDefId = aDef.id
 
-    val bDef = graph.newDef("b", genId, None)
+    val bDef = builder.newDef("b", genId, None)
 
-    val aUse1   = graph.newUse("a", genId, None)
+    val aUse1   = builder.newUse("a", genId, None)
     val aUse1Id = aUse1.id
 
-    val aUse2   = graph.newUse("a", genId, None)
+    val aUse2   = builder.newUse("a", genId, None)
     val aUse2Id = aUse2.id
 
-    val cUse   = graph.newUse("c", genId, None)
+    val cUse   = builder.newUse("c", genId, None)
     val cUseId = cUse.id
 
     rootScope.add(aDef)
@@ -336,29 +341,30 @@ class AliasAnalysisTest extends CompilerTest {
     }
 
     "correctly determine the identifiers of bindings shadowed by a definition" in {
-      val graph = new Graph()
+      val builder = GraphBuilder.create()
+      val graph   = builder.toGraph()
 
-      val rootScope  = graph.rootScope
-      val child1     = rootScope.addChild()
-      val child2     = rootScope.addChild()
+      val rootScope  = builder.toScope()
+      val child1     = builder.addChild()
+      val child2     = builder.addChild()
       val grandChild = child1.addChild()
 
-      val aDefInRoot = graph.newDef("a", genId, None)
+      val aDefInRoot = builder.newDef("a", genId, None)
       rootScope.add(aDefInRoot)
 
-      val aDefInChild1 = graph.newDef("a", genId, None)
+      val aDefInChild1 = builder.newDef("a", genId, None)
       child1.add(aDefInChild1)
 
-      val aDefInChild2 = graph.newDef("a", genId, None)
+      val aDefInChild2 = builder.newDef("a", genId, None)
       child2.add(aDefInChild2)
 
-      val aDefInGrandChild = graph.newDef("a", genId, None)
+      val aDefInGrandChild = builder.newDef("a", genId, None)
       grandChild.add(aDefInGrandChild)
 
-      val bDefInRoot = graph.newDef("b", genId, None)
+      val bDefInRoot = builder.newDef("b", genId, None)
       rootScope.add(bDefInRoot)
 
-      val bDefInChild2 = graph.newDef("b", genId, None)
+      val bDefInChild2 = builder.newDef("b", genId, None)
       child2.add(bDefInChild2)
 
       graph.knownShadowedDefinitions(aDefInGrandChild) shouldEqual Set(


### PR DESCRIPTION
### Pull Request Description

Another refactoring in the line of #11486 to set us better up for #11365. Introducing `GraphBuilder` with methods to modify the `Graph` and its `Scope`. Keeping _"getter-like methods"_ in `Graph` and `Graph.Scope`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
