### PR TITLE
Edges always end with arrows

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser.vue
@@ -41,6 +41,8 @@ const PAN_MARGINS = {
 }
 const COMPONENT_EDITOR_PADDING = 12
 const ICON_WIDTH = 16
+// Component editor is larger than a typical node, so the edge should touch it a bit higher.
+const EDGE_Y_OFFSET = -6
 
 const cssComponentEditorPadding = `${COMPONENT_EDITOR_PADDING}px`
 
@@ -199,7 +201,9 @@ watchEffect(() => {
     return
   }
   const scenePos = originScenePos.value.add(
-    new Vec2(COMPONENT_EDITOR_PADDING + ICON_WIDTH / 2, 0).scale(clientToSceneFactor.value),
+    new Vec2(COMPONENT_EDITOR_PADDING + ICON_WIDTH / 2, 0)
+      .scale(clientToSceneFactor.value)
+      .add(new Vec2(0, EDGE_Y_OFFSET)),
   )
   graphStore.cbEditedEdge = {
     source,

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -105,17 +105,6 @@ const rootStyle = computed(() => {
   isolation: isolate;
 }
 
-.iconPort::before {
-  content: '';
-  position: absolute;
-  top: calc(var(--port-padding) - var(--component-editor-padding));
-  width: var(--port-edge-width);
-  height: calc(var(--component-editor-padding) - var(--port-padding) + var(--icon-height) / 2);
-  transform: translate(-50%, 0);
-  background-color: var(--node-color-port);
-  z-index: -1;
-}
-
 .nodeIcon {
   color: white;
   width: var(--icon-height);

--- a/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphEdge.vue
@@ -73,8 +73,7 @@ const targetPos = computed<Vec2 | undefined>(() => {
   if (expr != null && targetNode.value != null && targetNodeRect.value != null) {
     const targetRectRelative = graph.getPortRelativeRect(expr)
     if (targetRectRelative == null) return
-    const yAdjustment =
-      targetIsSelfArgument.value ? -(selfArgumentArrowHeight + selfArgumentArrowYOffset) : 0
+    const yAdjustment = -(arrowHeight + arrowYOffset)
     return targetNodeRect.value.pos.add(new Vec2(targetRectRelative.center().x, yAdjustment))
   } else if (mouseAnchorPos.value != null) {
     return mouseAnchorPos.value
@@ -509,29 +508,18 @@ const backwardEdgeArrowTransform = computed<string | undefined>(() => {
   return svgTranslate(origin.add(points[1]))
 })
 
-const targetIsSelfArgument = computed(() => {
-  if ('targetIsSelfArgument' in props.edge && props.edge?.targetIsSelfArgument) return true
-  if (!targetExpr.value) return
-  const nodeId = graph.getPortNodeId(targetExpr.value)
-  if (!nodeId) return
-  const primarySubject = graph.db.nodeIdToNode.get(nodeId)?.primarySubject
-  if (!primarySubject) return
-  return targetExpr.value === primarySubject
-})
-
-const selfArgumentArrowHeight = 9
-const selfArgumentArrowYOffset = 0
-const selfArgumentArrowTransform = computed<string | undefined>(() => {
-  const selfArgumentArrowTopOffset = 4
-  const selfArgumentArrowWidth = 12
-  if (!targetIsSelfArgument.value) return
+const arrowHeight = 9
+const arrowYOffset = 0
+const arrowTransform = computed<string | undefined>(() => {
+  const arrowTopOffset = 4
+  const arrowWidth = 12
   const target = targetPos.value
   if (target == null) return
-  const pos = target.sub(new Vec2(selfArgumentArrowWidth / 2, selfArgumentArrowTopOffset))
+  const pos = target.sub(new Vec2(arrowWidth / 2, arrowTopOffset))
   return svgTranslate(pos)
 })
 
-const selfArgumentArrowPath = [
+const arrowPath = [
   'M10.9635 1.5547',
   'L6.83205 7.75193',
   'C6.43623 8.34566 5.56377 8.34566 5.16795 7.75192',
@@ -620,9 +608,9 @@ const sourceHoverAnimationStyle = computed(() => {
         :data-target-node-id="targetNode"
       />
       <path
-        v-if="selfArgumentArrowTransform"
-        :transform="selfArgumentArrowTransform"
-        :d="selfArgumentArrowPath"
+        v-if="arrowTransform"
+        :transform="arrowTransform"
+        :d="arrowPath"
         :class="{ arrow: true, visible: true, dimmed: targetEndIsDimmed }"
         :style="baseStyle"
       />

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
@@ -189,7 +189,6 @@ export const widgetDefinition = defineWidget(
       enabled,
       connected,
       isTarget,
-      isSelfArgument,
       widgetRounded: connected,
       newToConnect: !hasConnection && isCurrentEdgeHoverTarget,
       primary: props.nesting < 2,
@@ -247,17 +246,5 @@ export const widgetDefinition = defineWidget(
     left: 0px;
     right: 0px;
   }
-}
-
-.WidgetPort.isTarget:not(.isSelfArgument):after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  left: 50%;
-  width: 4px;
-  height: 5px;
-  transform: translate(-50%, 0);
-  background-color: var(--node-color-port);
-  z-index: -1;
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

Closes #11535

https://github.com/user-attachments/assets/87ca934d-2d7e-4f34-b3b3-f3f4e2696298

Case when the node is vertically big:

<img width="541" alt="image" src="https://github.com/user-attachments/assets/45f339c2-fce9-4f57-aecc-3ceb2810280f">

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
