### PR TITLE
Add date support for filter drilldown

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -637,15 +637,12 @@ const createDateTimePattern = (pattern: string, numberOfParts: number) => {
   };
 }
   if (columnType === 'Date') {
-  console.log(1)
   return createDateTimePattern('(Date.new __ __ __)', 3);
 }
   if (columnType === 'Date_Time') {
-  console.log(2)
   return createDateTimePattern('(Date_Time.new __ __ __ __ __ __ __ __ __)', 9);
 }
   if (columnType === 'Time') {
-  console.log(3)
   return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6);
 }
   return (item: string) => Ast.TextLiteral.new(item)

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -628,7 +628,7 @@ const getColumnValueToEnso = (columnName: string) => {
   if (columnType === 'Date') {
     const datePattern = Pattern.parseExpression('(Date.new __ __ __)')
     return (item: string, module: Ast.MutableModule) => {
-      const [year, month, day] = item.match(/\d+/g)!.map(Number);
+      const [year, month, day] = item.match(/\d+/g)!.map(Number)
       return datePattern.instantiateCopied([
         Ast.tryNumberToEnso(Number(year ?? 0), module)!,
         Ast.tryNumberToEnso(Number(month ?? 0), module)!,
@@ -639,7 +639,9 @@ const getColumnValueToEnso = (columnName: string) => {
   if (columnType === 'Date_Time') {
     const dateTimePattern = Pattern.parseExpression('(Date_Time.new __ __ __ __ __ __ __ __ __)')
     return (item: string, module: Ast.MutableModule) => {
-      const [year, month, day, hour, minute, second, milisecond, microsecond, nanosecond] = item.match(/\d+/g)!.map(Number);
+      const [year, month, day, hour, minute, second, milisecond, microsecond, nanosecond] = item
+        .match(/\d+/g)!
+        .map(Number)
       return dateTimePattern.instantiateCopied([
         Ast.tryNumberToEnso(Number(year ?? 0), module)!,
         Ast.tryNumberToEnso(Number(month ?? 0), module)!,
@@ -656,7 +658,9 @@ const getColumnValueToEnso = (columnName: string) => {
   if (columnType === 'Time') {
     const timePattern = Pattern.parseExpression('(Time_Of_Day.new __ __ __ __ __ __)')
     return (item: string, module: Ast.MutableModule) => {
-      const [hour, minute, second, milisecond, microsecond, nanosecond] = item.match(/\d+/g)!.map(Number);
+      const [hour, minute, second, milisecond, microsecond, nanosecond] = item
+        .match(/\d+/g)!
+        .map(Number)
       return timePattern.instantiateCopied([
         Ast.tryNumberToEnso(Number(hour ?? 0), module)!,
         Ast.tryNumberToEnso(Number(minute ?? 0), module)!,

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -639,11 +639,11 @@ const getColumnValueToEnso = (columnName: string) => {
   if (columnType === 'Date') {
     return createDateTimePattern('(Date.new __ __ __)', 3)
   }
-  if (columnType === 'Date_Time') {
-    return createDateTimePattern('(Date_Time.new __ __ __ __ __ __ __ __ __)', 9)
-  }
   if (columnType === 'Time') {
     return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6)
+  }
+  if (columnType === 'Date_Time') {
+    return (item: string) => Ast.parseExpression(`(Date_Time.parse '${item}')`)
   }
   return (item: string) => Ast.TextLiteral.new(item)
 }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -643,7 +643,7 @@ const getColumnValueToEnso = (columnName: string) => {
     return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6)
   }
   if (columnType === 'Date_Time') {
-    return (item: string) => Ast.parseExpression(`(Date_Time.parse '${item}')`)
+    return (item: string) => Ast.parseExpression(`(Date_Time.parse '${item}')`)!
   }
   return (item: string) => Ast.TextLiteral.new(item)
 }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -625,52 +625,29 @@ const getColumnValueToEnso = (columnName: string) => {
   if (isNumber.indexOf(columnType) != -1) {
     return (item: string, module: Ast.MutableModule) => Ast.tryNumberToEnso(Number(item), module)!
   }
+const createDateTimePattern = (pattern: string, numberOfParts: number) => {
+  const dateOrTimePattern = Pattern.parseExpression(pattern);
+  return (item: string, module: Ast.MutableModule) => {
+    const dateTimeParts = item.match(/\d+/g)!.map(Number);
+    const dateTimePartsNumeric = [];
+    for (let i = 0; i < numberOfParts; i++) {
+      dateTimePartsNumeric.push(Ast.tryNumberToEnso(Number(dateTimeParts[i] ?? 0), module)!)
+    }
+    return dateOrTimePattern.instantiateCopied(dateTimePartsNumeric);
+  };
+}
   if (columnType === 'Date') {
-    const datePattern = Pattern.parseExpression('(Date.new __ __ __)')
-    return (item: string, module: Ast.MutableModule) => {
-      const [year, month, day] = item.match(/\d+/g)!.map(Number)
-      return datePattern.instantiateCopied([
-        Ast.tryNumberToEnso(Number(year ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(month ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(day ?? 0), module)!,
-      ])
-    }
-  }
+  console.log(1)
+  return createDateTimePattern('(Date.new __ __ __)', 3);
+}
   if (columnType === 'Date_Time') {
-    const dateTimePattern = Pattern.parseExpression('(Date_Time.new __ __ __ __ __ __ __ __ __)')
-    return (item: string, module: Ast.MutableModule) => {
-      const [year, month, day, hour, minute, second, milisecond, microsecond, nanosecond] = item
-        .match(/\d+/g)!
-        .map(Number)
-      return dateTimePattern.instantiateCopied([
-        Ast.tryNumberToEnso(Number(year ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(month ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(day ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(hour ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(minute ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(second ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(milisecond ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(microsecond ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(nanosecond ?? 0), module)!,
-      ])
-    }
-  }
+  console.log(2)
+  return createDateTimePattern('(Date_Time.new __ __ __ __ __ __ __ __ __)', 9);
+}
   if (columnType === 'Time') {
-    const timePattern = Pattern.parseExpression('(Time_Of_Day.new __ __ __ __ __ __)')
-    return (item: string, module: Ast.MutableModule) => {
-      const [hour, minute, second, milisecond, microsecond, nanosecond] = item
-        .match(/\d+/g)!
-        .map(Number)
-      return timePattern.instantiateCopied([
-        Ast.tryNumberToEnso(Number(hour ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(minute ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(second ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(milisecond ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(microsecond ?? 0), module)!,
-        Ast.tryNumberToEnso(Number(nanosecond ?? 0), module)!,
-      ])
-    }
-  }
+  console.log(3)
+  return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6);
+}
   return (item: string) => Ast.TextLiteral.new(item)
 }
 

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -625,6 +625,48 @@ const getColumnValueToEnso = (columnName: string) => {
   if (isNumber.indexOf(columnType) != -1) {
     return (item: string, module: Ast.MutableModule) => Ast.tryNumberToEnso(Number(item), module)!
   }
+  if (columnType === 'Date') {
+    const datePattern = Pattern.parseExpression('(Date.new __ __ __)')
+    return (item: string, module: Ast.MutableModule) => {
+      const [year, month, day] = item.match(/\d+/g)!.map(Number);
+      return datePattern.instantiateCopied([
+        Ast.tryNumberToEnso(Number(year ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(month ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(day ?? 0), module)!,
+      ])
+    }
+  }
+  if (columnType === 'Date_Time') {
+    const dateTimePattern = Pattern.parseExpression('(Date_Time.new __ __ __ __ __ __ __ __ __)')
+    return (item: string, module: Ast.MutableModule) => {
+      const [year, month, day, hour, minute, second, milisecond, microsecond, nanosecond] = item.match(/\d+/g)!.map(Number);
+      return dateTimePattern.instantiateCopied([
+        Ast.tryNumberToEnso(Number(year ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(month ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(day ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(hour ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(minute ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(second ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(milisecond ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(microsecond ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(nanosecond ?? 0), module)!,
+      ])
+    }
+  }
+  if (columnType === 'Time') {
+    const timePattern = Pattern.parseExpression('(Time_Of_Day.new __ __ __ __ __ __)')
+    return (item: string, module: Ast.MutableModule) => {
+      const [hour, minute, second, milisecond, microsecond, nanosecond] = item.match(/\d+/g)!.map(Number);
+      return timePattern.instantiateCopied([
+        Ast.tryNumberToEnso(Number(hour ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(minute ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(second ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(milisecond ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(microsecond ?? 0), module)!,
+        Ast.tryNumberToEnso(Number(nanosecond ?? 0), module)!,
+      ])
+    }
+  }
   return (item: string) => Ast.TextLiteral.new(item)
 }
 

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -625,26 +625,26 @@ const getColumnValueToEnso = (columnName: string) => {
   if (isNumber.indexOf(columnType) != -1) {
     return (item: string, module: Ast.MutableModule) => Ast.tryNumberToEnso(Number(item), module)!
   }
-const createDateTimePattern = (pattern: string, numberOfParts: number) => {
-  const dateOrTimePattern = Pattern.parseExpression(pattern);
-  return (item: string, module: Ast.MutableModule) => {
-    const dateTimeParts = item.match(/\d+/g)!.map(Number);
-    const dateTimePartsNumeric = [];
-    for (let i = 0; i < numberOfParts; i++) {
-      dateTimePartsNumeric.push(Ast.tryNumberToEnso(Number(dateTimeParts[i] ?? 0), module)!)
+  const createDateTimePattern = (pattern: string, numberOfParts: number) => {
+    const dateOrTimePattern = Pattern.parseExpression(pattern)
+    return (item: string, module: Ast.MutableModule) => {
+      const dateTimeParts = item.match(/\d+/g)!.map(Number)
+      const dateTimePartsNumeric = []
+      for (let i = 0; i < numberOfParts; i++) {
+        dateTimePartsNumeric.push(Ast.tryNumberToEnso(Number(dateTimeParts[i] ?? 0), module)!)
+      }
+      return dateOrTimePattern.instantiateCopied(dateTimePartsNumeric)
     }
-    return dateOrTimePattern.instantiateCopied(dateTimePartsNumeric);
-  };
-}
+  }
   if (columnType === 'Date') {
-  return createDateTimePattern('(Date.new __ __ __)', 3);
-}
+    return createDateTimePattern('(Date.new __ __ __)', 3)
+  }
   if (columnType === 'Date_Time') {
-  return createDateTimePattern('(Date_Time.new __ __ __ __ __ __ __ __ __)', 9);
-}
+    return createDateTimePattern('(Date_Time.new __ __ __ __ __ __ __ __ __)', 9)
+  }
   if (columnType === 'Time') {
-  return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6);
-}
+    return createDateTimePattern('(Time_Of_Day.new __ __ __ __ __ __)', 6)
+  }
   return (item: string) => Ast.TextLiteral.new(item)
 }
 


### PR DESCRIPTION
### Pull Request Description

![filter-drilldown-date](https://github.com/user-attachments/assets/9574a172-95af-41c6-aef1-a586ee6cda98)
![filter-drilldown-time](https://github.com/user-attachments/assets/9fd5c3f0-0594-4d9c-8c00-c9616ae997be)

Date Time using Date_Time.parse
![date-drilldown-date-time-1](https://github.com/user-attachments/assets/9960cdba-8f13-4f72-9c11-b681ae63e988)
![date-drilldown-date-time-2](https://github.com/user-attachments/assets/caaeb53d-8d2e-4332-aaa4-3d3e210a0893)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
