### PR TITLE
Delegate slf4j in HostClassLoader to system class loader

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/example/LoggingTestUtils.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/example/LoggingTestUtils.java
@@ -1,0 +1,13 @@
+package org.enso.example;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingTestUtils {
+  private static Logger logger = LoggerFactory.getLogger(LoggingTestUtils.class);
+
+  public static boolean logSomething() {
+    logger.info("Logging something");
+    return true;
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/StdLibLoggingTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/StdLibLoggingTest.java
@@ -46,10 +46,11 @@ public class StdLibLoggingTest {
 
   @Test
   public void testLogInRef() {
-    ctx.eval(logExample).invokeMember("eval_expression", "test");
     var context = (LoggerContext) LoggerFactory.getILoggerFactory();
     var logger = context.getLogger(Logger.ROOT_LOGGER_NAME);
     var appender = (MemoryAppender) logger.getAppender("memory");
+    appender.reset();
+    ctx.eval(logExample).invokeMember("eval_expression", "test");
     var events = appender.getEvents().stream().map(ILoggingEvent::getMessage).toList();
 
     assertEquals(events, List.of("Logging something"));

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/StdLibLoggingTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/StdLibLoggingTest.java
@@ -1,0 +1,57 @@
+package org.enso.interpreter.test;
+
+import static org.junit.Assert.assertEquals;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.util.List;
+import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.logging.service.logback.MemoryAppender;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+import org.junit.*;
+import org.slf4j.LoggerFactory;
+
+public class StdLibLoggingTest {
+  private Context ctx;
+  private static EnsoContext ensoContext;
+
+  @Before
+  public void initializeContext() {
+    this.ctx = ContextUtils.createDefaultContext();
+    this.ensoContext = ContextUtils.leakContext(ctx);
+  }
+
+  @After
+  public void disposeCtx() {
+    ctx.close();
+    ctx = null;
+    ensoContext.shutdown();
+    ensoContext = null;
+  }
+
+  private final Source logExample =
+      Source.newBuilder(
+              "enso",
+              """
+                  polyglot java import org.enso.example.LoggingTestUtils
+
+                  test =
+                      LoggingTestUtils.logSomething
+                  """,
+              "logs.enso")
+          .buildLiteral();
+
+  @Test
+  public void testLogInRef() {
+    ctx.eval(logExample).invokeMember("eval_expression", "test");
+    var context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    var logger = context.getLogger(Logger.ROOT_LOGGER_NAME);
+    var appender = (MemoryAppender) logger.getAppender("memory");
+    var events = appender.getEvents().stream().map(ILoggingEvent::getMessage).toList();
+
+    assertEquals(events, List.of("Logging something"));
+  }
+}

--- a/engine/runtime-integration-tests/src/test/resources/application-test.conf
+++ b/engine/runtime-integration-tests/src/test/resources/application-test.conf
@@ -10,6 +10,7 @@ logging-service {
     slick."*" = error
     org.eclipse.jgit = error
     io.methvin.watcher = error
+    org.enso.example = info
   }
   appenders = [
     {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/HostClassLoader.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/HostClassLoader.java
@@ -61,6 +61,12 @@ final class HostClassLoader extends URLClassLoader implements AutoCloseable {
     if (!isRuntimeModInBootLayer && name.startsWith("org.graalvm")) {
       return polyglotClassLoader.loadClass(name);
     }
+    if (name.startsWith("org.slf4j")) {
+      // Delegating to system class loader ensures that log classes are not loaded again
+      // and do not require special setup. In other words, it is using log configuration that
+      // has been setup by the runner that started the process. See #11641.
+      return polyglotClassLoader.loadClass(name);
+    }
     try {
       l = findClass(name);
       if (resolve) {

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/MemoryAppender.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/MemoryAppender.java
@@ -31,8 +31,10 @@ public class MemoryAppender extends AppenderBase<ILoggingEvent> {
   }
 
   public void reset() {
-    this.forwardLogs = true;
-    this.underlying.start();
+    this.forwardLogs = underlying != null;
+    if (forwardLogs) {
+      this.underlying.start();
+    }
     events.clear();
   }
 


### PR DESCRIPTION
### Pull Request Description

That way in Enso and Java code any usage of slf4j will use the same configuration as the rest of the process that started it.

With
```diff
diff --git a/build.sbt b/build.sbt
index df8e5fdfd4..e0a1b4ccc5 100644
--- a/build.sbt
+++ b/build.sbt
@@ -4484,7 +4484,8 @@ lazy val `std-base` = project
     libraryDependencies ++= Seq(
       "org.graalvm.polyglot"       % "polyglot"                % graalMavenPackagesVersion,
       "org.netbeans.api"           % "org-openide-util-lookup" % netbeansApiVersion % "provided",
-      "com.fasterxml.jackson.core" % "jackson-databind"        % jacksonVersion
+      "com.fasterxml.jackson.core" % "jackson-databind"        % jacksonVersion,
+      "org.slf4j"                  % "slf4j-api"               % JPMSUtils.slf4jVersion,
     ),
     Compile / packageBin := Def.task {
       val result = (Compile / packageBin).value
diff --git a/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso b/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso
index c1daaa75b1..7d2ad76a6e 100644
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso
@@ -16,6 +16,7 @@ import project.System
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Numbers import Float, Integer
 from project.Data.Range.Extensions import all
+from project.Logging import all
 
 polyglot java import java.lang.Integer as Java_Integer
 polyglot java import java.util.Random as Java_Random
@@ -293,6 +294,7 @@ type Random_Generator
     ## PRIVATE
     boolean : Boolean
     boolean self =
+        self.log_message "Foo!" Log_Level.Warning
         self.java_random.nextBoolean
 
     ## PRIVATE
diff --git a/std-bits/base/src/main/java/org/enso/base/random/Random_Utils.java b/std-bits/base/src/main/java/org/enso/base/random/Random_Utils.java
index 9d11d23bdd..11e82b240f 100644
--- a/std-bits/base/src/main/java/org/enso/base/random/Random_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/random/Random_Utils.java
@@ -2,10 +2,15 @@ package org.enso.base.random;
 
 import java.util.Arrays;
 import java.util.Random;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Random_Utils {
+  private static Logger logger = LoggerFactory.getLogger(Random_Utils.class);
+
   /** Default `seed` used to initialize new instances of `Random` */
   public static long getDefaultSeed() {
+    logger.info("Bar!");
     return java.lang.System.nanoTime();
   }
```

and project containing an actual call
```
node1 = Random.new_generator Nothing
node2 = node2.boolean
```
it would print the expected log messages in the format matching the rest of logs:
```
[INFO] [2024-11-26T17:00:31+01:00] [org.enso.base.random.Random_Utils] Bar!
[WARN] [2024-11-26T17:00:31+01:00] [Standard.Base.Random.Random_Generator] Foo!
```

Previously no logs would be present or they would misformatted.

Closes #11641 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
