### PR TITLE
`HelloWorldCacheTest` CI failures fix + more logging

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
@@ -53,6 +53,7 @@ public class HelloWorldCacheTest {
             .option(RuntimeOptions.LOG_LEVEL, Level.FINE.getName())
             .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
             .option(RuntimeOptions.PROJECT_ROOT, findBenchmarks(src).getAbsolutePath())
+            .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
             .build()) {
       var code = Source.newBuilder("enso", src).build();
       var res = ContextUtils.evalModule(ctx, code, "main");

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
@@ -215,18 +215,22 @@ public final class Cache<T, M> {
                             + "].");
                     return Optional.of(localCache);
                   } catch (IOException localEx) {
-                    logger.log(
-                        Level.FINE,
-                        "Unable to load a global cache [" + logName + "]: " + globalEx.getMessage(),
-                        globalEx);
-                    logger.log(
-                        Level.FINE,
-                        "Unable to load a local cache [" + logName + "]: " + localEx.getMessage(),
-                        localEx);
+                    logCacheLoadFailure(
+                        logger, "Unable to load a global cache [" + logName + "]: ", globalEx);
+                    logCacheLoadFailure(
+                        logger, "Unable to load a local cache [" + logName + "]: ", localEx);
                   }
                   return Optional.empty();
                 }
               });
