### PR TITLE
Allow a block to contain mixed indentation levels

### DIFF
--- a/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
+++ b/app/gui/src/project-view/util/ast/__tests__/abstract.test.ts
@@ -30,14 +30,6 @@ test('Raw block abstracts to Ast.BodyBlock', () => {
 const normalizingCases = [
   { input: ' a', normalized: '    a' },
   { input: 'a ', normalized: 'a \n' },
-  {
-    input: ['main =', '  foo', ' bar', '  baz'].join('\n'),
-    normalized: ['main =', '  foo', '  bar', '  baz'].join('\n'),
-  },
-  {
-    input: ['main =', '  foo', ' bar', 'baz'].join('\n'),
-    normalized: ['main =', '  foo', '  bar', 'baz'].join('\n'),
-  },
 ]
 const cases = [
   'Console.',
@@ -383,6 +375,8 @@ const cases = [
   '\n\n',
   '\na',
   '\n\na',
+  ['main =', '  foo', ' bar', '  baz'].join('\n'),
+  ['main =', '  foo', ' bar', 'baz'].join('\n'),
   ...normalizingCases,
 ]
 test.each(cases)('parse/print round-trip: %s', (testCase) => {

--- a/app/ydoc-shared/src/ast/tree.ts
+++ b/app/ydoc-shared/src/ast/tree.ts
@@ -2681,17 +2681,14 @@ export class BodyBlock extends BaseExpression {
 
   /** TODO: Add docs */
   *concreteChildren({ indent }: PrintContext): IterableIterator<RawConcreteChild> {
-    let linesIndent: string | undefined = undefined
     for (const line of this.fields.get('lines')) {
       yield preferUnspaced(line.newline)
       if (line.statement) {
         const whitespace: string =
-          linesIndent ??
           (line.statement.whitespace && line.statement.whitespace.length > (indent || '').length ?
             line.statement.whitespace
           : undefined) ??
           (indent != null ? indent + '    ' : '')
-        linesIndent = whitespace
         yield { whitespace, node: line.statement.node }
       }
     }

--- a/app/ydoc-shared/src/ast/tree.ts
+++ b/app/ydoc-shared/src/ast/tree.ts
@@ -2687,8 +2687,7 @@ export class BodyBlock extends BaseExpression {
         const whitespace: string =
           (line.statement.whitespace && line.statement.whitespace.length > (indent || '').length ?
             line.statement.whitespace
-          : undefined) ??
-          (indent != null ? indent + '    ' : '')
+          : undefined) ?? (indent != null ? indent + '    ' : '')
         yield { whitespace, node: line.statement.node }
       }
     }


### PR DESCRIPTION
### Pull Request Description

Don't force block to have consistent indentation. Fixes #11798.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
