### PR TITLE
Look and feel: Lists and dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [Table Input Widget is now matched for Table.input method instead of
   Table.new. Values must be string literals, and their content is parsed to the
   suitable type][11612].
+- [New design for vector-editing widget][11620]
 
 [11151]: https://github.com/enso-org/enso/pull/11151
 [11271]: https://github.com/enso-org/enso/pull/11271
@@ -55,6 +56,7 @@
 [11564]: https://github.com/enso-org/enso/pull/11564
 [11597]: https://github.com/enso-org/enso/pull/11597
 [11612]: https://github.com/enso-org/enso/pull/11612
+[11620]: https://github.com/enso-org/enso/pull/11620
 
 #### Enso Standard Library
 

--- a/app/gui/e2e/project-view/locate.ts
+++ b/app/gui/e2e/project-view/locate.ts
@@ -126,7 +126,7 @@ export function addItemButton(page: Locator | Page) {
   return page.getByRole('button', { name: 'new item' })
 }
 
-/** Button to delete a specific item to a vector */
+/** Button to delete a specific item from a vector */
 export function deleteItemButton(page: Locator | Page) {
   return page.getByRole('button', { name: 'Remove item' })
 }

--- a/app/gui/e2e/project-view/locate.ts
+++ b/app/gui/e2e/project-view/locate.ts
@@ -121,6 +121,16 @@ export function bottomDock(page: Page) {
   return page.getByTestId('bottomDock')
 }
 
