### PR TITLE
Increase package tests' timeout on expectations after loading a new page.

### DIFF
--- a/app/ide-desktop/client/playwright.config.ts
+++ b/app/ide-desktop/client/playwright.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
   testDir: './tests',
   forbidOnly: !!process.env.CI,
   workers: 1,
-  timeout: 120000,
+  timeout: 180000,
   reportSlowTests: { max: 5, threshold: 60000 },
   globalSetup: './tests/setup.ts',
   expect: {
-    timeout: 5000,
+    timeout: 30000,
     toHaveScreenshot: { threshold: 0 },
   },
   use: {


### PR DESCRIPTION
### Pull Request Description

The package tests started failing randomly, because loading initial screen started taking more than 5 seconds.

The investigation is still in progress, but this is to not block innocent PRs.

