### PR TITLE
Disallow a confusing constructor syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 #### Enso Language & Runtime
 
 - [Intersection types & type checks][11600]
+- A constructor or type definition with a single inline argument definition was
+  previously allowed to use spaces in the argument definition without
+  parentheses. [This is now a syntax error.][11856]
 
 [11600]: https://github.com/enso-org/enso/pull/11600
+[11856]: https://github.com/enso-org/enso/pull/11856
 
 # Next Release
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/AnnotationsCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/AnnotationsCompilerTest.java
@@ -67,7 +67,7 @@ public class AnnotationsCompilerTest extends CompilerTests {
     type Foo
         @a foo
         @b bar
-        Cons a (b = a b)
+        Cons a b
     """);
 
     var typeDefinition = (Definition.SugaredType) ir.bindings().apply(0);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/AnnotationsCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/AnnotationsCompilerTest.java
@@ -67,7 +67,7 @@ public class AnnotationsCompilerTest extends CompilerTests {
     type Foo
         @a foo
         @b bar
-        Cons a b = a b
+        Cons a (b = a b)
     """);
 
     var typeDefinition = (Definition.SugaredType) ir.bindings().apply(0);

--- a/lib/rust/parser/debug/src/lib.rs
+++ b/lib/rust/parser/debug/src/lib.rs
@@ -67,7 +67,11 @@ where T: serde::Serialize + Reflect {
     let text_escape_token = rust_to_meta[&TextEscape::reflect().id];
     let token_to_str = move |token: Value| {
         let range = token_code_range(&token, base);
-        code[range].to_owned().into_boxed_str()
+        if range.is_empty() {
+            "".into()
+        } else {
+            code[range].to_owned().into_boxed_str()
+        }
     };
     for token in identish_tokens {
         let token_to_str_ = token_to_str.clone();
@@ -158,6 +162,9 @@ fn token_code_range(token: &Value, base: usize) -> std::ops::Range<usize> {
         |field| fields(token).find(|(name, _)| *name == field).unwrap().1.as_u64().unwrap() as u32;
     let begin = get_u32(":codeReprBegin");
     let len = get_u32(":codeReprLen");
+    if len == 0 {
+        return 0..0;
+    }
     let begin = (begin as u64) | (base as u64 & !(u32::MAX as u64));
     let begin = if begin < (base as u64) { begin + 1 << 32 } else { begin };
     let begin = begin as usize - base;

--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -346,12 +346,14 @@ fn type_def_full() {
 
 #[test]
 fn type_def_defaults() {
-    let code = ["type Result error ok=Nothing", "    Ok value:ok = Nothing"];
-    test!(code.join("\n"),
+    test!("type Result error ok=Nothing\n    Ok value:ok=Nothing\n    Error (value:e = Nothing)",
         (TypeDef Result #((() (Ident error) () ())
                                (() (Ident ok) () ((Ident Nothing))))
          #(,(Constructor::new("Ok")
-             .with_arg(sexp![(() (Ident value) (":" (Ident ok)) ((Ident Nothing)))])))));
+             .with_arg(sexp![(() (Ident value) (":" (Ident ok)) ((Ident Nothing)))]))
+           ,(Constructor::new("Error")
+             .with_arg(sexp![(() (Ident value) (":" (Ident e)) ((Ident Nothing)))])))));
+    expect_invalid_node("type Result\n    Ok value:ok = Nothing");
 }
 
 #[test]

--- a/lib/rust/parser/src/macros/built_in.rs
+++ b/lib/rust/parser/src/macros/built_in.rs
@@ -277,7 +277,8 @@ fn lambda_body<'s>(
     let (body, mut rest) = segments.pop();
     let arguments = rest.pop().unwrap();
     let backslash = arguments.header.with_variant(token::variant::LambdaOperator());
-    let arguments = syntax::parse_args(&mut arguments.result.tokens(), 0, precedence);
+    let arguments =
+        syntax::parse_args(&mut arguments.result.tokens(), 0, precedence, &mut default());
     let arrow = body.header.with_variant(token::variant::ArrowOperator());
     let body_expression = precedence.resolve(&mut body.result.tokens());
     let body_expression =

--- a/lib/rust/parser/src/syntax/statement/type_def.rs
+++ b/lib/rust/parser/src/syntax/statement/type_def.rs
@@ -5,8 +5,8 @@ use crate::syntax::maybe_with_error;
 use crate::syntax::operator::Precedence;
 use crate::syntax::statement::apply_excess_private_keywords;
 use crate::syntax::statement::compound_lines;
+use crate::syntax::statement::function_def::parse_args;
 use crate::syntax::statement::function_def::parse_constructor_definition;
-use crate::syntax::statement::function_def::parse_type_args;
 use crate::syntax::statement::parse_statement;
 use crate::syntax::statement::scan_private_keywords;
 use crate::syntax::statement::EvaluationContext;
@@ -66,7 +66,7 @@ pub fn try_parse_type_def<'s>(
         default()
     };
 
-    let params = parse_type_args(items, start + 2, precedence, args_buffer);
+    let params = parse_args(items, start + 2, precedence, args_buffer);
 
     let name = items.pop().unwrap().into_token().unwrap().try_into().unwrap();
 


### PR DESCRIPTION
### Pull Request Description

Previously, a constructor or type definition with a single argument defined inline could use spaces within the argument's definition without parentheses, as in the draft spec. This syntax was found confusing and is no longer allowed. No usages occurred in our `.enso` files. Fixes #10812.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
