### PR TITLE
Some more QA fixes

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -359,7 +359,7 @@ Text.match self pattern:Text|Regex=".*" case_sensitivity:Case_Sensitivity=..Sens
 Text.to_regex : Boolean -> Regex ! Regex_Syntax_Error | Illegal_Argument
 Text.to_regex self case_insensitive=False = Regex.compile self case_insensitive
 
-## ALIAS split text
+## ALIAS tokenize, parse
    GROUP Conversions
    ICON split
 
@@ -407,7 +407,7 @@ Text.split self delimiter="," case_sensitivity:Case_Sensitivity=..Sensitive use_
         if delimiter_is_singleton_vector then self.split delimiter=(delimiter.first) case_sensitivity=case_sensitivity use_regex=use_regex else
             case use_regex of
                 False ->
-                    delimiters = split_find_delimiters self delimiter case_sensitivity
+                    delimiters = _split_find_delimiters self delimiter case_sensitivity
                     Vector.new delimiters.length+1 i->
                         start = if i == 0 then 0 else
                             delimiters.at i-1 . codeunit_end
@@ -425,7 +425,8 @@ Text.split self delimiter="," case_sensitivity:Case_Sensitivity=..Sensitive use_
                         combined_delimiter = parenthesize (delimiter.map parenthesize . join '|')
                         self.split combined_delimiter case_sensitivity=case_sensitivity use_regex=True
 
-## ADVANCED
+## ALIAS split, parse, regex
+   ADVANCED
    GROUP Conversions
    ICON split
    Takes an input string and and a pattern and returns all the matches as a
@@ -452,6 +453,7 @@ Text.split self delimiter="," case_sensitivity:Case_Sensitivity=..Sensitive use_
 
         'Hello Big\r\nWide\tWorld\nGoodbye!' . tokenize "(\S+)(?:\s+|$)"
             == ["Hello","Big","Wide","World","Goodbye!"]
+@pattern Widget.Text_Input
 Text.tokenize : Text|Regex -> Case_Sensitivity -> Vector Text
 Text.tokenize self pattern:Text|Regex=(Missing_Argument.throw "pattern") case_sensitivity:Case_Sensitivity=..Sensitive =
     case_insensitive = case_sensitivity.is_case_insensitive_in_memory
@@ -1075,7 +1077,7 @@ Text.take self range:(Text_Sub_Range | Index_Sub_Range | Range | Integer)=..Firs
         Range.Between start end 1 ->
             Text_Utils.substring self start end
         Codepoint_Ranges.Value char_ranges _ ->
-            slice_text self char_ranges
+            _slice_text self char_ranges
 
 ## ALIAS remove, skip
    GROUP Selections
@@ -1130,7 +1132,7 @@ Text.drop self range:(Text_Sub_Range | Index_Sub_Range | Range | Integer)=..Firs
             sorted_char_ranges_to_remove = ranges.sorted_and_distinct_ranges
             char_length = Text_Utils.char_length self
             inverted = invert_range_selection sorted_char_ranges_to_remove char_length needs_sorting=False
-            slice_text self inverted
+            _slice_text self inverted
 
 ## ALIAS lower, proper, title, upper
    GROUP Text
@@ -1972,7 +1974,7 @@ Text.substring self start:Integer length:Integer=self.length =
    input's range.
 
    The input ranges are in UTF-16 code unit space.
-slice_text text char_ranges =
+private _slice_text text char_ranges =
     sb = StringBuilder.new
     char_ranges.map char_range->
        sb.append text char_range.start char_range.end
@@ -1981,8 +1983,8 @@ slice_text text char_ranges =
 ## PRIVATE
 
    Find occurrences of delimiters in a string.
-split_find_delimiters : Text -> Text | Vector Text  -> Case_Sensitivity -> Vector Text | Illegal_Argument
-split_find_delimiters input delimiter case_sensitivity =
+_split_find_delimiters : Text -> Text | Vector Text  -> Case_Sensitivity -> Vector Text | Illegal_Argument
+private _split_find_delimiters input delimiter case_sensitivity =
     Vector.from_polyglot_array <| case delimiter of
         _ : Text -> case case_sensitivity of
             Case_Sensitivity.Sensitive ->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -305,7 +305,7 @@ Text.find_all self pattern:Text|Regex=".*" case_sensitivity:Case_Sensitivity=..S
     compiled_pattern = Regex.compile pattern case_insensitive=case_insensitive
     compiled_pattern.match_all self
 
-## ALIAS check matches
+## ALIAS check matches, regex, like
    GROUP Text
    ICON preparation
 
