### PR TITLE
Allow renaming secrets

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1283,7 +1283,8 @@ export interface CreateSecretRequestBody {
 
 /** HTTP request body for the "update secret" endpoint. */
 export interface UpdateSecretRequestBody {
-  readonly value: string
+  readonly title: string | null
+  readonly value: string | null
 }
 
 /** HTTP request body for the "create datalink" endpoint. */

--- a/app/gui/src/dashboard/components/dashboard/SecretNameColumn.tsx
+++ b/app/gui/src/dashboard/components/dashboard/SecretNameColumn.tsx
@@ -8,14 +8,15 @@ import * as toastAndLogHooks from '#/hooks/toastAndLogHooks'
 
 import * as modalProvider from '#/providers/ModalProvider'
 
-import * as ariaComponents from '#/components/AriaComponents'
 import type * as column from '#/components/dashboard/column'
 import SvgMask from '#/components/SvgMask'
 
 import UpsertSecretModal from '#/modals/UpsertSecretModal'
 
-import type * as backendModule from '#/services/Backend'
+import * as backendModule from '#/services/Backend'
 
+import EditableSpan from '#/components/EditableSpan'
+import { useText } from '#/providers/TextProvider'
 import * as eventModule from '#/utilities/event'
 import * as indent from '#/utilities/indent'
 import * as object from '#/utilities/object'
@@ -37,11 +38,17 @@ export interface SecretNameColumnProps extends column.AssetColumnProps {
  */
 export default function SecretNameColumn(props: SecretNameColumnProps) {
   const { item, selected, state, rowState, setRowState, isEditable, depth } = props
-  const { backend } = state
+  const { backend, nodeMap } = state
   const toastAndLog = toastAndLogHooks.useToastAndLog()
+  const { getText } = useText()
   const { setModal } = modalProvider.useSetModal()
 
   const updateSecretMutation = useMutation(backendMutationOptions(backend, 'updateSecret'))
+
+  const doRename = async (newTitle: string) => {
+    await updateSecretMutation.mutateAsync([item.id, { title: newTitle, value: null }, item.title])
+    setIsEditing(false)
+  }
 
   const setIsEditing = (isEditingName: boolean) => {
     if (isEditable) {
@@ -69,9 +76,9 @@ export default function SecretNameColumn(props: SecretNameColumnProps) {
             <UpsertSecretModal
               id={item.id}
               name={item.title}
-              doCreate={async (_name, value) => {
+              doCreate={async (title, value) => {
                 try {
-                  await updateSecretMutation.mutateAsync([item.id, { value }, item.title])
+                  await updateSecretMutation.mutateAsync([item.id, { title, value }, item.title])
                 } catch (error) {
                   toastAndLog(null, error)
                 }
@@ -82,14 +89,28 @@ export default function SecretNameColumn(props: SecretNameColumnProps) {
       }}
     >
       <SvgMask src={KeyIcon} className="m-name-column-icon size-4" />
-      {/* Secrets cannot be renamed. */}
-      <ariaComponents.Text
+      <EditableSpan
         data-testid="asset-row-name"
-        font="naming"
-        className="grow bg-transparent"
+        editable={rowState.isEditingName}
+        className="grow bg-transparent font-naming"
+        onSubmit={doRename}
+        onCancel={() => {
+          setIsEditing(false)
+        }}
+        schema={(z) =>
+          z.refine(
+            (value) =>
+              backendModule.isNewTitleUnique(
+                item,
+                value,
+                nodeMap.current.get(item.parentId)?.children?.map((child) => child.item),
+              ),
+            { message: getText('nameShouldBeUnique') },
+          )
+        }
       >
         {item.title}
-      </ariaComponents.Text>
+      </EditableSpan>
     </div>
   )
 }

--- a/app/gui/src/dashboard/layouts/AssetProperties.tsx
+++ b/app/gui/src/dashboard/layouts/AssetProperties.tsx
@@ -356,8 +356,8 @@ function AssetPropertiesInternal(props: AssetPropertiesInternalProps) {
             canCancel={false}
             id={item.id}
             name={item.title}
-            doCreate={async (name, value) => {
-              await updateSecretMutation.mutateAsync([item.id, { value }, name])
+            doCreate={async (title, value) => {
+              await updateSecretMutation.mutateAsync([item.id, { title, value }, title])
             }}
           />
         </div>

--- a/app/gui/src/dashboard/layouts/AssetsTable.tsx
+++ b/app/gui/src/dashboard/layouts/AssetsTable.tsx
@@ -934,9 +934,13 @@ function AssetsTable(props: AssetsTableProps) {
                   <UpsertSecretModal
                     id={item.item.id}
                     name={item.item.title}
-                    doCreate={async (_name, value) => {
+                    doCreate={async (title, value) => {
                       try {
-                        await updateSecretMutation.mutateAsync([id, { value }, item.item.title])
+                        await updateSecretMutation.mutateAsync([
+                          id,
+                          { title, value },
+                          item.item.title,
+                        ])
                       } catch (error) {
                         toastAndLog(null, error)
                       }

--- a/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
+++ b/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
@@ -35,6 +35,7 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
     defaultValues: { title: nameRaw ?? '', value: '' },
     onSubmit: async ({ title, value }) => {
       await doCreate(title, value)
+      form.reset({ title, value })
     },
   })
 

--- a/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
+++ b/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
@@ -27,40 +27,35 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
   const { getText } = useText()
 
   const isCreatingSecret = id == null
-  const isNameEditable = nameRaw == null
 
   const form = Form.useForm({
     method: 'dialog',
     schema: (z) =>
-      z.object({ name: z.string().min(1, getText('emptyStringError')), value: z.string() }),
-    defaultValues: { name: nameRaw ?? '', value: '' },
-    onSubmit: async ({ name, value }) => {
-      await doCreate(name, value)
+      z.object({ title: z.string().min(1, getText('emptyStringError')), value: z.string() }),
+    defaultValues: { title: nameRaw ?? '', value: '' },
+    onSubmit: async ({ title, value }) => {
+      await doCreate(title, value)
     },
   })
 
   const content = (
     <Form form={form} testId="upsert-secret-modal" gap="none" className="w-full">
-      {isNameEditable && (
-        <Input
-          form={form}
-          name="name"
-          autoFocus={isNameEditable}
-          autoComplete="off"
-          isDisabled={!isNameEditable}
-          label={getText('name')}
-          placeholder={getText('secretNamePlaceholder')}
-        />
-      )}
+      <Input
+        form={form}
+        name="title"
+        autoFocus
+        autoComplete="off"
+        label={getText('name')}
+        placeholder={getText('secretNamePlaceholder')}
+      />
       <Input
         form={form}
         name="value"
         type="password"
-        autoFocus={!isNameEditable}
         autoComplete="off"
         label={getText('value')}
         placeholder={
-          isNameEditable ? getText('secretValuePlaceholder') : getText('secretValueHidden')
+          nameRaw == null ? getText('secretValuePlaceholder') : getText('secretValueHidden')
         }
       />
       <ButtonGroup className="mt-2">


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/1597
  - Allow renaming secrets:
    - Make name column editable
    - Make name field in secret form (in sidebar) editable
    - Sync values from secret form to row heading (syncing from row heading to secret form is a bit harder in the current architecture)

### Important Notes
None

### Testing Instructions
- Rename via name column
- Rename via form in sidebar
- Refresh to make sure names are indeed being updated on backend
- Ensure that names are not editable in "Trash" category

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
