### PR TITLE
Simplify shutdown logic on client disconnect in project-manager

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -166,6 +166,9 @@ final class ContextRegistry(
           sender() ! AccessDenied
         }
 
+      case DestroyContextResponse(_) =>
+      // Initiated by *this* registry. Ignore
+
       case PushContextRequest(client, contextId, stackItem) =>
         if (store.hasContext(client.clientId, contextId)) {
           val item = getRuntimeStackItem(stackItem)

--- a/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
+++ b/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
@@ -75,9 +75,12 @@ class JsonRpcServer(
         }
         .to(
           Sink.actorRef[MessageHandler.WebMessage](
-            messageHandler,
-            MessageHandler.Disconnected(port),
-            { _: Throwable =>
+            messageHandler, {
+              logger.trace("JSON sink stream finished with no failure")
+              MessageHandler.Disconnected(port)
+            },
+            { e: Throwable =>
+              logger.trace("JSON sink stream finished with a failure", e)
               MessageHandler.Disconnected(port)
             }
           )
@@ -100,7 +103,7 @@ class JsonRpcServer(
           logger.trace(s"Sent text message ${textMessage.text}.")
         }
 
-    Flow.fromSinkAndSource(incomingMessages, outgoingMessages)
+    Flow.fromSinkAndSourceCoupled(incomingMessages, outgoingMessages)
   }
 
   override protected def serverRoute(port: Int): Route = {

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectShutdownSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectShutdownSpec.scala
@@ -122,7 +122,7 @@ class ProjectShutdownSpec
     deleteProject(projectId)(client2, implicitly[Position])
   }
 
-  "ensure language server does eventually shutdown after last client disconnects" in {
+  "ensure language server does not shutdown after last client disconnects and can re-connect" in {
     val client    = new WsTestClient(address)
     val projectId = createProject("Foo")(client, implicitly[Position])
     val socket1   = openProject(projectId)(client, implicitly[Position])
@@ -154,7 +154,7 @@ class ProjectShutdownSpec
     )
     val client2 = new WsTestClient(address)
     val socket2 = openProject(projectId)(client2, implicitly[Position])
-    socket2 shouldNot be(socket1)
+    socket2 shouldBe socket1
 
     closeProject(projectId)(client2, implicitly[Position])
     deleteProject(projectId)(client2, implicitly[Position])


### PR DESCRIPTION
### Pull Request Description

Suspend on Windows confuses the re-connection logic by essentially triggering a full 
language server shutdown when waking up from suspend.
This change simply drops logic that delayed shutdown after last client disconnect.
project-manager now expects an explicit request to shutdown.

Partially fixes #11389 (no more app crash). This bug unmasks a bug in GUI where multiple
execution context requests are being made on re-connect.

Partially cherry-picked from experiments in #11518.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
