### PR TITLE
Fix numeric input widget.

### DIFF
--- a/app/rust-ffi/src/lib.rs
+++ b/app/rust-ffi/src/lib.rs
@@ -61,7 +61,6 @@ pub fn is_numeric_literal(code: &str) -> bool {
                 }),
         _ => false,
     }
-    })
 }
 
 #[wasm_bindgen(start)]

--- a/app/rust-ffi/src/lib.rs
+++ b/app/rust-ffi/src/lib.rs
@@ -48,20 +48,19 @@ pub fn is_numeric_literal(code: &str) -> bool {
     let parsed = PARSER.with(|parser| parser.parse_block(code));
     let enso_parser::syntax::tree::Variant::BodyBlock(body) = parsed.variant else { return false };
     let [stmt] = &body.statements[..] else { return false };
-    stmt.expression.as_ref().map_or(false, |expr| {
-        let variant = match &expr.variant {
-            enso_parser::syntax::tree::Variant::ExpressionStatement(expr) => &expr.expression.variant,
-            variant => variant,
-        };
-        match variant {
-            enso_parser::syntax::tree::Variant::Number(_) => true,
-            enso_parser::syntax::tree::Variant::UnaryOprApp(app) =>
-                app.opr.code == "-"
-                    && app.rhs.as_ref().map_or(false, |rhs| {
-                        matches!(rhs.variant, enso_parser::syntax::tree::Variant::Number(_))
-                    }),
-            _ => false,
-        }
+    let Some(stmt) = &stmt.expression else { return false };
+    let enso_parser::syntax::tree::Variant::ExpressionStatement(stmt) = &stmt.variant else {
+        return false;
+    };
+    match &stmt.expression.variant {
+        enso_parser::syntax::tree::Variant::Number(_) => true,
+        enso_parser::syntax::tree::Variant::UnaryOprApp(app) =>
+            app.opr.code == "-"
+                && app.rhs.as_ref().map_or(false, |rhs| {
+                    matches!(rhs.variant, enso_parser::syntax::tree::Variant::Number(_))
+                }),
+        _ => false,
+    }
     })
 }
 


### PR DESCRIPTION
Fixes #11557

The issue was caused by a recent parser change, where `is_numeric_literal` function was not adjusted properly and stopped recognizing any numbers as valid. That caused the numeric input widget to always reject any change.