### PR TITLE
Tiny fixes in animations

### DIFF
--- a/app/gui/src/dashboard/components/AriaComponents/Dialog/Dialog.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Dialog/Dialog.tsx
@@ -147,12 +147,12 @@ const DIALOG_STYLES = tv({
 })
 
 const TRANSITION: Spring = {
+  type: 'spring',
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  stiffness: 2_000,
+  stiffness: 1_200,
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   damping: 90,
-  type: 'spring',
-  mass: 1,
+  mass: 3,
 }
 
 // ==============
@@ -255,6 +255,7 @@ function DialogContent(props: DialogContentProps) {
   const isFullscreen = type === 'fullscreen'
 
   const [isScrolledToTop, setIsScrolledToTop] = React.useState(true)
+
   const [isLayoutDisabled, setIsLayoutDisabled] = React.useState(true)
 
   const [contentDimensionsRef, dimensions] = useMeasure({
@@ -322,17 +323,24 @@ function DialogContent(props: DialogContentProps) {
     fitContent,
   })
 
-  const dialogHeight =
-    dimensions == null || headerDimensions == null ?
-      null
-    : dimensions.height + headerDimensions.height
+  const dialogHeight = () => {
+    if (isFullscreen) {
+      return ''
+    }
+
+    if (dimensions == null || headerDimensions == null) {
+      return ''
+    }
+
+    return dimensions.height + headerDimensions.height
+  }
 
   return (
     <>
       <MotionDialog
         layout
         transition={TRANSITION}
-        style={dialogHeight != null ? { height: dialogHeight } : undefined}
+        style={{ height: dialogHeight() }}
         id={dialogId}
         onLayoutAnimationStart={() => {
           if (scrollerRef.current) {

--- a/app/gui/src/dashboard/hooks/debounceCallbackHooks.ts
+++ b/app/gui/src/dashboard/hooks/debounceCallbackHooks.ts
@@ -7,7 +7,8 @@ import { useUnmount } from './unmountHooks'
 /** Wrap a callback into a debounced function */
 export function useDebouncedCallback<Fn extends (...args: never[]) => unknown>(
   callback: Fn,
-  delay: number,
+  /** The delay in milliseconds. Set to `false` to disable debouncing. */
+  delay: number | false,
   maxWait: number | null = null,
 ): DebouncedFunction<Fn> {
   const stableCallback = useEventCallback(callback)
@@ -49,7 +50,7 @@ export function useDebouncedCallback<Fn extends (...args: never[]) => unknown>(
 
     lastCallRef.current = { args }
 
-    if (delay === 0) {
+    if (delay === false) {
       execute()
     } else {
       // plan regular execution

--- a/app/gui/src/dashboard/hooks/measureHooks.ts
+++ b/app/gui/src/dashboard/hooks/measureHooks.ts
@@ -53,7 +53,7 @@ export type OnResizeCallback = (bounds: RectReadOnly) => void
  * A type that represents the options for the useMeasure hook.
  */
 export interface Options {
-  readonly debounce?: number | { readonly scroll: number; readonly resize: number }
+  readonly debounce?: number | false | { readonly scroll: number | false; readonly resize: number | false }
   readonly scroll?: boolean
   readonly offsetSize?: boolean
   readonly onResize?: OnResizeCallback
@@ -133,7 +133,7 @@ const DEFAULT_MAX_WAIT = 500
  */
 export function useMeasureCallback(options: Options & Required<Pick<Options, 'onResize'>>) {
   const {
-    debounce = 0,
+    debounce = false,
     scroll = false,
     offsetSize = false,
     onResize,
@@ -158,8 +158,8 @@ export function useMeasureCallback(options: Options & Required<Pick<Options, 'on
   const resizeMaxWait = typeof maxWait === 'number' ? maxWait : maxWait.resize
 
   // set actual debounce values early, so effects know if they should react accordingly
-  const scrollDebounce = typeof debounce === 'number' ? debounce : debounce.scroll
-  const resizeDebounce = typeof debounce === 'number' ? debounce : debounce.resize
+  const scrollDebounce = typeof debounce === 'number' || debounce === false ? debounce : debounce.scroll
+  const resizeDebounce = typeof debounce === 'number' || debounce === false ? debounce : debounce.resize
 
   const callback = useEventCallback(() => {
     frame.read(measureCallback)

--- a/app/gui/src/dashboard/hooks/measureHooks.ts
+++ b/app/gui/src/dashboard/hooks/measureHooks.ts
@@ -53,7 +53,10 @@ export type OnResizeCallback = (bounds: RectReadOnly) => void
  * A type that represents the options for the useMeasure hook.
  */
 export interface Options {
-  readonly debounce?: number | false | { readonly scroll: number | false; readonly resize: number | false }
+  readonly debounce?:
+    | number
+    | false
+    | { readonly scroll: number | false; readonly resize: number | false }
   readonly scroll?: boolean
   readonly offsetSize?: boolean
   readonly onResize?: OnResizeCallback
@@ -158,8 +161,10 @@ export function useMeasureCallback(options: Options & Required<Pick<Options, 'on
   const resizeMaxWait = typeof maxWait === 'number' ? maxWait : maxWait.resize
 
   // set actual debounce values early, so effects know if they should react accordingly
-  const scrollDebounce = typeof debounce === 'number' || debounce === false ? debounce : debounce.scroll
-  const resizeDebounce = typeof debounce === 'number' || debounce === false ? debounce : debounce.resize
+  const scrollDebounce =
+    typeof debounce === 'number' || debounce === false ? debounce : debounce.scroll
+  const resizeDebounce =
+    typeof debounce === 'number' || debounce === false ? debounce : debounce.resize
 
   const callback = useEventCallback(() => {
     frame.read(measureCallback)


### PR DESCRIPTION
### Pull Request Description

This PR improves the behavior of `useMeasure`: it used to ignore measuring the initial bounds if it's disabled by default. Now the behavior is fixed.

Also this PR removes the scrollbar appearing while resizing.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
