### PR TITLE
Implement proper hash and equals for `FrameVariableNames`

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameVariableNames.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameVariableNames.java
@@ -1,6 +1,7 @@
 package org.enso.compiler.pass.analyse;
 
 import java.util.List;
+import java.util.Objects;
 import org.enso.compiler.core.CompilerStub;
 import org.enso.compiler.core.ir.ProcessingPass;
 import org.enso.persist.Persistable;
@@ -11,7 +12,7 @@ import scala.jdk.javaapi.CollectionConverters;
 public final class FrameVariableNames implements FrameAnalysisMeta {
   private final List<String> names;
 
-  public FrameVariableNames(List<String> variableNames) {
+  FrameVariableNames(List<String> variableNames) {
     this.names = variableNames;
   }
 
@@ -41,5 +42,32 @@ public final class FrameVariableNames implements FrameAnalysisMeta {
   @Override
   public Option<ProcessingPass.Metadata> duplicate() {
     return Option.apply(new FrameVariableNames(names));
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 3;
+    hash = 59 * hash + Objects.hashCode(this.names);
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final FrameVariableNames other = (FrameVariableNames) obj;
+    return Objects.equals(this.names, other.names);
+  }
+
+  @Override
+  public String toString() {
+    return "FrameVariableNames{" + "names=" + names + '}';
   }
 }


### PR DESCRIPTION
### Pull Request Description

Work on https://github.com/enso-org/enso/issues/11171#issuecomment-2462828693 has revealed missing `equals` and `hashCode` of `FrameVariableNames` metadata element.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
