### PR TITLE
Revert veaury back to 2.4

### DIFF
--- a/app/gui/package.json
+++ b/app/gui/package.json
@@ -126,7 +126,7 @@
     "tiny-invariant": "^1.3.3",
     "ts-results": "^3.3.0",
     "validator": "^13.12.0",
-    "veaury": "^2.6.1",
+    "veaury": "^2.4.5",
     "vue": "^3.5.13",
     "vue-component-type-helpers": "^2.2.0",
     "y-protocols": "^1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
         specifier: ^13.12.0
         version: 13.12.0
       veaury:
-        specifier: ^2.6.1
-        version: 2.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.2)
@@ -7271,8 +7271,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  veaury@2.6.1:
-    resolution: {integrity: sha512-oxkMUqov5NoS0I1CUGMn/eIUHTeK5fuSEXzDefurilfEOBCGsDI9YpvFWGZbdBtBvKXnxJSDa+wxCkw4q0lP8A==}
+  veaury@2.4.5:
+    resolution: {integrity: sha512-BGGu74jj+PMu4ToraUTKkOaqZqWfbCjh+yNLLf+h8hZUgzTy618KiXmRtp3fgNJ9K99upoQdRUMuihYfJK81Pw==}
     peerDependencies:
       react: '>= 16.4.0'
       react-dom: '>= 16.4.0'
@@ -15575,7 +15575,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  veaury@2.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  veaury@2.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
### Pull Request Description

Versions 2.5+ are causing a strange error: in dev server, the project view is not loaded at all:

![image](https://github.com/user-attachments/assets/33c1464f-02e5-4af0-9722-c09683e50677)

Nothing is printed to logs. When switching tab back to assets panel, an exception is raised from inside veaury.

