### PR TITLE
Add missing teardown to a few cloud tests

### DIFF
--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -412,6 +412,9 @@ impl Processor {
                                 "Table_Tests".to_string(),
                                 // AWS tests check copying between Cloud and S3
                                 "AWS_Tests".to_string(),
+                                // Image tests check interaction between Image read/write and
+                                // datalinks
+                                "Image_Tests".to_string(),
                             ]),
                         ),
                     }

--- a/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
@@ -175,6 +175,9 @@ type Mock_Credentials
         new_expire_at = Date_Time.now + (Duration.new minutes=1)
         Mock_Credentials.Value self.access_token new_expire_at self.refresh_token self.refresh_url self.client_id
 
+## A temporary directory created in the Cloud.
+   Always make sure to register the `cleanup` method to `teardown` of a test
+   group to ensure that the directory is cleared after the tests are finished.
 type Temporary_Directory
     Value was_initialized:Ref ~get
 

--- a/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Context
+import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Problems
@@ -176,18 +177,25 @@ type Mock_Credentials
         Mock_Credentials.Value self.access_token new_expire_at self.refresh_token self.refresh_url self.client_id
 
 type Temporary_Directory
-    Value was_initialized:Ref ~get
+    Value was_initialized:Ref gc_sentinel:Managed_Resource ~initialize
 
     timestamp_text -> Text = Date_Time.now.format "yyyy-MM-dd_HHmmss.fV" . replace "/" "."
 
     make (name : Text) (with_initializer : (Enso_File -> Any) = (_->Nothing)) -> Temporary_Directory =
         was_initialized = Ref.new False
-        Temporary_Directory.Value was_initialized <|
+        gc_sentinel = Managed_Resource.register [name, was_initialized] _check_on_gc
+        Temporary_Directory.Value was_initialized gc_sentinel <|
             directory_name = "test-run-"+name+"-"+Temporary_Directory.timestamp_text
             test_root = (Enso_File.home / directory_name).create_directory
             test_root.if_not_error <|
                 was_initialized.put True
                 with_initializer test_root . if_not_error test_root
+
+    get self =
+        directory = self.initialize
+        if self.was_initialized.get.not then
+            Panic.throw (Illegal_State.Error "Temporary directory "+directory.path+" is being used after it has been cleaned up.")
+        directory
 
     cleanup self =
         ## Only run the cleanup if the directory was initialized.
@@ -195,6 +203,17 @@ type Temporary_Directory
            initialize it - creating a new directory just to delete it, wasting time.
         if self.was_initialized.get then
             self.get.delete_if_exists recursive=True
+
+            # Avoid double cleanup - unset the flag.
+            self.was_initialized.put False
+
+_check_on_gc sentinel_pair =
+    name = sentinel_pair.first
+    is_initialized = sentinel_pair.second
+    if is_initialized.get then
+        message = "Temporary_Directory "+name+" has not been cleaned up before being GCed."
+        IO.println message
+        Panic.throw (Illegal_State.Error message)
 
 create_local_datalink_to enso_file:Enso_File =
     config = JS_Object.from_pairs [["type", "Enso_File"], ["libraryName", "Standard.Base"], ["path", enso_file.path]]

--- a/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Tests_Setup.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Context
-import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Problems
@@ -177,25 +176,18 @@ type Mock_Credentials
         Mock_Credentials.Value self.access_token new_expire_at self.refresh_token self.refresh_url self.client_id
 
 type Temporary_Directory
-    Value was_initialized:Ref gc_sentinel:Managed_Resource ~initialize
+    Value was_initialized:Ref ~get
 
     timestamp_text -> Text = Date_Time.now.format "yyyy-MM-dd_HHmmss.fV" . replace "/" "."
 
     make (name : Text) (with_initializer : (Enso_File -> Any) = (_->Nothing)) -> Temporary_Directory =
         was_initialized = Ref.new False
-        gc_sentinel = Managed_Resource.register [name, was_initialized] _check_on_gc
-        Temporary_Directory.Value was_initialized gc_sentinel <|
+        Temporary_Directory.Value was_initialized <|
             directory_name = "test-run-"+name+"-"+Temporary_Directory.timestamp_text
             test_root = (Enso_File.home / directory_name).create_directory
             test_root.if_not_error <|
                 was_initialized.put True
                 with_initializer test_root . if_not_error test_root
-
-    get self =
-        directory = self.initialize
-        if self.was_initialized.get.not then
-            Panic.throw (Illegal_State.Error "Temporary directory "+directory.path+" is being used after it has been cleaned up.")
-        directory
 
     cleanup self =
         ## Only run the cleanup if the directory was initialized.
@@ -203,17 +195,6 @@ type Temporary_Directory
            initialize it - creating a new directory just to delete it, wasting time.
         if self.was_initialized.get then
             self.get.delete_if_exists recursive=True
-
-            # Avoid double cleanup - unset the flag.
-            self.was_initialized.put False
-
-_check_on_gc sentinel_pair =
-    name = sentinel_pair.first
-    is_initialized = sentinel_pair.second
-    if is_initialized.get then
-        message = "Temporary_Directory "+name+" has not been cleaned up before being GCed."
-        IO.println message
-        Panic.throw (Illegal_State.Error message)
 
 create_local_datalink_to enso_file:Enso_File =
     config = JS_Object.from_pairs [["type", "Enso_File"], ["libraryName", "Standard.Base"], ["path", enso_file.path]]

--- a/test/Image_Tests/src/Image_Read_Write_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Write_Spec.enso
@@ -110,6 +110,7 @@ add_specs suite_builder =
     cloud_setup = Cloud_Tests_Setup.prepare
     suite_builder.group "Data Links to Images" pending=cloud_setup.real_cloud_pending group_builder->
         subdirectory_for_tests = Temporary_Directory.make "Image"
+        group_builder.teardown subdirectory_for_tests.cleanup
         group_builder.specify "should be able to write image data to a data link and read it back" <|
             datalink = create_local_datalink_to (subdirectory_for_tests.get / "image.png")
             local_image = Image.read rgba_file

--- a/test/Table_Tests/src/Database/Common/Audit_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Audit_Spec.enso
@@ -95,6 +95,7 @@ add_specs suite_builder prefix ~datalink_to_connection database_pending =
         # Once the tests above can be run on real cloud too (#10919), we can merge all 3 cloud setups into a single one.
         real_cloud = Cloud_Tests_Setup.prepare
         test_root = Temporary_Directory.make "Audit-Logs-Datalinks"
+        group_builder.teardown test_root.cleanup
         group_builder.specify "should know the asset id of the data link used for the connection" pending=real_cloud.real_cloud_pending <| real_cloud.with_prepared_environment <|
             # Upload our local reference data link to the cloud
             cloud_data_link = test_root.get / "audited-db.datalink"


### PR DESCRIPTION
### Pull Request Description

- Every `Temporary_Directory` should have `cleanup` registered in the `teardown` of a test group: added 2 missing ones and a doc reminding to do that.
- Tried automatically detecting missed ones but simple solution failed to work - not continuing for now.
- Added `Image_Tests` to cloud test run as some data link integration tests are there.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
