### PR TITLE
Upload file chunks in parallel

### DIFF
--- a/app/gui/src/dashboard/hooks/backendHooks.tsx
+++ b/app/gui/src/dashboard/hooks/backendHooks.tsx
@@ -56,9 +56,11 @@ import { tryCreateOwnerPermission } from '#/utilities/permissions'
 import { usePreventNavigation } from '#/utilities/preventNavigation'
 import { toRfc3339 } from 'enso-common/src/utilities/data/dateTime'
 
-// The number of bytes in 1 megabyte.
+/** The number of bytes in 1 megabyte. */
 const MB_BYTES = 1_000_000
 const S3_CHUNK_SIZE_MB = Math.round(backendModule.S3_CHUNK_SIZE_BYTES / MB_BYTES)
+/** The maximum number of file chunks to upload at the same time. */
+const FILE_UPLOAD_CONCURRENCY = 5
 
 // ============================
 // === DefineBackendMethods ===
@@ -1222,7 +1224,7 @@ export function useUploadFileMutation(backend: Backend, options: UploadFileMutat
           })
           return fullPromise
         }
-        await Promise.all(Array.from({ length: 5 }).map(uploadNextChunk))
+        await Promise.all(Array.from({ length: FILE_UPLOAD_CONCURRENCY }).map(uploadNextChunk))
         const result = await uploadFileEndMutation.mutateAsync([
           {
             parentDirectoryId: body.parentDirectoryId,


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/1640
  - Upload chunks of large files in parallel.
    - Currently, 5 chunks are uploaded at any given time.

### Important Notes
None

### Testing Instructions
- Just upload a large file to the Cloud backend! No other code should be affected.
  - Uploading small files, and uploading to the Local backend, should still be tested though.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
