### PR TITLE
Reissue request when cached tempfile is missing

### DIFF
--- a/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
@@ -100,6 +100,9 @@ public class LRUCache<M> {
       }
     } catch (LRUCacheException e) {
       // Re-issue the request without caching.
+      // We don't re-attempt to store the cache file and entry. In some cases
+      // (such as a cache file deleted from the outside), we could, but this is
+      // a rare case so it seems unnecessary.
       logger.log(
           Level.WARNING,
           "Error in cache file handling; will re-execute without caching: {}",
@@ -151,7 +154,12 @@ public class LRUCache<M> {
     }
   }
 
-  /** Mark cache entry used and return a stream reading from the cache file. */
+  /**
+   * Mark cache entry used and return a stream reading from the cache file.
+   *
+   * If the file has been deleted, an LRUCacheException is thrown, causing
+   * .makeRequest to re-issue the request without caching.
+   */
   private CacheResult<M> getResultForCacheEntry(String cacheKey) throws IOException, LRUCacheException {
     var cacheFile = cache.get(cacheKey).responseData;
 

--- a/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
@@ -84,9 +84,8 @@ public class LRUCache<M> {
   }
 
   /**
-   * IOExceptions thrown by the HTTP request are propagated; exceptions thrown
-   * while creating or accessing cache files are caught, and the request is
-   * re-issued without caching.
+   * IOExceptions thrown by the HTTP request are propagated; exceptions thrown while creating or
+   * accessing cache files are caught, and the request is re-issued without caching.
    */
   public CacheResult<M> getResult(ItemBuilder<M> itemBuilder)
       throws IOException, InterruptedException, ResponseTooLargeException {
@@ -113,7 +112,7 @@ public class LRUCache<M> {
   }
 
   private CacheResult<M> makeRequestAndCache(String cacheKey, ItemBuilder<M> itemBuilder)
-      throws IOException, InterruptedException, LRUCacheException , ResponseTooLargeException {
+      throws IOException, InterruptedException, LRUCacheException, ResponseTooLargeException {
     assert !cache.containsKey(cacheKey) : "Cache should not contain key " + cacheKey;
 
     Item<M> item = itemBuilder.buildItem();
@@ -149,7 +148,8 @@ public class LRUCache<M> {
 
       return getResultForCacheEntry(cacheKey);
     } catch (IOException e) {
-      // Throw this to re-issue the request since we don't know if we've consumed any of the response.
+      // Throw this to re-issue the request since we don't know if we've consumed any of the
+      // response.
       throw new LRUCacheException("Failure storing cache entry", e);
     }
   }
@@ -157,10 +157,11 @@ public class LRUCache<M> {
   /**
    * Mark cache entry used and return a stream reading from the cache file.
    *
-   * If the file has been deleted, an LRUCacheException is thrown, causing
-   * .makeRequest to re-issue the request without caching.
+   * <p>If the file has been deleted, an LRUCacheException is thrown, causing .makeRequest to
+   * re-issue the request without caching.
    */
-  private CacheResult<M> getResultForCacheEntry(String cacheKey) throws IOException, LRUCacheException {
+  private CacheResult<M> getResultForCacheEntry(String cacheKey)
+      throws IOException, LRUCacheException {
     var cacheFile = cache.get(cacheKey).responseData;
 
     if (!cacheFile.exists()) {
@@ -169,8 +170,7 @@ public class LRUCache<M> {
     }
 
     markCacheEntryUsed(cacheKey);
-    return new CacheResult<>(
-        new FileInputStream(cacheFile), cache.get(cacheKey).metadata());
+    return new CacheResult<>(new FileInputStream(cacheFile), cache.get(cacheKey).metadata());
   }
 
   /**
@@ -333,7 +333,10 @@ public class LRUCache<M> {
   /** Public for testing. */
   public List<String> getFiles() {
     return new ArrayList<>(
-        cache.values().stream().map(CacheEntry::responseData).map(f -> f.getPath()).collect(Collectors.toList()));
+        cache.values().stream()
+            .map(CacheEntry::responseData)
+            .map(f -> f.getPath())
+            .collect(Collectors.toList()));
   }
 
   /** Public for testing. */

--- a/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
@@ -83,22 +83,34 @@ public class LRUCache<M> {
     this.diskSpaceGetter = diskSpaceGetter;
   }
 
+  /**
+   * IOExceptions thrown by the HTTP request are propagated; exceptions thrown
+   * while creating or accessing cache files are caught, and the request is
+   * re-issued without caching.
+   */
   public CacheResult<M> getResult(ItemBuilder<M> itemBuilder)
       throws IOException, InterruptedException, ResponseTooLargeException {
     String cacheKey = itemBuilder.makeCacheKey();
-    if (cache.containsKey(cacheKey)) {
-      return getResultForCacheEntry(cacheKey);
-    } else {
-      return makeRequestAndCache(cacheKey, itemBuilder);
+
+    try {
+      if (cache.containsKey(cacheKey)) {
+        return getResultForCacheEntry(cacheKey);
+      } else {
+        return makeRequestAndCache(cacheKey, itemBuilder);
+      }
+    } catch (LRUCacheException e) {
+      // Re-issue the request without caching.
+      logger.log(
+          Level.WARNING,
+          "Error in cache file handling; will re-execute without caching: {}",
+          e.getMessage());
+      Item<M> rerequested = itemBuilder.buildItem();
+      return new CacheResult<>(rerequested.stream(), rerequested.metadata());
     }
   }
 
-  /**
-   * IOExceptions thrown by the HTTP request are propagated; IOExceptions thrown while storing the
-   * data in the cache are caught, and the request is re-issued without caching.
-   */
   private CacheResult<M> makeRequestAndCache(String cacheKey, ItemBuilder<M> itemBuilder)
-      throws IOException, InterruptedException, ResponseTooLargeException {
+      throws IOException, InterruptedException, LRUCacheException , ResponseTooLargeException {
     assert !cache.containsKey(cacheKey) : "Cache should not contain key " + cacheKey;
 
     Item<M> item = itemBuilder.buildItem();
@@ -134,21 +146,23 @@ public class LRUCache<M> {
 
       return getResultForCacheEntry(cacheKey);
     } catch (IOException e) {
-      logger.log(
-          Level.WARNING,
-          "Failure storing cache entry; will re-execute without caching: {}",
-          e.getMessage());
-      // Re-issue the request since we don't know if we've consumed any of the response.
-      Item<M> rerequested = itemBuilder.buildItem();
-      return new CacheResult<>(rerequested.stream(), rerequested.metadata());
+      // Throw this to re-issue the request since we don't know if we've consumed any of the response.
+      throw new LRUCacheException("Failure storing cache entry", e);
     }
   }
 
   /** Mark cache entry used and return a stream reading from the cache file. */
-  private CacheResult<M> getResultForCacheEntry(String cacheKey) throws IOException {
+  private CacheResult<M> getResultForCacheEntry(String cacheKey) throws IOException, LRUCacheException {
+    var cacheFile = cache.get(cacheKey).responseData;
+
+    if (!cacheFile.exists()) {
+      removeCacheEntry(cacheKey, cache.get(cacheKey));
+      throw new LRUCacheException("Missing cache file " + cacheFile.getPath());
+    }
+
     markCacheEntryUsed(cacheKey);
     return new CacheResult<>(
-        new FileInputStream(cache.get(cacheKey).responseData), cache.get(cacheKey).metadata());
+        new FileInputStream(cacheFile), cache.get(cacheKey).metadata());
   }
 
   /**
@@ -217,8 +231,11 @@ public class LRUCache<M> {
 
   /** Remove a cache entry: from `cache`, `lastUsed`, and the filesystem. */
   private void removeCacheEntry(Map.Entry<String, CacheEntry<M>> toRemove) {
-    var key = toRemove.getKey();
-    var value = toRemove.getValue();
+    removeCacheEntry(toRemove.getKey(), toRemove.getValue());
+  }
+
+  /** Remove a cache entry: from `cache`, `lastUsed`, and the filesystem. */
+  private void removeCacheEntry(String key, CacheEntry<M> value) {
     cache.remove(key);
     lastUsed.remove(key);
     removeCacheFile(key, value);
@@ -306,6 +323,12 @@ public class LRUCache<M> {
   }
 
   /** Public for testing. */
+  public List<String> getFiles() {
+    return new ArrayList<>(
+        cache.values().stream().map(CacheEntry::responseData).map(f -> f.getPath()).collect(Collectors.toList()));
+  }
+
+  /** Public for testing. */
   public LRUCacheSettings getSettings() {
     return settings;
   }
@@ -344,4 +367,21 @@ public class LRUCache<M> {
 
   private final Comparator<Map.Entry<String, CacheEntry<M>>> cacheEntryLRUComparator =
       Comparator.comparing(me -> lastUsed.get(me.getKey()));
+
+  /** Represents an internal error in creating or accessing the cache file. */
+  private static class LRUCacheException extends Exception {
+    public LRUCacheException(String errorMessage) {
+      super(errorMessage);
+    }
+
+    public LRUCacheException(String errorMessage, Throwable cause) {
+      super(errorMessage, cause);
+    }
+
+    public String getMessage() {
+      var cause = getCause();
+      var causeMessage = cause == null ? "" : ": " + cause.getMessage();
+      return super.getMessage() + causeMessage;
+    }
+  }
 }

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -176,14 +176,10 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     }
   }
 
-  private static EnsoHTTPResponseCache getOrCreateCache() {
+  public static EnsoHTTPResponseCache getOrCreateCache() {
     if (cache == null) {
       cache = new EnsoHTTPResponseCache();
     }
-    return cache;
-  }
-
-  public static EnsoHTTPResponseCache getCache() {
     return cache;
   }
 

--- a/test/Table_Tests/src/IO/Fetch_Spec.enso
+++ b/test/Table_Tests/src/IO/Fetch_Spec.enso
@@ -122,7 +122,7 @@ add_specs suite_builder =
                 action
 
         get_lru_cache =
-            EnsoSecretHelper.getCache.getLRUCache
+            EnsoSecretHelper.getOrCreateCache.getLRUCache
 
         get_num_response_cache_entries =
             get_lru_cache.getNumEntries
@@ -137,15 +137,19 @@ add_specs suite_builder =
             counts = with_counts action
             counts . should_equal expected_counts frames_to_skip=1
 
+        get_cache_files : Vector Text
+        get_cache_files -> Vector Text =
+            Vector.from_polyglot_array EnsoSecretHelper.getOrCreateCache.getLRUCache.getFiles . sort Sort_Direction.Ascending
+
         get_cache_file_sizes : Vector Integer
         get_cache_file_sizes -> Vector Integer =
-            Vector.from_polyglot_array EnsoSecretHelper.getCache.getLRUCache.getFileSizes . sort Sort_Direction.Ascending
+            Vector.from_polyglot_array EnsoSecretHelper.getOrCreateCache.getLRUCache.getFileSizes . sort Sort_Direction.Ascending
 
         # Craetes a new cache each time, then resets it at the end
         with_lru_cache lru_cache ~action =
-            reset = EnsoSecretHelper.getCache.setLRUCache LRUCache.new
+            reset = EnsoSecretHelper.getOrCreateCache.setLRUCache LRUCache.new
             Panic.with_finalizer reset <|
-                EnsoSecretHelper.getCache.setLRUCache lru_cache
+                EnsoSecretHelper.getOrCreateCache.setLRUCache lru_cache
                 action
 
         # Craetes a new cache each time, then resets it at the end
@@ -462,44 +466,44 @@ add_specs suite_builder =
             Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_FILE_SIZE_MB" "8" <|
                 Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_TOTAL_CACHE_LIMIT" "30" <|
                     with_default_cache <|
-                        EnsoSecretHelper.getCache.getLRUCache.getSettings.getMaxFileSize . should_equal (8 * 1024 * 1024)
-                        EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal (30 * 1024 * 1024)
+                        EnsoSecretHelper.getOrCreateCache.getLRUCache.getSettings.getMaxFileSize . should_equal (8 * 1024 * 1024)
+                        EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal (30 * 1024 * 1024)
 
         group_builder.specify "Should be able to set the max file size and total cache size (as a percentage) via environment variable, and track changes to available disk space" <|
             Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_FILE_SIZE_MB" "8" <|
                 Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_TOTAL_CACHE_LIMIT" "10%" <|
                     with_mocks _-> disk_space->
-                        EnsoSecretHelper.getCache.getLRUCache.getSettings.getMaxFileSize . should_equal (8 * 1024 * 1024)
+                        EnsoSecretHelper.getOrCreateCache.getLRUCache.getSettings.getMaxFileSize . should_equal (8 * 1024 * 1024)
                         disk_space.mocked 300
-                        EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 30
+                        EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 30
                         disk_space.mocked 400
-                        EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 40
+                        EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 40
 
         group_builder.specify "Includes the existing cache files in the total cache size calculation, for a percentage total cache limit" pending=pending_has_url <| Test.with_retries <|
             with_config 1000 (TotalCacheLimit.Percentage.new 0.5) _-> disk_space->
                 disk_space.mocked 100
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
                 fetch_n 30
                 disk_space.mocked 70
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
                 fetch_n 20
                 disk_space.mocked 50
                 get_num_response_cache_entries . should_equal 2
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
                 fetch_n 10
                 disk_space.mocked 70
                 get_num_response_cache_entries . should_equal 2
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 50
 
         group_builder.specify "Total cache size, specified in MB, should not go over the percentage hard limit" <|
             with_config 1000 (TotalCacheLimit.Bytes.new 200) _-> disk_space->
                 disk_space.mocked 100
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 90
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 90
 
         group_builder.specify "Total cache size, specified as a percentage, should not go over the percentage hard limit" <|
             with_config 1000 (TotalCacheLimit.Percentage.new 0.95) _-> disk_space->
                 disk_space.mocked 100
-                EnsoSecretHelper.getCache.getLRUCache.getMaxTotalCacheSize . should_equal 90
+                EnsoSecretHelper.getOrCreateCache.getLRUCache.getMaxTotalCacheSize . should_equal 90
 
         group_builder.specify "Falls back to the default if an environment variable is incorrectly formatted" <|
             Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_FILE_SIZE_MB" "abcd" <|
@@ -512,3 +516,16 @@ add_specs suite_builder =
                 LRUCache.new . getSettings . getTotalCacheLimit . should_equal (TotalCacheLimit.Percentage.new 0.2)
             Test_Environment.unsafe_with_environment_override "ENSO_LIB_HTTP_CACHE_MAX_TOTAL_CACHE_LIMIT" "101%" <|
                 LRUCache.new . getSettings . getTotalCacheLimit . should_equal (TotalCacheLimit.Percentage.new 0.2)
+
+        group_builder.specify "Reissues the request if the cache file disappears" pending=pending_has_url <| Test.with_retries <|
+            with_default_cache <|
+                url = base_url_with_slash+'test_download?max-age=16&length=10'
+                result0 = HTTP.fetch url . decode_as_text
+                result0.length . should_equal 10
+                HTTP.fetch url . decode_as_text . should_equal result0
+                get_num_response_cache_entries . should_equal 1
+
+                get_cache_files.map (f-> File.new f . delete)
+                result1 = HTTP.fetch url . decode_as_text
+                result1 . should_not_equal result0
+                result1.length . should_equal 10


### PR DESCRIPTION
Also fixes a testing error in which certain tests would fail if a request was made to a test cache inside of a test cache helper.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
