### PR TITLE
Update licenses codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,5 +59,9 @@ tsconfig.json
 /test/ @jdunkerley @radeusgd @GregoryTravis @AdRiley @marthasharkey
 /tools/http-test-helper/ @radeusgd @jdunkerley @GregoryTravis @AdRiley @marthasharkey
 
+# Licenses
+/distribution/engine/
+/tools/legal-review/
+
 # The default project template is owned by the libraries team
 /lib/scala/pkg/src/main/resources/default/src/ @radeusgd @jdunkerley @GregoryTravis @AdRiley @marthasharkey


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Currently, license directories are owned by both libs (`/distribution/` entry) and engine (`/tools/` entry) teams, and require review from both teams even though there are no related changes in the PR.

License changes are caused by changed dependencies in either libs or the engine. By making the license directories unowned, only the necessary reviewers will be added to the PR

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

