### PR TITLE
Include jline in non-linux setup

### DIFF
--- a/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/proxy-config.json
+++ b/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/proxy-config.json
@@ -1,5 +1,5 @@
 [
   {
-    "interfaces":["org.jline.terminal.impl.jna.linux.CLibrary"]
+    "interfaces":["org.jline.terminal.impl.jna.linux.CLibrary", "org.jline.terminal.impl.jna.osx.CLibrary", "org.jline.terminal.impl.jna.win.CLibrary"]
   }
 ]

--- a/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/reflect-config.json
+++ b/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/reflect-config.json
@@ -3437,6 +3437,22 @@
   "allDeclaredFields":true
 },
 {
+  "name":"org.jline.terminal.impl.jna.osx.CLibrary$termios",
+  "allDeclaredFields":true
+},
+{
+  "name":"org.jline.terminal.impl.jna.osx.CLibrary$winsize",
+  "allDeclaredFields":true
+},
+{
+  "name":"org.jline.terminal.impl.jna.windows.CLibrary$termios",
+  "allDeclaredFields":true
+},
+{
+  "name":"org.jline.terminal.impl.jna.windows.CLibrary$winsize",
+  "allDeclaredFields":true
+},
+{
   "name":"org.openide.util.RequestProcessor"
 },
 {


### PR DESCRIPTION

### Pull Request Description

Loading jline appears to be broken on non-linux system. Native image configs appear to be one location where there is a difference.

### Important Notes

This change appears to fix issues on MacOS for #11957. 