### PR TITLE
Add import field to metadata to satisfy older versions

### DIFF
--- a/app/ydoc-server/src/edits.ts
+++ b/app/ydoc-server/src/edits.ts
@@ -76,7 +76,11 @@ export function applyDocumentUpdates(
   if (codeChanged || idsChanged || metadataChanged) {
     // Update the metadata object.
     // Depth-first key order keeps diffs small.
-    newMetadata = { node: {}, widget: {} }
+    newMetadata = {
+      node: {},
+      widget: {},
+      import: {}, // "import" is required by older versions (even though they don't use it)
+    }
     root.visitRecursive(ast => {
       let pos = ast.nodeMetadata.get('position')
       const vis = ast.nodeMetadata.get('visualization')

--- a/app/ydoc-server/src/languageServerSession.ts
+++ b/app/ydoc-server/src/languageServerSession.ts
@@ -349,7 +349,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
       // @ts-expect-error This is SAFE. `this.state` is only `readonly` to ensure that
       // this is the only place where it is mutated.
       this.state = state
-      if (state === LsSyncState.Synchronized) this.trySyncRemoveUpdates()
+      if (state === LsSyncState.Synchronized) this.trySyncRemoteUpdates()
     } else {
       throw new Error('LsSync disposed')
     }
@@ -449,10 +449,10 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
     } else {
       this.updateToApply = update
     }
-    this.trySyncRemoveUpdates()
+    this.trySyncRemoteUpdates()
   }
 
-  trySyncRemoveUpdates() {
+  trySyncRemoteUpdates() {
     if (this.updateToApply == null) return
     // apply updates to the ls-representation doc if we are already in sync with the LS.
     if (!this.inState(LsSyncState.Synchronized)) return


### PR DESCRIPTION
### Pull Request Description

Fixes #11742

I was [wrong](https://github.com/enso-org/enso/issues/11742#issuecomment-2514109015) - not the _new_ fields make metadata broken for older versions, but removing an _old_ field. 

This PR bring it back, which solves the issue - for a while.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
