### PR TITLE
Fix performance deterioration after many external or code-editor edits.

### DIFF
--- a/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
+++ b/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
@@ -679,11 +679,14 @@ describe('Code edit', () => {
     const edit = beforeRoot.module.edit()
     const newCode = 'main = func 10 2\n'
     let changes: Record<string, number> | undefined = undefined
-    edit.observe((update) => (changes = {
-      added: update.nodesAdded.size,
-      deleted: update.nodesDeleted.size,
-      updated: update.nodesUpdated.size,
-    }))
+    edit.observe(
+      (update) =>
+        (changes = {
+          added: update.nodesAdded.size,
+          deleted: update.nodesDeleted.size,
+          updated: update.nodesUpdated.size,
+        }),
+    )
     edit.syncToCode(newCode)
     expect(edit.root()?.code()).toBe(newCode)
     expect(edit.root()?.id).toBe(beforeRoot.id)

--- a/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
+++ b/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
@@ -673,6 +673,27 @@ describe('Code edit', () => {
     expect(after['func 123 arg2'].id).toBe(before['func arg1 arg2'].id)
   })
 
+  test('syncToCode does not create unneeded AST nodes', () => {
+    const beforeRoot = Ast.parseModule('main = func 1 2\n')
+    beforeRoot.module.setRoot(beforeRoot)
+    const edit = beforeRoot.module.edit()
+    const newCode = 'main = func 10 2\n'
+    let changes: Record<string, number> | undefined = undefined
+    edit.observe((update) => (changes = {
+      added: update.nodesAdded.size,
+      deleted: update.nodesDeleted.size,
+      updated: update.nodesUpdated.size,
+    }))
+    edit.syncToCode(newCode)
+    expect(edit.root()?.code()).toBe(newCode)
+    expect(edit.root()?.id).toBe(beforeRoot.id)
+    expect(changes).toEqual({
+      added: 0,
+      deleted: 0,
+      updated: 1,
+    })
+  })
+
   test('Insert argument names', () => {
     const beforeRoot = Ast.parseExpression('func arg1 arg2')
     assertDefined(beforeRoot)

--- a/app/ydoc-shared/src/ast/mutableModule.ts
+++ b/app/ydoc-shared/src/ast/mutableModule.ts
@@ -180,6 +180,19 @@ export class MutableModule implements Module {
     return materializeMutable(this, fields) as Owned<Mutable<typeof ast>>
   }
 
+  /**
+   * Copy the node into the module *without copying children*. The returned object, and the module containing it, may be
+   * in an invalid state until the callee has ensured all references are resolvable, e.g. by recursing into children.
+   * @internal
+   */
+  splice<T extends Ast>(ast: T): Owned<Mutable<T>> {
+    assert(ast.module !== this)
+    const fields = ast.fields.clone() as any
+    this.nodes.set(ast.id, fields)
+    fields.set('parent', undefined)
+    return materializeMutable(this, fields) as Owned<Mutable<typeof ast>>
+  }
+
   /** TODO: Add docs */
   static Transient() {
     return new this(new Y.Doc())

--- a/app/ydoc-shared/src/ast/parse.ts
+++ b/app/ydoc-shared/src/ast/parse.ts
@@ -538,7 +538,7 @@ export function setExternalIds(edit: MutableModule, spans: SpanMap, ids: IdMap):
 export function parseInSameContext(
   code: string,
   ast: Ast,
-  { module }: { module?: MutableModule } = {},
+  module?: MutableModule,
 ): { root: Owned; spans: SpanMap } {
   const rawParsed = rawParseInContext(code, getParseContext(ast))
   return abstract(module ?? MutableModule.Transient(), rawParsed, code)

--- a/app/ydoc-shared/src/ast/parse.ts
+++ b/app/ydoc-shared/src/ast/parse.ts
@@ -536,12 +536,12 @@ export function setExternalIds(edit: MutableModule, spans: SpanMap, ids: IdMap):
  * context.
  */
 export function parseInSameContext(
-  module: MutableModule,
   code: string,
   ast: Ast,
+  { module }: { module?: MutableModule } = {},
 ): { root: Owned; spans: SpanMap } {
   const rawParsed = rawParseInContext(code, getParseContext(ast))
-  return abstract(module, rawParsed, code)
+  return abstract(module ?? MutableModule.Transient(), rawParsed, code)
 }
 
 type ParseContext = 'module' | 'block' | 'expression' | 'statement'


### PR DESCRIPTION
### Pull Request Description

Fix performance issue reported by @JaroslavTulach on Discord.

- Fix accumulation of unreferenced AST objects when reconciling module content with `syncToCode`.
- Add a unit test checking that `syncToCode` does not allocate unneeded objects in the module.

Fixes #10768.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
