### PR TITLE
Simplify pattern matching of `CallArgument`

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -653,13 +653,13 @@ case object AliasAnalysis extends IRPass {
     args: List[CallArgument],
     builder: GraphBuilder
   ): List[CallArgument] = {
-    args.map { case arg @ CallArgument.Specified(_, expr, _, _, _) =>
-      val currentScope = expr match {
+    args.map { case arg: CallArgument.Specified =>
+      val currentScope = arg.value match {
         case _: Literal => builder
         case _          => builder.addChild()
       }
       arg
-        .copy(value = analyseExpression(expr, currentScope))
+        .copy(value = analyseExpression(arg.value, currentScope))
         .updateMetadata(
           new MetadataPair(
             this,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
@@ -322,9 +322,18 @@ object AutomaticParallelism extends IRPass {
             val refWrite = Application.Prefix(
               Name.Special(Name.Special.WriteRef, null),
               List(
-                CallArgument
-                  .Specified(None, refVars(bind.name).duplicate(), true, null),
-                CallArgument.Specified(None, bind.name.duplicate(), true, null)
+                new CallArgument.Specified(
+                  None,
+                  refVars(bind.name).duplicate(),
+                  true,
+                  null
+                ),
+                new CallArgument.Specified(
+                  None,
+                  bind.name.duplicate(),
+                  true,
+                  null
+                )
               ),
               false,
               null
@@ -335,7 +344,7 @@ object AutomaticParallelism extends IRPass {
       val spawn = Application.Prefix(
         Name.Special(Name.Special.RunThread, null),
         List(
-          CallArgument.Specified(
+          new CallArgument.Specified(
             None,
             Expression.Block(blockBody.init, blockBody.last, null),
             true,
@@ -355,7 +364,9 @@ object AutomaticParallelism extends IRPass {
     val threadJoins = threadSpawns.map { bind =>
       Application.Prefix(
         Name.Special(Name.Special.JoinThread, null),
-        List(CallArgument.Specified(None, bind.name.duplicate(), true, null)),
+        List(
+          new CallArgument.Specified(None, bind.name.duplicate(), true, null)
+        ),
         false,
         null
       )
@@ -367,7 +378,7 @@ object AutomaticParallelism extends IRPass {
           name.duplicate(),
           Application.Prefix(
             Name.Special(Name.Special.ReadRef, null),
-            List(CallArgument.Specified(None, ref.duplicate(), true, null)),
+            List(new CallArgument.Specified(None, ref.duplicate(), true, null)),
             false,
             null
           ),

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -745,12 +745,12 @@ case object DataflowAnalysis extends IRPass {
     info: DependencyInfo
   ): CallArgument = {
     argument match {
-      case spec @ CallArgument.Specified(name, value, _, _, _) =>
+      case spec: CallArgument.Specified =>
         val specDep  = asStatic(spec)
-        val valueDep = asStatic(value)
+        val valueDep = asStatic(spec.value)
         info.dependents.updateAt(valueDep, Set(specDep))
         info.dependencies.updateAt(specDep, Set(valueDep))
-        name.foreach(name => {
+        spec.name.foreach(name => {
           val nameDep = asStatic(name)
           info.dependents.updateAt(nameDep, Set(specDep))
           info.dependencies.updateAt(specDep, Set(nameDep))
@@ -758,7 +758,7 @@ case object DataflowAnalysis extends IRPass {
 
         spec
           .copy(
-            value = analyseExpression(value, info)
+            value = analyseExpression(spec.value, info)
           )
           .updateMetadata(new MetadataPair(this, info))
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/FramePointerAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/FramePointerAnalysis.scala
@@ -242,13 +242,12 @@ case object FramePointerAnalysis extends IRPass {
     arguments: List[CallArgument],
     graph: Graph
   ): Unit = {
-    arguments.foreach {
-      case arg @ CallArgument.Specified(name, value, _, _, _) =>
-        maybeAttachFramePointer(arg, graph)
-        name.foreach(maybeAttachFramePointer(_, graph))
-        processExpression(value, graph, false)
-        maybAttachFrameVariableNames(value)
-        maybAttachFrameVariableNames(arg)
+    arguments.foreach { case arg: CallArgument.Specified =>
+      maybeAttachFramePointer(arg, graph)
+      arg.name.foreach(maybeAttachFramePointer(_, graph))
+      processExpression(arg.value, graph, false)
+      maybAttachFrameVariableNames(arg.value)
+      maybAttachFrameVariableNames(arg)
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
@@ -34,8 +34,10 @@ class LambdaShorthandToLambdaMini(
     parent match {
       case Application.Prefix(fn, args, _, _, _) =>
         val hasBlankArg = args.exists {
-          case CallArgument.Specified(_, _: Name.Blank, _, _, _) => true
-          case _                                                 => false
+          case arg: CallArgument.Specified
+              if arg.value.isInstanceOf[Name.Blank] =>
+            true
+          case _ => false
         }
         val hasBlankFn = fn.isInstanceOf[Name.Blank]
         hasBlankArg || hasBlankFn

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -224,7 +224,7 @@ case object GlobalNames extends IRPass {
                       val app = Application.Prefix(
                         fun,
                         List(
-                          CallArgument.Specified(
+                          new CallArgument.Specified(
                             None,
                             self,
                             true,
@@ -352,7 +352,12 @@ case object GlobalNames extends IRPass {
             )
           )
         val selfArg =
-          CallArgument.Specified(None, self, true, identifiedLocation = null)
+          new CallArgument.Specified(
+            None,
+            self,
+            true,
+            identifiedLocation = null
+          )
         processedFun.passData.remove(this) // Necessary for IrToTruffle
         app.copy(function = processedFun, arguments = selfArg :: processedArgs)
       case _ =>

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -26,7 +26,12 @@ class GatherDiagnosticsTest extends CompilerTest {
     val plusApp = Application.Prefix(
       plusOp,
       List(
-        CallArgument.Specified(None, error1, false, identifiedLocation = null)
+        new CallArgument.Specified(
+          None,
+          error1,
+          false,
+          identifiedLocation = null
+        )
       ),
       hasDefaultsSuspended = false,
       identifiedLocation   = null

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
@@ -65,9 +65,9 @@ class OperatorToFunctionTest extends MiniPassTest {
     val loc = new IdentifiedLocation(new Location(1, 33))
 
     val leftArg =
-      CallArgument.Specified(None, left, false, left.identifiedLocation())
+      new CallArgument.Specified(None, left, false, left.identifiedLocation())
     val rightArg =
-      CallArgument.Specified(None, right, false, right.identifiedLocation())
+      new CallArgument.Specified(None, right, false, right.identifiedLocation())
 
     val binOp =
       Operator.Binary(leftArg, name, rightArg, loc)
@@ -86,19 +86,19 @@ class OperatorToFunctionTest extends MiniPassTest {
     Name.Literal("=:=", isMethod = true, null)
   val left     = Empty(null)
   val right    = Empty(null)
-  val rightArg = CallArgument.Specified(None, Empty(null), false, null)
+  val rightArg = new CallArgument.Specified(None, Empty(null), false, null)
 
   val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
-  val oprArg   = CallArgument.Specified(None, operator, false, null)
-  val oprFnArg = CallArgument.Specified(None, operatorFn, false, null)
+  val oprArg   = new CallArgument.Specified(None, operator, false, null)
+  val oprFnArg = new CallArgument.Specified(None, operatorFn, false, null)
 
   "Operators" should {
     val opName =
       Name.Literal("=:=", isMethod = true, identifiedLocation = null)
     val left  = Empty(identifiedLocation = null)
     val right = Empty(identifiedLocation = null)
-    val rightArg = CallArgument.Specified(
+    val rightArg = new CallArgument.Specified(
       None,
       Empty(identifiedLocation = null),
       false,
@@ -108,9 +108,19 @@ class OperatorToFunctionTest extends MiniPassTest {
     val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
     val oprArg =
-      CallArgument.Specified(None, operator, false, identifiedLocation = null)
+      new CallArgument.Specified(
+        None,
+        operator,
+        false,
+        identifiedLocation = null
+      )
     val oprFnArg =
-      CallArgument.Specified(None, operatorFn, false, identifiedLocation = null)
+      new CallArgument.Specified(
+        None,
+        operatorFn,
+        false,
+        identifiedLocation = null
+      )
 
     "be translated to functions" in {
       OperatorToFunctionTestPass.runExpression(

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
@@ -105,7 +105,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
       case sectionLeft @ Section.Left(arg, op, loc, passData) =>
         val rightArgName = freshNameSupply.newName()
         val rightCallArg =
-          CallArgument.Specified(
+          new CallArgument.Specified(
             None,
             rightArgName,
             true,
@@ -122,7 +122,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
         if (arg.value.isInstanceOf[Name.Blank]) {
           val leftArgName = freshNameSupply.newName()
           val leftCallArg =
-            CallArgument.Specified(
+            new CallArgument.Specified(
               None,
               leftArgName,
               true,
@@ -171,7 +171,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
       case sectionSides @ Section.Sides(op, loc, passData) =>
         val leftArgName = freshNameSupply.newName()
         val leftCallArg =
-          CallArgument.Specified(
+          new CallArgument.Specified(
             None,
             leftArgName,
             true,
@@ -187,7 +187,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
 
         val rightArgName = freshNameSupply.newName()
         val rightCallArg =
-          CallArgument.Specified(
+          new CallArgument.Specified(
             None,
             rightArgName,
             true,
@@ -244,7 +244,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
       case sectionRight @ Section.Right(op, arg, loc, passData) =>
         val leftArgName = freshNameSupply.newName()
         val leftCallArg =
-          CallArgument.Specified(
+          new CallArgument.Specified(
             None,
             leftArgName,
             true,
@@ -263,7 +263,7 @@ case object SectionsToBinOpMegaPass extends IRPass {
           // Note [Blanks in Sections]
           val rightArgName = freshNameSupply.newName()
           val rightCallArg =
-            CallArgument.Specified(
+            new CallArgument.Specified(
               None,
               rightArgName,
               true,

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/CallArgument.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/CallArgument.scala
@@ -83,7 +83,8 @@ object CallArgument {
         || diagnostics != this.diagnostics
         || id != this.id
       ) {
-        val res = Specified(name, value, isSynthetic, location.orNull, passData)
+        val res =
+          new Specified(name, value, isSynthetic, location.orNull, passData)
         res.diagnostics = diagnostics
         res.id          = id
         res

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2468,7 +2468,9 @@ class IrToTruffle(
       subjectToInstrumentation: Boolean
     ): callable.argument.CallArgument =
       arg match {
-        case CallArgument.Specified(name, value, _, _, _) =>
+        case specifiedArg: CallArgument.Specified =>
+          val name      = specifiedArg.name
+          val value     = specifiedArg.value
           val scopeInfo = childScopeInfo("call argument", arg)
 
           def valueHasSomeTypeCheck() =


### PR DESCRIPTION
Preliminary for https://github.com/enso-org/enso/pull/11770#issuecomment-2561360450

### Pull Request Description

Refactor usages of `CallArgument.Specified` such that:
- It is not used in extractor pattern matches (no usages of `unapply`).
- Explicit use of `new` keyword instead of bracket operator.

This refactoring allows simple migration towards `Specified` as generated Java class (#11770 ).

### Important Notes

This refactoring effectively changes `Specified` from a `case class` to normal `class`. So that the Scala compiler does not have to use its magical `apply` and `unapply` generated methods. More details in https://github.com/enso-org/enso/pull/11770#issuecomment-2563704660.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
