### PR TITLE
Fix sending same refreshToken as accessToken in open project request

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,7 +11,7 @@ build/build/release-body.md
 distribution/launcher/THIRD-PARTY
 distribution/engine/THIRD-PARTY
 distribution/project-manager/THIRD-PARTY
-tools/legal-review
+tools
 distribution/lib/Standard/*/*/manifest.yaml
 distribution/lib/Standard/*/*/polyglot
 distribution/lib/Standard/*/*/THIRD-PARTY

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -177,7 +177,7 @@ export function useOpenProjectMutation() {
           executeAsync: inBackground,
           cognitoCredentials: {
             accessToken: session.accessToken,
-            refreshToken: session.accessToken,
+            refreshToken: session.refreshToken,
             clientId: session.clientId,
             expireAt: session.expireAt,
             refreshUrl: session.refreshUrl,


### PR DESCRIPTION
### Pull Request Description

In `open_project` request body we send `cognitoCredentials` for the project to be able to communicate with Cloud API. Currently the `refreshToken` has the same value as `accessToken` making that communication buggy.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
