### PR TITLE
`aggregate ..Sum` of integer column remains integer and handles overflow

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
@@ -1,17 +1,17 @@
 package org.enso.table.aggregations;
 
 import java.util.List;
+
+import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.ProblemAggregator;
 
 /** Interface used to define aggregate columns. */
 public abstract class Aggregator {
   private final String name;
-  private final StorageType type;
 
-  protected Aggregator(String name, StorageType type) {
+  protected Aggregator(String name) {
     this.name = name;
-    this.type = type;
   }
 
   /**
@@ -23,14 +23,8 @@ public abstract class Aggregator {
     return name;
   }
 
-  /**
-   * Return type of the column
-   *
-   * @return The type of the new column.
-   */
-  public StorageType getType() {
-    return type;
-  }
+  /** Creates a builder that can hold results of this aggregator. */
+  public abstract Builder makeBuilder(int size, ProblemAggregator problemAggregator);
 
   /**
    * Compute the value for a set of rows

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
@@ -1,9 +1,7 @@
 package org.enso.table.aggregations;
 
 import java.util.List;
-
 import org.enso.table.data.column.builder.Builder;
-import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.ProblemAggregator;
 
 /** Interface used to define aggregate columns. */

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Concatenate.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Concatenate.java
@@ -10,7 +10,7 @@ import org.enso.table.problems.ColumnAggregatedProblemAggregator;
 import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
-public class Concatenate extends Aggregator {
+public class Concatenate extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final String separator;
   private final String prefix;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Count.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Count.java
@@ -5,7 +5,7 @@ import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.problems.ProblemAggregator;
 
 /** Aggregate Column counting the number of entries in a group. */
-public class Count extends Aggregator {
+public class Count extends KnownTypeAggregator {
   public Count(String name) {
     super(name, IntegerType.INT_64);
   }

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
@@ -18,7 +18,7 @@ import org.graalvm.polyglot.Context;
  * Aggregate Column counting the number of distinct items in a group. If `ignoreAllNull` is true,
  * does count when all items are null.
  */
-public class CountDistinct extends Aggregator {
+public class CountDistinct extends KnownTypeAggregator {
   private final Storage<?>[] storage;
   private final List<TextFoldingStrategy> textFoldingStrategy;
   private final boolean ignoreAllNull;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/CountEmpty.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/CountEmpty.java
@@ -13,7 +13,7 @@ import org.graalvm.polyglot.Context;
  * Aggregate Column counting the number of (non-)empty entries in a group. If `isEmpty` is true,
  * counts null or empty entries. If `isEmpty` is false, counts non-empty entries.
  */
-public class CountEmpty extends Aggregator {
+public class CountEmpty extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final boolean isEmpty;
 

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/CountNothing.java
@@ -11,7 +11,7 @@ import org.graalvm.polyglot.Context;
  * Aggregate Column counting the number of (not-)null entries in a group. If `isNothing` is true,
  * counts null entries. If `isNothing` is false, counts non-null entries.
  */
-public class CountNothing extends Aggregator {
+public class CountNothing extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final boolean isNothing;
 

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/First.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/First.java
@@ -9,7 +9,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column finding the first value in a group. */
-public class First extends Aggregator {
+public class First extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final Storage<?>[] orderByColumns;
   private final int[] orderByDirections;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/GroupBy.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/GroupBy.java
@@ -6,7 +6,7 @@ import org.enso.table.data.table.Column;
 import org.enso.table.problems.ProblemAggregator;
 
 /** Aggregate Column getting the grouping key. */
-public class GroupBy extends Aggregator {
+public class GroupBy extends KnownTypeAggregator {
   private final Storage<?> storage;
 
   public GroupBy(String name, Column column) {

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/KnownTypeAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/KnownTypeAggregator.java
@@ -1,0 +1,28 @@
+package org.enso.table.aggregations;
+
+import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.problems.ProblemAggregator;
+
+public abstract class KnownTypeAggregator extends Aggregator {
+  private final StorageType type;
+
+  protected KnownTypeAggregator(String name, StorageType type) {
+    super(name);
+    this.type = type;
+  }
+
+  @Override
+  public Builder makeBuilder(int size, ProblemAggregator problemAggregator) {
+    return Builder.getForType(type, size, problemAggregator);
+  }
+
+  /**
+   * Return type of the column
+   *
+   * @return The type of the new column.
+   */
+  public StorageType getType() {
+    return type;
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/KnownTypeAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/KnownTypeAggregator.java
@@ -4,6 +4,10 @@ import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.ProblemAggregator;
 
+/**
+ * A common subclass for aggregators that know their type on construction and use a standard
+ * builder.
+ */
 public abstract class KnownTypeAggregator extends Aggregator {
   private final StorageType type;
 

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Last.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Last.java
@@ -8,7 +8,7 @@ import org.enso.table.data.table.Column;
 import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
-public class Last extends Aggregator {
+public class Last extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final Storage<?>[] orderByColumns;
   private final int[] orderByDirections;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
@@ -1,9 +1,18 @@
 package org.enso.table.aggregations;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.List;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
+import org.enso.table.data.column.storage.numeric.DoubleStorage;
+import org.enso.table.data.column.storage.type.AnyObjectType;
+import org.enso.table.data.column.storage.type.BigDecimalType;
+import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.FloatType;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.InvalidAggregation;
 import org.enso.table.problems.ColumnAggregatedProblemAggregator;
@@ -12,49 +21,138 @@ import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing the mean value in a group. */
 public class Mean extends KnownTypeAggregator {
-  private static class Calculation {
-    public long count;
-    public double total;
-
-    public Calculation(double value) {
-      count = 1;
-      total = value;
-    }
-  }
-
   private final Storage<?> storage;
+  private final String columnName;
 
   public Mean(String name, Column column) {
-    super(name, FloatType.FLOAT_64);
+    super(name, resultTypeFromInput(column.getStorage()));
     this.storage = column.getStorage();
+    this.columnName = column.getName();
+  }
+
+  private static StorageType resultTypeFromInput(Storage<?> inputStorage) {
+    StorageType inputType = inputStorage.getType();
+    if (inputType instanceof AnyObjectType) {
+      inputType = inputStorage.inferPreciseType();
+    }
+
+    return switch (inputType) {
+      case FloatType floatType -> FloatType.FLOAT_64;
+      case IntegerType integerType -> FloatType.FLOAT_64;
+      case BigIntegerType bigIntegerType -> BigDecimalType.INSTANCE;
+      case BigDecimalType bigDecimalType -> BigDecimalType.INSTANCE;
+      default -> throw new IllegalStateException(
+          "Unexpected input type for Mean aggregate: " + inputType);
+    };
   }
 
   @Override
   public Object aggregate(List<Integer> indexes, ProblemAggregator problemAggregator) {
     ColumnAggregatedProblemAggregator innerAggregator =
         new ColumnAggregatedProblemAggregator(problemAggregator);
-    Context context = Context.getCurrent();
-    Calculation current = null;
-    for (int row : indexes) {
-      Object value = storage.getItemBoxed(row);
-      if (value != null) {
-        Double dValue = NumericConverter.tryConvertingToDouble(value);
-        if (dValue == null) {
-          innerAggregator.reportColumnAggregatedProblem(
-              new InvalidAggregation(this.getName(), row, "Cannot convert to a number."));
-          return null;
-        }
+    MeanAccumulator accumulator = makeAccumulator();
+    accumulator.accumulate(indexes, storage, innerAggregator);
+    return accumulator.summarize();
+  }
 
-        if (current == null) {
-          current = new Calculation(dValue);
-        } else {
-          current.count++;
-          current.total += dValue;
+  private MeanAccumulator makeAccumulator() {
+    return switch (getType()) {
+      case FloatType floatType -> new FloatMeanAccumulator();
+      case BigDecimalType bigDecimalType -> new BigDecimalMeanAccumulator();
+      default -> throw new IllegalStateException(
+          "Unexpected output type in Mean aggregate: " + getType());
+    };
+  }
+
+  private abstract static class MeanAccumulator {
+    abstract void accumulate(
+        List<Integer> indexes, Storage<?> storage, ProblemAggregator problemAggregator);
+
+    abstract Object summarize();
+  }
+
+  private final class FloatMeanAccumulator extends MeanAccumulator {
+    private double total = 0;
+    private long count = 0;
+
+    @Override
+    void accumulate(
+        List<Integer> indexes, Storage<?> storage, ProblemAggregator problemAggregator) {
+      Context context = Context.getCurrent();
+      if (storage instanceof DoubleStorage doubleStorage) {
+        for (int i : indexes) {
+          if (!doubleStorage.isNothing(i)) {
+            total += doubleStorage.getItemAsDouble(i);
+            count++;
+          }
+          context.safepoint();
+        }
+      } else if (storage instanceof AbstractLongStorage longStorage) {
+        for (int i : indexes) {
+          if (!longStorage.isNothing(i)) {
+            total += longStorage.getItem(i);
+            count++;
+          }
+          context.safepoint();
+        }
+      } else {
+        ColumnAggregatedProblemAggregator innerAggregator =
+            new ColumnAggregatedProblemAggregator(problemAggregator);
+        for (int i : indexes) {
+          Object value = storage.getItemBoxed(i);
+          if (value != null) {
+            Double dValue = NumericConverter.tryConvertingToDouble(value);
+            if (dValue == null) {
+              innerAggregator.reportColumnAggregatedProblem(
+                  new InvalidAggregation(columnName, i, "Cannot convert to a Float."));
+              continue;
+            }
+
+            total += dValue;
+            count++;
+          }
+          context.safepoint();
         }
       }
-
-      context.safepoint();
     }
-    return current == null ? null : current.total / current.count;
+
+    @Override
+    Object summarize() {
+      return count == 0 ? null : total / count;
+    }
+  }
+
+  private final class BigDecimalMeanAccumulator extends MeanAccumulator {
+    private BigDecimal total = BigDecimal.ZERO;
+    private long count = 0;
+
+    @Override
+    void accumulate(
+        List<Integer> indexes, Storage<?> storage, ProblemAggregator problemAggregator) {
+      ColumnAggregatedProblemAggregator innerAggregator =
+          new ColumnAggregatedProblemAggregator(problemAggregator);
+      Context context = Context.getCurrent();
+      for (int i : indexes) {
+        Object value = storage.getItemBoxed(i);
+        if (value != null) {
+          try {
+            BigDecimal valueAsBigDecimal = NumericConverter.coerceToBigDecimal(value);
+            total = total.add(valueAsBigDecimal);
+            count++;
+          } catch (UnsupportedOperationException error) {
+            innerAggregator.reportColumnAggregatedProblem(
+                new InvalidAggregation(
+                    columnName, i, "Cannot convert to a BigDecimal: " + error.getMessage()));
+            continue;
+          }
+        }
+        context.safepoint();
+      }
+    }
+
+    @Override
+    Object summarize() {
+      return count == 0 ? null : total.divide(BigDecimal.valueOf(count), MathContext.DECIMAL128);
+    }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
@@ -11,7 +11,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing the mean value in a group. */
-public class Mean extends Aggregator {
+public class Mean extends KnownTypeAggregator {
   private static class Calculation {
     public long count;
     public double total;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/MinOrMax.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/MinOrMax.java
@@ -13,7 +13,7 @@ import org.graalvm.polyglot.Context;
 /**
  * Aggregate Column finding the minimum (minOrMax = -1) or maximum (minOrMax = 1) entry in a group.
  */
-public class MinOrMax extends Aggregator {
+public class MinOrMax extends KnownTypeAggregator {
   public static final int MIN = -1;
   public static final int MAX = 1;
 

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mode.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mode.java
@@ -12,7 +12,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing the most common value in a group (ignoring Nothing). */
-public class Mode extends Aggregator {
+public class Mode extends KnownTypeAggregator {
   private final Storage<?> storage;
 
   public Mode(String name, Column column) {

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Percentile.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Percentile.java
@@ -14,7 +14,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing a percentile value in a group. */
-public class Percentile extends Aggregator {
+public class Percentile extends KnownTypeAggregator {
   private final Storage<?> storage;
   private final double percentile;
 

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/ShortestOrLongest.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/ShortestOrLongest.java
@@ -11,7 +11,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column finding the longest or shortest string in a group. */
-public class ShortestOrLongest extends Aggregator {
+public class ShortestOrLongest extends KnownTypeAggregator {
   public static final int SHORTEST = -1;
   public static final int LONGEST = 1;
   private final Storage<?> storage;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/StandardDeviation.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/StandardDeviation.java
@@ -11,7 +11,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing the standard deviation of a group. */
-public class StandardDeviation extends Aggregator {
+public class StandardDeviation extends KnownTypeAggregator {
   private static class Calculation {
     public long count;
     public double total;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -67,7 +67,7 @@ public class Sum extends Aggregator {
     abstract Object summarize();
   }
 
-  private static class IntegerSumAccumulator extends SumAccumulator {
+  private static final class IntegerSumAccumulator extends SumAccumulator {
     private Object accumulator = null;
 
     void add(Object value) {
@@ -153,7 +153,7 @@ public class Sum extends Aggregator {
     }
   }
 
-  private static class FloatSumAccumulator extends SumAccumulator {
+  private static final class FloatSumAccumulator extends SumAccumulator {
     private Double accumulator = null;
 
     void add(Object value) {

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -1,9 +1,15 @@
 package org.enso.table.aggregations;
 
+import java.math.BigInteger;
 import java.util.List;
 import org.enso.base.polyglot.NumericConverter;
+import org.enso.table.data.column.builder.BigIntegerBuilder;
+import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.builder.DoubleBuilder;
+import org.enso.table.data.column.builder.InferredIntegerBuilder;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.table.Column;
@@ -13,11 +19,22 @@ import org.graalvm.polyglot.Context;
 
 /** Aggregate Column computing the total value in a group. */
 public class Sum extends Aggregator {
-  private final Storage<?> storage;
+  private final Storage<?> inputStorage;
 
   public Sum(String name, Column column) {
-    super(name, FloatType.FLOAT_64);
-    this.storage = column.getStorage();
+    super(name);
+    this.inputStorage = column.getStorage();
+  }
+
+  @Override
+  public Builder makeBuilder(int size, ProblemAggregator problemAggregator) {
+    var preciseInputType = inputStorage.inferPreciseType();
+    return switch (preciseInputType) {
+      case IntegerType integerType -> new InferredIntegerBuilder(size, problemAggregator);
+      case BigIntegerType bigIntegerType -> new BigIntegerBuilder(size, problemAggregator);
+      case FloatType floatType -> DoubleBuilder.createDoubleBuilder(size, problemAggregator);
+      default -> throw new IllegalStateException("Unexpected input type for Sum aggregate: " + preciseInputType);
+    };
   }
 
   @Override
@@ -25,38 +42,98 @@ public class Sum extends Aggregator {
     MapOperationProblemAggregator innerAggregator =
         new MapOperationProblemAggregator(problemAggregator, getName());
     Context context = Context.getCurrent();
-    Object current = null;
+    SumAccumulator accumulator = new SumAccumulator();
     for (int row : indexes) {
-      Object value = storage.getItemBoxed(row);
-      if (value != null) {
-        if (current == null) {
-          current = 0L;
-        }
-
-        Long lCurrent = NumericConverter.tryConvertingToLong(current);
-        Long lValue = NumericConverter.tryConvertingToLong(value);
-        if (lCurrent != null && lValue != null) {
-          try {
-            current = Math.addExact(lCurrent, lValue);
-          } catch (ArithmeticException exception) {
-            innerAggregator.reportOverflow(IntegerType.INT_64, "Sum");
-            return null;
-          }
-        } else {
-          Double dCurrent = NumericConverter.tryConvertingToDouble(current);
-          Double dValue = NumericConverter.tryConvertingToDouble(value);
-          if (dCurrent != null && dValue != null) {
-            current = dCurrent + dValue;
-          } else {
-            innerAggregator.reportColumnAggregatedProblem(
-                new InvalidAggregation(this.getName(), row, "Cannot convert to a number."));
-            return null;
-          }
-        }
-      }
-
+      Object value = inputStorage.getItemBoxed(row);
+      accumulator.add(value);
       context.safepoint();
     }
-    return current;
+    return accumulator.summarize();
+  }
+
+  private static class SumAccumulator {
+    private Object accumulator = null;
+
+    void add(Object value) {
+      if (value == null) {
+        return;
+      }
+
+      Long valueAsLong = NumericConverter.tryConvertingToLong(value);
+      if (valueAsLong != null) {
+        addLong(valueAsLong);
+      } else if (value instanceof BigInteger) {
+        addBigInteger((BigInteger) value);
+      } else {
+        Double valueAsDouble = NumericConverter.tryConvertingToDouble(value);
+        if (valueAsDouble != null) {
+          addDouble(valueAsDouble);
+        } else {
+          throw new IllegalStateException("Unexpected value type: " + value.getClass());
+        }
+      }
+    }
+
+    private void addLong(long value) {
+      switch (accumulator) {
+        case Long accumulatorAsLong -> {
+          try {
+            accumulator = Math.addExact(accumulatorAsLong, value);
+          } catch (ArithmeticException exception) {
+            accumulator = BigInteger.valueOf(accumulatorAsLong).add(BigInteger.valueOf(value));
+          }
+        }
+        case BigInteger accumulatorAsBigInteger -> {
+          accumulator = accumulatorAsBigInteger.add(BigInteger.valueOf(value));
+        }
+        case Double accumulatorAsDouble -> {
+          accumulator = accumulatorAsDouble + value;
+        }
+        case null -> {
+          accumulator = value;
+        }
+        default -> throw new IllegalStateException("Unexpected accumulator type: " + accumulator.getClass());
+      }
+    }
+
+    private void addBigInteger(BigInteger value) {
+      switch (accumulator) {
+        case Long accumulatorAsLong -> {
+          accumulator = BigInteger.valueOf(accumulatorAsLong).add(value);
+        }
+        case BigInteger accumulatorAsBigInteger -> {
+          accumulator = accumulatorAsBigInteger.add(value);
+        }
+        case Double accumulatorAsDouble -> {
+          accumulator = accumulatorAsDouble + value.doubleValue();
+        }
+        case null -> {
+          accumulator = value;
+        }
+        default -> throw new IllegalStateException("Unexpected accumulator type: " + accumulator.getClass());
+      }
+    }
+
+    private void addDouble(double value) {
+      switch (accumulator) {
+        case Long accumulatorAsLong -> {
+          accumulator = ((double) accumulatorAsLong) + value;
+        }
+        case BigInteger accumulatorAsBigInteger -> {
+          accumulator = accumulatorAsBigInteger.doubleValue() + value;
+        }
+        case Double accumulatorAsDouble -> {
+          accumulator = accumulatorAsDouble + value;
+        }
+        case null -> {
+          accumulator = value;
+        }
+        default -> throw new IllegalStateException("Unexpected accumulator type: " + accumulator.getClass());
+      }
+    }
+
+    Object summarize() {
+      return accumulator;
+    }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
@@ -19,12 +19,10 @@ public class InferredIntegerBuilder extends Builder {
   private TypedBuilder bigIntegerBuilder = null;
   private int currentSize = 0;
   private final int initialSize;
-  private final ProblemAggregator problemAggregator;
 
   /** Creates a new instance of this builder, with the given known result length. */
   public InferredIntegerBuilder(int initialSize, ProblemAggregator problemAggregator) {
     this.initialSize = initialSize;
-    this.problemAggregator = problemAggregator;
 
     longBuilder =
         NumericBuilder.createLongBuilder(this.initialSize, IntegerType.INT_64, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/data/index/CrossTabIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/CrossTabIndex.java
@@ -140,8 +140,7 @@ public class CrossTabIndex {
     for (int i = 0; i < xKeysCount(); i++) {
       int offset = yColumns.length + i * aggregates.length;
       for (int j = 0; j < aggregates.length; j++) {
-        storage[offset + j] =
-            Builder.getForType(aggregates[j].getType(), yKeysCount(), problemAggregator);
+        storage[offset + j] = aggregates[j].makeBuilder(yKeysCount(), problemAggregator);
         context.safepoint();
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -115,7 +115,7 @@ public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
     boolean emptyScenario = size == 0 && keyColumns.length == 0;
     Builder[] storage =
         Arrays.stream(columns)
-            .map(c -> Builder.getForType(c.getType(), emptyScenario ? 1 : size, problemAggregator))
+            .map(c -> c.makeBuilder(emptyScenario ? 1 : size, problemAggregator))
             .toArray(Builder[]::new);
 
     if (emptyScenario) {

--- a/test/Base_Tests/src/Data/Statistics_Spec.enso
+++ b/test/Base_Tests/src/Data/Statistics_Spec.enso
@@ -83,10 +83,17 @@ add_specs suite_builder =
             text_set.compute Statistic.Maximum . should_equal "D"
 
         group_builder.specify "should be able to get sum of values" <|
-            simple_set.compute Statistic.Sum . should_equal 15 epsilon=double_error
+            int_sum = simple_set.compute Statistic.Sum
+            int_sum.should_equal 15
+            int_sum.should_be_a Integer
             number_set.compute Statistic.Sum . should_equal -101.28 epsilon=double_error
             missing_set.compute Statistic.Sum . should_equal -81.8 epsilon=double_error
             with_nans_set.compute Statistic.Sum . should_equal -81.8 epsilon=double_error
+
+        group_builder.specify "should be able to get a sum of big integer values" <|
+            r1 = [2^62, 2^62, 2^62, 2^62, 2^62].compute ..Sum
+            r1.should_equal (5 * 2^62)
+            r1.should_be_a Integer
 
         group_builder.specify "should be able to get product of values" <|
             simple_set.compute Statistic.Product . should_equal 120 epsilon=double_error
@@ -371,4 +378,3 @@ main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
     suite.run_with_filter filter
-

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1008,6 +1008,7 @@ add_aggregate_specs suite_builder setup =
         if setup.is_database.not then group_builder.specify "should return a Decimal column when input is Decimal" <|
             table = table_builder [["X", [2^62, 2^62, 2^62, 2^62]]]
                 . cast "X" (Value_Type.Decimal scale=0)
+            table.at "X" . value_type . should_be_a (Value_Type.Decimal ...)
             result = table.aggregate [] [Average "X"]
             within_table result <|
                 result.row_count . should_equal 1
@@ -1016,9 +1017,10 @@ add_aggregate_specs suite_builder setup =
                 materialized.column_count . should_equal 1
                 materialized.columns.at 0 . name . should_equal "Average X"
                 materialized.columns.at 0 . to_vector . should_equal [2^62]
+                materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
+
                 # Map to text to ensure that the equality is _exact_ and does not rely on Float rounding
                 materialized.columns.at 0 . to_vector . map .to_text . should_equal [(2^62).to_text]
-                materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
 
     # Special case for Snowflake until the https://github.com/enso-org/enso/issues/10412 ticket is resolved.
     if setup.prefix.contains "Snowflake" then

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -965,7 +965,7 @@ add_aggregate_specs suite_builder setup =
                 materialized2.columns.at 0 . value_type . should_be_a (Value_Type.Integer ...)
 
         if setup.is_database.not then group_builder.specify "should return a Decimal column when the sum overflows 64-bit Integers" <|
-            table = table_builder [["int_column", [2^62, 2^62, 2^62, 2^62, 2^62, 2^62, 2^62]]]
+            table = table_builder [["int_column", [2^62, 2^62, 2^62, 2^62, 2^62, 2^62, 2^62, 1, 2, 4]], ["group", ["big", "big", "big", "big", "big", "big", "big", "small", "small", "small"]]]
             table.at "int_column" . value_type . should_equal Value_Type.Integer
 
             result = table.aggregate [] [Sum "int_column"]
@@ -975,8 +975,20 @@ add_aggregate_specs suite_builder setup =
                 Problems.assume_no_problems materialized
                 materialized.column_count . should_equal 1
                 materialized.columns.at 0 . name . should_equal "Sum int_column"
-                materialized.columns.at 0 . to_vector . should_equal [(2^62) * table.row_count]
+                materialized.columns.at 0 . to_vector . should_equal [((2^62) * 7) + 7]
                 materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
+
+            result2 = table.aggregate ["group"] [Sum "int_column"] . sort "group"
+            within_table result2 <|
+                result2.row_count . should_equal 2
+                materialized2 = materialize result2
+                Problems.assume_no_problems materialized2
+                materialized2.column_count . should_equal 2
+                materialized2.columns.at 0 . name . should_equal "group"
+                materialized2.columns.at 0 . to_vector . should_equal ["big", "small"]
+                materialized2.columns.at 1 . name . should_equal "Sum int_column"
+                materialized2.columns.at 1 . to_vector . should_equal [(2^62) * 7, 7]
+                materialized2.columns.at 1 . value_type . should_be_a (Value_Type.Decimal ...)
 
         if setup.is_database.not then group_builder.specify "should allow to sum big-integer column" <|
             table = table_builder [["big_column", [2^100, 2^70]]]
@@ -989,6 +1001,23 @@ add_aggregate_specs suite_builder setup =
                 materialized.column_count . should_equal 1
                 materialized.columns.at 0 . name . should_equal "Sum big_column"
                 materialized.columns.at 0 . to_vector . should_equal [2^100 + 2^70]
+                materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
+
+    suite_builder.group prefix+"Table.aggregate Average" group_builder->
+        # The types of aggregates are only tested in-memory, in DB they will depend on each backend
+        if setup.is_database.not then group_builder.specify "should return a Decimal column when input is Decimal" <|
+            table = table_builder [["X", [2^62, 2^62, 2^62, 2^62]]]
+                . cast "X" (Value_Type.Decimal scale=0)
+            result = table.aggregate [] [Average "X"]
+            within_table result <|
+                result.row_count . should_equal 1
+                materialized = materialize result
+                Problems.assume_no_problems materialized
+                materialized.column_count . should_equal 1
+                materialized.columns.at 0 . name . should_equal "Average X"
+                materialized.columns.at 0 . to_vector . should_equal [2^62]
+                # Map to text to ensure that the equality is _exact_ and does not rely on Float rounding
+                materialized.columns.at 0 . to_vector . map .to_text . should_equal [(2^62).to_text]
                 materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
 
     # Special case for Snowflake until the https://github.com/enso-org/enso/issues/10412 ticket is resolved.

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Floating_Point_Equality
 
-from Standard.Table import Table, Sort_Column, expr
+from Standard.Table import Table, Sort_Column, Value_Type, expr
 from Standard.Table.Aggregate_Column.Aggregate_Column import all
 import Standard.Table.Expression.Expression_Error
 from Standard.Table.Errors import all
@@ -934,6 +934,62 @@ add_aggregate_specs suite_builder setup =
                 materialized.columns.at 1 . name . should_equal "Shortest B"
                 materialized.columns.at 1 . to_vector . should_equal ["f"]
 
+    suite_builder.group prefix+"Table.aggregate Sum" group_builder->
+        # The types of aggregates are only tested in-memory, in DB they will depend on each backend
+        if setup.is_database.not then group_builder.specify "should return an Integer column when summing an Integer input" <|
+            table = table_builder [["int_column", [1, 2, 3, 4, 5, 6, 7]]]
+            table.at "int_column" . value_type . should_equal Value_Type.Integer
+
+            result = table.aggregate [] [Sum "int_column"]
+            within_table result <|
+                result.row_count . should_equal 1
+                materialized = materialize result
+                Problems.assume_no_problems materialized
+                materialized.column_count . should_equal 1
+                materialized.columns.at 0 . name . should_equal "Sum int_column"
+                materialized.columns.at 0 . to_vector . should_equal [28]
+                materialized.columns.at 0 . value_type . should_equal Value_Type.Integer
+
+            table2 = table_builder [["int_column", [31000, 31000, 31000, 31000, 31000]]]
+                . cast "int_column" (Value_Type.Integer ..Bits_16)
+            table2.at "int_column" . value_type . should_equal (Value_Type.Integer ..Bits_16)
+
+            result2 = table2.aggregate [] [Sum "int_column"]
+            within_table result2 <|
+                result2.row_count . should_equal 1
+                materialized2 = materialize result2
+                Problems.assume_no_problems materialized2
+                materialized2.column_count . should_equal 1
+                materialized2.columns.at 0 . name . should_equal "Sum int_column"
+                materialized2.columns.at 0 . to_vector . should_equal [5*31000]
+                materialized2.columns.at 0 . value_type . should_be_a (Value_Type.Integer ...)
+
+        if setup.is_database.not then group_builder.specify "should return a Decimal column when the sum overflows 64-bit Integers" <|
+            table = table_builder [["int_column", [2^62, 2^62, 2^62, 2^62, 2^62, 2^62, 2^62]]]
+            table.at "int_column" . value_type . should_equal Value_Type.Integer
+
+            result = table.aggregate [] [Sum "int_column"]
+            within_table result <|
+                result.row_count . should_equal 1
+                materialized = materialize result
+                Problems.assume_no_problems materialized
+                materialized.column_count . should_equal 1
+                materialized.columns.at 0 . name . should_equal "Sum int_column"
+                materialized.columns.at 0 . to_vector . should_equal [(2^62) * table.row_count]
+                materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
+
+        if setup.is_database.not then group_builder.specify "should allow to sum big-integer column" <|
+            table = table_builder [["big_column", [2^100, 2^70]]]
+            table.at "big_column" . value_type . should_be_a (Value_Type.Decimal ...)
+            result = table.aggregate [] [Sum "big_column"]
+            within_table result <|
+                result.row_count . should_equal 1
+                materialized = materialize result
+                Problems.assume_no_problems materialized
+                materialized.column_count . should_equal 1
+                materialized.columns.at 0 . name . should_equal "Sum big_column"
+                materialized.columns.at 0 . to_vector . should_equal [2^100 + 2^70]
+                materialized.columns.at 0 . value_type . should_be_a (Value_Type.Decimal ...)
 
     # Special case for Snowflake until the https://github.com/enso-org/enso/issues/10412 ticket is resolved.
     if setup.prefix.contains "Snowflake" then

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -764,7 +764,7 @@ add_specs suite_builder =
 
             t4 = table.aggregate ["mixed"] [Aggregate_Column.Sum "ints", Aggregate_Column.Sum "floats"]
             t4.column_info.at "Column" . to_vector . should_equal ["mixed", "Sum ints", "Sum floats"]
-            t4.column_info.at "Value Type" . to_vector . should_equal [Value_Type.Mixed, Value_Type.Float, Value_Type.Float]
+            t4.column_info.at "Value Type" . to_vector . should_equal [Value_Type.Mixed, Value_Type.Integer, Value_Type.Float]
 
         group_builder.specify "should take Unicode normalization into account when grouping by Text" <|
             texts = ["texts", ['ściana', 'ściana', 'łąka', 's\u0301ciana', 'ła\u0328ka', 'sciana']]


### PR DESCRIPTION
### Pull Request Description

- This was mentioned in #7192 but didn't get a proper ticket.
- Ensuring that summing integers gives an integer and not a float.
	- Only in-memory, as in Database the result type is database-dependent and we want it to be like that.
- Also allowing the integer sum to overflow and become a `BigInteger`, in that case the resulting column will become `Decimal`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
