### PR TITLE
Avoiding problems of missing `==` by using `Meta.is_same_object`

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -201,7 +201,7 @@ type No_Such_Method
     to_display_text self =
         target_name =
           is_poly = Meta.is_polyglot self.target
-          is_fn = Meta.type_of self.target == Function
+          is_fn = Meta.is_same_object Function (Meta.type_of self.target)
           if is_poly then "type " + self.target.to_display_text else
              if is_fn then self.target.to_text else
                 "type " + (Meta.type_of self.target).to_display_text


### PR DESCRIPTION
### Pull Request Description

Based on [the logs](https://github.com/enso-org/enso/pull/11393#issuecomment-2569703849) we know that the error behind #11127 is in Common.enso line 204. If we change it to:
 ```diff
 diff --git distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
index 9ee140e332..be8e212fa8 100644
--- distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -201,7 +201,7 @@ type No_Such_Method
     to_display_text self =
         target_name =
           is_poly = Meta.is_polyglot self.target
-          is_fn = Meta.type_of self.target == Function
+          is_fn = False # Meta.type_of self.target == Function
           if is_poly then "type " + self.target.to_display_text else
              if is_fn then self.target.to_text else
                 "type " + (Meta.type_of self.target).to_display_text
```
we get __2 tests failed.__ when running `test/Base_Tests`:
```
sbt:enso> runEngineDistribution --run test/Base_Tests no.conversion.of.\.\.B|no.conversion.of.function.value
[FAILED] No_Such_Method: [0/2, 161ms]

    - [FAILED] no conversion of ..B [146ms]
        Reason: The value (Error: Method `sample` of type Function could not be found.) did not contain the element (of ..B) (at /home/devel/NetBeansProjects/enso/enso.master/test/Base_Tests/src/Data/Function_Spec.enso:65:13-55).


    - [FAILED] no conversion of function value [14ms]
        Reason: The value (Error: Method `sample` of type Function could not be found.) did not contain the element (of Function_Spec.add_specs) (at /home/devel/NetBeansProjects/enso/enso.master/test/Base_Tests/src/Data/Function_Spec.enso:83:13-75).
```

Let's rewrite the code and eliminate the usage of `==` at this location. Let's replace it with more _bullet proof_ `Meta.is_same_object`. The tests work again and maybe we eliminate #11127.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the Enso guidelines
- [x] Unit tests continue to pass
