### PR TITLE
Robust against `IllegalArgumentException`

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/util/DiagnosticFormatter.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/util/DiagnosticFormatter.scala
@@ -169,9 +169,15 @@ class DiagnosticFormatter(
     endCol: Int
   ): String = {
     val line = source.createSection(lineNum).getCharacters.toString
-    linePrefix(lineNum) + fansi
-      .Str(line)
-      .overlay(textAttrs, startCol - 1, endCol)
+    val suffix =
+      try {
+        fansi
+          .Str(line)
+          .overlay(textAttrs, startCol - 1, endCol)
+      } catch {
+        case _: IllegalArgumentException => line
+      }
+    linePrefix(lineNum) + suffix
   }
 
   private def linePrefix(lineNum: Int): String = {


### PR DESCRIPTION
### Pull Request Description

Fixes #11526 by catching the `IllegalArgumentException` and continuing with the original value.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Manually tested