+/** Button to add an item to a vector */
+export function addItemButton(page: Locator | Page) {
+  return page.getByRole('button', { name: 'new item' })
+}
+
+/** Button to delete a specific item to a vector */
+export function deleteItemButton(page: Locator | Page) {
+  return page.getByRole('button', { name: 'Remove item' })
+}
+
 export const navBreadcrumb = componentLocator('.NavBreadcrumb')
 export const componentBrowserInput = componentLocator('.ComponentEditor')
 

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -238,7 +238,7 @@ const innerWidgetInput = computed<WidgetInput>(() => {
 
 const parentSelectionArrow = injectSelectionArrow(true)
 const arrowSuppressed = ref(false)
-const showArrow = computed(() => isHovered.value && !arrowSuppressed.value)
+const showArrow = computed(() => !arrowSuppressed.value && (tree.extended || isHovered.value))
 provideSelectionArrow(
   proxyRefs({
     id: computed(() => {
@@ -464,7 +464,11 @@ declare module '@/providers/widgetRegistry' {
   >
     <NodeWidget :input="innerWidgetInput" />
     <Teleport v-if="showArrow" defer :disabled="!arrowLocation" :to="arrowLocation">
-      <SvgIcon name="arrow_right_head_only" class="arrow widgetOutOfLayout" />
+      <SvgIcon
+        name="arrow_right_head_only"
+        class="arrow widgetOutOfLayout"
+        :class="{ hovered: isHovered }"
+      />
     </Teleport>
     <Teleport v-if="tree.nodeElement" :to="tree.nodeElement">
       <div ref="dropdownElement" :style="floatingStyles" class="widgetOutOfLayout floatingElement">
@@ -515,6 +519,9 @@ svg.arrow {
   opacity: 0.5;
   /* Prevent the parent from receiving a pointerout event if the mouse is over the arrow, which causes flickering. */
   pointer-events: none;
+  &.hovered {
+    opacity: 0.9;
+  }
 }
 
 .activityElement {

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -79,13 +79,13 @@ const draggedIndex = ref<number>()
 
 interface BaseItem {
   key: string | number
-  hintDeletable: Ref<boolean>
 }
 
 interface NonPlaceholderItem extends BaseItem {
   type: 'item'
   index: number
   item: T
+  hintDeletable: Ref<boolean>
 }
 
 interface PlaceholderItem extends BaseItem {
@@ -131,7 +131,6 @@ const displayedChildren = computed(() => {
       type: 'placeholder',
       width: meta.width,
       key,
-      hintDeletable: ref(false),
     } as const)
   }
   return items.filter((item) => item.type !== 'item' || item.index !== draggedIndex.value)

--- a/app/gui/src/project-view/components/widgets/ListWidget.vue
+++ b/app/gui/src/project-view/components/widgets/ListWidget.vue
@@ -1,15 +1,16 @@
-<script lang="ts">
+<script setup lang="ts" generic="T">
+import SizeTransition from '@/components/SizeTransition.vue'
+import SvgButton from '@/components/SvgButton.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useRaf } from '@/composables/animation'
 import { useEvent } from '@/composables/events'
 import { useAppClass } from '@/providers/appClass'
+import { injectWidgetTree } from '@/providers/widgetTree'
 import { Range } from '@/util/data/range'
 import { Vec2 } from '@/util/data/vec2'
 import { uuidv4 } from 'lib0/random'
-import { computed, ref, shallowReactive, watchEffect, watchPostEffect } from 'vue'
-</script>
+import { computed, type Ref, ref, shallowReactive, watchEffect, watchPostEffect } from 'vue'
 
-<script setup lang="ts" generic="T">
 const props = defineProps<{
   modelValue: T[]
   newItem: () => T | undefined
@@ -44,6 +45,8 @@ const emit = defineEmits<{
   'update:modelValue': [modelValue: T[]]
 }>()
 
+const tree = injectWidgetTree()
+
 const listUuid = uuidv4()
 
 const mimeType = computed(() => props.dragMimeType ?? 'application/octet-stream')
@@ -74,30 +77,34 @@ function decodeMetadataFromMime(mime: string): DropMetadata | undefined {
 
 const draggedIndex = ref<number>()
 
-type DragItem =
-  | {
-      type: 'item'
-      index: number
-      item: T
-      key: string | number
-    }
-  | {
-      type: 'placeholder'
-      width: number
-      key: string | number
-    }
+interface BaseItem {
+  key: string | number
+  hintDeletable: Ref<boolean>
+}
+
+interface NonPlaceholderItem extends BaseItem {
+  type: 'item'
+  index: number
+  item: T
+}
+
+interface PlaceholderItem extends BaseItem {
+  type: 'placeholder'
+  width: number
+}
+
+type DragItem = NonPlaceholderItem | PlaceholderItem
 
 const defaultPlaceholderKey = '__placeholder_key__'
 
-const mappedItems = computed(() => {
-  return props.modelValue.map(
-    (item, index): DragItem => ({
-      type: 'item',
-      index,
-      item,
-      key: props.getKey?.(item) ?? index,
-    }),
-  )
+const mappedItems = computed<DragItem[]>(() => {
+  return props.modelValue.map((item, index) => ({
+    type: 'item',
+    index,
+    item,
+    key: props.getKey?.(item) ?? index,
+    hintDeletable: ref(false),
+  }))
 })
 
 const dropInfo = ref<DropHoverInfo>()
@@ -124,10 +131,10 @@ const displayedChildren = computed(() => {
       type: 'placeholder',
       width: meta.width,
       key,
+      hintDeletable: ref(false),
     } as const)
   }
-  const x = items.filter((item) => item.type !== 'item' || item.index !== draggedIndex.value)
-  return x
+  return items.filter((item) => item.type !== 'item' || item.index !== draggedIndex.value)
 })
 
 const rootNode = ref<HTMLElement>()
@@ -135,69 +142,66 @@ const rootNode = ref<HTMLElement>()
 const cssPropsToCopy = ['--color-node-primary', '--node-color-port', '--node-border-radius']
 
 function onDragStart(event: DragEvent, index: number) {
-  if (
-    !(event.target instanceof HTMLElement && event.target.nextElementSibling instanceof HTMLElement)
-  )
-    return
+  if (!event.dataTransfer) return
+  if (!(event.target instanceof HTMLElement)) return
+  // The element that will be shown following the mouse.
+  const previewElement = event.target.parentElement
+  if (!(previewElement instanceof HTMLElement)) return
+  // The element being replaced with a placeholder during the operation.
+  const sizeElement = previewElement.parentElement
+  if (!(sizeElement instanceof HTMLElement)) return
 
-  if (event.dataTransfer) {
-    // The dragged widget contents is the next sibling of the drag handle.
-    const previewElement = event.target.nextElementSibling
+  // Create a fake offscreen DOM element to use as the drag "ghost" image. It will hold a visual
+  // clone of the widget being dragged. The ghost style is modified to add a background color
+  // and additional border, as well as apply appropriate element scaling in cross-browser way.
+  const elementOffsetWidth = sizeElement.offsetWidth
+  const elementRect = originalBoundingClientRect.call(sizeElement)
+  const elementScale = elementRect.width / elementOffsetWidth
+  const dragGhost = document.createElement('div')
+  dragGhost.classList.add('ListWidget-drag-ghost')
+  const previewElementStyle = getComputedStyle(previewElement)
+  const elementTopLeft = props.toDragPosition(new Vec2(elementRect.left, elementRect.top))
+  const currentMousePos = props.toDragPosition(new Vec2(event.clientX, event.clientY))
+  const elementRelativeOffset = currentMousePos.sub(elementTopLeft)
+  // To maintain appropriate styling, we have to copy over a set of node tree CSS variables from
+  // the preview element to the ghost element.
+  cssPropsToCopy.forEach((prop) => {
+    dragGhost.style.setProperty(prop, previewElementStyle.getPropertyValue(prop))
+  })
+  dragGhost.style.setProperty('transform', `scale(${elementScale})`)
+  dragGhost.appendChild(previewElement.cloneNode(true))
+  document.body.appendChild(dragGhost)
+  event.dataTransfer.setDragImage(dragGhost, elementRelativeOffset.x, elementRelativeOffset.y)
+  // Remove the ghost element after a short delay, giving the browser time to render it and set
+  // the drag image.
+  setTimeout(() => dragGhost.remove(), 0)
 
-    // Create a fake offscreen DOM element to use as the drag "ghost" image. It will hold a visual
-    // clone of the widget being dragged. The ghost style is modified to add a background color
-    // and additional border, as well as apply appropriate element scaling in cross-browser way.
-    const elementOffsetWidth = previewElement.offsetWidth
-    const elementRect = originalBoundingClientRect.call(previewElement)
-    const elementScale = elementRect.width / elementOffsetWidth
-    const dragGhost = document.createElement('div')
-    dragGhost.classList.add('ListWidget-drag-ghost')
-    const dragGhostInner = document.createElement('div')
-    dragGhost.appendChild(dragGhostInner)
-    const previewElementStyle = getComputedStyle(previewElement)
-    const elementTopLeft = props.toDragPosition(new Vec2(elementRect.left, elementRect.top))
-    const currentMousePos = props.toDragPosition(new Vec2(event.clientX, event.clientY))
-    const elementRelativeOffset = currentMousePos.sub(elementTopLeft)
-    // To maintain appropriate styling, we have to copy over a set of node tree CSS variables from
-    // the original preview element to the ghost element.
-    cssPropsToCopy.forEach((prop) => {
-      dragGhostInner.style.setProperty(prop, previewElementStyle.getPropertyValue(prop))
-    })
-    dragGhostInner.style.setProperty('transform', `scale(${elementScale})`)
-    dragGhostInner.appendChild(previewElement.cloneNode(true))
-    document.body.appendChild(dragGhost)
-    event.dataTransfer.setDragImage(dragGhost, elementRelativeOffset.x, elementRelativeOffset.y)
-    // Remove the ghost element after a short delay, giving the browser time to render it and set
-    // the drag image.
-    setTimeout(() => dragGhost.remove(), 0)
+  event.dataTransfer.effectAllowed = 'move'
+  // `dropEffect: none` does not work for removing an element - it disables drop completely.
+  event.dataTransfer.dropEffect = 'move'
+  const dragItem = props.modelValue[index]!
 
-    event.dataTransfer.effectAllowed = 'move'
-    // `dropEffect: none` does not work for removing an element - it disables drop completely.
-    event.dataTransfer.dropEffect = 'move'
-    const dragItem = props.modelValue[index]!
-
-    const meta: DropMetadata = {
-      list: listUuid,
-      key: props.getKey?.(dragItem) ?? index,
-      width: elementOffsetWidth,
-    }
-    const payload = props.toDragPayload(dragItem)
-    event.dataTransfer.setData(mimeType.value, payload)
-
-    if (props.toPlainText) {
-      event.dataTransfer.setData('text/plain', props.toPlainText(dragItem))
-    }
-
-    const metaMime = encodeMetadataToMime(meta)
-    event.dataTransfer.setData(metaMime, '')
-    // The code below will remove the item from list; because doing it in the same frame ends drag
-    // immediately, we need to put it in setTimeout (nextTick is not enough).
-    setTimeout(() => {
-      updateItemBounds()
-      draggedIndex.value = index
-      dropInfo.value = { meta, position: currentMousePos }
-    }, 0)
+  const meta: DropMetadata = {
+    list: listUuid,
+    key: props.getKey?.(dragItem) ?? index,
+    width: elementOffsetWidth,
   }
+  const payload = props.toDragPayload(dragItem)
+  event.dataTransfer.setData(mimeType.value, payload)
+
+  if (props.toPlainText) {
+    event.dataTransfer.setData('text/plain', props.toPlainText(dragItem))
+  }
+
+  const metaMime = encodeMetadataToMime(meta)
+  event.dataTransfer.setData(metaMime, '')
+  // The code below will remove the item from list; because doing it in the same frame ends drag
+  // immediately, we need to put it in setTimeout (nextTick is not enough).
+  setTimeout(() => {
+    updateItemBounds()
+    draggedIndex.value = index
+    dropInfo.value = { meta, position: currentMousePos }
+  }, 0)
 }
 
 interface DropMetadata {
@@ -219,6 +223,7 @@ function areaDragOver(e: DragEvent) {
   const metaMime = e.dataTransfer?.types.find((ty) => ty.startsWith(dragMetaMimePrefix))
   const typesMatch = e.dataTransfer?.types.includes(mimeType.value)
   if (!metaMime || !typesMatch) return
+  e.preventDefault()
   const meta = decodeMetadataFromMime(metaMime)
   if (meta == null) return
 
@@ -367,6 +372,11 @@ function addItem() {
   const item = props.newItem()
   if (item) emit('update:modelValue', [...props.modelValue, item])
 }
+
+function deleteItem(index: number) {
+  const modelValue = props.modelValue.filter((_, i) => i !== index)
+  emit('update:modelValue', modelValue)
+}
 </script>
 
 <template>
@@ -388,21 +398,49 @@ function addItem() {
       >
         <template v-for="entry in displayedChildren" :key="entry.key">
           <template v-if="entry.type === 'item'">
-            <li :ref="(el) => setItemRef(el, entry.index)" class="item">
+            <li :ref="patchBoundingClientRectScaling" class="item">
+              <div :ref="(el) => setItemRef(el, entry.index)" class="draggableContent">
+                <SizeTransition width>
+                  <!-- This wrapper is needed because an SVG element cannot directly be draggable. -->
+                  <div
+                    v-if="tree.extended"
+                    class="deletable"
+                    :class="{ hintDeletable: entry.hintDeletable.value }"
+                    draggable="true"
+                    @dragstart="onDragStart($event, entry.index)"
+                    @dragend="onDragEnd"
+                  >
+                    <SvgIcon name="grab" class="handle" />
+                  </div>
+                </SizeTransition>
+                <div
+                  class="deletable"
+                  :class="{ hintDeletable: entry.hintDeletable.value }"
+                  data-testid="list-item-content"
+                >
+                  <slot :item="entry.item"></slot>
+                </div>
+                <SizeTransition width>
+                  <!-- This wrapper is needed to animate an `SvgButton` because it ultimately contains a `TooltipTrigger`,
+                       which has a fragment root. -->
+                  <div v-if="tree.extended" class="displayContents">
+                    <SvgButton
+                      class="item-button"
+                      name="close"
+                      title="Remove item"
+                      @click.stop="deleteItem(entry.index)"
+                      @pointerenter="entry.hintDeletable.value = true"
+                      @pointerleave="entry.hintDeletable.value = false"
+                    />
+                  </div>
+                </SizeTransition>
+              </div>
               <div
-                class="handle"
-                draggable="true"
-                @dragstart="onDragStart($event, entry.index)"
-                @dragend="onDragEnd"
-              ></div>
-              <slot :item="entry.item"></slot>
-            </li>
-            <li
-              v-show="entry.index != props.modelValue.length - 1"
-              :ref="patchBoundingClientRectScaling"
-              class="token widgetApplyPadding"
-            >
-              ,&nbsp;
+                v-if="entry.index != props.modelValue.length - 1"
+                class="token widgetApplyPadding"
+              >
+                ,&nbsp;
+              </div>
             </li>
           </template>
           <template v-else>
@@ -414,7 +452,18 @@ function addItem() {
           </template>
         </template>
       </TransitionGroup>
-      <SvgIcon class="add-item" name="vector_add" @click.stop="addItem" />
+      <SizeTransition width>
+        <!-- This wrapper is a workaround: If the `v-if` is applied to the `SvgIcon`, once the button is shown it will
+             never go back to hidden. This might be a Vue bug? -->
+        <div v-if="tree.extended" class="displayContents">
+          <SvgButton
+            class="item-button after-last-item"
+            name="vector_add"
+            title="Add a new item"
+            @click.stop="addItem"
+          />
+        </div>
+      </SizeTransition>
       <span class="token widgetApplyPadding">]</span>
     </div>
     <div
@@ -489,10 +538,10 @@ div {
   align-items: center;
 }
 
-.item .preview {
-  background: var(--color-node-primary);
-  padding: 4px;
-  border-radius: var(--node-border-radius);
+.draggableContent {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .token {
@@ -514,85 +563,60 @@ div {
 }
 
 .handle {
-  position: absolute;
-  display: block;
-  left: -6px;
-  height: calc(100% - 12px);
-  width: 2px;
-  box-shadow:
-    2px 0 0 transparent,
-    -2px 0 0 transparent;
-  transition: box-shadow 0.2s ease;
-  pointer-events: none;
+  transition: color 0.2s ease;
   cursor: grab;
+
+  color: var(--color-widget-unfocus);
+
+  &:hover {
+    color: var(--color-widget-focus);
+  }
 }
 
 .item:hover {
   z-index: 0;
 }
 
-.item:hover .handle {
-  box-shadow:
-    2px 0 0 var(--color-widget-unfocus),
-    -2px 0 0 var(--color-widget-unfocus);
-
-  &:hover {
-    box-shadow:
-      2px 0 0 var(--color-widget-focus),
-      -2px 0 0 var(--color-widget-focus);
-  }
-
-  background: var(--color-node-background);
-  pointer-events: all;
-
-  &:before {
-    opacity: 0.5;
-  }
-
-  &:after {
-    content: '';
-    position: absolute;
-    display: block;
-    left: -1px;
-    right: -4px;
-    top: -3px;
-    bottom: -3px;
-    z-index: 1;
-  }
-}
-
-.item:hover .handle:hover::before {
-  opacity: 1;
-}
-
-.GraphEditor.draggingEdge .handle {
-  display: none;
-}
-
-.add-item {
+.item-button {
   transition-property: opacity;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
   opacity: 0.5;
-  margin-left: 4px;
   transition: margin 0.2s ease-in-out;
   .items:empty + & {
     margin: 0 2px;
   }
+  &:hover {
+    opacity: 1;
+  }
 }
 
-.add-item:hover {
-  opacity: 1;
+.after-last-item {
+  margin-left: 4px;
 }
 
 :global(.ListWidget-drag-ghost) {
   position: absolute;
   left: -5000px;
-}
-:global(.ListWidget-drag-ghost > div) {
   background-color: var(--color-node-primary);
   border-radius: var(--node-border-radius);
   padding: 4px;
   color: white;
+}
+
+.deletable {
+  opacity: 1;
+  transition: opacity 0.2s ease-in-out;
+  &.hintDeletable {
+    opacity: 0.3;
+  }
+}
+
+.displayContents {
+  display: contents;
+}
+
+.SvgButton {
+  --color-menu-entry-hover-bg: transparent;
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

https://github.com/user-attachments/assets/d8c039e6-670c-4ff5-9d71-c07ee6114570

Lists:
- Drag handles are icons.
- List controls are shown only when component is sole selection.
- Each item has delete button.
- Integration tests cover dragging, adding, removing.

https://github.com/user-attachments/assets/58054cb2-22bc-4279-850c-0bc4929fc246

Dropdowns:
- Arrows are shown when hovered or component is sole selection.
- Arrows change opacity when hovered.

Implements #11533.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
