### PR TITLE
Project Manager fails to create directory when one exists

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/BlockingFileSystem.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/BlockingFileSystem.scala
@@ -73,7 +73,10 @@ class BlockingFileSystem[F[+_, +_]: Sync: ErrorChannel](
   /** @inheritdoc */
   override def createDir(path: File): F[FileSystemFailure, Unit] =
     Sync[F]
-      .blockingOp { FileUtils.forceMkdir(path) }
+      .blockingOp {
+        if (path.exists()) throw new FileExistsException()
+        FileUtils.forceMkdir(path)
+      }
       .mapError(toFsFailure)
       .timeoutFail(OperationTimeout)(ioTimeout)
 

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/service/filesystem/FileSystemServiceSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/service/filesystem/FileSystemServiceSpec.scala
@@ -110,6 +110,29 @@ class FileSystemServiceSpec
       FileUtils.deleteQuietly(directoryPath)
     }
 
+    "create directory fail when one exists with the same name" in {
+      val testDir = testStorageConfig.userProjectsPath
+
+      val directoryName = "filesystem_test_create_dir_with_same_name"
+      val directoryPath = new File(testDir, directoryName)
+
+      val result1 = fileSystemService
+        .createDirectory(directoryPath)
+        .unsafeRunSync()
+
+      result1 shouldEqual Right(())
+      Files.isDirectory(directoryPath.toPath) shouldEqual true
+
+      val result2 = fileSystemService
+        .createDirectory(directoryPath)
+        .unsafeRunSync()
+
+      result2.isLeft shouldEqual true
+
+      // cleanup
+      FileUtils.deleteQuietly(directoryPath)
+    }
+
     "delete directory" in {
       implicit val client: WsTestClient = new WsTestClient(address)
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #11758 

Changelog:
- update: FileSystemService fails to create directory if one exists

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