@@ -334,6 +334,7 @@ Text.find_all self pattern:Text|Regex=".*" case_sensitivity:Case_Sensitivity=..S
              regex = ".+ct@.+"
              # Evaluates to true
              "CONTACT@enso.org".match regex Case_Sensitivity.Insensitive
+@pattern Widget.Text_Input
 Text.match : Text|Regex -> Case_Sensitivity -> Boolean ! Regex_Syntax_Error | Illegal_Argument
 Text.match self pattern:Text|Regex=".*" case_sensitivity:Case_Sensitivity=..Sensitive -> Boolean ! Regex_Syntax_Error | Illegal_Argument =
     case_insensitive = case_sensitivity.is_case_insensitive_in_memory

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -165,7 +165,8 @@ type Regex
     find_all self (input : Text) =
        self.match_all input . map match_to_group_maybe
 
-    ## GROUP Conversions
+    ## ALIAS tokenize, parse
+       GROUP Conversions
        ICON split
        Splits the `input` text based on the pattern described by `self`.
 
@@ -209,7 +210,8 @@ type Regex
                     builder.append filler.text
             go it.next
 
-    ## GROUP Conversions
+    ## ALIAS split, parse
+       GROUP Conversions
        ICON split
        Takes an input string and returns all the matches as a `Vector Text`.
        If the pattern contains marked groups, the values are concatenated
@@ -235,7 +237,7 @@ type Regex
              Regex.compile '(\S+)(?:\s+|$)' . tokenize 'Hello Big\r\nWide\tWorld\nGoodbye!'
                  == ['Hello','Big','Wide','World','Goodbye!']
     tokenize : Text -> Vector Text
-    tokenize self input =
+    tokenize self input:Text =
         self.match_all input . map (build_tokenization_output_from_match self _)
 
     ## GROUP Text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -91,9 +91,7 @@ export project.Data.Text.Extensions.repeat
 export project.Data.Text.Extensions.replace
 export project.Data.Text.Extensions.reverse
 export project.Data.Text.Extensions.second
-export project.Data.Text.Extensions.slice_text
 export project.Data.Text.Extensions.split
-export project.Data.Text.Extensions.split_find_delimiters
 export project.Data.Text.Extensions.starts_with
 export project.Data.Text.Extensions.substring
 export project.Data.Text.Extensions.take

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1546,7 +1546,8 @@ type DB_Column
             if self.connection.dialect.is_operation_supported operator then self.make_binary_op operator what new_name else
                 Error.throw (Unsupported_Database_Operation.Error ("`trim "+where.to_text+"`"))
 
-    ## GROUP Standard.Base.Text
+    ## ALIAS regex, substitute
+       GROUP Standard.Base.Text
        ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row. If `term` is empty, the function returns the table unchanged.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -906,7 +906,7 @@ type DB_Table
                         associated_selector = element.associated_selector
                         self.connection.dialect.prepare_order_descriptor column associated_selector.direction text_ordering=Nothing
                     True -> case self.default_ordering of
-                        Nothing -> Error.throw (Illegal_Argument.Error "No `order_by` is specified and the table has no existing ordering (e.g. from an `order_by` operation or a primary key). Some ordering is required for `add_row_number` in Database tables.")
+                        Nothing -> Error.throw (Illegal_Argument.Error "The table has no existing ordering (e.g. from a `sort` operation or primary key). `add_row_number` requires an ordering in database.")
                         descriptors -> descriptors
                 grouping_expressions = (grouping_columns.map _.as_internal).map .expression
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -1417,7 +1417,8 @@ type DB_Table
         _ = [columns, case_sensitivity, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "duplicates")
 
-    ## GROUP Standard.Base.Calculations
+    ## ALIAS merge, xlookup, vlookup, hlookup, lookup
+       GROUP Standard.Base.Calculations
        ICON join
        Joins two tables according to the specified join conditions.
 
@@ -1609,7 +1610,7 @@ type DB_Table
             on_problems.attach_problems_before limit_problems <|
                 self.join_or_cross_join right join_kind=Join_Kind_Cross on=[] right_prefix on_problems
 
-    ## ALIAS lookup
+    ## ALIAS join, xlookup, vlookup, hlookup, lookup
        GROUP Standard.Base.Calculations
        ICON join
        Merges this table with a lookup table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2912,7 +2912,8 @@ type DB_Table
         transformer col = col.fill_empty resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
