### PR TITLE
Don't cache the parsed markdows in the docs

### DIFF
--- a/app/common/src/queryClient.ts
+++ b/app/common/src/queryClient.ts
@@ -59,7 +59,7 @@ export type QueryClient = vueQuery.QueryClient
 const DEFAULT_QUERY_STALE_TIME_MS = Infinity
 const DEFAULT_QUERY_PERSIST_TIME_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 
-const DEFAULT_BUSTER = 'v1.1'
+const DEFAULT_BUSTER = 'v1.2'
 
 export interface QueryClientOptions<TStorageValue = string> {
   readonly persisterStorage?: AsyncStorage<TStorageValue> & {

--- a/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
@@ -31,6 +31,8 @@ export function MarkdownViewer(props: MarkdownViewerProps) {
   const { data: markdownToHtml } = useSuspenseQuery({
     queryKey: ['markdownToHtml', { text, imgUrlResolver, markedInstance }] as const,
     meta: { persist: false },
+    gcTime: 0,
+    staleTime: 0,
     queryFn: ({ queryKey: [, args] }) =>
       args.markedInstance.parse(args.text, {
         async: true,

--- a/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
@@ -30,6 +30,7 @@ export function MarkdownViewer(props: MarkdownViewerProps) {
 
   const { data: markdownToHtml } = useSuspenseQuery({
     queryKey: ['markdownToHtml', { text, imgUrlResolver, markedInstance }] as const,
+    meta: { persist: false },
     queryFn: ({ queryKey: [, args] }) =>
       args.markedInstance.parse(args.text, {
         async: true,
@@ -38,15 +39,10 @@ export function MarkdownViewer(props: MarkdownViewerProps) {
             const href = token.href
 
             token.raw = href
-            token.href = await args
-              .imgUrlResolver(href)
-              .then((url) => {
-                return url
-              })
-              .catch((error) => {
-                logger.error(error)
-                return null
-              })
+            token.href = await args.imgUrlResolver(href).catch((error) => {
+              logger.error(error)
+              return null
+            })
             token.text = getText('arbitraryFetchImageError')
           }
         },


### PR DESCRIPTION
### Pull Request Description

This PR removes caching images in the Persister, which could potentially cause bugs

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
