### PR TITLE
Refactor Storage.vectorizedOrFallbackBinaryMap to accept Value instea…

### DIFF
--- a/std-bits/base/src/main/java/org/enso/base/polyglot/NumericConverter.java
+++ b/std-bits/base/src/main/java/org/enso/base/polyglot/NumericConverter.java
@@ -33,6 +33,22 @@ public class NumericConverter {
     };
   }
 
+  public static double coerceToDouble(Value val) {
+    if (val.fitsInDouble()) {
+      return val.asDouble();
+    }
+    if (val.fitsInFloat()) {
+      return Float.valueOf(val.asFloat()).doubleValue();
+    }
+    if (val.fitsInBigInteger()) {
+      return val.asBigInteger().doubleValue();
+    }
+    if (Polyglot_Utils.asBigDecimal(val) instanceof BigDecimal bigDec) {
+      return bigDec.doubleValue();
+    }
+    return (double) coerceToLong(val);
+  }
+
   /**
    * Coerces a number to an Integer.
    *
@@ -50,6 +66,22 @@ public class NumericConverter {
     };
   }
 
+  public static long coerceToLong(Value val) {
+    if (val.fitsInLong()) {
+      return val.asLong();
+    }
+    if (val.fitsInInt()) {
+      return Integer.valueOf(val.asInt()).longValue();
+    }
+    if (val.fitsInShort()) {
+      return Short.valueOf(val.asShort()).longValue();
+    }
+    if (val.fitsInByte()) {
+      return Byte.valueOf(val.asByte()).longValue();
+    }
+    throw new UnsupportedOperationException("Cannot coerce " + val + " to a numeric type.");
+  }
+
   public static BigInteger coerceToBigInteger(Object o) {
     if (o instanceof BigInteger bigInteger) {
       return bigInteger;
@@ -57,6 +89,14 @@ public class NumericConverter {
       long longValue = coerceToLong(o);
       return BigInteger.valueOf(longValue);
     }
+  }
+
+  public static BigInteger coerceToBigInteger(Value val) {
+    if (val.fitsInBigInteger()) {
+      return val.asBigInteger();
+    }
+    var longValue = coerceToLong(val);
+    return BigInteger.valueOf(longValue);
   }
 
   /**
@@ -78,14 +118,55 @@ public class NumericConverter {
     };
   }
 
+  /**
+   * Coerces a polyglot value to a BigDecimal.
+   *
+   * <p>Will throw an exception if the object is not a number.
+   */
+  public static BigDecimal coerceToBigDecimal(Value val) {
+    if (val.fitsInDouble()) {
+      return BigDecimal.valueOf(val.asDouble());
+    }
+    if (Polyglot_Utils.asBigDecimal(val) instanceof BigDecimal bd) {
+      return bd;
+    }
+    if (val.fitsInFloat()) {
+      return BigDecimal.valueOf(val.asFloat());
+    }
+    if (val.fitsInBigInteger()) {
+      return new BigDecimal(val.asBigInteger());
+    }
+    if (val.fitsInLong()) {
+      return BigDecimal.valueOf(val.asLong());
+    }
+    if (val.fitsInInt()) {
+      return BigDecimal.valueOf(val.asInt());
+    }
+    if (val.fitsInShort()) {
+      return BigDecimal.valueOf(val.asShort());
+    }
+    if (val.fitsInByte()) {
+      return BigDecimal.valueOf(val.asByte());
+    }
+    throw new UnsupportedOperationException("Cannot coerce " + val + " to a BigDecimal.");
+  }
+
   /** Returns true if the object is any supported number. */
   public static boolean isCoercibleToDouble(Object o) {
     return isFloatLike(o)|| isCoercibleToLong(o) || o instanceof BigInteger;
   }
 