-    ## GROUP Standard.Base.Text
+    ## ALIAS regex, substitute
+       GROUP Standard.Base.Text
        ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row of the specified column. If `term` is empty, the function returns the

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2309,7 +2309,8 @@ type DB_Table
         _ = [columns, format, locale, error_on_missing_columns, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "format")
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS tokenize, parse
+       GROUP Standard.Base.Conversions
        ICON split
        Splits a column of text into a set of new columns.
        The original column will be removed from the table.
@@ -2334,7 +2335,8 @@ type DB_Table
         _ = [column, delimiter, column_count.columns_to_split, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "split_to_columns")
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS tokenize, parse
+       GROUP Standard.Base.Conversions
        ICON split
        Splits a column of text into a set of new rows.
        The values of other columns are repeated for the new rows.
@@ -2349,7 +2351,8 @@ type DB_Table
         _ = [column, delimiter]
         Error.throw (Unsupported_Database_Operation.Error "split_to_rows")
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, parse, regex
+       GROUP Standard.Base.Conversions
        ICON split
        Tokenizes a column of text into a set of new columns using a regular
        expression.
@@ -2377,7 +2380,8 @@ type DB_Table
         _ = [column, pattern, case_sensitivity, column_count, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "tokenize_to_columns")
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, parse, regex
+       GROUP Standard.Base.Conversions
        ICON split
        Tokenizes a column of text into a set of new rows using a regular
        expression.
@@ -2399,7 +2403,8 @@ type DB_Table
         _ = [column, pattern, case_sensitivity, at_least_one_row]
         Error.throw (Unsupported_Database_Operation.Error "tokenize_to_rows")
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, tokenize, regex
+       GROUP Standard.Base.Conversions
        ICON split
        Converts a Text column into new columns using a regular expression
        pattern.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -1436,7 +1436,8 @@ type Column
             mapped = self_vec.map_with_index i->t-> trim_fn t (trim_get i)
             Column.from_vector new_name mapped
 
-    ## GROUP Standard.Base.Text
+    ## ALIAS regex, substitute
+       GROUP Standard.Base.Text
        ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row. If `term` is empty, the function returns the column unchanged.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -94,11 +94,11 @@ make_column_name_multi_selector table display:Display=..Always add_regex:Boolean
 
 ## PRIVATE
    Make a column reference by name selector.
-make_column_ref_by_name_selector table display:Display=..Always add_text:Boolean=False add_regex:Boolean=False add_number:Boolean=False add_boolean:Boolean=False add_named_pattern:Boolean=False add_date:Boolean=False add_time:Boolean=False add_date_time:Boolean=False add_nothing:Boolean=False =
+make_column_ref_by_name_selector table display:Display=..Always add_text:Boolean=False add_regex:Boolean=False add_number:Boolean=False add_boolean:Boolean=False add_named_pattern:Boolean=False add_date:Boolean=False add_time:Boolean=False add_date_time:Boolean=False add_nothing:Boolean=False columns_first:Boolean=False =
     constants = make_any_selector add_text=add_text add_regex=add_regex add_named_pattern=add_named_pattern add_number=add_number add_boolean=add_boolean add_date=add_date add_time=add_time add_date_time=add_date_time add_nothing=add_nothing . values
     expression = if table.is_nothing then [] else [Option "<Expression>" "(expr '["+table.column_names.first+"]')"]
     col_names = if table.is_nothing then [] else table.column_names.map (name -> Option name "(..Name "+name.pretty+")")
-    values = constants + expression + col_names
+    values = if columns_first then col_names + constants + expression else constants + expression + col_names
     Single_Choice values=values display=display
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
@@ -68,7 +68,6 @@ type Simple_Expression
        Create a widget for operation
     default_widget table:Table_Ref display:Display=..Always -> Widget =
         with_everything = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True add_date=True add_time=True add_date_time=True add_nothing=True
-        with_all_types = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True add_date=True add_time=True add_date_time=True
         with_number_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True
         filter_cond = Widget_Helpers.make_filter_condition_selector table
 
@@ -87,8 +86,10 @@ type Simple_Expression
         ## Constants
         constants = make_any_selector add_text=True add_number=True add_boolean=True add_date=True add_time=True add_date_time=True . values
         expression = Option "<Expression>" "(expr '["+table.column_names.first+"]')"
-        derived = Option "<Simple Expression>" "..Simple_Expr" [["input", with_all_types], ["operation", Single_Choice options]]
-        Single_Choice constants+[expression, derived] display=display
+
+        input_column = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True add_date=True add_time=True add_date_time=True columns_first=True
+        derived = Option "<Simple Expression>" "..Simple_Expr" [["input", input_column], ["operation", Single_Choice options]]
+        Single_Choice [derived, expression]+constants display=display
 
 ## Defines a set of Text based operations.
 type Text_Operation

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -3544,7 +3544,8 @@ type Table
         transformer col = col.fill_empty resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
