### PR TITLE
Do not send the generated name to the Backend

### DIFF
--- a/app/gui/integration-test/dashboard/api.ts
+++ b/app/gui/integration-test/dashboard/api.ts
@@ -24,7 +24,7 @@ import LATEST_GITHUB_RELEASES from './latestGithubReleases.json' with { type: 'j
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const MOCK_SVG = `
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 100 100">
   <defs>
     <pattern id="checkerboard" width="20" height="20" patternUnits="userSpaceOnUse">
       <rect width="10" height="10" fill="white"/>
@@ -179,11 +179,16 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
     return wasDeleted
   }
 
-  const createDirectory = (
-    title: string,
-    rest: Partial<backend.DirectoryAsset> = {},
-  ): backend.DirectoryAsset =>
-    object.merge(
+  const createDirectory = (rest: Partial<backend.DirectoryAsset> = {}): backend.DirectoryAsset => {
+    const directoryTitles = new Set(
+      assets
+        .filter((asset) => asset.type === backend.AssetType.directory)
+        .map((asset) => asset.title),
+    )
+
+    const title = rest.title ?? `New Folder ${directoryTitles.size + 1}`
+
+    return object.merge(
       {
         type: backend.AssetType.directory,
         id: backend.DirectoryId('directory-' + uniqueString.uniqueString()),
@@ -191,7 +196,7 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
         extension: null,
         title,
         modifiedAt: dateTime.toRfc3339(new Date()),
-        description: null,
+        description: rest.description ?? '',
         labels: [],
         parentId: defaultDirectoryId,
         permissions: [
@@ -210,12 +215,18 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
       },
       rest,
     )
+  }
 
-  const createProject = (
-    title: string,
-    rest: Partial<backend.ProjectAsset> = {},
-  ): backend.ProjectAsset =>
-    object.merge(
+  const createProject = (rest: Partial<backend.ProjectAsset> = {}): backend.ProjectAsset => {
+    const projectNames = new Set(
+      assets
+        .filter((asset) => asset.type === backend.AssetType.project)
+        .map((asset) => asset.title),
+    )
+
+    const title = rest.title ?? `New Project ${projectNames.size + 1}`
+
+    return object.merge(
       {
         type: backend.AssetType.project,
         id: backend.ProjectId('project-' + uniqueString.uniqueString()),
@@ -226,7 +237,7 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
         extension: null,
         title,
         modifiedAt: dateTime.toRfc3339(new Date()),
-        description: null,
+        description: rest.description ?? '',
         labels: [],
         parentId: defaultDirectoryId,
         permissions: [],
@@ -235,17 +246,18 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
       },
       rest,
     )
+  }
 
-  const createFile = (title: string, rest: Partial<backend.FileAsset> = {}): backend.FileAsset =>
+  const createFile = (rest: Partial<backend.FileAsset> = {}): backend.FileAsset =>
     object.merge(
       {
         type: backend.AssetType.file,
         id: backend.FileId('file-' + uniqueString.uniqueString()),
         projectState: null,
         extension: '',
-        title,
+        title: rest.title ?? '',
         modifiedAt: dateTime.toRfc3339(new Date()),
-        description: null,
+        description: rest.description ?? '',
         labels: [],
         parentId: defaultDirectoryId,
         permissions: [],
@@ -255,19 +267,16 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
       rest,
     )
 
-  const createSecret = (
-    title: string,
-    rest: Partial<backend.SecretAsset> = {},
-  ): backend.SecretAsset =>
+  const createSecret = (rest: Partial<backend.SecretAsset>): backend.SecretAsset =>
     object.merge(
       {
         type: backend.AssetType.secret,
         id: backend.SecretId('secret-' + uniqueString.uniqueString()),
         projectState: null,
         extension: null,
-        title,
+        title: rest.title ?? '',
         modifiedAt: dateTime.toRfc3339(new Date()),
-        description: null,
+        description: rest.description ?? '',
         labels: [],
         parentId: defaultDirectoryId,
         permissions: [],
@@ -283,20 +292,20 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
     color,
   })
 
-  const addDirectory = (title: string, rest?: Partial<backend.DirectoryAsset>) => {
-    return addAsset(createDirectory(title, rest))
+  const addDirectory = (rest: Partial<backend.DirectoryAsset>) => {
+    return addAsset(createDirectory(rest))
   }
 
-  const addProject = (title: string, rest?: Partial<backend.ProjectAsset>) => {
-    return addAsset(createProject(title, rest))
+  const addProject = (rest: Partial<backend.ProjectAsset>) => {
+    return addAsset(createProject(rest))
   }
 
-  const addFile = (title: string, rest?: Partial<backend.FileAsset>) => {
-    return addAsset(createFile(title, rest))
+  const addFile = (rest: Partial<backend.FileAsset>) => {
+    return addAsset(createFile(rest))
   }
 
-  const addSecret = (title: string, rest?: Partial<backend.SecretAsset>) => {
-    return addAsset(createSecret(title, rest))
+  const addSecret = (rest: Partial<backend.SecretAsset>) => {
+    return addAsset(createSecret(rest))
   }
 
   const addLabel = (value: string, color: backend.LChColor) => {
@@ -784,7 +793,7 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
     await post(remoteBackendPaths.UPLOAD_FILE_END_PATH + '*', (_route, request) => {
       const body: backend.UploadFileEndRequestBody = request.postDataJSON()
 
-      const file = addFile(body.fileName, {
+      const file = addFile({
         id: backend.FileId(body.uploadId),
         title: body.fileName,
         ...(body.parentDirectoryId != null ? { parentId: body.parentDirectoryId } : {}),
@@ -795,7 +804,9 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
 
     await post(remoteBackendPaths.CREATE_SECRET_PATH + '*', async (_route, request) => {
       const body: backend.CreateSecretRequestBody = await request.postDataJSON()
-      const secret = addSecret(body.name)
+      const secret = addSecret({
+        title: body.name,
+      })
       return secret.id
     })
 
@@ -978,19 +989,13 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
     })
     await post(remoteBackendPaths.CREATE_PROJECT_PATH + '*', (_route, request) => {
       const body: backend.CreateProjectRequestBody = request.postDataJSON()
-      const title = body.projectName
       const id = backend.ProjectId(`project-${uniqueString.uniqueString()}`)
       const parentId =
         body.parentDirectoryId ?? backend.DirectoryId(`directory-${uniqueString.uniqueString()}`)
-      const json: backend.CreatedProject = {
-        name: title,
-        organizationId: defaultOrganizationId,
-        packageName: 'Project_root',
-        projectId: id,
-        state: { type: backend.ProjectState.closed, volumeId: '' },
-      }
 
-      addProject(title, {
+      const state = { type: backend.ProjectState.closed, volumeId: '' }
+
+      const project = addProject({
         description: null,
         id,
         labels: [],
@@ -1007,19 +1012,26 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
             permission: permissions.PermissionAction.own,
           },
         ],
-        projectState: json.state,
+        projectState: state,
       })
 
-      return json
+      return {
+        title: project.title,
+        id: project.id,
+        parentId: project.parentId,
+        state: project.projectState,
+        organizationId: defaultOrganizationId,
+        packageName: 'Project_root',
+        projectId: id,
+      }
     })
 
     await post(remoteBackendPaths.CREATE_DIRECTORY_PATH + '*', (_route, request) => {
       const body: backend.CreateDirectoryRequestBody = request.postDataJSON()
-      const title = body.title
       const id = backend.DirectoryId(`directory-${uniqueString.uniqueString()}`)
       const parentId = body.parentId ?? defaultDirectoryId
-      const json: backend.CreatedDirectory = { title, id, parentId }
-      addDirectory(title, {
+
+      const directory = addDirectory({
         description: null,
         id,
         labels: [],
@@ -1038,7 +1050,12 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
         ],
         projectState: null,
       })
-      return json
+
+      return {
+        title: directory.title,
+        id: directory.id,
+        parentId: directory.parentId,
+      }
     })
 
     await get(remoteBackendPaths.getProjectContentPath(GLOB_PROJECT_ID), (route) => {
@@ -1059,6 +1076,10 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
     })
 
     await page.route('mock/svg.svg', (route) => {
+      return route.fulfill({ body: MOCK_SVG, contentType: 'image/svg+xml' })
+    })
+
+    await page.route('**/assets/*.svg', (route) => {
       return route.fulfill({ body: MOCK_SVG, contentType: 'image/svg+xml' })
     })
 

--- a/app/gui/integration-test/dashboard/assetPanel.spec.ts
+++ b/app/gui/integration-test/dashboard/assetPanel.spec.ts
@@ -39,7 +39,7 @@ test('asset panel contents', ({ page }) =>
       page,
       setupAPI: (api) => {
         const { defaultOrganizationId, defaultUserId } = api
-        api.addProject('project', {
+        api.addProject({
           description: DESCRIPTION,
           permissions: [
             {
@@ -70,7 +70,7 @@ test('Asset Panel Documentation view', ({ page }) => {
     .mockAllAndLogin({
       page,
       setupAPI: (api) => {
-        api.addProject('project', { description: DESCRIPTION })
+        api.addProject({})
       },
     })
     .driveTable.clickRow(0)

--- a/app/gui/integration-test/dashboard/assetSearchBar.spec.ts
+++ b/app/gui/integration-test/dashboard/assetSearchBar.spec.ts
@@ -68,10 +68,10 @@ test.test('suggestions', async ({ page }) => {
   await actions.mockAllAndLogin({
     page,
     setupAPI: (api) => {
-      api.addDirectory('foo')
-      api.addProject('bar')
-      api.addSecret('baz')
-      api.addSecret('quux')
+      api.addDirectory({ title: 'foo' })
+      api.addProject({ title: 'bar' })
+      api.addSecret({ title: 'baz' })
+      api.addSecret({ title: 'quux' })
     },
   })
 
@@ -94,10 +94,10 @@ test.test('suggestions (keyboard)', async ({ page }) => {
   await actions.mockAllAndLogin({
     page,
     setupAPI: (api) => {
-      api.addDirectory('foo')
-      api.addProject('bar')
-      api.addSecret('baz')
-      api.addSecret('quux')
+      api.addDirectory({ title: 'foo' })
+      api.addProject({ title: 'bar' })
+      api.addSecret({ title: 'baz' })
+      api.addSecret({ title: 'quux' })
     },
   })
 
@@ -119,10 +119,10 @@ test.test('complex flows', async ({ page }) => {
   await actions.mockAllAndLogin({
     page,
     setupAPI: (api) => {
-      api.addDirectory(firstName)
-      api.addProject('bar')
-      api.addSecret('baz')
-      api.addSecret('quux')
+      api.addDirectory({ title: firstName })
+      api.addProject({ title: 'bar' })
+      api.addSecret({ title: 'baz' })
+      api.addSecret({ title: 'quux' })
     },
   })
   const searchBarInput = actions.locateSearchBarInput(page)

--- a/app/gui/integration-test/dashboard/sort.spec.ts
+++ b/app/gui/integration-test/dashboard/sort.spec.ts
@@ -29,14 +29,15 @@ test.test('sort', async ({ page }) => {
       const date6 = dateTime.toRfc3339(new Date(START_DATE_EPOCH_MS + 5 * MIN_MS))
       const date7 = dateTime.toRfc3339(new Date(START_DATE_EPOCH_MS + 6 * MIN_MS))
       const date8 = dateTime.toRfc3339(new Date(START_DATE_EPOCH_MS + 7 * MIN_MS))
-      api.addDirectory('a directory', { modifiedAt: date4 })
-      api.addDirectory('G directory', { modifiedAt: date6 })
-      api.addProject('C project', { modifiedAt: date7 })
-      api.addSecret('H secret', { modifiedAt: date2 })
-      api.addProject('b project', { modifiedAt: date1 })
-      api.addFile('d file', { modifiedAt: date8 })
-      api.addSecret('f secret', { modifiedAt: date3 })
-      api.addFile('e file', { modifiedAt: date5 })
+
+      api.addDirectory({ modifiedAt: date4, title: 'a directory' })
+      api.addDirectory({ modifiedAt: date6, title: 'G directory' })
+      api.addProject({ modifiedAt: date7, title: 'C project' })
+      api.addProject({ modifiedAt: date1, title: 'b project' })
+      api.addFile({ modifiedAt: date8, title: 'd file' })
+      api.addFile({ modifiedAt: date5, title: 'e file' })
+      api.addSecret({ modifiedAt: date2, title: 'H secret' })
+      api.addSecret({ modifiedAt: date3, title: 'f secret' })
       // By date:
       // b project
       // h secret
@@ -59,88 +60,102 @@ test.test('sort', async ({ page }) => {
   await test.expect(actions.locateSortDescendingIcon(nameHeading)).not.toBeVisible()
   await actions.expectOpacity0(actions.locateSortAscendingIcon(modifiedHeading))
   await test.expect(actions.locateSortDescendingIcon(modifiedHeading)).not.toBeVisible()
-  await test.expect(assetRows.nth(0)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^f secret/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(1)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(2)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(3)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(4)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(6)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(7)).toHaveText(/^f secret/),
+  ])
 
   // Sort by name ascending.
   await nameHeading.click()
   await actions.expectNotOpacity0(actions.locateSortAscendingIcon(nameHeading))
-  await test.expect(assetRows.nth(0)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^f secret/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^H secret/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(1)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(2)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(3)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(4)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^f secret/),
+    test.expect(assetRows.nth(6)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(7)).toHaveText(/^H secret/),
+  ])
 
   // Sort by name descending.
   await nameHeading.click()
   await actions.expectNotOpacity0(actions.locateSortDescendingIcon(nameHeading))
-  await test.expect(assetRows.nth(0)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^f secret/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^a directory/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(1)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(2)).toHaveText(/^f secret/),
+    test.expect(assetRows.nth(3)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(4)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(6)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(7)).toHaveText(/^a directory/),
+  ])
 
   // Sorting should be unset.
   await nameHeading.click()
   await page.mouse.move(0, 0)
   await actions.expectOpacity0(actions.locateSortAscendingIcon(nameHeading))
   await test.expect(actions.locateSortDescendingIcon(nameHeading)).not.toBeVisible()
-  await test.expect(assetRows.nth(0)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^f secret/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(1)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(2)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(3)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(4)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(6)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(7)).toHaveText(/^f secret/),
+  ])
 
   // Sort by date ascending.
   await modifiedHeading.click()
   await actions.expectNotOpacity0(actions.locateSortAscendingIcon(modifiedHeading))
-  await test.expect(assetRows.nth(0)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^f secret/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^d file/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(1)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(2)).toHaveText(/^f secret/),
+    test.expect(assetRows.nth(3)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(4)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(6)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(7)).toHaveText(/^d file/),
+  ])
 
   // Sort by date descending.
   await modifiedHeading.click()
   await actions.expectNotOpacity0(actions.locateSortDescendingIcon(modifiedHeading))
-  await test.expect(assetRows.nth(0)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^f secret/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^b project/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(1)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(2)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(3)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(4)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(5)).toHaveText(/^f secret/),
+    test.expect(assetRows.nth(6)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(7)).toHaveText(/^b project/),
+  ])
 
   // Sorting should be unset.
   await modifiedHeading.click()
   await page.mouse.move(0, 0)
   await actions.expectOpacity0(actions.locateSortAscendingIcon(modifiedHeading))
   await test.expect(actions.locateSortDescendingIcon(modifiedHeading)).not.toBeVisible()
-  await test.expect(assetRows.nth(0)).toHaveText(/^a directory/)
-  await test.expect(assetRows.nth(1)).toHaveText(/^G directory/)
-  await test.expect(assetRows.nth(2)).toHaveText(/^C project/)
-  await test.expect(assetRows.nth(3)).toHaveText(/^b project/)
-  await test.expect(assetRows.nth(4)).toHaveText(/^d file/)
-  await test.expect(assetRows.nth(5)).toHaveText(/^e file/)
-  await test.expect(assetRows.nth(6)).toHaveText(/^H secret/)
-  await test.expect(assetRows.nth(7)).toHaveText(/^f secret/)
+  await Promise.all([
+    test.expect(assetRows.nth(0)).toHaveText(/^a directory/),
+    test.expect(assetRows.nth(1)).toHaveText(/^G directory/),
+    test.expect(assetRows.nth(2)).toHaveText(/^C project/),
+    test.expect(assetRows.nth(3)).toHaveText(/^b project/),
+    test.expect(assetRows.nth(4)).toHaveText(/^d file/),
+    test.expect(assetRows.nth(5)).toHaveText(/^e file/),
+    test.expect(assetRows.nth(6)).toHaveText(/^H secret/),
+    test.expect(assetRows.nth(7)).toHaveText(/^f secret/),
+  ])
 })

--- a/app/gui/src/dashboard/hooks/backendHooks.tsx
+++ b/app/gui/src/dashboard/hooks/backendHooks.tsx
@@ -645,7 +645,6 @@ function useDeleteAsset(backend: Backend, category: Category) {
 
 /** A function to create a new folder. */
 export function useNewFolder(backend: Backend, category: Category) {
-  const insertAssets = useInsertAssets(backend, category)
   const ensureListDirectory = useEnsureListDirectory(backend, category)
   const toggleDirectoryExpansion = useToggleDirectoryExpansion()
   const setNewestFolderId = useSetNewestFolderId()
@@ -676,8 +675,6 @@ export function useNewFolder(backend: Backend, category: Category) {
       ),
     )
 
-    insertAssets([placeholderItem], parentId)
-
     return await createDirectoryMutation
       .mutateAsync([{ parentId: placeholderItem.parentId, title: placeholderItem.title }])
       .then((result) => {
@@ -691,12 +688,12 @@ export function useNewFolder(backend: Backend, category: Category) {
 
 /** A function to create a new project. */
 export function useNewProject(backend: Backend, category: Category) {
-  const insertAssets = useInsertAssets(backend, category)
   const ensureListDirectory = useEnsureListDirectory(backend, category)
   const toastAndLog = useToastAndLog()
   const doOpenProject = useOpenProject()
   const deleteAsset = useDeleteAsset(backend, category)
   const toggleDirectoryExpansion = useToggleDirectoryExpansion()
+
   const { user } = useFullUserSession()
   const { data: users } = useBackendQuery(backend, 'listUsers', [])
   const { data: userGroups } = useBackendQuery(backend, 'listUserGroups', [])
@@ -717,6 +714,7 @@ export function useNewProject(backend: Backend, category: Category) {
       parentPath: string | null | undefined,
     ) => {
       toggleDirectoryExpansion(parentId, true)
+
       const siblings = await ensureListDirectory(parentId)
       const projectName = (() => {
         const prefix = `${templateName ?? 'New Project'} `
@@ -727,6 +725,7 @@ export function useNewProject(backend: Backend, category: Category) {
           .map((maybeIndex) => (maybeIndex != null ? parseInt(maybeIndex, 10) : 0))
         return `${prefix}${Math.max(0, ...projectIndices) + 1}`
       })()
+
       const path = backend instanceof LocalBackend ? backend.joinPath(parentId, projectName) : null
 
       const placeholderItem = backendModule.createPlaceholderProjectAsset(
@@ -742,8 +741,6 @@ export function useNewProject(backend: Backend, category: Category) {
         user,
         path,
       )
-
-      insertAssets([placeholderItem], parentId)
 
       return await createProjectMutation
         .mutateAsync([
@@ -764,8 +761,9 @@ export function useNewProject(backend: Backend, category: Category) {
             id: createdProject.projectId,
             type: backend.type,
             parentId: placeholderItem.parentId,
-            title: placeholderItem.title,
+            title: createdProject.name,
           })
+
           return createdProject
         })
     },

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -533,9 +533,14 @@ export default class RemoteBackend extends Backend {
     body: backend.CreateDirectoryRequestBody,
   ): Promise<backend.CreatedDirectory> {
     const path = remoteBackendPaths.CREATE_DIRECTORY_PATH
-    const response = await this.post<backend.CreatedDirectory>(path, body)
+
+    // Remote backend doesn't need the title in the body.
+    // It's generated on the server side.
+    const { title, ...rest } = body
+
+    const response = await this.post<backend.CreatedDirectory>(path, rest)
     if (!responseIsSuccessful(response)) {
-      return await this.throw(response, 'createFolderBackendError', body.title)
+      return await this.throw(response, 'createFolderBackendError', title)
     } else {
       return await response.json()
     }
@@ -684,9 +689,13 @@ export default class RemoteBackend extends Backend {
     body: backend.CreateProjectRequestBody,
   ): Promise<backend.CreatedProject> {
     const path = remoteBackendPaths.CREATE_PROJECT_PATH
-    const response = await this.post<backend.CreatedProject>(path, body)
+    // Remote backend doesn't need the project name in the body.
+    // It's generated on the server side.
+    const { projectName, ...rest } = body
+
+    const response = await this.post<backend.CreatedProject>(path, rest)
     if (!responseIsSuccessful(response)) {
-      return await this.throw(response, 'createProjectBackendError', body.projectName)
+      return await this.throw(response, 'createProjectBackendError', projectName)
     } else {
       return await response.json()
     }


### PR DESCRIPTION
### Pull Request Description

This PR removes sending the pre-generated name to the remote backend. We don't have full control over this and can't guarantee the uniqness of the name purely client-side. 

Closes: https://github.com/enso-org/cloud-v2/issues/1600

For the local backend we still generate the name though. 

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
