### PR TITLE
Allow (42 : Text & Integer) at the end of function

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
@@ -318,7 +318,7 @@ case object TypeSignatures extends IRPass {
       case a => Some(resolveExpression(a))
     } ::: lastSignature
       .map({
-        case asc @ Type.Ascription(_: Name, sig, comment, _, _) =>
+        case asc @ Type.Ascription(_, sig, comment, _, _) =>
           asc.updateMetadata(
             new MetadataPair(this, Signature(sig, comment))
           )

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -1026,6 +1026,30 @@ public class SignatureTest extends ContextTest {
     }
   }
 
+  @Test
+  public void returnTypeCheckByLastStatementOfMain() throws Exception {
+    final URI uri = new URI("memory://rts.enso");
+    final Source src =
+        Source.newBuilder(
+                "enso",
+                """
+                from Standard.Base import all
+
+                fn =
+                    (42 : Text & Integer)
+
+                Text.from (that:Integer) = that.to_text
+                """,
+                uri.getAuthority())
+            .uri(uri)
+            .buildLiteral();
+
+    var module = ctx.eval(src);
+    var main = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fn");
+    assertEquals(42, main.asInt());
+    assertEquals("42", main.asString());
+  }
+
   /**
    * Similar scenario to {@code returnTypeCheckOptInError}, but with the opt out signature the check
    * is not currently performed.


### PR DESCRIPTION
### Pull Request Description

Fixes #11574 by relaxing the match to include any expression, not just a `ir.Name`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
