### PR TITLE
Enable prettier on docs markdown

### DIFF
--- a/.github/workflows/gui-checks.yml
+++ b/.github/workflows/gui-checks.yml
@@ -31,17 +31,6 @@ jobs:
           node-version-file: .node-version
           cache: "pnpm"
 
-      - uses: actions/cache/restore@v4
-        name: Download cache
-        id: cache
-        with:
-          path: |
-            **/.eslintcache
-            node_modules/.cache/prettier
-          key: ${{ runner.os }}-gui-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gui
-
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -51,10 +40,15 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: 📝 Prettier
-        id: prettier
-        continue-on-error: true
-        run: pnpm run ci:prettier
+      - uses: actions/cache/restore@v4
+        name: Download cache
+        id: cache
+        with:
+          path: |
+            **/.eslintcache
+          key: ${{ runner.os }}-gui-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gui
 
       # Next Tasks are depend on Typecheck, because we build libraries at this stage
       - name: 🧠 Typecheck
@@ -88,7 +82,6 @@ jobs:
       - name: ❌ Fail if any check failed
         if: always() && (steps.prettier.outcome == 'failure' || steps.lint.outcome == 'failure' || steps.typecheck.outcome == 'failure' || steps.unit-tests.outcome == 'failure')
         run: |
-          echo "Prettier outcome: ${{ steps.prettier.outcome }}"
           echo "Lint outcome: ${{ steps.lint.outcome }}"
           echo "Typecheck outcome: ${{ steps.typecheck.outcome }}"
           echo "Unit tests outcome: ${{ steps.unit-tests.outcome }}"
@@ -102,7 +95,6 @@ jobs:
           key: ${{ steps.cache.outputs.cache-primary-key }}
           path: |
             **/.eslintcache
-            node_modules/.cache/prettier
 
   playwright:
     name: 🎭 Playwright Tests

--- a/.github/workflows/gui-pull-request.yml
+++ b/.github/workflows/gui-pull-request.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           files: |
             app/**
-            docs/**/*.md
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml
@@ -58,6 +57,52 @@ jobs:
           for file in ${ALL_CHANGED_FILES}; do
             echo "$file was changed"
           done
+
+  prettier:
+    name: 🧹 Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        name: ⎔ Setup Node
+        with:
+          node-version-file: .node-version
+          cache: "pnpm"
+
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.12.1
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - uses: actions/cache/restore@v4
+        name: Download cache
+        id: cache
+        with:
+          path: |
+            node_modules/.cache/prettier
+          key: ${{ runner.os }}-gui-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gui
+
+      - name: Run prettier
+        run: pnpm run ci:prettier
+
+      - name: 💾 Save cache
+        uses: actions/cache/save@v4
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        id: save-cache
+        with:
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+          path: |
+            node_modules/.cache/prettier
 
   checks:
     name: 🧰 Checks

--- a/.github/workflows/gui-pull-request.yml
+++ b/.github/workflows/gui-pull-request.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           files: |
             app/**
+            docs/**/*.md
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,7 +16,6 @@ distribution/lib/Standard/*/*/manifest.yaml
 distribution/lib/Standard/*/*/polyglot
 distribution/lib/Standard/*/*/THIRD-PARTY
 distribution/docs-js
-docs/**/*.md
 
 built-distribution/
 THIRD-PARTY

--- a/docs/semantics/errors.md
+++ b/docs/semantics/errors.md
@@ -20,8 +20,7 @@ users to deal with errors at runtime in the language.
 
 ## Asynchronous Exceptions
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Why do we call it asynchronous, when they are synchronous!?
 > - Specify the semantics of Enso's async exceptions.
@@ -32,19 +31,16 @@ There is a special [dynamic dispatch](../types/dynamic-dispatch.md) for `Error`
 values. A dataflow error dispatch first checks if it may call a method on
 `Error` type.
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Specify the semantics of Enso's broken values.
 
 ## Warnings
 
-> [!WARNING]
-> TODO
+> [!WARNING] TODO
 >
 > - Values in Enso may have warnings attached
 
 There is a special [dynamic dispatch](../types/dynamic-dispatch.md) for _values
-with warnings_. Before we pass the dispatch to the underlying value,
-we check if warning has a method 'overridden' - this is used for `remove_warnings`,
-etc.
+with warnings_. Before we pass the dispatch to the underlying value, we check if
+warning has a method 'overridden' - this is used for `remove_warnings`, etc.

--- a/docs/syntax/README.md
+++ b/docs/syntax/README.md
@@ -43,7 +43,8 @@ The various components of Enso's syntax are described below:
 - [**Functions:**](./functions.md) The syntax for writing functions in Enso.
 - [**Function Arguments:**](./function-arguments.md) The syntax for function
   arguments in Enso.
-- [**Conversions:**](./conversions.md) The syntax of special _conversion functions_ in Enso.
+- [**Conversions:**](./conversions.md) The syntax of special _conversion
+  functions_ in Enso.
 - [**Field Access:**](./projections.md) The syntax for working with fields of
   data types in Enso.
 - [**Comments:**](./comments.md) The syntax for writing comments in Enso.

--- a/docs/syntax/conversions.md
+++ b/docs/syntax/conversions.md
@@ -8,28 +8,36 @@ order: 10
 
 # Conversions
 
-Conversions are special [functions](./functions.md) associated with a [type](../types/hierarchy.md),
-named `from` and taking single `that` argument. Following example:
+Conversions are special [functions](./functions.md) associated with a
+[type](../types/hierarchy.md), named `from` and taking single `that` argument.
+Following example:
+
 ```ruby
 type Complex
     Num re:Float im:Float
 
 Complex.from (that:Float) = Complex.Num that 0
 ```
-defines type `Complex` and a **conversion** from `Float` which uses the provided `Float` value as
-real part of a complex number while setting the imaginary part to zero.
+
+defines type `Complex` and a **conversion** from `Float` which uses the provided
+`Float` value as real part of a complex number while setting the imaginary part
+to zero.
 
 ## Type Checks
 
