### PR TITLE
Including opencv native libraries as resources in enso runner binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3620,6 +3620,7 @@ lazy val `engine-runner` = project
       ).distinct
       val stdLibsJars =
         `base-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+        `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
       core ++ stdLibsJars
     },

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -690,7 +690,13 @@ pub async fn runner_sanity_test(
             .run_ok()
             .await;
 
-        let all_cmds = test_base.and(test_internal_base).and(test_geo);
+        let test_image = Command::new(&enso)
+            .args(["--run", repo_root.test.join("Image_Tests").as_str()])
+            .set_env(ENSO_DATA_DIRECTORY, engine_package)?
+            .run_ok()
+            .await;
+
+        let all_cmds = test_base.and(test_internal_base).and(test_geo).and(test_image);
 
         // The following test does not actually run anything, it just checks if the engine
         // can accept `--jvm` argument and evaluates something.

--- a/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
+++ b/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
@@ -12,10 +12,17 @@ import org.enso.pkg.PackageManager$;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
 
 public final class EnsoLibraryFeature implements Feature {
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
+    try {
+      registerOpenCV(access.getApplicationClassLoader());
+    } catch (ReflectiveOperationException ex) {
+      ex.printStackTrace();
+      throw new IllegalStateException(ex);
+    }
     var libs = new LinkedHashSet<Path>();
     for (var p : access.getApplicationClassPath()) {
       var p1 = p.getParent();
@@ -94,5 +101,35 @@ public final class EnsoLibraryFeature implements Feature {
       System.err.println("  " + className);
     }
     System.err.println("Registered " + classes.size() + " classes for reflection");
+  }
+
+  private static void registerOpenCV(ClassLoader cl) throws ReflectiveOperationException {
+    var moduleOpenCV = cl.getUnnamedModule();
+    var currentOS = System.getProperty("os.name").toUpperCase().replace(" ", "");
+
+    var libOpenCV =
+        switch (currentOS) {
+          case "LINUX" -> "nu/pattern/opencv/linux/x86_64/libopencv_java470.so";
+          case "WINDOWS" -> "nu/pattern/opencv/windows/x86_64/opencv_java470.dll";
+          case "MACOSX" -> {
+            var arch = System.getProperty("os.arch").toUpperCase();
+            yield switch (arch) {
+              case "X86_64" -> "nu/pattern/opencv/osx/x86_64/libopencv_java470.dylib";
+              case "AARCH64" -> "nu/pattern/opencv/osx/ARMv8/libopencv_java470.dylib";
+              default -> null;
+            };
+          }
+          default -> null;
+        };
+
+    if (libOpenCV != null) {
+      var verify = cl.getResource(libOpenCV);
+      if (verify == null) {
+        throw new IllegalStateException("Cannot find " + libOpenCV + " resource in " + cl);
+      }
+      RuntimeResourceAccess.addResource(moduleOpenCV, libOpenCV);
+    } else {
+      throw new IllegalStateException("No resource suggested for " + currentOS);
+    }
   }
 }

--- a/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
+++ b/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
@@ -105,13 +105,13 @@ public final class EnsoLibraryFeature implements Feature {
 
   private static void registerOpenCV(ClassLoader cl) throws ReflectiveOperationException {
     var moduleOpenCV = cl.getUnnamedModule();
-    var currentOS = System.getProperty("os.name").toUpperCase().replace(" ", "");
+    var currentOS = System.getProperty("os.name").toUpperCase().replaceAll(" .*$", "");
 
     var libOpenCV =
         switch (currentOS) {
           case "LINUX" -> "nu/pattern/opencv/linux/x86_64/libopencv_java470.so";
           case "WINDOWS" -> "nu/pattern/opencv/windows/x86_64/opencv_java470.dll";
-          case "MACOSX" -> {
+          case "MAC" -> {
             var arch = System.getProperty("os.arch").toUpperCase();
             yield switch (arch) {
               case "X86_64" -> "nu/pattern/opencv/osx/x86_64/libopencv_java470.dylib";

--- a/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/resource-config.json
+++ b/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/resource-config.json
@@ -5,14 +5,6 @@
   }, {
     "pattern":"\\QMETA-INF/org/enso/interpreter/node/expression/builtin/BuiltinMethods.metadata\\E"
   }, {
-    "pattern":"\\Qnu/pattern/opencv/linux/x86_64/libopencv_java470.so\\E"
-  }, {
-    "pattern":"\\Qnu/pattern/opencv/windows/x86_64/opencv_java470.dll\\E"
-  }, {
-    "pattern":"\\Qnu/pattern/opencv/osx/x86_64/libopencv_java470.dylib\\E"
-  }, {
-    "pattern":"\\Qnu/pattern/opencv/osx/ARMv8/libopencv_java470.dylib\\E"
-  }, {
     "pattern":"\\QMETA-INF/org/enso/interpreter/node/expression/builtin/BuiltinTypes.metadata\\E"
   }, {
     "pattern":"\\QMETA-INF/services/ch.qos.logback.classic.spi.Configurator\\E"

--- a/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/resource-config.json
+++ b/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/resource-config.json
@@ -5,6 +5,14 @@
   }, {
     "pattern":"\\QMETA-INF/org/enso/interpreter/node/expression/builtin/BuiltinMethods.metadata\\E"
   }, {
+    "pattern":"\\Qnu/pattern/opencv/linux/x86_64/libopencv_java470.so\\E"
+  }, {
+    "pattern":"\\Qnu/pattern/opencv/windows/x86_64/opencv_java470.dll\\E"
+  }, {
+    "pattern":"\\Qnu/pattern/opencv/osx/x86_64/libopencv_java470.dylib\\E"
+  }, {
+    "pattern":"\\Qnu/pattern/opencv/osx/ARMv8/libopencv_java470.dylib\\E"
+  }, {
     "pattern":"\\QMETA-INF/org/enso/interpreter/node/expression/builtin/BuiltinTypes.metadata\\E"
   }, {
     "pattern":"\\QMETA-INF/services/ch.qos.logback.classic.spi.Configurator\\E"


### PR DESCRIPTION
### Pull Request Description

`test/Image_Tests` can now be executed in _native image_ mode of `enso` runner. All that's needed is to include (the right) _native_libraries_ present in `opencv-4.7.0-0.jar` as resources in the _native image binary_. This is another step in the #10121 quest.

### Important Notes

- originally (with 60269cd91ce70066c98ca64a46988d014b105a5f) the size of ` bin/enso` executable went up too much - e.g. from ~**200MB** to 441MB 
- the size bloat was caused by the same problem as #11483
- we don't want to fix _native binaries_ for all the platforms when building executable for a single OS and architecture
- by [selecting just the right lib](https://github.com/enso-org/enso/pull/11807#issuecomment-2527023557) we go down to **265MB**
- given the `libopencv.so` has ~65MB itself, it seems natural the binary grew by such amount
- of course with #11483 we would do even better: the `bin/enso` executable would stay ~200MB and it would load the 65MB `libopencv.so` from `lib/Standard/Base/polyglot/lib/linux/amd64/libopencv.so`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] Unit tests have been written where possible.
