### PR TITLE
Introducing Enso Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
     <img src="https://img.shields.io/static/v1?label=GUI%20License&message=AGPL%20v3&color=2ec352&labelColor=2c3239"
          alt="License">
   </a>
+  <a href="https://gurubase.io/g/enso">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20Enso%20Guru-006BFF"
+         alt="Gurubase">
+  </a>
 </p>
 
 <br/>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Enso Guru](https://gurubase.io/g/enso) to Gurubase. Enso Guru uses the data from this repo and data from the [docs](https://help.enso.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Enso Guru", which highlights that Enso now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Enso Guru in Gurubase, just let me know that's totally fine.
