### PR TITLE
Run SBT clean before CI build

### DIFF
--- a/build/build/src/engine.rs
+++ b/build/build/src/engine.rs
@@ -179,6 +179,8 @@ impl Benchmarks {
 /// Basically a recipe of what to do with `sbt` and its artifacts.
 #[derive(Clone, Debug)]
 pub struct BuildConfigurationFlags {
+    /// Clean before performing other build steps.
+    pub clean_before: bool,
     /// Run JVM tests.
     pub test_jvm: bool,
     /// Whether the Enso standard library should be tested.
@@ -297,6 +299,7 @@ impl BuildConfigurationFlags {
 impl Default for BuildConfigurationFlags {
     fn default() -> Self {
         Self {
+            clean_before: true,
             test_jvm: false,
             test_standard_library: None,
             build_benchmarks: false,

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -345,11 +345,16 @@ impl RunContext {
 
         if !tasks.is_empty() {
             debug!("Building distributions and native images.");
+            let mut sbt_arg;
             if crate::ci::big_memory_machine() {
-                sbt.call_arg(Sbt::concurrent_tasks(tasks)).await?;
+                sbt_arg = Sbt::concurrent_tasks(tasks);
             } else {
-                sbt.call_arg(Sbt::sequential_tasks(tasks)).await?;
+                sbt_arg = Sbt::sequential_tasks(tasks);
             }
+            if self.config.clean_before {
+                sbt_arg = Sbt::sequential_tasks(vec!["clean", &sbt_arg]);
+            }
+            sbt.call_arg(sbt_arg).await?;
         }
 
         // === End of Build project-manager distribution and native image ===


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- update: run `clean` SBT command before running other commands on CI


### Important Notes

This is a low-effort attempt to stabilize the backend building on CI. The problem is that each time the branch is picked up by a random worker that has an arbitrary state of the SBT cache. And because SBT can not track dependencies perfectly in our project due to the heavy annotations and preprocessor usage, it results in sporadic build failures.

Other approaches:
- @JaroslavTulach suggested to attach `Clean build required` label using the [Labeler](https://github.com/marketplace/actions/labeler) action each time the engine sources are modified. But it will require significantly more work to integrate this extra step because it needs to be executed before other build steps.

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
