### PR TITLE
Prefer distribution/lib/Standard files when runEngineDistribution

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleSources.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleSources.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.source.Source;
 import java.io.IOException;
+import java.util.LinkedList;
 import org.enso.common.LanguageInfo;
 import org.enso.pkg.QualifiedName;
 import org.enso.text.buffer.Rope;
@@ -68,7 +69,9 @@ record ModuleSources(TruffleFile file, Rope rope, Source source) {
       Source src = Source.newBuilder(LanguageInfo.ID, rope.characters(), name.toString()).build();
       return new ModuleSources(file, rope, src);
     } else if (file != null) {
-      Source src = Source.newBuilder(LanguageInfo.ID, file).build();
+      var b = Source.newBuilder(LanguageInfo.ID, file);
+      assert alternativeFile(b, file) : "Cannot find alternative for " + file;
+      var src = b.build();
       org.enso.text.buffer.Rope lit = Rope.apply(src.getCharacters().toString());
       return new ModuleSources(file, lit, src);
     }
@@ -82,5 +85,49 @@ record ModuleSources(TruffleFile file, Rope rope, Source source) {
    */
   String getPath() {
     return file() == null ? null : file().getPath();
+  }
+
+  /**
+   * Special support for reassigning locations of sources when running development version. When
+   * {@code -ea} is enabled, then we try to locate library files under the {@code
+   * distribution}/{@code lib} directories.
+   */
+  private static boolean alternativeFile(Source.SourceBuilder b, TruffleFile file) {
+    var root = file;
+    var stack = new LinkedList<String>();
+    while (root != null) {
+      if ("0.0.0-dev".equals(root.getName())) {
+        break;
+      }
+      stack.addFirst(root.getName());
+      root = root.getParent();
+    }
+    if (root == null) {
+      return true;
+    }
+    var libName = root.getParent();
+    var libNamespace = libName.getParent();
+    var libVersion = libNamespace.getParent().getParent();
+    var builtDistribution = libVersion.getParent().getParent();
+    if ("built-distribution".equals(builtDistribution.getName())) {
+      var repositoryRoot = builtDistribution.getParent();
+      var distRoot = repositoryRoot.resolve("distribution").resolve("lib");
+      var newLibRoot =
+          distRoot
+              .resolve(libNamespace.getName())
+              .resolve(libName.getName())
+              .resolve(root.getName());
+      if (newLibRoot.isDirectory()) {
+        var newFile = newLibRoot;
+        for (var n : stack) {
+          newFile = newFile.resolve(n);
+        }
+        if (newFile.exists()) {
+          b.uri(newFile.toUri());
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
### Pull Request Description

Prefer `distribution/lib/Standard/*` files over the files in `built-distribution/enso-engine-*/enso-0.0.0-dev/lib/Standard/`. This solves the common error when _one debugs thru files_ and edits them just to find out _they are rewritten by next build_.

### Important Notes

The support for locating `alternativeFile` is only enabled for developers. E.g. when Enso version is `0.0.0-dev`. This is satisfied when one uses:
```bash
enso$ sbt
sbt:enso> runEngineDistribution --run test/Base_Tests --debug
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Debugging was manually tested
