### PR TITLE
Fix scheduled nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,13 @@ on:
         options:
           - nodejs
           - polyglot
+  workflow_call:
+    inputs:
+      ydoc:
+        description: What kind of Ydoc image to build.
+        required: false
+        type: string
+        default: nodejs
 jobs:
   promote-nightly:
     name: Promote nightly

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -489,7 +489,9 @@ pub fn changelog() -> Result<Workflow> {
 pub fn nightly() -> Result<Workflow> {
     let workflow_dispatch =
         WorkflowDispatch::default().with_input(input::name::YDOC, input::ydoc());
+    let workflow_call = WorkflowCall::try_from(workflow_dispatch.clone())?;
     let on = Event {
+        workflow_call: Some(workflow_call),
         workflow_dispatch: Some(workflow_dispatch),
         // 2am (UTC) every day.
         schedule: vec![Schedule::new("0 2 * * *")?],


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
Followup to #11517

Fixes the scheduled dispatch of Nightly Release workflow. The scheduled dispatch requires the `workflow_call` section specifying the inputs.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

