### PR TITLE
Fix required launcher version

### DIFF
--- a/distribution/manifest.template.yaml
+++ b/distribution/manifest.template.yaml
@@ -1,5 +1,5 @@
-minimum-launcher-version: 2024.5.1-rc1
-minimum-project-manager-version: 2024.5.1-rc1
+minimum-launcher-version: 2024.5.1-nightly.2024.11.29
+minimum-project-manager-version: 2024.5.1-nightly.2024.11.29
 jvm-options:
   - value: "-Dgraal.PrintGraph=Network"
   - value: "--add-opens=java.base/java.nio=ALL-UNNAMED"


### PR DESCRIPTION
### Pull Request Description

- When comparing pre-release version, the last part is compared lexicographically. In #11796, I did not consider that `rc` is a suffix that is 'larger' than `nightly` (because `r > n`).
- Now, we set this to a relatively recent nightly build.
- The self-upgrade mechanism will use the latest available build, so once the stable version is released it will be preferred.
- The project-manager should be working again because `2024.5.1-nightly.2024.12.10 > 2024.5.1-nightly.2024.11.29` and also `2024.5.1-rc1 > 2024.5.1-nightly.2024.11.29`.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