-Conversions are integral part of [type checking](../types/inference-and-checking.md#type-checking-algorithm)
+Conversions are integral part of
+[type checking](../types/inference-and-checking.md#type-checking-algorithm)
 during runtime. Having the right conversion in scope one can write:
+
 ```ruby
 complex_pi = 3.14:Complex
 ```
-to create a new instance of type `Complex`. The Enso runtime represents
-the `3.14` literal as `Float` value and that would fail the `Complex` type check if there was no
-conversion method available. However as there is one, the runtime uses `Complex.from` behind the
-scene and `complex_pi` then becomes `Complex.Num 3.14 0` value.
 
-Type checks may perform no, one or multiple conversions (like in case of 
+to create a new instance of type `Complex`. The Enso runtime represents the
+`3.14` literal as `Float` value and that would fail the `Complex` type check if
+there was no conversion method available. However as there is one, the runtime
+uses `Complex.from` behind the scene and `complex_pi` then becomes
+`Complex.Num 3.14 0` value.
+
+Type checks may perform no, one or multiple conversions (like in case of
 [intersection types](../types/intersection-types.md)).

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -39,8 +39,7 @@ instrumental for ensuring that we build the right language.
 > described in the [syntax](../syntax/README.md) document makes no promises as
 > to whether said syntax will be exposed in the surface language.
 
-> [!WARNING]
-> The specification in this section is very outdated and far from
+> [!WARNING] The specification in this section is very outdated and far from
 > reality. Sections that are known to be _"off"_ are marked as _warning_.
 
 Information on the type system is broken up into the following sections:

--- a/docs/types/access-modifiers.md
+++ b/docs/types/access-modifiers.md
@@ -8,23 +8,23 @@ order: 4
 
 # Access Modifiers
 
-> [!WARNING]
-> Everybody who ever maintained a large system knows [encapsulation is essential](../semantics/encapsulation.md).
+> [!WARNING] Everybody who ever maintained a large system knows
+> [encapsulation is essential](../semantics/encapsulation.md).
 >
-> While we don't usually like making things private in a programming language, it
-> sometimes the case that it is necessary to indicate that certain fields should
-> not be touched (as this might break invariants and such like). To this end, Enso
-> provides an explicit mechanism for access modification.
+> While we don't usually like making things private in a programming language,
+> it sometimes the case that it is necessary to indicate that certain fields
+> should not be touched (as this might break invariants and such like). To this
+> end, Enso provides an explicit mechanism for access modification.
 
 Enso targets large user base of _non-programmers_. They are mostly focused on
-getting their job done and [encapsulation](../semantics/encapsulation.md) of their own code is the last thing
-that comes to their mind.
+getting their job done and [encapsulation](../semantics/encapsulation.md) of
+their own code is the last thing that comes to their mind.
 
-On the other hand, Enso supports and encourages creation of *sharable libraries*.
-Maintainers of such libraries are likely to treat API design and its
-backward compatibility seriously. As such they need a way to [encapsulate](../semantics/encapsulation.md)
-internals of their libraries and clearly *differentiate public API* and
-implementations details.
+On the other hand, Enso supports and encourages creation of _sharable
+libraries_. Maintainers of such libraries are likely to treat API design and its
+backward compatibility seriously. As such they need a way to
+[encapsulate](../semantics/encapsulation.md) internals of their libraries and
+clearly _differentiate public API_ and implementations details.
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 
@@ -35,27 +35,26 @@ implementations details.
 
 ## Access Modification
 
-*By default* Enso elements (functions, types, methods) are *public*.
-One has to use an access modifier to hide and [encapsulate](../semantics/encapsulation.md) them. The
-reasoning is: those who don't care can access everything they create without
-any restriction. Those who care can make things `private` with an additional
-effort.
+_By default_ Enso elements (functions, types, methods) are _public_. One has to
+use an access modifier to hide and [encapsulate](../semantics/encapsulation.md)
+them. The reasoning is: those who don't care can access everything they create
+without any restriction. Those who care can make things `private` with an
+additional effort.
 
+Accessing any member under an access modifier is an error when performed from
+another project. Such a check is enforced during runtime.
 
-Accessing any member under an access modifier is an error when performed from another project.
-Such a check is enforced during runtime.
-
-There is a command line switch to _disable access modifier check_.
-It maybe be useful for experimentation. However the general suggestion is:
-Avoid using it in production.
+There is a command line switch to _disable access modifier check_. It maybe be
+useful for experimentation. However the general suggestion is: Avoid using it in
+production.
 
 ## Private
 
 Encapsulation is an effective _communication mechanism_ among _distributed
-groups_ of developers. The `private` modifier hides implementation details from clients of the API.
-The primary groups in the Enso case are those who *publish a library*
-and those who *consume such a library*.
+groups_ of developers. The `private` modifier hides implementation details from
+clients of the API. The primary groups in the Enso case are those who _publish a
+library_ and those who _consume such a library_.
 
-As such Enso supports _library private_ encapsulation.
-To hide any element (module, type, constructor, function) away
-from *library consumers* prefix such an element with `private` keyword.
+As such Enso supports _library private_ encapsulation. To hide any element
+(module, type, constructor, function) away from _library consumers_ prefix such
+an element with `private` keyword.

--- a/docs/types/contexts.md
+++ b/docs/types/contexts.md
@@ -8,21 +8,20 @@ order: 8
 
 # Monadic Contexts
 
-> [!WARNING]
-> Reword for people without Haskell background who don't know what _lifting_ is.
+> [!WARNING] Reword for people without Haskell background who don't know what
+> _lifting_ is.
 >
 > Coming from a Haskell background, we have found that Monads provide a great
 > abstraction with which to reason about program behaviour, but they have some
-> severe usability issues. The main one of these is the lack of automatic lifting,
-> requiring users to explicitly lift computations through their monad transformer
-> stack.
+> severe usability issues. The main one of these is the lack of automatic
+> lifting, requiring users to explicitly lift computations through their monad
+> transformer stack.
 
 For a language as focused on usability as Enso is importing all the _complexity
-of Haskell monads_ really isn't feasible. To
-that end, we have created the notion of a 'Monadic Context', which is a monad
-transformer based on Supermonads (see
-[references](./references.md#monadic-contexts)). These have special support in
-the compiler, and hence can be automatically lifted to aid usability.
+of Haskell monads_ really isn't feasible. To that end, we have created the
+notion of a 'Monadic Context', which is a monad transformer based on Supermonads
+(see [references](./references.md#monadic-contexts)). These have special support
+in the compiler, and hence can be automatically lifted to aid usability.
 
 > The actionables for this section are:
 >
@@ -45,63 +44,68 @@ the compiler, and hence can be automatically lifted to aid usability.
 
 ## Context Syntax
 
-> [!WARNING]
-> There used to be three main notes about the syntax of contexts:
+> [!WARNING] There used to be three main notes about the syntax of contexts:
 >
 > 1. Monadic contexts are defined using the `in` keyword (e.g. `Int in IO`).
 > 2. We have a symbol `!`, which is short-hand for putting something into the
->   `Exception` monadic context. This is related to broken values.
+>    `Exception` monadic context. This is related to broken values.
 > 3. Contexts can be combined by using the standard typeset operators, or nested
->   through repeated uses of `in`.
+>    through repeated uses of `in`.
 
-There is no special syntax for contexts anymore.
-Since [#3828](https://github.com/enso-org/enso/pull/3828) 
-Enso is no longer relaying on a haskelly solution. 
-Rather than that _contexts_ are being manupulated by
-_standard library_ functions grouped around 
-`Standard.Base.Runtime.Context` & co.
+There is no special syntax for contexts anymore. Since
+[#3828](https://github.com/enso-org/enso/pull/3828) Enso is no longer relaying
+on a haskelly solution. Rather than that _contexts_ are being manupulated by
+_standard library_ functions grouped around `Standard.Base.Runtime.Context` &
+co.
+
 ```ruby
 Runtime.Context.Output.with_enabled <|
     File.new "c:\trash.txt" . delete
 ```
 
 There is still the `!` symbol signaling [presence of errors](./errors.md)
-- e.g. _broken values_. However the runtime can handle _broken values_ 
-even without presence of these _exception type signatures_. Thus the
-compiler only verifies the referenced types are valid.
+
+- e.g. _broken values_. However the runtime can handle _broken values_ even
+  without presence of these _exception type signatures_. Thus the compiler only
+  verifies the referenced types are valid.
 
 ## Monadic Bind
 
-> [!WARNING]
-> Who knows what `<-` means in Haskell?
-> 
+> [!WARNING] Who knows what `<-` means in Haskell?
+>
 > It is also important to note that Enso has no equivalent to `<-` in Haskell.
-> Instead, pure computations are implicitly placed in the `Pure` monadic context,
-> and `=` acts to 'peel off' the outermost layer of contexts. As such, this means
-> that `=` _always_ acts as `bind`, greatly simplifying how the type-checker has
-> to work.
+> Instead, pure computations are implicitly placed in the `Pure` monadic
+> context, and `=` acts to 'peel off' the outermost layer of contexts. As such,
+> this means that `=` _always_ acts as `bind`, greatly simplifying how the
+> type-checker has to work.
 
 ## Inbuilt Contexts
 
-Enso standard library defines `Input`, `Output` and `Dataflow_Stack_Trace` 
+Enso standard library defines `Input`, `Output` and `Dataflow_Stack_Trace`
 contects as of Enso 2024.5.1 version. Users cannot define their own.
 
 ### State
 
-The _state_ concept is implement by standard libraries with _no support in the type system_.
+The _state_ concept is implement by standard libraries with _no support in the
+type system_.
 
-State acts as a [thread local](https://en.wikipedia.org/wiki/Thread-local_storage) variable
-of operating system:
+State acts as a
+[thread local](https://en.wikipedia.org/wiki/Thread-local_storage) variable of
+operating system:
+
 <!-- (well, it will when #7117 gets fixed)  -->
+
 - an _initializing code_ can set `State` up
 - execute some code
-- a code somewhere deep the stack (while _initializing code_ is still on the stack)
+- a code somewhere deep the stack (while _initializing code_ is still on the
+  stack)
 - may pick the state up
 - once the _initializing code_ finishes execution
 - the state is gone
 
-It is an example of _tunnelling a value_ from one side (e.g. code) of the "tunnel" to another,
-without the "tunnel" (e.g. thee code in between) knowing about it.
+It is an example of _tunnelling a value_ from one side (e.g. code) of the
+"tunnel" to another, without the "tunnel" (e.g. thee code in between) knowing
+about it.
 
 <!--
 > There has to be some Haskell monad concept for it all... but we don't need it

--- a/docs/types/dynamic-dispatch.md
+++ b/docs/types/dynamic-dispatch.md
@@ -31,45 +31,45 @@ one to select, the compiler needs to have a notion of _specificity_, which is
 effectively an algorithm for determining which candidate is more specific than
 another.
 
-> [!WARNING]
-> Static compiler selects nothing. The right method to invoke is _selected in the runtime_.
+> [!WARNING] Static compiler selects nothing. The right method to invoke is
+> _selected in the runtime_.
 >
 > - Always prefer a member function for both `x.f y` and `f y x` notations.
-> - Only member functions, current module's functions, and imported functions are
->   considered to be in scope. Local variable `f` could not be used in the `x.f y`
->   syntax.
+> - Only member functions, current module's functions, and imported functions
+>   are considered to be in scope. Local variable `f` could not be used in the
+>   `x.f y` syntax.
 > - Selecting the matching function:
 >   1. Look up the member function. If it exists, select it.
->   2. If not, find all functions with the matching name in the current module and
->      all directly imported modules. These functions are the _candidates_.
->   3. Eliminate any candidate `X` for which there is another candidate `Y` whose
->      `this` argument type is strictly more specific. That is, `Y` this type is a
->      substitution of `X` this type but not vice versa.
->   4. If not all of the remaining candidates have the same this type, the search
->      fails.
->   5. Eliminate any candidate `X` for which there is another candidate `Y` which
->      type signature is strictly more specific. That is, `Y` type signature is a
->      substitution of `X` type signature.
+>   2. If not, find all functions with the matching name in the current module
+>      and all directly imported modules. These functions are the _candidates_.
+>   3. Eliminate any candidate `X` for which there is another candidate `Y`
+>      whose `this` argument type is strictly more specific. That is, `Y` this
+>      type is a substitution of `X` this type but not vice versa.
+>   4. If not all of the remaining candidates have the same this type, the
+>      search fails.
+>   5. Eliminate any candidate `X` for which there is another candidate `Y`
+>      which type signature is strictly more specific. That is, `Y` type
+>      signature is a substitution of `X` type signature.
 >   6. If exactly one candidate remains, select it. Otherwise, the search fails.
 
-The runtime system of Enso identifies the type of a value in `obj.method_name` invocation.
-It checks the _table of virtual methods_ for given type and finds proper
-implementation of `method_name` to invoke. Should there be no method of given
-name in the value's type (or its supertypes like `Any`) to invoke,
-a `No_Such_Method` panic is raised.
+The runtime system of Enso identifies the type of a value in `obj.method_name`
+invocation. It checks the _table of virtual methods_ for given type and finds
+proper implementation of `method_name` to invoke. Should there be no method of
+given name in the value's type (or its supertypes like `Any`) to invoke, a
+`No_Such_Method` panic is raised.
 
-There is a special dispatch for [broken values & warnings](../semantics/errors.md).
+There is a special dispatch for
+[broken values & warnings](../semantics/errors.md).
 
 ## Multiple Dispatch
 
 Multiple dispatch is currently used for
 [binary operators](../syntax/functions.md#type-ascriptions-and-operator-resolution).
 
-Multiple dispatch is also used on `from` conversions, because in
-expression `T.from x` the function to use is based on both `T` and `x`.
+Multiple dispatch is also used on `from` conversions, because in expression
+`T.from x` the function to use is based on both `T` and `x`.
 
-> [!WARNING]
-> Supporting general _multiple dispatch is unlikely_
+> [!WARNING] Supporting general _multiple dispatch is unlikely_
 >
 > Supporting it for general functions remains an open question as to whether we
 > want to support proper multiple dispatch in Enso. Multiple dispatch refers to
@@ -105,5 +105,5 @@ expression `T.from x` the function to use is based on both `T` and `x`.
 >     greet 7  # I have no name
 > ```
 >
->   Here, because `Person` conforms to the `HasName` interface, the second `greet`
->   implementation is chosen because the constraints make it more specific.
+> Here, because `Person` conforms to the `HasName` interface, the second `greet`
+> implementation is chosen because the constraints make it more specific.

--- a/docs/types/errors.md
+++ b/docs/types/errors.md
@@ -8,12 +8,10 @@ order: 12
 
 # Errors
 
-Enso supports two notions of errors. One is the standard exceptions
-model, while the other is a theory of 'broken values' that propagate through
-computations.
+Enso supports two notions of errors. One is the standard exceptions model, while
+the other is a theory of 'broken values' that propagate through computations.
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Greatly expand on the reasoning and theory behind the two exception models.
 > - Explain why broken values serve the GUI well.
@@ -28,17 +26,17 @@ computations.
 
 ## Async Exceptions
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
-> - why is this called _"asynchronous"_ when the `Panic` is raised synchronously?
+> - why is this called _"asynchronous"_ when the `Panic` is raised
+>   synchronously?
 > - Formalise the model of async exceptions as implemented.
 
 ## Broken Values
 
 In Enso we have the notion of a 'broken' value: one which is in an invalid state
-but not an error. While these may initially seem a touch useless,
-they are actually key for the display of errors in the GUI.
+but not an error. While these may initially seem a touch useless, they are
+actually key for the display of errors in the GUI.
 
 Broken values can be thought of like checked monadic exceptions in Haskell, but
 with an automatic propagation mechanism:
@@ -64,8 +62,7 @@ with an automatic propagation mechanism:
 
 - This allows for very natural error handling in the GUI.
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Determine what kinds of APIs we want to use async exceptions for, and which
 >   broken values are more suited for.

--- a/docs/types/evaluation.md
+++ b/docs/types/evaluation.md
@@ -14,16 +14,14 @@ design of certain APIs.
 
 To that end, Enso provides a mechanism for this through the type system.
 
-> [!WARNING]
-> Enso is using `~` and `...` to defer computations and perform them lazily
-> when needed.
+> [!WARNING] Enso is using `~` and `...` to defer computations and perform them
+> lazily when needed.
 >
-> The
-> standard library defines a `Suspend a` type which, when used in explicit type
-> signatures, will cause the corresponding expression to be suspended.
+> The standard library defines a `Suspend a` type which, when used in explicit
+> type signatures, will cause the corresponding expression to be suspended.
 >
-> - The explicit calls to `Suspend` and `force` are inserted automatically by the
->   compiler doing demand analysis.
+> - The explicit calls to `Suspend` and `force` are inserted automatically by
+>   the compiler doing demand analysis.
 > - This demand analysis process will also ensure that there are not polynomial
 >   chains of suspend and force being inserted to ensure performance.
 >
@@ -33,15 +31,15 @@ To that end, Enso provides a mechanism for this through the type system.
 
 A function argument can be prefixed by `~`. That instructs the Enso runtime
 system to provide such an arguments a thunk - a function to be evaluated later.
-Such a thunk function is they evaluated when the value of the argument
-is accessed/used. Such an evaluation is performed every time the argument value
-is used.
+Such a thunk function is they evaluated when the value of the argument is
+accessed/used. Such an evaluation is performed every time the argument value is
+used.
 
 An atom argument can be prefixed by `~`. That instructs the Enso runtime system
 to defer evaluation of the argument until it is first accessed. Then its thunk
-is evaluated and when the evaluation is over, the atom argument value is replaced
-by the computed value. Subsequent access to the atom argument will then use
-the already evaluated value.
+is evaluated and when the evaluation is over, the atom argument value is
+replaced by the computed value. Subsequent access to the atom argument will then
+use the already evaluated value.
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 
@@ -51,11 +49,10 @@ the already evaluated value.
 
 ## Specifying Suspension in the Type System
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Actually specify how the type system interacts with eager and lazy
 >   evaluation.
 
-Just use `~` to mark lazily computed function or atom arguments. The rest is handled
-by the Enso runtime system.
+Just use `~` to mark lazily computed function or atom arguments. The rest is
+handled by the Enso runtime system.

--- a/docs/types/function-types.md
+++ b/docs/types/function-types.md
@@ -11,8 +11,7 @@ order: 3
 As a functional programming language, the type of functions in Enso (`->`) is
 key. There are a few things that should be noted about functions in Enso.
 
-> [!NOTE]
-> The actionables for this section:
+> [!NOTE] The actionables for this section:
 >
 > - Work out a full specification for function typing and behaviour.
 > - Calling a function with an upper-case letter instantiates all of its type
@@ -55,8 +54,8 @@ lexical scoping. For a detailed discussion of scoping, please see
 > ## Structural Type Shorthand
 >
 > In Enso, we want to be able to write a type-signature that represents types in
-> terms of the operations that take place on the input values. A classical example
-> is `add`:
+> terms of the operations that take place on the input values. A classical
+> example is `add`:
 >
 > ```ruby
 > add : a -> b -> b + a
@@ -69,8 +68,8 @@ lexical scoping. For a detailed discussion of scoping, please see
 >   signature that can't work, but the return type, in combination with our
 >   integrated `Convertible` mechanism gives us the tools to make it work.
 > - The return type is `a + b`. This is a shorthand expression for a detailed
->   desugaring. The desugaring provided below is what the typechecker would infer
->   based on such a signature.
+>   desugaring. The desugaring provided below is what the typechecker would
+>   infer based on such a signature.
 >
 > ```ruby
 > add : forall a b c d. ({+ : Convertible b c => a -> c -> d} <: a) => a -> b -> d
@@ -80,23 +79,23 @@ lexical scoping. For a detailed discussion of scoping, please see
 > follows:
 >
 > 1. The expression `b + a` is syntactic sugar for a method call on a: `a.+ b`.
-> 2. This means that there must be a `+` method on a that takes both an `a` and a
->    `b`, with return-type unspecified as of yet: `+ : a -> b -> ?`
+> 2. This means that there must be a `+` method on a that takes both an `a` and
+>    a `b`, with return-type unspecified as of yet: `+ : a -> b -> ?`
 > 3. However, as `Convertible` is built into the language, we have to consider
->    that for `a.+ b` to work, the `+` method can actually take any type to which
->    `b` converts. This introduces the constraint `Convertible b c`, and we get
->    `+ : a -> c -> ?`
+>    that for `a.+ b` to work, the `+` method can actually take any type to
+>    which `b` converts. This introduces the constraint `Convertible b c`, and
+>    we get `+ : a -> c -> ?`
 > 4. The return type from a function need not be determined by its arguments, so
->    hence in the general case we have to default to an unrestricted type variable
->    giving `+ a -> c -> d`.
-> 5. This method must exist on the type `a`, resulting in the constraint that the
->    row `{+ : a -> c -> d} <: a` must conform to that interface.
+>    hence in the general case we have to default to an unrestricted type
+>    variable giving `+ a -> c -> d`.
+> 5. This method must exist on the type `a`, resulting in the constraint that
+>    the row `{+ : a -> c -> d} <: a` must conform to that interface.
 > 6. We now know the return type of `a + b`, and can rewrite it in the signature
 >    as `d`.
 >
-> Please note that `a <: b` (which can be flipped as `:>`) means that `a` is a row
-> that is a sub-row contained within the row `b`. The containment relation allows
-> for the possibility that `a == b`.
+> Please note that `a <: b` (which can be flipped as `:>`) means that `a` is a
+> row that is a sub-row contained within the row `b`. The containment relation
+> allows for the possibility that `a == b`.
 >
 > The inferred type for any function should, in general, match the given type
 > signature. Cases where this break down should only exist where the type
@@ -115,8 +114,7 @@ all arguments have been applied. This operator is `>>` (and its backwards cousin
 arguments, and the result consumes `n` arguments, applies them to `f`, and then
 applies the result of that plus any additional arguments to `g`.
 
-> [!WARNING]
-> Enso does support `>>` as well as `<<` operators, but
+> [!WARNING] Enso does support `>>` as well as `<<` operators, but
 >
 > ```ruby
 > computeCoeff = (+) >> (*5)
@@ -134,8 +132,7 @@ applies the result of that plus any additional arguments to `g`.
 In addition, we have the operator `.`, which acts as standard forward function
 chaining in Enso, and its backwards chaining cousin `<|`.
 
-> [!NOTE]
-> The actionables from this section are:
+> [!NOTE] The actionables from this section are:
 >
 > - Examples for the more advanced use-cases of `>>` to decide if the type
 >   complexity is worth it.

--- a/docs/types/goals.md
+++ b/docs/types/goals.md
@@ -23,8 +23,7 @@ needs to be as unobtrusive as possible.
 
 The high-level goals for the Enso type system are as follows:
 
-> [!WARNING] 
-> _Not a goal anymore_: Enso is a dynamic language. Static type
+> [!WARNING] _Not a goal anymore_: Enso is a dynamic language. Static type
 > inference is _not needed for execution_. As such _static typing_ is an
 > optional component - more a _linter_ than essential part of the system.
 >

--- a/docs/types/hierarchy.md
+++ b/docs/types/hierarchy.md
@@ -14,8 +14,7 @@ most generic type is `Any`. If a value has no better (more specific) type, it
 has the type `Any`. All operations defined on type `Any` can be performed on any
 value in the system.
 
-> [!WARNING] 
-> _Typeset theory is far from current state of affairs_:
+> [!WARNING] _Typeset theory is far from current state of affairs_:
 >
 > Enso is a statically typed language based upon a theory of set-based typing,
 > what we call `typesets`. This is a novel approach, and it is key to our intent
@@ -39,8 +38,7 @@ A value in Enso can have multiple different types attributed to it. It is
 possible to query/inspect these types during runtime and thus decide what
 operations are available for a particular value at hand.
 
-> [!WARNING]
-> _Probably not true in current system at all_
+> [!WARNING] > _Probably not true in current system at all_
 >
 > A brief note on naming (for more, please see the
 > [naming syntax](../syntax/naming.md)):
@@ -87,8 +85,7 @@ v:Maybe
 v.value:Text
 ```
 
-> [!WARNING]
-> There are no _Typesets_ in Enso anymore
+> [!WARNING] There are no _Typesets_ in Enso anymore
 >
 > Typesets in Enso are an entity unique to Enso's type system. They are a
 > fundamental recognition of types as 'sets of values' in Enso, and while they
@@ -144,8 +141,7 @@ They are as follows:
 - **Intersection - `&`:** This operator creates a typeset that contains the
   members in the [intersection of its operands](./intersection-types.md).
 
-> [!WARNING]
-> These operators _don't seem to be supported_. There is no plan to
+> [!WARNING] These operators _don't seem to be supported_. There is no plan to
 > support following operators now:
 >
 > - **Subsumption - `<:`:** This operator asserts that the left hand operand is
@@ -160,8 +156,7 @@ For information on the syntactic usage of these operators, please see the
 section on [type operators](#../syntax/types.md#type-operators) in the syntax
 design documentation.
 
-> [!NOTE]
-> The actionables for this section are:
+> [!NOTE] The actionables for this section are:
 >
 > - When necessary, we need to _explicitly formalise_ the semantics of all of
 >   these operators.
@@ -169,8 +164,7 @@ design documentation.
 >   generative) types?
 > - Are `<:` and `:` equivalent in the surface syntax?
 
-> [!WARNING]
-> _Typeset Subsumption_ isn't relevant
+> [!WARNING] > _Typeset Subsumption_ isn't relevant
 >
 > For two typesets `a` and `b`, `a` is said to be subsumed by `b` (written using
 > the notation `a <: b`) if the following hold recursively. This can be thought
@@ -244,11 +238,11 @@ Historically interfaces used to be defined by _duck typing_. As Enso is a
 dynamic language, having two types with the same operations means they can be
 used interchangingly.
 
-> [!NOTE]
-> A work on [type classes](https://github.com/orgs/enso-org/discussions/11366) support is under way
+> [!NOTE] A work on
+> [type classes](https://github.com/orgs/enso-org/discussions/11366) support is
+> under way
 
-> [!WARNING]
->  _Doesn't match reality:_
+> [!WARNING] _Doesn't match reality:_
 >
 > Because typesets can be matched _structurally_, all typesets implicitly define
 > interfaces. A type `t` conforming to an interface `i` in Enso is as simple as
@@ -305,8 +299,7 @@ _finalizers_.
 An expression `a : b` says that the expression denoted by `a` has the type
 denoted by the expression `b`.
 
-> [!WARNING]
-> No support for Scoping in Type Ascription
+> [!WARNING] No support for Scoping in Type Ascription
 >
 > Enso intends to support some form of mutual scoping between the left and right
 > sides of the type ascription operator. This introduces some complexity into
@@ -323,8 +316,7 @@ denoted by the expression `b`.
 >   bindings in groups, and the desugaring needs to depend on combinations of
 >   `>>=` and `fix`.
 
-> [!WARNING]
-> There are _no projections_ right now and none are planned
+> [!WARNING] There are _no projections_ right now and none are planned
 >
 > In order to work efficiently with typesets, we need the ability to seamlessly
 > access and modify (immutably) their properties. In the context of our type

--- a/docs/types/inference-and-checking.md
+++ b/docs/types/inference-and-checking.md
@@ -8,8 +8,8 @@ order: 13
 
 # Inference and Checking
 
-In spite of being dynamically-typed language, Enso is built with a sophisticated type checker
-capable of reasoning about Enso typed system. However, a type
+In spite of being dynamically-typed language, Enso is built with a sophisticated
+type checker capable of reasoning about Enso typed system. However, a type
 checker on its own is quite useless. For Enso to truly be usable, it must also
 have a powerful type inference engine.
 
@@ -43,8 +43,7 @@ In order to make Enso's type inference as helpful and friendly as possible to
 our users, we want the ability to infer the _maximal subset_ of the types that
 Enso can express.
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - How do we do inference for higher-rank and impredicative instantiations.
 > - How do we infer contexts, and how do we make that inference granular (e.g.
@@ -59,21 +58,18 @@ Enso can express.
 
 ## Type Inference Algorithm
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Specify the inference algorithm.
 
 ### Inferring Dependency
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Specify how (if at all) we can infer dependent quantifiers.
 
 ## Type Checking Algorithm
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Specify the type checking algorithm.

--- a/docs/types/intersection-types.md
+++ b/docs/types/intersection-types.md
@@ -8,50 +8,60 @@ order: 2
 
 # Intersection Types
 
-Intersection types play an important role in Enso [type hierarchy](./hierarchy.md)
-and its visual representation. Having a value that can play _multiple roles_
-at once is essential for smooth _live programming_ manipulation of such a value.
+Intersection types play an important role in Enso
+[type hierarchy](./hierarchy.md) and its visual representation. Having a value
+that can play _multiple roles_ at once is essential for smooth _live
+programming_ manipulation of such a value.
 
-Intersections types are created with the use of [`&` operator](./hierarchy.md#typeset-operators).
-In an attempt to represent `Complex` numbers (with real and imaginary component)
-one may decide to create a type that is both `Complex` and `Float` when the
-imaginary part is `0`:
+Intersections types are created with the use of
+[`&` operator](./hierarchy.md#typeset-operators). In an attempt to represent
+`Complex` numbers (with real and imaginary component) one may decide to create a
+type that is both `Complex` and `Float` when the imaginary part is `0`:
+
 ```ruby
 type Complex
     Num re:Float im:Float
-    
-    plain_or_both self = 
+
+    plain_or_both self =
         if self.im != 0 then self else
             both = self.re : Complex&Float
             both # value with both types: Complex and Float
-```   
+```
+
 Having a value with such _intersection type_ allows the IDE to offer operations
 available on all individual types.
 
 ## Creating
 
-Creating a value of _intersection types_ is as simple as performing a type check:
+Creating a value of _intersection types_ is as simple as performing a type
+check:
+
 ```ruby
 self : Complex&Float
 ```
-However such a _type check_ is closely associated with [conversions](../syntax/conversions.md).
-If the value doesn't represent all the desired types yet, then the system looks 
-for [conversion methods](../syntax/conversions.md) being available in the scope like:
+
+However such a _type check_ is closely associated with
+[conversions](../syntax/conversions.md). If the value doesn't represent all the
+desired types yet, then the system looks for
+[conversion methods](../syntax/conversions.md) being available in the scope
+like:
+
 ```
 Complex.from (that:Float) = Complex.Num that 0
 ```
+
 and uses them to create all the values the _intersection type_ represents.
 
-> [!NOTE]
-> Note that if a `Float.from (that:Complex)` conversion were available in the scope, 
-> any `Complex` instance would be convertible to `Float` regardless of how it was constructed. 
-> To ensure that such mix-ins are only available on values that opt-in to being 
-> an intersection type (like in the `Complex` example above where we include 
-> the `Float` mix-in only if `self.im == 0`), we need to ensure that the conversion 
-> used to create the intersection type is not available in the default 
-> conversion resolution scope. Thus it cannot be defined in the same module 
-> as `Complex` or `Float` types, but instead it should be defined in a separate 
-> module that is only imported in the place that will be constructing the multi-values.
+> [!NOTE] Note that if a `Float.from (that:Complex)` conversion were available
+> in the scope, any `Complex` instance would be convertible to `Float`
+> regardless of how it was constructed. To ensure that such mix-ins are only
+> available on values that opt-in to being an intersection type (like in the
+> `Complex` example above where we include the `Float` mix-in only if
+> `self.im == 0`), we need to ensure that the conversion used to create the
+> intersection type is not available in the default conversion resolution scope.
+> Thus it cannot be defined in the same module as `Complex` or `Float` types,
+> but instead it should be defined in a separate module that is only imported in
+> the place that will be constructing the multi-values.
 
 <!--
 Just as demonstrated at
@@ -60,94 +70,113 @@ https://github.com/enso-org/enso/commit/3d8a0e1b90b20cfdfe5da8d2d3950f644a4b45b8
 
 ## Narrowing Type Check
 
-When an _intersection type_ value is being downcast to _some of the types it already represents_,
-these types become its _visible_ types. Any additional types it represents become _hidden_.
+When an _intersection type_ value is being downcast to _some of the types it
+already represents_, these types become its _visible_ types. Any additional
+types it represents become _hidden_.
 
 The following operations consider only the _visible_ part of the type:
+
 - [dynamic dispatch](../types/dynamic-dispatch.md)
 - cases when value is passed as an argument
 
 However the value still keeps internal knowledge of all the types it represents.
 
-Thus, after casting a value `cf:Complex&Float` to just `Complex`, e.g. `c = cf:Complex`:
+Thus, after casting a value `cf:Complex&Float` to just `Complex`, e.g.
+`c = cf:Complex`:
+
 - method calls on `c` will only consider methods defined on `Complex`
-- the value `c` can only be passed as argument to methods expecting `Complex` type
+- the value `c` can only be passed as argument to methods expecting `Complex`
+  type
 - a type error is raised when a `Float` parameter is expected
 
-As such a _static analysis_ knows the type a value _has been cast to_ (the _visible_ part)
-and  can deduce the set of operations that can be performed with it. Moreover, any
-method calls will also only accept the value if it satisfies the type it 
-_has been cast to_. Any additional remaining _hidden_ types
-can only be brought back through an _explicit_ cast.
-To perform an explicit cast that can uncover the 'hidden' part of a type write
-`f = c:Float` or inspect the types in a `case` expression, e.g.
+As such a _static analysis_ knows the type a value _has been cast to_ (the
+_visible_ part) and can deduce the set of operations that can be performed with
+it. Moreover, any method calls will also only accept the value if it satisfies
+the type it _has been cast to_. Any additional remaining _hidden_ types can only
+be brought back through an _explicit_ cast. To perform an explicit cast that can
+uncover the 'hidden' part of a type write `f = c:Float` or inspect the types in
+a `case` expression, e.g.
+
 ```ruby
 case c of
     f : Float -> f.sqrt
     _ -> "Not a float"
 ```
-Remember to use `f.sqrt` and not `c.sqrt`. `f` in the case branch _has been cast to_ `Float` while
-`c` in the case branch only _can be cast to_.
 
-> [!WARNING]
-> Keep in mind that while both argument type check in method definitions and a 
-> 'type asserting' expression look similarly, they have slightly different behaviour.
+Remember to use `f.sqrt` and not `c.sqrt`. `f` in the case branch _has been cast
+to_ `Float` while `c` in the case branch only _can be cast to_.
+
+> [!WARNING] Keep in mind that while both argument type check in method
+> definitions and a 'type asserting' expression look similarly, they have
+> slightly different behaviour.
+>
 > ```
 > f a:Float = a
 > g a = a:Float
 > ```
-> These two functions, while very similar, will have different behaviour when 
-> passed a value like the value `c` above. The function `f` will fail with 
-> a type error, because the visible type of `c` is just `Complex` (assuming 
-> the conversion to `Float` is not available in the current scope). 
-> However, the function `g` will accept the same value and return it as 
-> a `Float` value, based on the 'hidden' part of its type.
+>
+> These two functions, while very similar, will have different behaviour when
+> passed a value like the value `c` above. The function `f` will fail with a
+> type error, because the visible type of `c` is just `Complex` (assuming the
+> conversion to `Float` is not available in the current scope). However, the
+> function `g` will accept the same value and return it as a `Float` value,
+> based on the 'hidden' part of its type.
 
-> [!NOTE]
-> In the **object oriented terminology** we can think of
-> a type `Complex&Float` as being a subclass of `Complex` and subclass of `Float` types.
-> As such a value of type `Complex&Float` may be used wherever `Complex` or `Float` types
-> are used. Let there, for example, be a function:
+> [!NOTE] In the **object oriented terminology** we can think of a type
+> `Complex&Float` as being a subclass of `Complex` and subclass of `Float`
+> types. As such a value of type `Complex&Float` may be used wherever `Complex`
+> or `Float` types are used. Let there, for example, be a function:
+>
 > ```ruby
 > use_complex c:Complex callback:(Any -> Any) = callback c
 > ```
-> that accepts `Complex` value and passes it back to a provided callback function.
-> It is possible to pass a value of `Complex&Float` type to such a function. Only
-> operations available on type `Complex` can be performed on value in variable `c`.
 >
-> However the `callback` function may still explicitly cast the value to `Float`.
-> E.g. the following is valid:
+> that accepts `Complex` value and passes it back to a provided callback
+> function. It is possible to pass a value of `Complex&Float` type to such a
+> function. Only operations available on type `Complex` can be performed on
+> value in variable `c`.
+>
+> However the `callback` function may still explicitly cast the value to
+> `Float`. E.g. the following is valid:
+>
 > ```ruby
 > both = v : Complex&Float
 > use_complex both (v-> v:Float . sqrt)
 > ```
-> This behavior is often described as being **open to subclasses**. E.g. the `c:Complex` 
-> check allows values with _intersection types_ that include `Complex` to pass thru with
-> all their runtime information available,
-> but one has to perform an explicit cast to extract the other types associated with
+>
+> This behavior is often described as being **open to subclasses**. E.g. the
+> `c:Complex` check allows values with _intersection types_ that include
+> `Complex` to pass thru with all their runtime information available, but one
+> has to perform an explicit cast to extract the other types associated with
 > such a value.
 
-This behavior allows creation of values with types like `Table&Column` to represent a table
-with a single column - something the users of visual _live programming_ environment of Enso find
-very useful.
+This behavior allows creation of values with types like `Table&Column` to
+represent a table with a single column - something the users of visual _live
+programming_ environment of Enso find very useful.
+
 ```ruby
 Table.join self right:Table -> Table = ...
 ```
-Such a `Table&Column` value can be returned from the above `Table.join` function and while
-having only `Table` behavior by default, still being able to be explicitly casted by the visual environment
-to `Column`. 
+
+Such a `Table&Column` value can be returned from the above `Table.join` function
+and while having only `Table` behavior by default, still being able to be
+explicitly casted by the visual environment to `Column`.
 
 ## Converting Type Check
 
-When an _intersection type_ is being checked against a type it doesn't represent,
-any of its component types can be used for [conversion](../syntax/conversions.md).
-Should there be a `Float` to `Text` conversion:
+When an _intersection type_ is being checked against a type it doesn't
+represent, any of its component types can be used for
+[conversion](../syntax/conversions.md). Should there be a `Float` to `Text`
+conversion:
+
 ```ruby
 Text.from (that:Float) = Float.to_text
 ```
-then `Complex&Float` value `cf` can be typed as `cf:Text`. The value can also
-be converted to another _intersection type_ like `ct = cf:Complex&Text`. In such case
-it looses its `Float` type and `ct:Float` would fail.
 
-In short: when a [conversion](../syntax/conversions.md) is needed to satisfy a type check
-a new value is created to satisfy just the types requested in the check.
+then `Complex&Float` value `cf` can be typed as `cf:Text`. The value can also be
+converted to another _intersection type_ like `ct = cf:Complex&Text`. In such
+case it looses its `Float` type and `ct:Float` would fail.
+
+In short: when a [conversion](../syntax/conversions.md) is needed to satisfy a
+type check a new value is created to satisfy just the types requested in the
+check.

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -26,21 +26,20 @@ types).
 
 ## Resolving Name Clashes
 
-> [!WARNING]
-> There is no `here` keyword anymore and the clash resultion is probably also
-> not working.
+> [!WARNING] There is no `here` keyword anymore and the clash resultion is
+> probably also not working.
 >
 > Enso modules employ the following rules in order to avoid name clashes:
 >
 > - Where the module name clashes with a member contained in the module, the
->   member is preferred. If you need the module you must import it qualified under
->   another name.
-> - We provide the alias `here` as a way to access the name of the current module.
+>   member is preferred. If you need the module you must import it qualified
+>   under another name.
+> - We provide the alias `here` as a way to access the name of the current
+>   module.
 
 ## Scoping and Imports
 
-> [!WARNING]
-> Review by an _imports expert_ is needed!
+> [!WARNING] Review by an _imports expert_ is needed!
 
 To use the contents of a module we need a way to bring them into scope. Like
 most languages, Enso provides an _import_ mechanism for this. Enso has four

--- a/docs/types/parallelism.md
+++ b/docs/types/parallelism.md
@@ -21,15 +21,13 @@ by the compiler to automatically parallelise some sections of Enso programs.
 
 ## Supporting Parallelism Analysis with Types
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Work out how the type checker can support parallelism analysis.
 
 ## Constructs That Can Be Parallelised
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Provide an analysis of the language constructs that could automatically be
 >   parallelised, and the typing predicates that make them so.

--- a/docs/types/pattern-matching.md
+++ b/docs/types/pattern-matching.md
@@ -48,8 +48,7 @@ case v of
   v3:Vector -> print v3.x
 ```
 
-> [!WARNING]
-> **Unsupported:** Name Matching on Labels
+> [!WARNING] > **Unsupported:** Name Matching on Labels
 >
 > Matching on the labels defined within a type for both atoms and typesets, with
 > renaming.

--- a/docs/types/type-directed-programming.md
+++ b/docs/types/type-directed-programming.md
@@ -14,8 +14,7 @@ based on types. This is an _advanced_ feature and is not expected to be used by
 the novice, but it is nonetheless an important feature for working with a
 powerful type system.
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Just _delete it all_!?
 > - Examine what other ways we can exploit type information to aid development.
@@ -31,30 +30,26 @@ powerful type system.
 
 ## Typed Holes
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Determine how we want to support typed holes.
 > - Determine the syntax for typed holes.
 
 ## Case Splitting
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Determine how we want to support case splitting.
 > - Determine the tooling for case splitting.
 
 ## Row Manipulation
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Determine how we want to support row manipulation.
 
 ## Dependent Sum Manipulation
 
-> [!WARNING]
-> The actionables for this section are:
+> [!WARNING] The actionables for this section are:
 >
 > - Determine how we want to support dependent sum manipulation.


### PR DESCRIPTION
### Pull Request Description

Reenables recently disabled formatting of `docs` files and adds them to the CI change detection list.

To run prettier over docs files, use:
```
pnpm prettier --write docs
```
