### PR TITLE
Refactor runtime-integration-tests - move some tests to more dedicated packages

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/hash/HashCodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/hash/HashCodeTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.hash;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -13,6 +13,7 @@ import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNodeGen;
 import org.enso.interpreter.node.expression.foreign.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.test.ValuesGenerator;
 import org.enso.test.utils.ContextUtils;
 import org.enso.test.utils.TestRootNode;
 import org.graalvm.polyglot.Context;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.instrument;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JsInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JsInteropTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
 import static org.junit.Assert.assertEquals;
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectPolyglotTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectPolyglotTest.java
@@ -1,5 +1,6 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
+import org.enso.interpreter.test.ValuesGenerator;
 import org.enso.interpreter.test.ValuesGenerator.Language;
 import org.graalvm.polyglot.Context;
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import org.enso.common.MethodNames;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.type.ConstantsGen;
+import org.enso.interpreter.test.ValuesGenerator;
 import org.enso.interpreter.test.ValuesGenerator.Language;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.interop;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypesExposeConstructorsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypesExposeConstructorsTest.java
@@ -1,0 +1,101 @@
+package org.enso.interpreter.test.interop;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.test.ValuesGenerator;
+import org.enso.interpreter.test.ValuesGenerator.Language;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests that every {@link org.enso.interpreter.runtime.data.Type} exposes its constructors as
+ * {@link com.oracle.truffle.api.interop.InteropLibrary#getMembers(Object) members}, and that such
+ * members are {@link com.oracle.truffle.api.interop.InteropLibrary#isInstantiable(Object)
+ * instantiable}.
+ */
+@RunWith(Parameterized.class)
+public class TypesExposeConstructorsTest {
+  private static Context ctx;
+
+  private final TypeWithWrapper typeWithWrapper;
+
+  public TypesExposeConstructorsTest(TypeWithWrapper typeWithWrapper) {
+    this.typeWithWrapper = typeWithWrapper;
+  }
+
+  private static Context ctx() {
+    if (ctx == null) {
+      ctx = ContextUtils.createDefaultContext();
+    }
+    return ctx;
+  }
+
+  @AfterClass
+  public static void disposeCtx() {
+    if (ctx != null) {
+      ctx.close();
+      ctx = null;
+    }
+  }
+
+  @Parameters(name = "{index}: {0}")
+  public static Iterable<TypeWithWrapper> collectTypes() {
+    var collectedTypes = new ArrayList<TypeWithWrapper>();
+    ContextUtils.executeInContext(
+        ctx(),
+        () -> {
+          var valuesGenerator = ValuesGenerator.create(ctx(), Language.ENSO);
+          valuesGenerator.allTypes().stream()
+              .map(
+                  tp -> {
+                    var unwrappedTp = ContextUtils.unwrapValue(ctx(), tp);
+                    if (unwrappedTp instanceof Type type) {
+                      return new TypeWithWrapper(type, tp);
+                    } else {
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .filter(tp -> !tp.type.getConstructors().isEmpty())
+              .forEach(collectedTypes::add);
+          return null;
+        });
+    return collectedTypes;
+  }
+
+  @Test
+  public void typesExposeConstructorsAsMembers() {
+    var type = typeWithWrapper.type;
+    var typeValue = typeWithWrapper.typeValue;
+    var consNames = type.getConstructors().keySet();
+    for (var consName : consNames) {
+      assertThat(
+          "Constructor " + consName + " should be exposed as a member",
+          typeValue.hasMember(consName),
+          is(true));
+      var consMember = typeValue.getMember(consName);
+      assertThat(consMember, is(notNullValue()));
+      assertThat(
+          "Constructor " + consName + " should be instantiable",
+          consMember.canInstantiate(),
+          is(true));
+    }
+  }
+
+  /**
+   * @param type
+   * @param typeValue The polyglot value of the type (not an object)
+   */
+  public record TypeWithWrapper(Type type, Value typeValue) {}
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsAPolyglotTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsAPolyglotTest.java
@@ -1,5 +1,6 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.meta;
 
+import org.enso.interpreter.test.ValuesGenerator;
 import org.enso.interpreter.test.ValuesGenerator.Language;
 import org.graalvm.polyglot.Context;
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsATest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsATest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.meta;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.test.ValuesGenerator;
 import org.enso.interpreter.test.ValuesGenerator.Language;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;


### PR DESCRIPTION
### Pull Request Description

Just refactoring PR. Add a new [TypesExposeConstructorsTest](https://github.com/enso-org/enso/blob/fb8a7fe345952e67224ab305c173e94f749fd6d0/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypesExposeConstructorsTest.java) to increase coverage a bit. Moves some tests from the giant `org.enso.interpreter.test` package to more dedicated ones.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
