### PR TITLE
Component menu button opens single-component menu

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -215,6 +215,7 @@ watch(menuVisible, (visible) => {
 
 function setSoleSelected() {
   nodeSelection?.setSelection(new Set([nodeId.value]))
+  graph.db.moveNodeToTop(nodeId.value)
 }
 
 function ensureSelected() {
@@ -513,7 +514,7 @@ const showMenuAt = ref<{ x: number; y: number }>()
       v-if="menuVisible"
       @pointerenter="menuHovered = true"
       @pointerleave="menuHovered = false"
-      @click.capture="ensureSelected"
+      @click.capture="setSoleSelected"
     />
     <GraphVisualization
       v-if="isVisualizationVisible"


### PR DESCRIPTION
### Pull Request Description

- Clicking a component's menu button makes the component the sole selection
- When a component becomes the sole selection due to a user interaction, it is raised to the top

Fixes #11767.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