+    }
+  }
+
+  private void logCacheLoadFailure(TruffleLogger logger, String prefix, IOException ex) {
+    if (ex instanceof FileNotFoundException) {
+      logger.log(Level.FINE, prefix + ex.getMessage());
+    } else {
+      logger.log(Level.FINE, prefix + ex.getMessage(), ex);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.caches;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
@@ -191,23 +192,20 @@ public final class Cache<T, M> {
       return spi.getCacheRoots(context)
           .flatMap(
               roots -> {
+                // Load from the global root as a priority.
                 try {
-                  Optional<T> loadedCache;
-                  // Load from the global root as a priority.
-                  loadedCache = loadCacheFrom(roots.globalCacheRoot(), context, logger);
-                  if (loadedCache.isPresent()) {
-                    logger.log(
-                        logLevel,
-                        "Using cache for ["
-                            + logName
-                            + " at location ["
-                            + toMaskedPath(roots.globalCacheRoot()).applyMasking()
-                            + "].");
-                    return loadedCache;
-                  }
-
-                  loadedCache = loadCacheFrom(roots.localCacheRoot(), context, logger);
-                  if (loadedCache.isPresent()) {
+                  var globalCache = loadCacheFrom(roots.globalCacheRoot(), context, logger);
+                  logger.log(
+                      logLevel,
+                      "Using cache for ["
+                          + logName
+                          + " at location ["
+                          + toMaskedPath(roots.globalCacheRoot()).applyMasking()
+                          + "].");
+                  return Optional.of(globalCache);
+                } catch (IOException globalEx) {
+                  try {
+                    var localCache = loadCacheFrom(roots.localCacheRoot(), context, logger);
                     logger.log(
                         logLevel,
                         "Using cache for ["
@@ -215,20 +213,19 @@ public final class Cache<T, M> {
                             + " at location ["
                             + toMaskedPath(roots.localCacheRoot()).applyMasking()
                             + "].");
-                    return loadedCache;
+                    return Optional.of(localCache);
+                  } catch (IOException localEx) {
+                    logger.log(
+                        Level.FINE,
+                        "Unable to load a global cache [" + logName + "]: " + globalEx.getMessage(),
+                        globalEx);
+                    logger.log(
+                        Level.FINE,
+                        "Unable to load a local cache [" + logName + "]: " + localEx.getMessage(),
+                        localEx);
                   }
-
-                  logger.log(logLevel, "Unable to load a cache [" + logName + "]");
-                } catch (IOException e) {
-                  logger.log(
-                      Level.FINE, "Unable to load a cache [" + logName + "]: " + e.getMessage(), e);
-                } catch (Exception e) {
-                  logger.log(
-                      Level.WARNING,
-                      "Unable to load a cache [" + logName + "]: " + e.getMessage(),
-                      e);
+                  return Optional.empty();
                 }
-                return Optional.empty();
               });
     }
   }
@@ -240,16 +237,15 @@ public final class Cache<T, M> {
    * @param cacheRoot the root at which to find the cache for this cache entry
    * @param context the language context in which loading is taking place
    * @param logger a logger
-   * @return the cached data if available, otherwise an empty [[Optional]].
+   * @return the cached data if available, otherwise throw exception
    */
-  private Optional<T> loadCacheFrom(
-      TruffleFile cacheRoot, EnsoContext context, TruffleLogger logger) throws IOException {
+  private T loadCacheFrom(TruffleFile cacheRoot, EnsoContext context, TruffleLogger logger)
+      throws IOException {
     TruffleFile metadataPath = getCacheMetadataPath(cacheRoot);
     TruffleFile dataPath = getCacheDataPath(cacheRoot);
 
-    Optional<M> optMeta = loadCacheMetadata(metadataPath, logger);
-    if (optMeta.isPresent()) {
-      M meta = optMeta.get();
+    var meta = loadCacheMetadata(metadataPath, logger);
+    if (meta != null) {
       boolean sourceDigestValid =
           !needsSourceDigestVerification
               || spi.computeDigestFromSource(context, logger)
@@ -270,45 +266,36 @@ public final class Cache<T, M> {
               || CacheUtils.computeDigestFromBytes(blobBytes).equals(spi.blobHash(meta));
 
       if (sourceDigestValid && blobDigestValid) {
-        T cachedObject = null;
         try {
           long now = System.currentTimeMillis();
-          cachedObject = spi.deserialize(context, blobBytes, meta, logger);
+          var cachedObject = spi.deserialize(context, blobBytes, meta, logger);
           long took = System.currentTimeMillis() - now;
           if (cachedObject != null) {
             logger.log(
                 Level.FINEST,
                 "Loaded cache for {0} with {1} bytes in {2} ms",
                 new Object[] {logName, blobBytes.limit(), took});
-            return Optional.of(cachedObject);
+            return cachedObject;
           } else {
-            logger.log(logLevel, "`{0}` was corrupt on disk.", logName);
             invalidateCache(cacheRoot, logger);
-            return Optional.empty();
+            throw new IOException(logName + " is corrupted on disk");
           }
-        } catch (ClassNotFoundException | IOException ex) {
-          logger.log(
-              Level.WARNING,
-              "`{0}` in {1} failed to load: {2}",
-              new Object[] {logName, dataPath, ex.getMessage()});
-          logger.log(Level.FINE, "`{0}` in {1} failed to load:", ex);
+        } catch (ClassNotFoundException ex) {
           invalidateCache(cacheRoot, logger);
-          return Optional.empty();
+          throw new IOException("Cannot load " + dataPath + " due to: " + ex.getMessage(), ex);
         }
       } else {
-        logger.log(logLevel, "One or more digests did not match for the cache for [{0}].", logName);
         invalidateCache(cacheRoot, logger);
-        return Optional.empty();
+        throw new IOException(
+            "One or more digests did not match for the cache for [" + logName + "].");
       }
 
     } else {
-      logger.log(
-          Level.FINE,
+      invalidateCache(cacheRoot, logger);
+      throw new FileNotFoundException(
           "Could not load the cache metadata at ["
               + toMaskedPath(metadataPath).applyMasking()
               + "].");
-      invalidateCache(cacheRoot, logger);
-      return Optional.empty();
     }
   }
 
@@ -318,11 +305,11 @@ public final class Cache<T, M> {
    * @param path location of the serialized metadata
    * @return deserialized metadata, or [[None]] if invalid
    */
-  private Optional<M> loadCacheMetadata(TruffleFile path, TruffleLogger logger) throws IOException {
+  private M loadCacheMetadata(TruffleFile path, TruffleLogger logger) throws IOException {
     if (path.isReadable()) {
       return spi.metadataFromBytes(path.readAllBytes(), logger);
     } else {
-      return Optional.empty();
+      throw new FileNotFoundException("Cannot read " + path);
     }
   }
 
@@ -489,8 +476,7 @@ public final class Cache<T, M> {
      * @return non-empty metadata, if de-serialization was successful
      * @throws IOException in case of I/O error
      */
-    public abstract Optional<M> metadataFromBytes(byte[] bytes, TruffleLogger logger)
-        throws IOException;
+    public abstract M metadataFromBytes(byte[] bytes, TruffleLogger logger) throws IOException;
 
     /**
      * Compute digest of cache's data

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -78,9 +78,8 @@ public final class ImportExportCache
   }
 
   @Override
-  public Optional<Metadata> metadataFromBytes(byte[] bytes, TruffleLogger logger)
-      throws IOException {
-    return Optional.of(Metadata.read(bytes));
+  public Metadata metadataFromBytes(byte[] bytes, TruffleLogger logger) throws IOException {
+    return Metadata.read(bytes);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -75,9 +75,8 @@ public final class ModuleCache
   }
 
   @Override
-  public Optional<Metadata> metadataFromBytes(byte[] bytes, TruffleLogger logger)
-      throws IOException {
-    return Optional.of(Metadata.read(bytes));
+  public Metadata metadataFromBytes(byte[] bytes, TruffleLogger logger) throws IOException {
+    return Metadata.read(bytes);
   }
 
   private Optional<String> computeDigestOfModuleSources(Source source) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
@@ -84,9 +84,8 @@ public final class SuggestionsCache
   }
 
   @Override
-  public Optional<Metadata> metadataFromBytes(byte[] bytes, TruffleLogger logger)
-      throws IOException {
-    return Optional.of(Metadata.read(bytes));
+  public Metadata metadataFromBytes(byte[] bytes, TruffleLogger logger) throws IOException {
+    return Metadata.read(bytes);
   }
 
   @Override


### PR DESCRIPTION
### Pull Request Description

Closes #11196 by adding more logging and delivering reasons (via `IOException` and its message) explaining why cache loading failed. Very likely a6b67e4c469f2d985d65a75c249f3e25ebc7820b - e.g. `RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true"` fixes #11196 at the end.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass.
- [x] Unit test output in case of failure improved
