### PR TITLE
Avoid storing 0.0.0-dev into package.yaml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -970,7 +970,8 @@ lazy val pkg = (project in file("lib/scala/pkg"))
       (`editions` / Compile / exportedModule).value,
       (`semver` / Compile / exportedModule).value,
       (`scala-yaml` / Compile / exportedModule).value,
-      (`scala-libs-wrapper` / Compile / exportedModule).value
+      (`scala-libs-wrapper` / Compile / exportedModule).value,
+      (`version-output` / Compile / exportedModule).value
     )
   )
   .dependsOn(editions)

--- a/lib/scala/pkg/src/main/java/module-info.java
+++ b/lib/scala/pkg/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module org.enso.pkg {
   requires org.apache.commons.compress;
   requires org.enso.editions;
   requires org.enso.semver;
+  requires org.enso.version.output;
   requires org.enso.scala.yaml;
   // For io.circe
   requires org.enso.scala.wrapper;

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -114,7 +114,16 @@ case class Config(
 
   /** Converts the configuration into a YAML representation. */
   def toYaml: String = {
-    val node          = implicitly[YamlEncoder[Config]].encode(this)
+    val config: Config = this
+    val noDevEdition: Config =
+      if (
+        config.edition.isDefined && config.edition.get.parent.get.toString == "0.0.0-dev"
+      ) {
+        config.copy(edition = None)
+      } else {
+        config
+      }
+    val node          = implicitly[YamlEncoder[Config]].encode(noDevEdition)
     val dumperOptions = new DumperOptions()
     dumperOptions.setIndent(2)
     dumperOptions.setPrettyFlow(true)

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -5,6 +5,7 @@ import org.enso.semver.SemVer
 import org.enso.editions.{EditionName, Editions}
 import org.enso.pkg.validation.NameValidation
 import org.enso.scala.yaml.{YamlDecoder, YamlEncoder}
+import org.enso.version.BuildVersion
 import org.yaml.snakeyaml.{DumperOptions, Yaml}
 import org.yaml.snakeyaml.error.YAMLException
 import org.yaml.snakeyaml.nodes.{MappingNode, Node}
@@ -117,7 +118,10 @@ case class Config(
     val config: Config = this
     val noDevEdition: Config =
       if (
-        config.edition.exists(_.parent.exists(p => p.toString == "0.0.0-dev"))
+        config.edition.exists(
+          _.parent
+            .exists(p => p.toString == BuildVersion.defaultDevEnsoVersion())
+        )
       ) {
         config.copy(edition = None)
       } else {

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -117,9 +117,7 @@ case class Config(
     val config: Config = this
     val noDevEdition: Config =
       if (
-        config.edition
-          .filter(_.parent.filter(p => p.toString == "0.0.0-dev").isDefined)
-          .isDefined
+        config.edition.exists(_.parent.exists(p => p.toString == "0.0.0-dev"))
       ) {
         config.copy(edition = None)
       } else {

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -117,7 +117,9 @@ case class Config(
     val config: Config = this
     val noDevEdition: Config =
       if (
-        config.edition.isDefined && config.edition.get.parent.get.toString == "0.0.0-dev"
+        config.edition
+          .filter(_.parent.filter(p => p.toString == "0.0.0-dev").isDefined)
+          .isDefined
       ) {
         config.copy(edition = None)
       } else {

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -46,6 +46,26 @@ class ConfigSpec
       parsed.edition shouldBe empty
     }
 
+    "persist normal edition" in {
+      val parsed = Config.fromYaml("name: fooBar\nedition: 2024.4.2").get
+      parsed.name shouldEqual "fooBar"
+      parsed.normalizedName shouldEqual None
+      parsed.moduleName shouldEqual "FooBar"
+
+      val ser = parsed.toYaml
+      ser shouldEqual "name: fooBar\nnamespace: local\nedition: 2024.4.2\n"
+    }
+
+    "don't persist dev edition" in {
+      val parsed = Config.fromYaml("name: fooBar\nedition: 0.0.0-dev").get
+      parsed.name shouldEqual "fooBar"
+      parsed.normalizedName shouldEqual None
+      parsed.moduleName shouldEqual "FooBar"
+
+      val ser = parsed.toYaml
+      ser shouldEqual "name: fooBar\nnamespace: local\n"
+    }
+
     "correctly de-serialize and serialize back the shortened edition syntax " +
     "if there are no overrides" in {
       val config =


### PR DESCRIPTION
### Pull Request Description

Storing `0.0.0-dev` into `package.yaml` makes little sense:
- no two _development version_ are the same
- there is no way to _download_ `0.0.0-dev` version via `ensoup`
- regular releases refuse to process `0.0.0-dev` projects

Better to avoid storing such _development version_ at all.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Unit tests have been written where possible.
