### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,8 +21,7 @@ jobs:
     uses: ./.github/workflows/promote.yml
     with:
       designator: nightly
-      ydoc: ${{ env.ENV_INPUTS_YDOC }}
+      ydoc: ${{ inputs.ydoc || 'nodejs' }}
     secrets: inherit
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
-  ENV_INPUTS_YDOC: ${{ inputs.ydoc || nodejs }}

--- a/build/build/src/ci/input.rs
+++ b/build/build/src/ci/input.rs
@@ -12,25 +12,6 @@ pub mod name {
     pub const YDOC: &str = "ydoc";
 }
 
-pub mod env {
-    use ide_ci::env::accessor::RawVariable;
-
-    #[derive(Clone, Copy, Debug, Default)]
-    pub struct Ydoc;
-
-    impl RawVariable for Ydoc {
-        fn name(&self) -> &str {
-            "ENV_INPUTS_YDOC"
-        }
-    }
-
-    impl From<Ydoc> for String {
-        fn from(val: Ydoc) -> Self {
-            val.name().to_owned()
-        }
-    }
-}
-
 pub fn designator() -> WorkflowDispatchInput {
     WorkflowDispatchInput::new_choice(
         "What kind of release should be promoted.",


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

followup #11517 

It turned out that `env` context is not available in the `jobs.<job-id>.with` key.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->
