### PR TITLE
Only single native image is built at a time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,11 @@ ThisBuild / publish / skip := true
 val simpleLibraryServerTag = Tags.Tag("simple-library-server")
 Global / concurrentRestrictions += Tags.limit(simpleLibraryServerTag, 1)
 
+/** Tag limiting the concurrent spawning of `native-image` subprocess.
+  */
+val nativeImageBuildTag = NativeImage.nativeImageBuildTag
+Global / concurrentRestrictions += Tags.limit(nativeImageBuildTag, 1)
+
 lazy val gatherLicenses =
   taskKey[Unit](
     "Gathers licensing information for relevant dependencies of all distributions"

--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -49,6 +49,12 @@ object NativeImage {
 
   val NATIVE_IMAGE_ARG_FILE = "native-image-args.txt"
 
+  /** Tag limiting the concurrent access to `native-image` subprocess spawning, i.e.,
+    * there should be just a single such subprocess. This should ensure that we do
+    * not run out of memory.
+    */
+  val nativeImageBuildTag = Tags.Tag("native-image-build")
+
   /** Creates a task that builds a native image for the current project.
     *
     * This task must be setup in such a way that the assembly JAR is built
@@ -262,6 +268,7 @@ object NativeImage {
       }
       log.info(s"$targetLoc native image build successful.")
     }
+    .tag(nativeImageBuildTag)
     .dependsOn(Compile / compile)
 
   /** Creates a task which watches for changes of any compiled files or


### PR DESCRIPTION
### Pull Request Description

#10783 introduced another definition of a buildnativeimage task. Since that time, our CI is transiently failing on out of memory error. This PR ensures that there can be just a single `buildNativeImage` task running at a time.

### Important Notes
Manually tested by running
```
sbt:enso> all engine-runner/buildNativeImage project-manager/buildNativeImage
```
And looking at spawn subprocesses. On develop, I have two `native-image` processes, on this PR, there is just a single one.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
