### PR TITLE
Revert "Disable visualizations for subexpressions (#11949)"

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -96,7 +96,6 @@ final class JobExecutionEngine(
             assertInJvm(timeSinceRequestedToCancel > 0)
             val timeToCancel =
               forceInterruptTimeout - timeSinceRequestedToCancel
-            assertInJvm(timeToCancel > 0)
             logger.log(
               Level.FINEST,
               "About to wait {}ms  to cancel job {}",
@@ -108,8 +107,7 @@ final class JobExecutionEngine(
             runningJob.future.get(timeToCancel, TimeUnit.MILLISECONDS)
             logger.log(
               Level.FINEST,
-              "Job {} finished within the allocated soft-cancel time",
-              runningJob.id
+              "Job {} finished within the allocated soft-cancel time"
             )
           } catch {
             case _: TimeoutException =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -484,8 +484,6 @@ class EnsureCompiledJob(
       )
     invalidatedVisualizations.foreach { visualization =>
       UpsertVisualizationJob.upsertVisualization(visualization)
-    // Cache invalidation disabled because of #11882
-    // ctx.state.executionHooks.add(InvalidateCaches(visualization.expressionId))
     }
     if (invalidatedVisualizations.nonEmpty) {
       ctx.executionService.getLogger.log(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -94,9 +94,9 @@ object ProgramExecutionSupport {
 
     val onComputedValueCallback: Consumer[ExpressionValue] = { value =>
       if (callStack.isEmpty) {
+        logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
 
         if (VisualizationResult.isInterruptedException(value.getValue)) {
-          logger.log(Level.FINEST, s"ON_INTERRUPTED ${value.getExpressionId}")
           value.getValue match {
             case e: AbstractTruffleException =>
               sendInterruptedExpressionUpdate(
@@ -110,7 +110,6 @@ object ProgramExecutionSupport {
             case _ =>
           }
         }
-        logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
         sendExpressionUpdate(contextId, executionFrame.syncState, value)
         sendVisualizationUpdates(
           contextId,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -121,8 +121,6 @@ class UpsertVisualizationJob(
                 )
                 None
               case None =>
-                // Caching disabled due to #11882
-                // ctx.state.executionHooks.add(InvalidateCaches(expressionId))
                 Some(Executable(config.executionContextId, stack))
             }
         }
@@ -162,7 +160,7 @@ class UpsertVisualizationJob(
 object UpsertVisualizationJob {
 
   /** Invalidate caches for a particular expression id. */
-  sealed case class InvalidateCaches(
+  sealed private case class InvalidateCaches(
     expressionId: Api.ExpressionId
   )(implicit ctx: RuntimeContext)
       extends Runnable {
@@ -513,6 +511,7 @@ object UpsertVisualizationJob {
         arguments
       )
     setCacheWeights(visualization)
+    ctx.state.executionHooks.add(InvalidateCaches(expressionId))
     ctx.contextManager.upsertVisualization(
       visualizationConfig.executionContextId,
       visualization

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -4419,8 +4419,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
       new String(data1, StandardCharsets.UTF_8) shouldEqual "C"
   }
 
-  // Attaching visualizations to subexpressions is currently disabled, see #11882
-  ignore should "emit visualization update for the target of a method call (subexpression) with IdMap" in withContext() {
+  it should "emit visualization update for the target of a method call (subexpression) with IdMap" in withContext() {
     context =>
       val contextId       = UUID.randomUUID()
       val requestId       = UUID.randomUUID()


### PR DESCRIPTION
### Pull Request Description

IDE gathers widget information by associating a visualization with the (sub-) expression. It appears that a recent change that reduced the number of evaluations by **not** invalidating unnecessarily the already computed results has caused a regression in #12047. 
When invalidation is not triggered it appears that expression is never executed, despite no result being present for it, yet. Hence no visualization update and no widget data. If a node is added to an already computed project, we follow a different path and a cached self argument is found easily. 

### Important Notes

I'd like to provide a better patch once we have a better understanding of the scenario. This PR will fix a serious regression that manifests itself on startup.
This reverts commit 1f763f7800c747a734074687a74671ac921a5d1a.

### Checklist

- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
