### PR TITLE
Conditionally trigger AMI build.

### DIFF
--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -807,11 +807,13 @@ pub async fn main_internal(config: Option<Config>) -> Result {
                 enso_build::release::deploy_ydoc_nodejs_to_ecr(&ctx, args.ecr_repository).await?;
             }
             Action::DispatchBuildImage => {
-                enso_build::repo::cloud::build_image_workflow_dispatch_input(
-                    &ctx.octocrab,
-                    &ctx.triple.versions.version,
-                )
-                .await?;
+                if !(&ctx.triple.versions.version.pre.to_string().starts_with("nightly")) {
+                    enso_build::repo::cloud::build_image_workflow_dispatch_input(
+                        &ctx.octocrab,
+                        &ctx.triple.versions.version,
+                    )
+                    .await?;
+                }
             }
             Action::Publish => {
                 enso_build::release::publish_release(&ctx).await?;


### PR DESCRIPTION
### Pull Request Description

Disabling causing the rebuild of AMIs so we can control the release in the cloud.
Nightlies pushed to the ECR but not AMI built.
Manual releases will be built and become the image run.
To be improved later.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
