### PR TITLE
Fix clicking-out Component Browser

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser.vue
@@ -73,7 +73,6 @@ const cbRoot = ref<HTMLElement>()
 const componentList = ref<ComponentInstance<typeof ComponentList>>()
 
 const clickOutsideAssociatedElements = (e: PointerEvent) => {
-  console.log(props.associatedElements)
   return props.associatedElements.length === 0 ?
       false
     : props.associatedElements.every((element) => targetIsOutside(e, element))

--- a/app/gui/src/project-view/components/ComponentBrowser.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser.vue
@@ -72,9 +72,8 @@ const emit = defineEmits<{
 const cbRoot = ref<HTMLElement>()
 const componentList = ref<ComponentInstance<typeof ComponentList>>()
 
-defineExpose({ cbRoot })
-
 const clickOutsideAssociatedElements = (e: PointerEvent) => {
+  console.log(props.associatedElements)
   return props.associatedElements.length === 0 ?
       false
     : props.associatedElements.every((element) => targetIsOutside(e, element))

--- a/app/gui/src/project-view/components/DockPanel.vue
+++ b/app/gui/src/project-view/components/DockPanel.vue
@@ -24,8 +24,6 @@ const props = defineProps<{
 }>()
 
 const slideInPanel = ref<HTMLElement>()
-const root = ref<HTMLElement>()
-defineExpose({ root })
 
 const computedSize = useResizeObserver(slideInPanel)
 const computedBounds = computed(() => new Rect(Vec2.Zero, computedSize.value))
@@ -48,7 +46,7 @@ const tabStyle = {
 </script>
 
 <template>
-  <div ref="root" class="DockPanel" data-testid="rightDockRoot">
+  <div class="DockPanel" data-testid="rightDockRoot">
     <ToggleIcon
       v-model="show"
       :title="`Documentation Panel (${documentationEditorBindings.bindings.toggle.humanReadable})`"

--- a/app/gui/src/project-view/components/GraphEditor.vue
+++ b/app/gui/src/project-view/components/GraphEditor.vue
@@ -456,13 +456,10 @@ watch(
   },
 )
 
-const componentBrowser = ref()
-const docPanel = ref()
+const componentBrowser = ref<ComponentInstance<typeof ComponentBrowser>>()
+const docPanel = ref<ComponentInstance<typeof RightDockPanel>>()
 
-const componentBrowserElements = computed(() => [
-  componentBrowser.value?.cbRoot,
-  docPanel.value?.root,
-])
+const componentBrowserElements = computed(() => [componentBrowser.value?.$el, docPanel.value?.$el])
 
 // === Node Creation ===
 


### PR DESCRIPTION
### Pull Request Description

Fixes #11829

There was implicit `any` on refs, so the typechecker didn't catch missing property.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
