### PR TITLE
Fill in `ydoc-polyfill` when running backend with the IDE

### DIFF
--- a/app/ydoc-server-polyglot/src/main.ts
+++ b/app/ydoc-server-polyglot/src/main.ts
@@ -1,8 +1,8 @@
 import { configureAllDebugLogs, docName, setupGatewayClient } from 'ydoc-server'
 
-const host = YDOC_HOST ?? 'localhost'
-const port = YDOC_PORT ?? 1234
-const debug = YDOC_LS_DEBUG ?? false
+const host = typeof YDOC_HOST == 'string' ? YDOC_HOST : 'localhost'
+const port = typeof YDOC_PORT == 'number' ? YDOC_PORT : 1234
+const debug = typeof YDOC_LS_DEBUG != 'undefined'
 
 configureAllDebugLogs(debug)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2650,6 +2650,9 @@ lazy val `runtime-language-epb` =
         "org.graalvm.sdk"      % "collections" % graalMavenPackagesVersion,
         "org.graalvm.sdk"      % "word"        % graalMavenPackagesVersion,
         "org.graalvm.sdk"      % "nativeimage" % graalMavenPackagesVersion
+      ),
+      Compile / internalModuleDependencies := Seq(
+        (`ydoc-polyfill` / Compile / exportedModule).value
       )
     )
 