+  public static boolean isCoercibleToDouble(Value val) {
+    return isFloatLike(val) || isCoercibleToLong(val) || val.fitsInBigInteger();
+  }
+
   public static boolean isFloatLike(Object o) {
     return o instanceof Double
         || o instanceof Float;
+  }
+
+  public static boolean isFloatLike(Value val) {
+    return val.fitsInDouble() || val.fitsInFloat();
   }
 
   /**
@@ -97,8 +178,19 @@ public class NumericConverter {
     return o instanceof Long || o instanceof Integer || o instanceof Short || o instanceof Byte;
   }
 
+  public static boolean isCoercibleToLong(Value val) {
+    if (val.isNumber()) {
+      return val.fitsInLong() || val.fitsInInt() || val.fitsInShort() || val.fitsInByte();
+    }
+    return false;
+  }
+
   public static boolean isCoercibleToBigInteger(Object o) {
     return o instanceof BigInteger || isCoercibleToLong(o);
+  }
+
+  public static boolean isCoercibleToBigInteger(Value val) {
+    return val.fitsInBigInteger() || isCoercibleToLong(val);
   }
 
   /**

--- a/std-bits/base/src/main/java/org/enso/base/polyglot/Polyglot_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/polyglot/Polyglot_Utils.java
@@ -1,5 +1,6 @@
 package org.enso.base.polyglot;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -40,6 +41,45 @@ public class Polyglot_Utils {
       return item.asLong();
     }
     return ret;
+  }
+
+  public static Boolean asBoolean(Value value) {
+    if (value.isBoolean()) {
+      return value.asBoolean();
+    }
+    return null;
+  }
+
+  public static String asString(Value value) {
+    if (value.isString()) {
+      return value.asString();
+    }
+    return null;
+  }
+
+  public static Long asLong(Value value) {
+    if (value.isNumber() && value.fitsInLong()) {
+      return value.asLong();
+    }
+    return null;
+  }
+
+  public static BigInteger asBigInteger(Value value) {
+    try {
+      value.as(BigInteger.class);
+    } catch (ClassCastException e) {
+      return null;
+    }
+    return null;
+  }
+
+  public static BigDecimal asBigDecimal(Value value) {
+    try {
+      value.as(BigDecimal.class);
+    } catch (ClassCastException e) {
+      return null;
+    }
+    return null;
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/BinaryMapOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/BinaryMapOperation.java
@@ -1,6 +1,7 @@
 package org.enso.table.data.column.operation.map;
 
 import org.enso.table.data.column.storage.Storage;
+import org.graalvm.polyglot.Value;
 
 /**
  * A representation of a map-like operation that can be performed on given storage types.
@@ -28,7 +29,7 @@ public abstract class BinaryMapOperation<T, I extends Storage<? super T>> {
    * @return the result of running the operation
    */
   public abstract Storage<?> runBinaryMap(
-      I storage, Object arg, MapOperationProblemAggregator problemAggregator);
+      I storage, Value arg, MapOperationProblemAggregator problemAggregator);
 
   /**
    * Run the operation in zip mode - combining corresponding rows of two storages.

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
@@ -32,7 +32,7 @@ public abstract class GenericBinaryObjectMapOperation<
   public Storage<?> runBinaryMap(
       InputStorageType storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     var convertedArg = Polyglot_Utils.convertPolyglotValue(arg);
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       int n = storage.size();
       Builder builder = createOutputBuilder(n);
       builder.appendNulls(n);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
@@ -6,6 +6,7 @@ import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class GenericBinaryObjectMapOperation<
         InputType, InputStorageType extends Storage<InputType>, OutputType>
@@ -29,15 +30,15 @@ public abstract class GenericBinaryObjectMapOperation<
 
   @Override
   public Storage<?> runBinaryMap(
-      InputStorageType storage, Object arg, MapOperationProblemAggregator problemAggregator) {
-    arg = Polyglot_Utils.convertPolyglotValue(arg);
+      InputStorageType storage, Value arg, MapOperationProblemAggregator problemAggregator) {
+    var convertedArg = Polyglot_Utils.convertPolyglotValue(arg);
     if (arg == null) {
       int n = storage.size();
       Builder builder = createOutputBuilder(n);
       builder.appendNulls(n);
       return builder.seal();
-    } else if (inputTypeClass.isInstance(arg)) {
-      InputType casted = inputTypeClass.cast(arg);
+    } else if (inputTypeClass.isInstance(convertedArg)) {
+      InputType casted = inputTypeClass.cast(convertedArg);
       int n = storage.size();
       Builder builder = createOutputBuilder(n);
       Context context = Context.getCurrent();
@@ -54,7 +55,7 @@ public abstract class GenericBinaryObjectMapOperation<
       return builder.seal();
     } else {
       throw new UnexpectedTypeException(
-          "a " + inputTypeClass.getName() + " but got " + arg.getClass().getName());
+          "a " + inputTypeClass.getName() + " but got " + convertedArg.getClass().getName());
     }
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationStorage.java
@@ -3,6 +3,7 @@ package org.enso.table.data.column.operation.map;
 import java.util.HashMap;
 import java.util.Map;
 import org.enso.table.data.column.storage.Storage;
+import org.graalvm.polyglot.Value;
 
 /**
  * Stores map-like operations that can be performed on a given type.
@@ -34,7 +35,7 @@ public class MapOperationStorage<T, S extends Storage<? super T>> {
    * @return the result of running the operation
    */
   public Storage<?> runBinaryMap(
-      String n, S storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      String n, S storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (!isSupportedBinary(n)) {
       throw new IllegalStateException(
           "Requested vectorized binary operation " + n + ", but no such operation is known.");

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/SpecializedIsInOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/SpecializedIsInOp.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /**
  * A specialized implementation for the IS_IN operation for builtin types, relying on hashing. Since
@@ -43,9 +44,9 @@ public abstract class SpecializedIsInOp<T, S extends Storage<T>> extends BinaryM
 
   @Override
   public Storage<?> runBinaryMap(
-      S storage, Object arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg instanceof List) {
-      return runMap(storage, (List<?>) arg);
+      S storage, Value arg, MapOperationProblemAggregator problemAggregator) {
+    if (arg.hasArrayElements()) {
+      return runMap(storage, arg.as(List.class));
     } else {
       throw new IllegalArgumentException("Argument to `is_in` must be a vector.");
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/BooleanIsInOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/BooleanIsInOp.java
@@ -7,6 +7,7 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.util.ImmutableBitSet;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /**
  * A specialized implementation for the IS_IN operation on booleans - since booleans have just three
@@ -20,9 +21,9 @@ public class BooleanIsInOp extends BinaryMapOperation<Boolean, BoolStorage> {
 
   @Override
   public BoolStorage runBinaryMap(
-      BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg instanceof List) {
-      return runMap(storage, (List<?>) arg);
+      BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
+    if (arg.hasArrayElements()) {
+      return runMap(storage, arg.as(List.class));
     } else {
       throw new IllegalArgumentException("Argument to `is_in` must be a vector.");
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/GenericBinaryOpReturningBoolean.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/GenericBinaryOpReturningBoolean.java
@@ -35,7 +35,7 @@ public abstract class GenericBinaryOpReturningBoolean<T, S extends SpecializedSt
   @Override
   public Storage<?> runBinaryMap(
       S storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return BoolStorage.makeEmpty(storage.size());
     } else {
       T argT = tryCast(arg);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/GenericBinaryOpReturningBoolean.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/bool/GenericBinaryOpReturningBoolean.java
@@ -7,6 +7,7 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /**
  * A generic binary operation that takes two values of some type T and returns a boolean.
@@ -33,7 +34,7 @@ public abstract class GenericBinaryOpReturningBoolean<T, S extends SpecializedSt
 
   @Override
   public Storage<?> runBinaryMap(
-      S storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      S storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       return BoolStorage.makeEmpty(storage.size());
     } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
@@ -8,6 +8,7 @@ import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class TimeLikeCoalescingOperation<T>
     extends BinaryMapOperation<T, SpecializedStorage<T>> {
@@ -24,7 +25,7 @@ public abstract class TimeLikeCoalescingOperation<T>
 
   @Override
   public Storage<?> runBinaryMap(
-      SpecializedStorage<T> storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      SpecializedStorage<T> storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
     if (arg == null) {
       return storage;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
@@ -27,7 +27,7 @@ public abstract class TimeLikeCoalescingOperation<T>
   public Storage<?> runBinaryMap(
       SpecializedStorage<T> storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return storage;
     } else {
       Object adapted = Polyglot_Utils.convertPolyglotValue(arg);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpImplementation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpImplementation.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.BitSet;
 import org.enso.base.polyglot.NumericConverter;
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.map.numeric.helpers.BigDecimalArrayAdapter;
@@ -21,6 +22,7 @@ import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /** An operation expecting a numeric argument and returning a numeric column. */
 public abstract class NumericBinaryOpImplementation<T extends Number, I extends Storage<? super T>>
@@ -35,11 +37,11 @@ public abstract class NumericBinaryOpImplementation<T extends Number, I extends 
 
   @Override
   public Storage<? extends Number> runBinaryMap(
-      I storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       return allNullStorageOfSameType(storage);
     } else {
-      if (arg instanceof BigInteger rhs) {
+      if (Polyglot_Utils.asBigInteger(arg) instanceof BigInteger rhs) {
         return switch (storage) {
           case AbstractLongStorage s -> runBigIntegerMap(
               BigIntegerArrayAdapter.fromStorage(s), rhs, problemAggregator);
@@ -82,7 +84,7 @@ public abstract class NumericBinaryOpImplementation<T extends Number, I extends 
           default -> throw new IllegalStateException(
               "Unsupported storage: " + storage.getClass().getCanonicalName());
         };
-      } else if (arg instanceof BigDecimal bd) {
+      } else if (Polyglot_Utils.asBigDecimal(arg) instanceof BigDecimal bd) {
         return runBigDecimalMap(
             BigDecimalArrayAdapter.fromAnyStorage(storage), bd, problemAggregator);
       } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpImplementation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpImplementation.java
@@ -38,7 +38,7 @@ public abstract class NumericBinaryOpImplementation<T extends Number, I extends 
   @Override
   public Storage<? extends Number> runBinaryMap(
       I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return allNullStorageOfSameType(storage);
     } else {
       if (Polyglot_Utils.asBigInteger(arg) instanceof BigInteger rhs) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningBigDecimal.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningBigDecimal.java
@@ -9,6 +9,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.map.numeric.helpers.BigDecimalArrayAdapter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.BigDecimalStorage;
+import org.graalvm.polyglot.Value;
 
 public abstract class NumericBinaryOpReturningBigDecimal<
         T extends Number, I extends Storage<? super T>>
@@ -19,7 +20,7 @@ public abstract class NumericBinaryOpReturningBigDecimal<
 
   @Override
   public Storage<? extends Number> runBinaryMap(
-      I storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       return BigDecimalStorage.makeEmpty(storage.size());
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningBigDecimal.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningBigDecimal.java
@@ -21,7 +21,7 @@ public abstract class NumericBinaryOpReturningBigDecimal<
   @Override
   public Storage<? extends Number> runBinaryMap(
       I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return BigDecimalStorage.makeEmpty(storage.size());
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningDouble.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningDouble.java
@@ -5,10 +5,12 @@ import static org.enso.table.data.column.operation.map.numeric.helpers.DoubleArr
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.enso.base.polyglot.NumericConverter;
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.map.numeric.helpers.DoubleArrayAdapter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
+import org.graalvm.polyglot.Value;
 
 public abstract class NumericBinaryOpReturningDouble<T extends Number, I extends Storage<? super T>>
     extends NumericBinaryOpImplementation<T, I> {
@@ -18,14 +20,14 @@ public abstract class NumericBinaryOpReturningDouble<T extends Number, I extends
 
   @Override
   public Storage<? extends Number> runBinaryMap(
-      I storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       return DoubleStorage.makeEmpty(storage.size());
     }
 
     DoubleArrayAdapter lhs = fromAnyStorage(storage);
     double rhs =
-        (arg instanceof BigInteger bigInteger)
+        (Polyglot_Utils.asBigInteger(arg) instanceof BigInteger bigInteger)
             ? bigInteger.doubleValue()
             : NumericConverter.coerceToDouble(arg);
     return runDoubleMap(lhs, rhs, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningDouble.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/arithmetic/NumericBinaryOpReturningDouble.java
@@ -21,7 +21,7 @@ public abstract class NumericBinaryOpReturningDouble<T extends Number, I extends
   @Override
   public Storage<? extends Number> runBinaryMap(
       I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return DoubleStorage.makeEmpty(storage.size());
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/comparisons/NumericComparison.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/comparisons/NumericComparison.java
@@ -7,6 +7,7 @@ import java.math.BigInteger;
 import java.util.BitSet;
 import org.enso.base.CompareException;
 import org.enso.base.polyglot.NumericConverter;
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.map.numeric.helpers.BigDecimalArrayAdapter;
@@ -21,6 +22,7 @@ import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.util.BitSets;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class NumericComparison<T extends Number, I extends Storage<? super T>>
     extends BinaryMapOperation<T, I> {
@@ -43,10 +45,10 @@ public abstract class NumericComparison<T extends Number, I extends Storage<? su
 
   @Override
   public BoolStorage runBinaryMap(
-      I storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+      I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       return BoolStorage.makeEmpty(storage.size());
-    } else if (arg instanceof BigInteger bigInteger) {
+    } else if (Polyglot_Utils.asBigInteger(arg) instanceof BigInteger bigInteger) {
       return switch (storage) {
         case AbstractLongStorage s -> runBigIntegerMap(
             BigIntegerArrayAdapter.fromStorage(s), bigInteger, problemAggregator);
@@ -58,7 +60,7 @@ public abstract class NumericComparison<T extends Number, I extends Storage<? su
         default -> throw new IllegalStateException(
             "Unsupported lhs storage: " + storage.getClass().getCanonicalName());
       };
-    } else if (arg instanceof BigDecimal bigDecimal) {
+    } else if (Polyglot_Utils.asBigDecimal(arg) instanceof BigDecimal bigDecimal) {
       return switch (storage) {
         case AbstractLongStorage s -> runBigDecimalMap(
             BigDecimalArrayAdapter.fromStorage(s), bigDecimal, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/comparisons/NumericComparison.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/comparisons/NumericComparison.java
@@ -46,7 +46,7 @@ public abstract class NumericComparison<T extends Number, I extends Storage<? su
   @Override
   public BoolStorage runBinaryMap(
       I storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return BoolStorage.makeEmpty(storage.size());
     } else if (Polyglot_Utils.asBigInteger(arg) instanceof BigInteger bigInteger) {
       return switch (storage) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/CoalescingStringStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/CoalescingStringStringOp.java
@@ -7,6 +7,7 @@ import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class CoalescingStringStringOp extends StringStringOp {
   public CoalescingStringStringOp(String name) {
@@ -16,12 +17,13 @@ public abstract class CoalescingStringStringOp extends StringStringOp {
   @Override
   public Storage<?> runBinaryMap(
       SpecializedStorage<String> storage,
-      Object arg,
+      Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
     if (arg == null) {
       return storage;
-    } else if (arg instanceof String argString) {
+    } else if (arg.isString()) {
+      var argString = arg.asString();
       String[] newVals = new String[size];
       Context context = Context.getCurrent();
       for (int i = 0; i < size; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/CoalescingStringStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/CoalescingStringStringOp.java
@@ -20,7 +20,7 @@ public abstract class CoalescingStringStringOp extends StringStringOp {
       Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       return storage;
     } else if (arg.isString()) {
       var argString = arg.asString();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/LikeOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/LikeOp.java
@@ -10,6 +10,7 @@ import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public class LikeOp extends StringBooleanOp {
   public LikeOp() {
@@ -37,14 +38,15 @@ public class LikeOp extends StringBooleanOp {
   @Override
   public BoolStorage runBinaryMap(
       SpecializedStorage<String> storage,
-      Object arg,
+      Value arg,
       MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();
       newIsNothing.set(0, storage.size());
       return new BoolStorage(newVals, newIsNothing, storage.size(), false);
-    } else if (arg instanceof String argString) {
+    } else if (arg.isString()) {
+      var argString = arg.asString();
       Pattern pattern = createRegexPatternFromSql(argString);
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/LikeOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/LikeOp.java
@@ -40,7 +40,7 @@ public class LikeOp extends StringBooleanOp {
       SpecializedStorage<String> storage,
       Value arg,
       MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();
       newIsNothing.set(0, storage.size());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringBooleanOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringBooleanOp.java
@@ -28,7 +28,7 @@ public abstract class StringBooleanOp
       SpecializedStorage<String> storage,
       Value arg,
       MapOperationProblemAggregator problemAggregator) {
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();
       newIsNothing.set(0, storage.size());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringBooleanOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringBooleanOp.java
@@ -9,6 +9,7 @@ import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class StringBooleanOp
     extends BinaryMapOperation<String, SpecializedStorage<String>> {
@@ -25,14 +26,15 @@ public abstract class StringBooleanOp
   @Override
   public BoolStorage runBinaryMap(
       SpecializedStorage<String> storage,
-      Object arg,
+      Value arg,
       MapOperationProblemAggregator problemAggregator) {
     if (arg == null) {
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();
       newIsNothing.set(0, storage.size());
       return new BoolStorage(newVals, newIsNothing, storage.size(), false);
-    } else if (arg instanceof String argString) {
+    } else if (arg.isString()) {
+      var argString = arg.asString();
       BitSet newVals = new BitSet();
       BitSet newIsNothing = new BitSet();
       Context context = Context.getCurrent();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringLongToStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringLongToStringOp.java
@@ -27,7 +27,7 @@ public abstract class StringLongToStringOp
       Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       StringBuilder builder = new StringBuilder(size, TextType.VARIABLE_LENGTH);
       builder.appendNulls(size);
       return builder.seal();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringLongToStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringLongToStringOp.java
@@ -1,5 +1,6 @@
 package org.enso.table.data.column.operation.map.text;
 
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.builder.StringBuilder;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
@@ -10,6 +11,7 @@ import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class StringLongToStringOp
     extends BinaryMapOperation<String, SpecializedStorage<String>> {
@@ -22,14 +24,14 @@ public abstract class StringLongToStringOp
   @Override
   public Storage<?> runBinaryMap(
       SpecializedStorage<String> storage,
-      Object arg,
+      Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
     if (arg == null) {
       StringBuilder builder = new StringBuilder(size, TextType.VARIABLE_LENGTH);
       builder.appendNulls(size);
       return builder.seal();
-    } else if (arg instanceof Long argLong) {
+    } else if (Polyglot_Utils.asLong(arg) instanceof Long argLong) {
       String[] newVals = new String[size];
       Context context = Context.getCurrent();
       for (int i = 0; i < size; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringStringOp.java
@@ -27,7 +27,7 @@ public abstract class StringStringOp
       Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
-    if (arg == null) {
+    if (arg == null || arg.isNull()) {
       StringBuilder builder = new StringBuilder(size, TextType.VARIABLE_LENGTH);
       builder.appendNulls(size);
       return builder.seal();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringStringOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/text/StringStringOp.java
@@ -9,6 +9,7 @@ import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class StringStringOp
     extends BinaryMapOperation<String, SpecializedStorage<String>> {
@@ -23,14 +24,15 @@ public abstract class StringStringOp
   @Override
   public Storage<?> runBinaryMap(
       SpecializedStorage<String> storage,
-      Object arg,
+      Value arg,
       MapOperationProblemAggregator problemAggregator) {
     int size = storage.size();
     if (arg == null) {
       StringBuilder builder = new StringBuilder(size, TextType.VARIABLE_LENGTH);
       builder.appendNulls(size);
       return builder.seal();
-    } else if (arg instanceof String argString) {
+    } else if (arg.isString()) {
+      String argString = arg.asString();
       String[] newVals = new String[size];
       Context context = Context.getCurrent();
       for (int i = 0; i < size; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -339,7 +339,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public BoolStorage runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return BoolStorage.makeEmpty(storage.size);
       } else if (Polyglot_Utils.asBoolean(arg) instanceof Boolean v) {
         if (v) {
@@ -381,7 +381,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public BoolStorage runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         if (storage.negated) {
           var newMissing = new BitSet(storage.size);
           newMissing.flip(0, storage.size);
@@ -452,7 +452,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public BoolStorage runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         if (storage.negated) {
           var newMissing = storage.isNothing.get(0, storage.size);
           newMissing.or(storage.values);
@@ -589,7 +589,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public Storage<?> runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
@@ -620,7 +620,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public Storage<?> runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
@@ -651,7 +651,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public Storage<?> runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
@@ -682,7 +682,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public Storage<?> runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
@@ -764,7 +764,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public BoolStorage runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return storage;
       }
 
@@ -796,7 +796,7 @@ public final class BoolStorage extends Storage<Boolean>
     @Override
     public BoolStorage runBinaryMap(
         BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
-      if (arg == null) {
+      if (arg == null || arg.isNull()) {
         return storage;
       }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -83,7 +83,7 @@ public final class BoolStorage extends Storage<Boolean>
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return ops.runBinaryMap(name, this, argument, problemAggregator);
   }
 
@@ -338,10 +338,10 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public BoolStorage runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return BoolStorage.makeEmpty(storage.size);
-      } else if (arg instanceof Boolean v) {
+      } else if (Polyglot_Utils.asBoolean(arg) instanceof Boolean v) {
         if (v) {
           return storage;
         } else {
@@ -380,7 +380,7 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public BoolStorage runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         if (storage.negated) {
           var newMissing = new BitSet(storage.size);
@@ -392,7 +392,7 @@ public final class BoolStorage extends Storage<Boolean>
           newMissing.or(storage.values);
           return new BoolStorage(new BitSet(), newMissing, storage.size, false);
         }
-      } else if (arg instanceof Boolean v) {
+      } else if (Polyglot_Utils.asBoolean(arg) instanceof Boolean v) {
         return v ? storage : new BoolStorage(new BitSet(), new BitSet(), storage.size, false);
       } else {
         throw new UnexpectedTypeException("a Boolean");
@@ -451,7 +451,7 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public BoolStorage runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         if (storage.negated) {
           var newMissing = storage.isNothing.get(0, storage.size);
@@ -463,7 +463,7 @@ public final class BoolStorage extends Storage<Boolean>
           newMissing.xor(storage.values);
           return new BoolStorage(storage.values, newMissing, storage.size, false);
         }
-      } else if (arg instanceof Boolean v) {
+      } else if (Polyglot_Utils.asBoolean(arg) instanceof Boolean v) {
         return v ? new BoolStorage(new BitSet(), new BitSet(), storage.size, true) : storage;
       } else {
         throw new UnexpectedTypeException("a Boolean");
@@ -588,13 +588,13 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public Storage<?> runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
-      if (arg instanceof Boolean b) {
-        if (b) {
+      if (arg.isBoolean()) {
+        if (arg.asBoolean()) {
           // false is smaller than true, so we want to negate
           return new BoolStorage(storage.negateNormalize(), storage.isNothing, storage.size, false);
         } else {
@@ -619,12 +619,12 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public Storage<?> runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
-      if (arg instanceof Boolean b) {
+      if (Polyglot_Utils.asBoolean(arg) instanceof Boolean b) {
         if (b) {
           // everything is <= true
           return new BoolStorage(new BitSet(), storage.isNothing, storage.size, true);
@@ -650,12 +650,12 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public Storage<?> runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
-      if (arg instanceof Boolean b) {
+      if (Polyglot_Utils.asBoolean(arg) instanceof Boolean b) {
         if (b) {
           // nothing is strictly greater than true
           return new BoolStorage(new BitSet(), storage.isNothing, storage.size, false);
@@ -681,12 +681,12 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public Storage<?> runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return BoolStorage.makeEmpty(storage.size);
       }
 
-      if (arg instanceof Boolean b) {
+      if (Polyglot_Utils.asBoolean(arg) instanceof Boolean b) {
         if (b) {
           // true is >= true
           return storage;
@@ -763,12 +763,12 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public BoolStorage runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return storage;
       }
 
-      if (arg instanceof Boolean b) {
+      if (Polyglot_Utils.asBoolean(arg) instanceof Boolean b) {
         if (b) {
           // true is larger than false, so we want to keep values as is, and fill missing ones with
           // true
@@ -795,12 +795,12 @@ public final class BoolStorage extends Storage<Boolean>
 
     @Override
     public BoolStorage runBinaryMap(
-        BoolStorage storage, Object arg, MapOperationProblemAggregator problemAggregator) {
+        BoolStorage storage, Value arg, MapOperationProblemAggregator problemAggregator) {
       if (arg == null) {
         return storage;
       }
 
-      if (arg instanceof Boolean b) {
+      if (Polyglot_Utils.asBoolean(arg) instanceof Boolean b) {
         if (b) {
           // true is larger than everything:
           return BoolStorage.makeConstant(storage.size, true);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorage.java
@@ -10,6 +10,7 @@ import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.BlackholeProblemAggregator;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /**
  * A column backing Mixed storage.
@@ -198,7 +199,7 @@ public final class MixedStorage extends ObjectStorage implements ColumnStorageWi
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     if (resolveBinaryOp(name) == VectorizedOperationAvailability.AVAILABLE_IN_SPECIALIZED_STORAGE) {
       return getInferredStorage().runVectorizedBinaryMap(name, argument, problemAggregator);
     } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorageFacade.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorageFacade.java
@@ -7,6 +7,7 @@ import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
+import org.graalvm.polyglot.Value;
 
 /**
  * Wraps a storage of any type and alters its reported storage to be of type AnyObject.
@@ -58,7 +59,7 @@ public class MixedStorageFacade extends Storage<Object> {
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return underlyingStorage.runVectorizedBinaryMap(name, argument, problemAggregator);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/SpecializedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/SpecializedStorage.java
@@ -10,6 +10,7 @@ import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class SpecializedStorage<T> extends Storage<T> {
 
@@ -73,7 +74,7 @@ public abstract class SpecializedStorage<T> extends Storage<T> {
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return ops.runBinaryMap(name, this, argument, problemAggregator);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -110,7 +110,7 @@ public abstract class Storage<T> implements ColumnStorage {
 
   /** Runs a vectorized operation on this storage, taking one scalar argument. */
   public abstract Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator);
+      String name, Value argument, MapOperationProblemAggregator problemAggregator);
 
   /* Specifies if the given ternary operation has a vectorized implementation available for this storage.*/
   public boolean isTernaryOpVectorized(String name) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -224,7 +224,7 @@ public abstract class Storage<T> implements ColumnStorage {
       String name,
       MapOperationProblemAggregator problemAggregator,
       BiFunction<Object, Object, Object> fallback,
-      Object argument,
+      Value argument,
       boolean skipNulls,
       StorageType expectedResultType) {
     if (isBinaryOpVectorized(name)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -95,7 +95,7 @@ public final class StringStorage extends SpecializedStorage<String> {
             BitSet isNothing = new BitSet();
             Context context = Context.getCurrent();
             for (int i = 0; i < storage.size(); i++) {
-              if (storage.getItem(i) == null || arg == null) {
+              if (storage.getItem(i) == null || arg == null || arg.isNull()) {
                 isNothing.set(i);
               } else if (Polyglot_Utils.asString(arg) instanceof String s
                   && Text_Utils.equals(storage.getItem(i), s)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.enso.base.CompareException;
 import org.enso.base.Text_Utils;
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.operation.CountUntrimmed;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
@@ -19,6 +20,7 @@ import org.enso.table.data.column.operation.map.text.StringStringOp;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 import org.slf4j.Logger;
 
 /** A column storing strings. */
@@ -87,7 +89,7 @@ public final class StringStorage extends SpecializedStorage<String> {
           @Override
           public BoolStorage runBinaryMap(
               SpecializedStorage<String> storage,
-              Object arg,
+              Value arg,
               MapOperationProblemAggregator problemAggregator) {
             BitSet r = new BitSet();
             BitSet isNothing = new BitSet();
@@ -95,7 +97,8 @@ public final class StringStorage extends SpecializedStorage<String> {
             for (int i = 0; i < storage.size(); i++) {
               if (storage.getItem(i) == null || arg == null) {
                 isNothing.set(i);
-              } else if (arg instanceof String s && Text_Utils.equals(storage.getItem(i), s)) {
+              } else if (Polyglot_Utils.asString(arg) instanceof String s
+                  && Text_Utils.equals(storage.getItem(i), s)) {
                 r.set(i);
               }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -22,6 +22,7 @@ import org.enso.table.data.column.storage.*;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 public abstract class AbstractLongStorage extends NumericStorage<Long>
     implements ColumnLongStorage, ColumnStorageWithNothingMap {
@@ -36,7 +37,7 @@ public abstract class AbstractLongStorage extends NumericStorage<Long>
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return ops.runBinaryMap(name, this, argument, problemAggregator);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -115,7 +115,7 @@ public final class DoubleStorage extends NumericStorage<Double>
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return ops.runBinaryMap(name, this, argument, problemAggregator);
   }
 

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/table_test_helpers/ExplodingStorage.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/table_test_helpers/ExplodingStorage.java
@@ -9,6 +9,7 @@ import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
+import org.graalvm.polyglot.Value;
 
 /**
  * A helper class used in the Upload_Spec test to purposefully interrupt a table upload in the
@@ -62,7 +63,7 @@ public class ExplodingStorage extends Storage<Long> {
 
   @Override
   public Storage<?> runVectorizedBinaryMap(
-      String name, Object argument, MapOperationProblemAggregator problemAggregator) {
+      String name, Value argument, MapOperationProblemAggregator problemAggregator) {
     return null;
   }
 


### PR DESCRIPTION
Blocks #11687

### Pull Request Description

Failure https://github.com/enso-org/enso/actions/runs/12257340893/job/34194878025?pr=11687#step:7:2460 on PR #11687 has a minimal reproducer in [BuiltinsJavaInteropTest](https://github.com/enso-org/enso/pull/11687/files#diff-c09f0ced93106a2c4274bdd63357c7b9f2f8358a100f9a65d6e687f2ffef3afeR36-R48). #11687 changes the interop protocol of, e.g., `EnsoDateTime` such that it is no longer only `isDate` and `isTime`, but also `hasMembers`. According to the docs in https://www.graalvm.org/truffle/javadoc/org/graalvm/polyglot/Value.html#object-target-type-mapping-heading, if there is a Java method:
```java
public final class Klazz {
  public static void foo(Object obj) { ... }
}
```
That gets called as
```
polyglot java import Klazz
from Standard.Base import Date_Time

main = Klazz.foo Date_Time.now
```
The `Object obj` will implement `java.util.Map`, and will not be `java.util.LocalDate`.

This PR tries to fix this by refactoring various Java methods in standard libraries that currently accepts objects from Enso as `Object` into `org.graalvm.polyglot.Value`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
