### PR TITLE
Fix reconnecting after hibernation on Windows

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/toasts.ts
+++ b/app/gui/src/project-view/components/GraphEditor/toasts.ts
@@ -16,9 +16,10 @@ export function useGraphEditorToasts(projectStore: ProjectStore) {
   toastStartup.show('Initializing the project. This can take up to one minute.')
   projectStore.firstExecution.then(toastStartup.dismiss)
 
-  useEvent(document, 'project-manager-loading-failed', () =>
+  projectStore.lsRpcConnection.on('transport/closed', () =>
     toastConnectionLost.show('Lost connection to Language Server.'),
   )
+  projectStore.lsRpcConnection.on('transport/connected', () => toastConnectionLost.dismiss())
 
   projectStore.lsRpcConnection.client.onError((e) =>
     toastLspError.show(`Language server error: ${e}`),

--- a/app/gui/src/project-view/components/GraphEditor/toasts.ts
+++ b/app/gui/src/project-view/components/GraphEditor/toasts.ts
@@ -1,4 +1,3 @@
-import { useEvent } from '@/composables/events'
 import { type ProjectStore } from '@/stores/project'
 import { useToast } from '@/util/toast'
 

--- a/app/gui/src/project-view/stores/project/executionContext.ts
+++ b/app/gui/src/project-view/stores/project/executionContext.ts
@@ -1,6 +1,6 @@
 import { findIndexOpt } from '@/util/data/array'
 import { isSome, type Opt } from '@/util/data/opt'
-import { Err, Ok, type Result } from '@/util/data/result'
+import { Err, Ok, ResultError, type Result } from '@/util/data/result'
 import { AsyncQueue, type AbortScope } from '@/util/net'
 import {
   qnReplaceProjectName,
@@ -12,7 +12,7 @@ import * as array from 'lib0/array'
 import { ObservableV2 } from 'lib0/observable'
 import * as random from 'lib0/random'
 import { reactive } from 'vue'
-import type { LanguageServer } from 'ydoc-shared/languageServer'
+import { ErrorCode, LsRpcError, RemoteRpcError, type LanguageServer } from 'ydoc-shared/languageServer'
 import {
   methodPointerEquals,
   stackItemsEqual,
@@ -97,6 +97,7 @@ type ExecutionContextNotification = {
 enum SyncStatus {
   NOT_SYNCED,
   QUEUED,
+  CREATING,
   SYNCING,
   SYNCED,
 }
@@ -163,13 +164,20 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
       // Connection closed: the created execution context is no longer available
       // There is no point in any scheduled action until resynchronization
       this.queue.clear()
-      this.syncStatus = SyncStatus.NOT_SYNCED
-      this.queue.pushTask(() => {
-        this.clearScheduled = false
-        this.sync()
-        return Promise.resolve({ status: 'not-created' })
-      })
-      this.clearScheduled = true
+      // If syncing is at the first step (creating missing execution context), it is 
+      // effectively waiting for reconnection to recreate the execution context. 
+      // We should not clear it's outcome, as it's likely the context will be created after
+      // reconnection (so it's valid).
+      if (this.syncStatus !== SyncStatus.CREATING) { 
+        // In other cases, any created context is destroyed after losing connection.
+        // The status should be cleared to 'not-created'.
+        this.queue.pushTask(() => {
+          this.clearScheduled = false
+          this.sync()
+          return Promise.resolve({ status: 'not-created' })
+        })
+        this.clearScheduled = true
+      }
     })
     this.lsRpc.on('refactoring/projectRenamed', ({ oldNormalizedName, newNormalizedName }) => {
       const newIdent = tryIdentifier(newNormalizedName)
@@ -346,15 +354,10 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
 
   private syncTask() {
     return async (state: ExecutionContextState) => {
-      this.syncStatus = SyncStatus.SYNCING
-      if (this.abort.signal.aborted) return state
       let newState = { ...state }
 
       const create = () => {
         if (newState.status === 'created') return Ok()
-        // if (newState.status === 'broken') {
-        //   this.withBackoff(() => this.lsRpc.destroyExecutionContext(this.id), 'Failed to destroy broken execution context')
-        // }
         return this.withBackoff(async () => {
           const result = await this.lsRpc.createExecutionContext(this.id)
           if (!result.ok) return result
@@ -487,25 +490,51 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
           .map((result) => (result.status === 'rejected' ? result.reason : null))
           .filter(isSome)
         if (errors.length > 0) {
-          console.error('Failed to synchronize visualizations:', errors)
+          const result = Err(`Failed to synchronize visualizations: ${errors}`)
+          result.error.log()
+          return result
+        }
+        return Ok()
+      }
+
+      const handleError = (error: ResultError): ExecutionContextState => {
+        // If error tells us that the execution context is missing, we schedule
+        // another sync to re-create it, and set proper state.
+        if (error.payload instanceof LsRpcError && error.payload.cause instanceof RemoteRpcError && error.payload.cause.code === ErrorCode.CONTEXT_NOT_FOUND) {
+          this.sync()
+          return { status: 'not-created' }
+        } else {
+          return newState
         }
       }
 
-      const createResult = await create()
-      if (!createResult.ok) return newState
-      const syncStackResult = await syncStack()
-      if (!syncStackResult.ok) return newState
-      const syncEnvResult = await syncEnvironment()
-      if (!syncEnvResult.ok) return newState
-      this.emit('newVisualizationConfiguration', [new Set(this.visualizationConfigs.keys())])
-      await syncVisualizations()
-      this.emit('visualizationsConfigured', [
-        new Set(state.status === 'created' ? state.visualizations.keys() : []),
-      ])
-      if (this.syncStatus === SyncStatus.SYNCING) {
-        this.syncStatus = SyncStatus.SYNCED
+      this.syncStatus = SyncStatus.CREATING
+      try {
+        if (this.abort.signal.aborted) return newState
+        const createResult = await create()
+        if (!createResult.ok) return newState
+        this.syncStatus = SyncStatus.SYNCING
+        const syncStackResult = await syncStack()
+        if (!syncStackResult.ok) return handleError(syncStackResult.error)
+        const syncEnvResult = await syncEnvironment()
+        if (!syncEnvResult.ok) return handleError(syncEnvResult.error)
+        this.emit('newVisualizationConfiguration', [new Set(this.visualizationConfigs.keys())])
+        const syncVisResult = await syncVisualizations()
+        this.emit('visualizationsConfigured', [
+          new Set(state.status === 'created' ? state.visualizations.keys() : []),
+        ])
+        if (!syncVisResult.ok) return handleError(syncVisResult.error)
+
+        if (this.syncStatus === SyncStatus.SYNCING) {
+          this.syncStatus = SyncStatus.SYNCED
+        }
+        return newState
+      } finally {
+        // On any exception or early return we assme we're not fully synced.
+        if (this.syncStatus === SyncStatus.SYNCING || this.syncStatus === SyncStatus.CREATING) {
+          this.syncStatus = SyncStatus.NOT_SYNCED
+        }
       }
-      return newState
     }
   }
 }

--- a/app/gui/src/project-view/stores/project/executionContext.ts
+++ b/app/gui/src/project-view/stores/project/executionContext.ts
@@ -12,7 +12,12 @@ import * as array from 'lib0/array'
 import { ObservableV2 } from 'lib0/observable'
 import * as random from 'lib0/random'
 import { reactive } from 'vue'
-import { ErrorCode, LsRpcError, RemoteRpcError, type LanguageServer } from 'ydoc-shared/languageServer'
+import {
+  ErrorCode,
+  LsRpcError,
+  RemoteRpcError,
+  type LanguageServer,
+} from 'ydoc-shared/languageServer'
 import {
   methodPointerEquals,
   stackItemsEqual,
@@ -164,11 +169,11 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
       // Connection closed: the created execution context is no longer available
       // There is no point in any scheduled action until resynchronization
       this.queue.clear()
-      // If syncing is at the first step (creating missing execution context), it is 
-      // effectively waiting for reconnection to recreate the execution context. 
+      // If syncing is at the first step (creating missing execution context), it is
+      // effectively waiting for reconnection to recreate the execution context.
       // We should not clear it's outcome, as it's likely the context will be created after
       // reconnection (so it's valid).
-      if (this.syncStatus !== SyncStatus.CREATING) { 
+      if (this.syncStatus !== SyncStatus.CREATING) {
         // In other cases, any created context is destroyed after losing connection.
         // The status should be cleared to 'not-created'.
         this.queue.pushTask(() => {
@@ -500,7 +505,11 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
       const handleError = (error: ResultError): ExecutionContextState => {
         // If error tells us that the execution context is missing, we schedule
         // another sync to re-create it, and set proper state.
-        if (error.payload instanceof LsRpcError && error.payload.cause instanceof RemoteRpcError && error.payload.cause.code === ErrorCode.CONTEXT_NOT_FOUND) {
+        if (
+          error.payload instanceof LsRpcError &&
+          error.payload.cause instanceof RemoteRpcError &&
+          error.payload.cause.code === ErrorCode.CONTEXT_NOT_FOUND
+        ) {
           this.sync()
           return { status: 'not-created' }
         } else {

--- a/app/ydoc-server/src/languageServerSession.ts
+++ b/app/ydoc-server/src/languageServerSession.ts
@@ -791,7 +791,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
               const reloading = this.ls.closeTextFile(this.path).then(async closing => {
                 if (!closing.ok) closing.error.log('Could not close file after write error:')
                 return exponentialBackoff(
-                  async () => {
+                  async (): Promise<Result<response.OpenTextFile>> => {
                     const result = await this.ls.openTextFile(this.path)
                     if (!result.ok) return result
                     if (!result.value.writeCapability) {

--- a/app/ydoc-shared/src/util/data/result.ts
+++ b/app/ydoc-shared/src/util/data/result.ts
@@ -37,8 +37,8 @@ export function Ok<T>(data?: T): Result<T | undefined, never> {
 }
 
 /** Constructor of error {@link Result}. */
-export function Err<E>(error: E): Result<never, E> {
-  return { ok: false, error: new ResultError(error) }
+export function Err<E>(error: E) {
+  return { ok: false, error: new ResultError(error) } as const satisfies Result<never, E>
 }
 
 /** Helper function for converting optional value to {@link Result}. */


### PR DESCRIPTION
### Pull Request Description

Fixes #11716

The previoud implementation of restoring execution context assumed, that any synchronization in progress on connection close will fail - but actually if the synchronization just waited for executionContext/create, it might be successfull and effective after reconnecting.

Also, show "Language Server connection lost" when the actual language server connection is lost, and dismiss the message on reconnect.

### Important Notes

The hibernation still does not work properly - connection to Project Manager is not restored.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
