### PR TITLE
use equals when only one item is selected in filter dropdown

### DIFF
--- a/app/gui/src/project-view/components/visualizations/tableVizToolbar.ts
+++ b/app/gui/src/project-view/components/visualizations/tableVizToolbar.ts
@@ -5,6 +5,7 @@ import { Ast } from '@/util/ast'
 import { Pattern } from '@/util/ast/match'
 import type { ToValue } from '@/util/reactivity'
 import { computed, type ComputedRef, type Ref, toValue } from 'vue'
+import { Expression, MutableExpression } from 'ydoc-shared/ast'
 
 type SortDirection = 'asc' | 'desc'
 export type SortModel = {
@@ -78,6 +79,16 @@ function useSortFilterNodesButton({
       ])
     }
     const valueFormatter = getColumnValueToEnso(columnName)
+    if (items?.length === 1) {
+      const item = items[0]
+      if (item) {
+        return filterPattern.value.instantiateCopied([
+          Ast.TextLiteral.new(columnName),
+          Ast.parseExpression('..Equal')!,
+          valueFormatter(item, module) as Expression | MutableExpression,
+        ])
+      }
+    }
     const itemList = items.map((i) => valueFormatter(i, module))
     return filterPattern.value.instantiateCopied([
       Ast.TextLiteral.new(columnName),


### PR DESCRIPTION
- #11566 

![equals-filter-drilldown](https://github.com/user-attachments/assets/791dc741-e329-41b6-bf37-952a7e56d77e)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
