### PR TITLE
Ignore E2E CI tests on Windows

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -365,13 +365,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_ENSO_AG_GRID_LICENSE_KEY: ${{ vars.ENSO_AG_GRID_LICENSE_KEY }}
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
-      - run: xvfb-run corepack pnpm -r --filter enso exec playwright test
-        env:
-          DEBUG: "pw:browser log:"
-          ENSO_TEST_APP_ARGS: --no-sandbox
-          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
-          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -438,12 +431,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_ENSO_AG_GRID_LICENSE_KEY: ${{ vars.ENSO_AG_GRID_LICENSE_KEY }}
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
-      - run: corepack pnpm -r --filter enso exec playwright test
-        env:
-          DEBUG: "pw:browser log:"
-          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
-          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -506,12 +493,6 @@ jobs:
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.MICROSOFT_CODE_SIGNING_CERT_PASSWORD }}
           WIN_CSC_LINK: ${{ secrets.MICROSOFT_CODE_SIGNING_CERT }}
-      - run: corepack pnpm -r --filter enso exec playwright test
-        env:
-          DEBUG: "pw:browser log:"
-          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
-          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -365,6 +365,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_ENSO_AG_GRID_LICENSE_KEY: ${{ vars.ENSO_AG_GRID_LICENSE_KEY }}
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
+      - run: xvfb-run corepack pnpm -r --filter enso exec playwright test
+        env:
+          DEBUG: "pw:browser log:"
+          ENSO_TEST_APP_ARGS: --no-sandbox
+          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
+          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -431,6 +438,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_ENSO_AG_GRID_LICENSE_KEY: ${{ vars.ENSO_AG_GRID_LICENSE_KEY }}
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
+      - run: corepack pnpm -r --filter enso exec playwright test
+        env:
+          DEBUG: "pw:browser log:"
+          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
+          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -493,6 +506,13 @@ jobs:
           VITE_ENSO_MAPBOX_API_TOKEN: ${{ vars.ENSO_MAPBOX_API_TOKEN }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.MICROSOFT_CODE_SIGNING_CERT_PASSWORD }}
           WIN_CSC_LINK: ${{ secrets.MICROSOFT_CODE_SIGNING_CERT }}
+      - run: corepack pnpm -r --filter enso exec playwright test
+        env:
+          DEBUG: "pw:browser log:"
+          ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
+          ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
       - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -538,22 +538,23 @@ impl JobArchetype for PackageIde {
         )
         .customize(move |step| {
             let mut steps = prepare_packaging_steps(target.0, step);
-            const TEST_COMMAND: &str = "corepack pnpm -r --filter enso exec playwright test";
-            let test_step = if target.0 == OS::Linux {
-                shell(format!("xvfb-run {TEST_COMMAND}"))
-                    // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
-                    .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
-            } else {
-                shell(TEST_COMMAND)
-            };
-            let test_step = test_step
-                .with_env("DEBUG", "pw:browser log:")
-                .with_secret_exposed_as(secret::ENSO_CLOUD_TEST_ACCOUNT_USERNAME, "ENSO_TEST_USER")
-                .with_secret_exposed_as(
-                    secret::ENSO_CLOUD_TEST_ACCOUNT_PASSWORD,
-                    "ENSO_TEST_USER_PASSWORD",
-                );
-            steps.push(test_step);
+            // TODO[ao]: Disabled because it stopped working and is blocking PRs unjustly.
+            // const TEST_COMMAND: &str = "corepack pnpm -r --filter enso exec playwright test";
+            // let test_step = if target.0 == OS::Linux {
+            //     shell(format!("xvfb-run {TEST_COMMAND}"))
+            //         // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
+            //         .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
+            // } else {
+            //     shell(TEST_COMMAND)
+            // };
+            // let test_step = test_step
+            //     .with_env("DEBUG", "pw:browser log:")
+            //     .with_secret_exposed_as(secret::ENSO_CLOUD_TEST_ACCOUNT_USERNAME,
+            // "ENSO_TEST_USER")     .with_secret_exposed_as(
+            //         secret::ENSO_CLOUD_TEST_ACCOUNT_PASSWORD,
+            //         "ENSO_TEST_USER_PASSWORD",
+            //     );
+            // steps.push(test_step);
 
             // After the E2E tests run, they create a credentials file in user home directory.
             // If that file is not cleaned up, future runs of our tests may randomly get

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -538,23 +538,27 @@ impl JobArchetype for PackageIde {
         )
         .customize(move |step| {
             let mut steps = prepare_packaging_steps(target.0, step);
-            // TODO[ao]: Disabled because it stopped working and is blocking PRs unjustly.
-            // const TEST_COMMAND: &str = "corepack pnpm -r --filter enso exec playwright test";
-            // let test_step = if target.0 == OS::Linux {
-            //     shell(format!("xvfb-run {TEST_COMMAND}"))
-            //         // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
-            //         .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
-            // } else {
-            //     shell(TEST_COMMAND)
-            // };
-            // let test_step = test_step
-            //     .with_env("DEBUG", "pw:browser log:")
-            //     .with_secret_exposed_as(secret::ENSO_CLOUD_TEST_ACCOUNT_USERNAME,
-            // "ENSO_TEST_USER")     .with_secret_exposed_as(
-            //         secret::ENSO_CLOUD_TEST_ACCOUNT_PASSWORD,
-            //         "ENSO_TEST_USER_PASSWORD",
-            //     );
-            // steps.push(test_step);
+            const TEST_COMMAND: &str = "corepack pnpm -r --filter enso exec playwright test";
+            let test_step = if target.0 == OS::Linux {
+                shell(format!("xvfb-run {TEST_COMMAND}"))
+                    // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
+                    .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
+            } else {
+                shell(TEST_COMMAND)
+            };
+            let mut test_step = test_step
+                .with_env("DEBUG", "pw:browser log:")
+                .with_secret_exposed_as(secret::ENSO_CLOUD_TEST_ACCOUNT_USERNAME, "ENSO_TEST_USER")
+                .with_secret_exposed_as(
+                    secret::ENSO_CLOUD_TEST_ACCOUNT_PASSWORD,
+                    "ENSO_TEST_USER_PASSWORD",
+                );
+            // Make E2E tests optional on Windows, as we have an ongoing issue with the runner.
+            // TODO[ib]: remove once the issue is resolved.
+            if target.0 == OS::Windows {
+                test_step.continue_on_error = Some(true);
+            }
+            steps.push(test_step);
 
             // After the E2E tests run, they create a credentials file in user home directory.
             // If that file is not cleaned up, future runs of our tests may randomly get


### PR DESCRIPTION
### Pull Request Description

The integration tests are constantly failing on Windows. For the time of investigation, they should be suppressed.