-    ## GROUP Standard.Base.Text
+    ## ALIAS regex, substitute
+       GROUP Standard.Base.Text
        ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row of the specified column. If `term` is empty, the function returns the

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1853,7 +1853,8 @@ type Table
         Warning.attach (Deprecated.Warning "Standard.Table.Table.Table" "auto_value_types" "Deprecated: `auto_value_types` has been replaced by `auto_cast`.") <|
             self.auto_cast columns shrink_types error_on_missing_columns on_problems
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS tokenize, parse
+       GROUP Standard.Base.Conversions
        ICON split
        Creates a new table by splitting the chosen column of text, by the
        specified delimiter into a set of new columns. The original column will
@@ -1883,7 +1884,8 @@ type Table
     split_to_columns self column delimiter="," (column_count : Columns_To_Add = ..All_Columns) on_problems:Problem_Behavior=..Report_Warning =
         Split_Tokenize.split_to_columns self column delimiter column_count=column_count on_problems
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS tokenize, parse
+       GROUP Standard.Base.Conversions
        ICON split
        Creates a new table by splitting the chosen column of text, by the
        specified delimiter into a set of new rows.
@@ -1902,7 +1904,8 @@ type Table
     split_to_rows self column delimiter="," =
         Split_Tokenize.split_to_rows self column delimiter
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, parse, regex
+       GROUP Standard.Base.Conversions
        ICON split
 
        Creates a new Table with the chosen column of Text split by the `pattern`
@@ -1934,7 +1937,8 @@ type Table
     tokenize_to_columns self column pattern="." case_sensitivity:Case_Sensitivity=..Sensitive (column_count : Columns_To_Add = ..All_Columns) on_problems:Problem_Behavior=..Report_Warning =
         Split_Tokenize.tokenize_to_columns self column pattern case_sensitivity column_count on_problems
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, parse, regex
+       GROUP Standard.Base.Conversions
        ICON split
 
        Creates a new Table with the chosen column of Text split by the `pattern`
@@ -1962,7 +1966,8 @@ type Table
     tokenize_to_rows self column pattern="." case_sensitivity:Case_Sensitivity=..Sensitive at_least_one_row:Boolean=False =
         Split_Tokenize.tokenize_to_rows self column pattern case_sensitivity at_least_one_row
 
-    ## GROUP Standard.Base.Conversions
+    ## ALIAS split, tokenize, regex
+       GROUP Standard.Base.Conversions
        ICON split
        Converts a Text column into new columns using a regular expression
        pattern.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2536,7 +2536,8 @@ type Table
         if self.row_count == 0 then Error.throw (Index_Out_Of_Bounds.Error 0 0) else
             Row.Value self (self.row_count-1)
 
-    ## GROUP Standard.Base.Calculations
+    ## ALIAS merge, xlookup, vlookup, hlookup, lookup
+       GROUP Standard.Base.Calculations
        ICON join
        Joins two tables according to the specified join conditions.
 
@@ -2673,7 +2674,7 @@ type Table
             self.java_table.join right.java_table java_conditions join_kind.to_java (columns_to_keep.at 0) (columns_to_keep.at 1) right_columns_to_drop right_prefix java_aggregator
         Table.Value new_java_table
 
-    ## ALIAS append, cartesian join
+    ## ALIAS append, cartesian
        GROUP Standard.Base.Calculations
        ICON join
        Joins tables by pairing every row of the left table with every row of the
@@ -2718,7 +2719,7 @@ type Table
                 self.java_table.crossJoin right.java_table right_prefix java_aggregator
             Table.Value new_java_table
 
-    ## ALIAS lookup
+    ## ALIAS join, xlookup, vlookup, hlookup, lookup
        GROUP Standard.Base.Calculations
        ICON join
        Merges this table with a lookup table

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Text.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Text.enso
@@ -59,4 +59,4 @@ get_chunk_from_line text chunk_size ix =
     end = (start + chunk_size).min upper_bound
     range = start.up_to end
     if start > text.length then Nothing else
-        slice_text text [range]
+        text.take range


### PR DESCRIPTION
### Pull Request Description

- Update error message for `order_by`.
- Add some ALIASes.
- Hide some internal methods exported by mistake.
- Reorder dropdown in set.
![image](https://github.com/user-attachments/assets/7e6df21a-8ab6-4e6c-90ff-826e88f7b53d)
![image](https://github.com/user-attachments/assets/215b3b74-5718-4033-9ec9-468695f942b5)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