--- a/engine/runtime-language-epb/src/main/java/module-info.java
+++ b/engine/runtime-language-epb/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 open module org.enso.runtime.language.epb {
   requires java.logging;
   requires org.graalvm.truffle;
+  requires org.enso.ydoc.polyfill;
 
   provides com.oracle.truffle.api.provider.TruffleLanguageProvider with
       org.enso.interpreter.epb.EpbLanguageProvider;

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/ForeignEvalNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/ForeignEvalNode.java
@@ -108,6 +108,8 @@ final class ForeignEvalNode extends RootNode {
     var context = EpbContext.get(this);
     var inner = context.getInnerContext();
     if (inner != null) {
+      context.initializePolyfill(this, inner);
+
       var code = foreignSource(langAndCode);
       var args = Arrays.stream(argNames).collect(Collectors.joining(","));
       var wrappedSrc = "var poly_enso_eval=function(" + args + "){" + code + "\n};poly_enso_eval";

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/Polyfill.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/Polyfill.java
@@ -1,8 +1,0 @@
-package org.enso.ydoc;
-
-import org.graalvm.polyglot.Context;
-
-public interface Polyfill {
-
-  void initialize(Context ctx);
-}

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/ParserPolyfill.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/ParserPolyfill.java
@@ -1,15 +1,14 @@
 package org.enso.ydoc.polyfill;
 
+import java.net.URL;
+import java.util.function.Function;
 import org.enso.syntax2.Parser;
-import org.enso.ydoc.Polyfill;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class ParserPolyfill implements ProxyExecutable, Polyfill {
+public final class ParserPolyfill implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(ParserPolyfill.class);
 
@@ -22,12 +21,9 @@ public final class ParserPolyfill implements ProxyExecutable, Polyfill {
 
   public ParserPolyfill() {}
 
-  @Override
-  public void initialize(Context ctx) {
-    Source parserJs =
-        Source.newBuilder("js", ParserPolyfill.class.getResource(PARSER_JS)).buildLiteral();
-
-    ctx.eval(parserJs).execute(this);
+  final void initialize(Function<URL, Value> eval) {
+    var fn = eval.apply(ParserPolyfill.class.getResource(PARSER_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/ParserPolyfill.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/ParserPolyfill.java
@@ -1,8 +1,8 @@
 package org.enso.ydoc.polyfill;
 
-import java.net.URL;
-import java.util.function.Function;
 import org.enso.syntax2.Parser;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
@@ -21,9 +21,11 @@ public final class ParserPolyfill implements ProxyExecutable {
 
   public ParserPolyfill() {}
 
-  final void initialize(Function<URL, Value> eval) {
-    var fn = eval.apply(ParserPolyfill.class.getResource(PARSER_JS));
-    fn.execute(this);
+  public void initialize(Context ctx) {
+    Source parserJs =
+        Source.newBuilder("js", ParserPolyfill.class.getResource(PARSER_JS)).buildLiteral();
+
+    ctx.eval(parserJs).execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/AbortController.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/AbortController.java
@@ -1,9 +1,7 @@
 package org.enso.ydoc.polyfill.web;
 
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
@@ -14,17 +12,14 @@ import org.slf4j.LoggerFactory;
  * href="https://nodejs.org/api/globals.html#class-abortcontroller">AbortController</a> Node.js
  * interface.
  */
-final class AbortController implements Polyfill, ProxyExecutable {
+final class AbortController implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(AbortController.class);
   private static final String ABORT_CONTROLLER_JS = "abort-controller.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource =
-        Source.newBuilder("js", getClass().getResource(ABORT_CONTROLLER_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(ABORT_CONTROLLER_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Crypto.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Crypto.java
@@ -1,17 +1,15 @@
 package org.enso.ydoc.polyfill.web;
 
 import java.util.UUID;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Implements the <a href="https://nodejs.org/api/crypto.html">Crypto</a> Node.js interface. */
-final class Crypto implements Polyfill, ProxyExecutable {
+final class Crypto implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(Crypto.class);
 
@@ -19,11 +17,10 @@ final class Crypto implements Polyfill, ProxyExecutable {
 
   private static final String CRYPTO_JS = "crypto.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource = Source.newBuilder("js", getClass().getResource(CRYPTO_JS)).buildLiteral();
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(CRYPTO_JS));
 
-    ctx.eval(jsSource).execute(this);
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventEmitter.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventEmitter.java
@@ -4,10 +4,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
@@ -17,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * Implements the <a href="https://nodejs.org/api/events.html#class-eventemitter">EventEmitter</a>
  * Node.js interface.
  */
-final class EventEmitter implements Polyfill, ProxyExecutable {
+final class EventEmitter implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(EventEmitter.class);
 
@@ -29,12 +27,9 @@ final class EventEmitter implements Polyfill, ProxyExecutable {
 
   private static final String EVENT_EMITTER_JS = "event-emitter.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource =
-        Source.newBuilder("js", getClass().getResource(EVENT_EMITTER_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(EVENT_EMITTER_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
@@ -3,10 +3,8 @@ package org.enso.ydoc.polyfill.web;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
@@ -16,7 +14,7 @@ import org.slf4j.LoggerFactory;
  * Implements the <a href="https://nodejs.org/api/events.html#class-eventtarget">EventTarget</a>
  * Node.js interface.
  */
-final class EventTarget implements Polyfill, ProxyExecutable {
+final class EventTarget implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(EventTarget.class);
 
@@ -28,12 +26,9 @@ final class EventTarget implements Polyfill, ProxyExecutable {
 
   private static final String EVENT_TARGET_JS = "event-target.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource =
-        Source.newBuilder("js", getClass().getResource(EVENT_TARGET_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(EVENT_TARGET_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Performance.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Performance.java
@@ -1,9 +1,7 @@
 package org.enso.ydoc.polyfill.web;
 
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
@@ -13,7 +11,7 @@ import org.slf4j.LoggerFactory;
  * Implements the <a href="https://nodejs.org/api/perf_hooks.html">Performance measurement</a>
  * Node.js API.
  */
-final class Performance implements Polyfill, ProxyExecutable {
+final class Performance implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(Performance.class);
 
@@ -21,12 +19,9 @@ final class Performance implements Polyfill, ProxyExecutable {
 
   private static final String PERFORMANCE_JS = "performance.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource =
-        Source.newBuilder("js", getClass().getResource(PERFORMANCE_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(PERFORMANCE_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Timers.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Timers.java
@@ -3,17 +3,15 @@ package org.enso.ydoc.polyfill.web;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Implements the <a href="https://nodejs.org/api/timers.html">Timers</a> Node.js API. */
-final class Timers implements Polyfill, ProxyExecutable {
+final class Timers implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(Timers.class);
 
@@ -34,11 +32,9 @@ final class Timers implements Polyfill, ProxyExecutable {
     this.executor = executor;
   }
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource = Source.newBuilder("js", getClass().getResource(TIMERS_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(TIMERS_JS));
+    fn.execute(this);
   }
 
   private Future<?> setTimeout(Value func, long delay, Object[] args) {

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Util.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Util.java
@@ -3,10 +3,8 @@ package org.enso.ydoc.polyfill.web;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.ByteSequence;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
@@ -14,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Implements the <a href="https://nodejs.org/api/util.html">Util</a> Node.js API. */
-final class Util implements Polyfill, ProxyExecutable {
+final class Util implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(Util.class);
 
@@ -23,11 +21,9 @@ final class Util implements Polyfill, ProxyExecutable {
 
   private static final String UTIL_JS = "util.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource = Source.newBuilder("js", getClass().getResource(UTIL_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(UTIL_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
@@ -17,10 +17,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import org.enso.ydoc.Polyfill;
+import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.ByteSequence;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
@@ -31,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * Implements the WebSocket and WebSocketServer interfaces of the <a
  * href="https://www.npmjs.com/package/ws">ws</a> NPM package.
  */
-final class WebSocket implements Polyfill, ProxyExecutable {
+final class WebSocket implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(WebSocket.class);
 
@@ -54,11 +52,9 @@ final class WebSocket implements Polyfill, ProxyExecutable {
     this.executor = executor;
   }
 
-  @Override
-  public void initialize(Context ctx) {
-    Source jsSource = Source.newBuilder("js", getClass().getResource(WEBSOCKET_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(WEBSOCKET_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Zlib.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/Zlib.java
@@ -6,12 +6,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.function.Function;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterOutputStream;
-import org.enso.ydoc.Polyfill;
 import org.enso.ydoc.polyfill.Arguments;
-import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.ByteSequence;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
@@ -19,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Implements the <a href="https://nodejs.org/api/zlib.html">Zlib</a> Node.js interface. */
-final class Zlib implements Polyfill, ProxyExecutable {
+final class Zlib implements ProxyExecutable {
 
   private static final Logger log = LoggerFactory.getLogger(Zlib.class);
 
@@ -33,11 +31,9 @@ final class Zlib implements Polyfill, ProxyExecutable {
 
   private static final String ZLIB_JS = "zlib.js";
 
-  @Override
-  public void initialize(Context ctx) {
-    final var jsSource = Source.newBuilder("js", getClass().getResource(ZLIB_JS)).buildLiteral();
-
-    ctx.eval(jsSource).execute(this);
+  final void initialize(Function<java.net.URL, Value> eval) {
+    var fn = eval.apply(getClass().getResource(ZLIB_JS));
+    fn.execute(this);
   }
 
   @Override

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ExecutorSetup.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ExecutorSetup.java
@@ -5,6 +5,10 @@ import static org.junit.Assert.fail;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
 import org.junit.After;
 import org.junit.Before;
 
@@ -27,5 +31,12 @@ public abstract class ExecutorSetup {
         fail("Pending " + pending.size() + " tasks: " + pending);
       }
     }
+  }
+
+  protected final Function<java.net.URL, Value> eval(Context ctx) {
+    return (url) -> {
+      var src = Source.newBuilder("js", url).buildLiteral();
+      return ctx.eval(src);
+    };
   }
 }

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ParserPolyfillTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ParserPolyfillTest.java
@@ -26,7 +26,7 @@ public class ParserPolyfillTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  parser.initialize(ctx);
+                  parser.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ParserPolyfillTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/ParserPolyfillTest.java
@@ -26,7 +26,7 @@ public class ParserPolyfillTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  parser.initialize(eval(ctx));
+                  parser.initialize(ctx);
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/AbortControllerTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/AbortControllerTest.java
@@ -25,8 +25,8 @@ public class AbortControllerTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  eventTarget.initialize(ctx);
-                  abortController.initialize(ctx);
+                  eventTarget.initialize(eval(ctx));
+                  abortController.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/CryptoTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/CryptoTest.java
@@ -26,7 +26,7 @@ public class CryptoTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  crypto.initialize(ctx);
+                  crypto.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventEmitterTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventEmitterTest.java
@@ -25,8 +25,8 @@ public class EventEmitterTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  eventTarget.initialize(ctx);
-                  eventEmitter.initialize(ctx);
+                  eventTarget.initialize(eval(ctx));
+                  eventEmitter.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventTargetTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventTargetTest.java
@@ -24,7 +24,7 @@ public class EventTargetTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  eventTarget.initialize(ctx);
+                  eventTarget.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/PerformanceTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/PerformanceTest.java
@@ -24,7 +24,7 @@ public class PerformanceTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  eventTarget.initialize(ctx);
+                  eventTarget.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/TimersTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/TimersTest.java
@@ -34,7 +34,7 @@ public class TimersTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  timers.initialize(ctx);
+                  timers.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/UtilTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/UtilTest.java
@@ -25,7 +25,7 @@ public class UtilTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  encoding.initialize(ctx);
+                  encoding.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/ZlibTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/ZlibTest.java
@@ -28,7 +28,7 @@ public class ZlibTest extends ExecutorSetup {
         CompletableFuture.supplyAsync(
                 () -> {
                   var ctx = contextBuilder.build();
-                  zlib.initialize(ctx);
+                  zlib.initialize(eval(ctx));
                   return ctx;
                 },
                 executor)


### PR DESCRIPTION
### Pull Request Description

- Another step towards #11477
- Turns on `WebEnvironment` polyfill
- So GraalVM Insight scripts start Ydoc server

### Important Notes

To execute `ydoc.cjs` in the engine/ls when launched by `project-manager`:
```bash
enso$ sbt ydoc-server/test
enso$ export ENSO_JVM_OPTS=-Denso.dev.insight=`pwd`/lib/java/ydoc-server/target/classes/org/enso/ydoc/server/ydoc.cjs
enso$ sbt runProjectManagerDistribution
```
and launching IDE in another terminal as `corepack pnpm run dev:gui`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
- [x] Unit tests updated
- [x] Manually tested to work
