### PR TITLE
Fix failure to parse an invalid syntax case

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
@@ -131,13 +131,7 @@ class ExpressionAnnotationsTest extends CompilerTest {
     "create an error on a misplaced annotation" in {
       val misplaced = items
         .expressions(4)
-        .asInstanceOf[Application.Prefix]
-        .arguments(0)
-        .value
-      misplaced shouldBe an[errors.Resolution]
-      misplaced
-        .asInstanceOf[errors.Resolution]
-        .reason shouldEqual errors.Resolution.UnexpectedAnnotation
+      misplaced shouldBe an[error.Syntax]
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
@@ -64,6 +64,8 @@ class ExpressionAnnotationsTest extends CompilerTest {
   // === The Tests ============================================================
 
   "Annotations resolution" should {
+    implicit val ctx: ModuleContext = mkModuleContext
+
     val ir =
       """
         |foo x =

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ExpressionAnnotationsTest.scala
@@ -64,8 +64,6 @@ class ExpressionAnnotationsTest extends CompilerTest {
   // === The Tests ============================================================
 
   "Annotations resolution" should {
-    implicit val ctx: ModuleContext = mkModuleContext
-
     val ir =
       """
         |foo x =
@@ -131,7 +129,7 @@ class ExpressionAnnotationsTest extends CompilerTest {
     "create an error on a misplaced annotation" in {
       val misplaced = items
         .expressions(4)
-      misplaced shouldBe an[error.Syntax]
+      misplaced shouldBe an[errors.Syntax]
     }
   }
 

--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -1753,6 +1753,7 @@ fn nonsense_inputs() {
     expect_invalid_node("if (asGuestValue\n  a");
     expect_invalid_node("foo(\n  a");
     expect_invalid_node("(Vector(), true)");
+    expect_invalid_node("x @Builtin_Method \"a\"");
 }
 
 #[test]

--- a/lib/rust/parser/src/syntax/operator/reducer.rs
+++ b/lib/rust/parser/src/syntax/operator/reducer.rs
@@ -48,7 +48,7 @@ impl<'s> OperatorConsumer<'s> for Reduce<'s> {
         // slightly more efficient and can simplify debugging.
         if !arity.expects_rhs() {
             let lhs = self.output.pop();
-            debug_assert!(!lhs.is_none());
+            debug_assert!(lhs.is_some());
             let mut applied = reduce_step(arity, lhs, &mut self.output);
             warnings.apply(&mut applied.value);
             self.push_operand(applied);

--- a/lib/rust/parser/src/syntax/operator/reducer.rs
+++ b/lib/rust/parser/src/syntax/operator/reducer.rs
@@ -44,6 +44,16 @@ impl<'s> OperatorConsumer<'s> for Reduce<'s> {
         } else {
             Default::default()
         };
+        // Eagerly reduce postfix operators. This does not affect the result of reduction, but is
+        // slightly more efficient and can simplify debugging.
+        if !arity.expects_rhs() {
+            let lhs = self.output.pop();
+            debug_assert!(!lhs.is_none());
+            let mut applied = reduce_step(arity, lhs, &mut self.output);
+            warnings.apply(&mut applied.value);
+            self.push_operand(applied);
+            return;
+        }
         self.operator_stack.push(StackOperator {
             right_precedence,
             associativity,

--- a/lib/rust/parser/src/syntax/operator/types.rs
+++ b/lib/rust/parser/src/syntax/operator/types.rs
@@ -1,3 +1,5 @@
+use crate::syntax::operator::annotations::Annotation;
+use crate::syntax::operator::named_app::NamedApp;
 use crate::syntax::operator::section::MaybeSection;
 use crate::syntax::token;
 use crate::syntax::tree;
@@ -6,9 +8,6 @@ use crate::syntax::Inspect;
 use crate::syntax::Token;
 use crate::syntax::Tree;
 use crate::syntax::TreeConsumer;
-
-use crate::syntax::operator::annotations::Annotation;
-use crate::syntax::operator::named_app::NamedApp;
 use std::fmt::Debug;
 
 
@@ -54,11 +53,23 @@ pub enum Arity<'s> {
 }
 
 impl<'s> Arity<'s> {
+    fn expected_operands(&self) -> (bool, bool) {
+        match self {
+            Arity::App | Arity::Binary { missing: None, .. } => (true, true),
+            Arity::Unary(_)
+            | Arity::Annotation(_)
+            | Arity::Binary { missing: Some(BinaryOperand::Left), .. } => (false, true),
+            Arity::NamedApp(_) | Arity::Binary { missing: Some(BinaryOperand::Right), .. } =>
+                (true, false),
+        }
+    }
+
+    pub fn expects_lhs(&self) -> bool {
+        self.expected_operands().0
+    }
+
     pub fn expects_rhs(&self) -> bool {
-        matches!(
-            self,
-            Arity::Unary(_) | Arity::Binary { missing: None | Some(BinaryOperand::Left), .. }
-        )
+        self.expected_operands().1
     }
 }
 

--- a/lib/rust/parser/src/syntax/statement.rs
+++ b/lib/rust/parser/src/syntax/statement.rs
@@ -725,7 +725,7 @@ fn parse_assignment_like_statement<'s>(
     }
     match match (expression, qn_len) {
         (Some(e), Some(qn_len))
-            if matches!(evaluation_context, EvaluationContext::Lazy)
+            if evaluation_context == EvaluationContext::Lazy
                 || matches!(e.variant, tree::Variant::BodyBlock(_)) =>
             Type::Function { expression: Some(e), qn_len },
         (Some(expression), None) => Type::Assignment { expression },
@@ -848,7 +848,7 @@ fn find_top_level_operator<'a, 's>(
     let mut after_first_space = false;
     for (i, item) in items.iter().enumerate() {
         let next_is_after_space =
-            i != 0 && (after_first_space || matches!(Spacing::of_item(item), Spacing::Spaced));
+            i != 0 && (after_first_space || Spacing::of_item(item) == Spacing::Spaced);
         if let Item::Token(token) = item {
             let is_spaced = token.is_spaced();
             if !after_first_space || is_spaced {
@@ -904,7 +904,7 @@ fn find_top_level_operator<'a, 's>(
 
 fn next_spaced(items: &[Item]) -> Option<usize> {
     for (i, item) in items.iter().enumerate().skip(1) {
-        if matches!(Spacing::of_item(item), Spacing::Spaced) {
+        if Spacing::of_item(item) == Spacing::Spaced {
             return Some(i);
         }
     }

--- a/lib/rust/parser/src/syntax/statement/function_def.rs
+++ b/lib/rust/parser/src/syntax/statement/function_def.rs
@@ -55,7 +55,7 @@ impl<'s> FunctionBuilder<'s> {
                 arrow = Some(i);
                 break;
             }
-            if i == start + qn_len || matches!(Spacing::of_item(item), Spacing::Spaced) {
+            if i == start + qn_len || Spacing::of_item(item) == Spacing::Spaced {
                 arg_starts.push(i);
             }
         }
@@ -185,7 +185,7 @@ pub fn parse_args<'s>(
 ) -> Vec<ArgumentDefinition<'s>> {
     let mut arg_starts = vec![];
     for (i, item) in items.iter().enumerate().skip(start) {
-        if i == start || matches!(Spacing::of_item(item), Spacing::Spaced) {
+        if i == start || Spacing::of_item(item) == Spacing::Spaced {
             arg_starts.push(i);
         }
     }
@@ -296,7 +296,7 @@ pub fn parse_type_args<'s>(
             expecting_rhs = true;
             continue;
         }
-        if matches!(Spacing::of_item(item), Spacing::Spaced) {
+        if Spacing::of_item(item) == Spacing::Spaced {
             arg_starts.push(i);
         }
     }
@@ -363,7 +363,7 @@ pub fn try_parse_foreign_function<'s>(
 
     let mut arg_starts = vec![];
     for (i, item) in items.iter().enumerate().skip(start + 3) {
-        if i == start + 3 || matches!(Spacing::of_item(item), Spacing::Spaced) {
+        if i == start + 3 || Spacing::of_item(item) == Spacing::Spaced {
             arg_starts.push(i);
         }
     }

--- a/lib/rust/parser/src/syntax/token/operator.rs
+++ b/lib/rust/parser/src/syntax/token/operator.rs
@@ -22,10 +22,41 @@ pub struct OperatorProperties {
 
 pub fn is_syntactic_binary_operator(variant: &Variant) -> bool {
     use Variant::*;
-    matches!(
-        variant,
-        AssignmentOperator(_) | TypeAnnotationOperator(_) | ArrowOperator(_) | CommaOperator(_)
-    )
+    match variant {
+        AssignmentOperator(_) | TypeAnnotationOperator(_) | ArrowOperator(_) | CommaOperator(_) =>
+            true,
+        Operator(_)
+        | DotOperator(_)
+        | UnaryOperator(_)
+        | AnnotationOperator(_)
+        | AutoscopeOperator(_)
+        | LambdaOperator(_)
+        | SuspensionOperator(_)
+        | NegationOperator(_)
+        | Newline(_)
+        | OpenSymbol(_)
+        | CloseSymbol(_)
+        | BlockStart(_)
+        | BlockEnd(_)
+        | Wildcard(_)
+        | SuspendedDefaultArguments(_)
+        | Ident(_)
+        | Digits(_)
+        | NumberBase(_)
+        | PrivateKeyword(_)
+        | TypeKeyword(_)
+        | ForeignKeyword(_)
+        | AllKeyword(_)
+        | CaseKeyword(_)
+        | OfKeyword(_)
+        | TextStart(_)
+        | TextEnd(_)
+        | TextSection(_)
+        | TextEscape(_)
+        | TextInitialNewline(_)
+        | TextNewline(_)
+        | Invalid(_) => false,
+    }
 }
 
 impl OperatorProperties {

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -1026,7 +1026,11 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
     let error = match Spacing::of_tree(&arg) {
         Spacing::Spaced => None,
         Spacing::Unspaced => Some("Space required between terms."),
-    };
+    }
+    .or_else(|| match &arg.variant {
+        Variant::AnnotatedBuiltin(_) => Some("Unexpected expression annotation."),
+        _ => None,
+    });
     maybe_with_error(Tree::app(func, arg), error)
 }
 

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -1027,7 +1027,7 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
         Spacing::Spaced => None,
         Spacing::Unspaced => Some("Space required between terms."),
     }
-    .or_else(|| match &arg.variant {
+    .or(match &arg.variant {
         Variant::AnnotatedBuiltin(_) => Some("Unexpected expression annotation."),
         _ => None,
     });

--- a/lib/rust/parser/src/syntax/treebuilding/whitespace.rs
+++ b/lib/rust/parser/src/syntax/treebuilding/whitespace.rs
@@ -57,14 +57,46 @@ fn token_starts_new_no_space_group<'a: 'b, 'b, T: Into<token::Ref<'a, 'b>>>(toke
 }
 
 fn tree_starts_new_no_space_group(tree: &Tree) -> bool {
+    use tree::Variant::*;
     tree.span.left_offset.visible.width_in_spaces != 0
-        || matches!(
-            &tree.variant,
-            tree::Variant::BodyBlock(_)
-                | tree::Variant::OperatorBlockApplication(_)
-                | tree::Variant::ArgumentBlockApplication(_)
-                | tree::Variant::SuspendedDefaultArguments(_)
-        )
+        || match &tree.variant {
+            BodyBlock(_)
+            | ArgumentBlockApplication(_)
+            | OperatorBlockApplication(_)
+            | SuspendedDefaultArguments(_) => true,
+            Invalid(_)
+            | Ident(_)
+            | Private(_)
+            | Number(_)
+            | Wildcard(_)
+            | TextLiteral(_)
+            | App(_)
+            | NamedApp(_)
+            | OprApp(_)
+            | UnaryOprApp(_)
+            | AutoscopedIdentifier(_)
+            | OprSectionBoundary(_)
+            | TemplateFunction(_)
+            | MultiSegmentApp(_)
+            | TypeDef(_)
+            | Assignment(_)
+            | Function(_)
+            | ForeignFunction(_)
+            | Import(_)
+            | Export(_)
+            | Group(_)
+            | TypeSignatureDeclaration(_)
+            | TypeAnnotated(_)
+            | CaseOf(_)
+            | Lambda(_)
+            | Array(_)
+            | Tuple(_)
+            | Annotation(_)
+            | AnnotatedBuiltin(_)
+            | Documentation(_)
+            | ExpressionStatement(_)
+            | ConstructorDefinition(_) => false,
+        }
 }
 
 


### PR DESCRIPTION
### Pull Request Description

Fix failure to parse a syntax case involving unexpected usage of annotated expressions (fixes #11691).

The root cause of the bug was usage of the `matches!` macro in a situation where a `match` statement should have been used to enforce exhaustiveness.

- I have corrected the bug, and reviewed all usages of the `matches!` macro. I didn't find any other *incorrect* usages of `matches!`, but I found and replaced some potentially *fragile* uses. I also simplified some unnecessary uses of `matches!`, replacing them with expressions that are more-obviously correct.
- Stricter parsing: It is now a syntax error for an inline annotation to occur in the RHS of an application (e.g. `fn @Tail_Call recur`)--the precedence in this case may be surprising, so parentheses should be used around the annotated expression.

`parse_all_enso_files.sh`: This PR does not affect any AST in the .enso corpus.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
