### PR TITLE
Add a test that verifies method resolution precedence between runtime and static analysis

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
@@ -354,6 +354,17 @@ abstract class TypePropagation {
         if (isConstructorOrType(function.name())) {
           return resolveConstructorOnType(typeObject, function.name(), relatedWholeApplicationIR);
         } else {
+          // Calling `Type.method` - first we check if `method` is defined on `Any` and call that as
+          // member method on _value_ `Type`.
+          if (!BuiltinTypes.isAny(typeObject.name())) {
+            var resolvedAnyMethod =
+                methodTypeResolver.resolveMethod(TypeScopeReference.ANY, function.name());
+            if (resolvedAnyMethod != null) {
+              return resolvedAnyMethod;
+            }
+          }
+
+          // Then we resolve the _static_ `method` on the `Type` - by looking at the eigen type.
           // We resolve static calls on the eigen type. It should also contain registrations of the
           // static variants of member methods, so we don't need to inspect member scope.
           var staticScope = TypeScopeReference.atomEigenType(typeObject.name());

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/ModuleResolver.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/ModuleResolver.java
@@ -27,7 +27,8 @@ public final class ModuleResolver {
     }
 
     var moduleIr = compilerModuleOpt.get().getIr();
-    assert moduleIr != null : "Once a module is found, its IR should be present.";
+    assert moduleIr != null
+        : "Once a module is found, its IR should be present but got missing IR for " + name;
     return moduleIr;
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -1535,6 +1536,72 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     var foo = ModuleUtils.findStaticMethod(module, "foo");
     var x1 = ModuleUtils.findAssignment(foo, "x1");
     assertAtomType("local.Project1.modA.My_Type", x1);
+  }
+
+  public static Source anyPrecedenceTestSource() throws URISyntaxException {
+    final URI uri = new URI("memory://local.Project1.modA.enso");
+    final Source src =
+        Source.newBuilder(
+                "enso",
+                """
+                    import Standard.Base.Any.Any
+
+                    type A
+                        A_Value
+                    type B
+                        B_Value
+                    type C
+                        C_Value
+
+                    Any.method self -> A = A.A_Value
+
+                    type My_Type
+                        Value
+
+                        method self -> B = B.B_Value
+
+                    method -> C = C.C_Value
+
+                    foo =
+                        x1 = 42.method
+                        x2 = My_Type.Value.method
+                        x3 = method
+                        x4 = My_Type.method
+                        x5 = Any.method My_Type.Value
+                        [x1, x2, x3, x4, x5]
+                    """,
+                uri.getAuthority())
+            .uri(uri)
+            .buildLiteral();
+    return src;
+  }
+
+  @Test
+  public void precedenceOfMethodsOnAny() throws URISyntaxException {
+    var module = compile(anyPrecedenceTestSource());
+    var foo = ModuleUtils.findStaticMethod(module, "foo");
+
+    // 42 dispatches to Any and gets A
+    var x1 = ModuleUtils.findAssignment(foo, "x1");
+    assertAtomType("local.Project1.modA.A", x1);
+
+    // My_Type dispatches to overridden and gets B
+    var x2 = ModuleUtils.findAssignment(foo, "x2");
+    assertAtomType("local.Project1.modA.B", x2);
+
+    // module method overrides Any method - we get C
+    var x3 = ModuleUtils.findAssignment(foo, "x3");
+    assertAtomType("local.Project1.modA.C", x3);
+
+    // Calling the Any method statically on a type calls the Any implementation (it's not a static
+    // syntax for the override)
+    var x4 = ModuleUtils.findAssignment(foo, "x4");
+    assertAtomType("local.Project1.modA.A", x4);
+
+    // Calling the Any method statically on a value calls ignores the override because we select the
+    // method explicitly
+    var x5 = ModuleUtils.findAssignment(foo, "x5");
+    assertAtomType("local.Project1.modA.A", x5);
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -1560,10 +1560,13 @@ public class TypeInferenceTest extends StaticAnalysisTest {
 
                         method self -> B = B.B_Value
 
+                    type Other_Type
+                        Value
+
                     method -> C = C.C_Value
 
                     foo =
-                        x1 = 42.method
+                        x1 = Other_Type.Value.method
                         x2 = My_Type.Value.method
                         x3 = method
                         x4 = My_Type.method
@@ -1581,7 +1584,7 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     var module = compile(anyPrecedenceTestSource());
     var foo = ModuleUtils.findStaticMethod(module, "foo");
 
-    // 42 dispatches to Any and gets A
+    // Other_Type dispatches to parent - Any and gets A
     var x1 = ModuleUtils.findAssignment(foo, "x1");
     assertAtomType("local.Project1.modA.A", x1);
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -1552,13 +1552,19 @@ public class TypeInferenceTest extends StaticAnalysisTest {
                         B_Value
                     type C
                         C_Value
+                    type D
+                        D_Value
+                    type E
+                        E_Value
 
                     Any.method self -> A = A.A_Value
+                    Any.static_method -> D = D.D_Value
 
                     type My_Type
                         Value
 
                         method self -> B = B.B_Value
+                        static_method -> E = E.E_Value
 
                     type Other_Type
                         Value
@@ -1571,7 +1577,9 @@ public class TypeInferenceTest extends StaticAnalysisTest {
                         x3 = method
                         x4 = My_Type.method
                         x5 = Any.method My_Type.Value
-                        [x1, x2, x3, x4, x5]
+                        x6 = Any.static_method
+                        x7 = My_Type.static_method
+                        [x1, x2, x3, x4, x5, x6, x7]
                     """,
                 uri.getAuthority())
             .uri(uri)
@@ -1632,6 +1640,12 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     // method explicitly
     var x5 = ModuleUtils.findAssignment(foo, "x5");
     assertAtomType("local.Project1.modA.A", x5);
+
+    var x6 = ModuleUtils.findAssignment(foo, "x6");
+    assertAtomType("local.Project1.modA.D", x6);
+
+    var x7 = ModuleUtils.findAssignment(foo, "x7");
+    assertAtomType("local.Project1.modA.E", x7);
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -1579,6 +1579,33 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     return src;
   }
 
+  @Ignore("TODO: missing IR on Numbers")
+  @Test
+  public void overrideMethodOnNumberThroughAny() throws URISyntaxException {
+    final URI uri = new URI("memory://local.Project1.modA.enso");
+    final Source src =
+        Source.newBuilder(
+                "enso",
+                """
+                    type A
+                        A_Value
+
+                    Any.method self -> A = A.A_Value
+
+                    foo =
+                        x1 = 42.method
+                        x1
+                    """,
+                uri.getAuthority())
+            .uri(uri)
+            .buildLiteral();
+
+    var module = compile(src);
+    var foo = ModuleUtils.findStaticMethod(module, "foo");
+    var x1 = ModuleUtils.findAssignment(foo, "x1");
+    assertAtomType("local.Project1.modA.A", x1);
+  }
+
   @Test
   public void precedenceOfMethodsOnAny() throws URISyntaxException {
     var module = compile(anyPrecedenceTestSource());

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
@@ -249,7 +249,7 @@ public class TypeInferenceConsistencyTest {
     var str = result.as(Object.class).toString();
     // See TypeInferenceTest.precedenceOfMethodsOnAny for the dissection of each value and
     // explanations.
-    assertEquals("[A_Value, B_Value, C_Value, A_Value, A_Value]", str);
+    assertEquals("[A_Value, B_Value, C_Value, A_Value, A_Value, D_Value, E_Value]", str);
   }
 
   /**

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import org.enso.common.MethodNames;
 import org.enso.common.RuntimeOptions;
+import org.enso.compiler.test.TypeInferenceTest;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
@@ -233,6 +235,21 @@ public class TypeInferenceConsistencyTest {
     assertEquals("(My_Type.Value 101)", result.as(Object.class).toString());
 
     assertEquals("No warning diagnostics are expected.", "", getOutput());
+  }
+
+  /*
+  The runtime counterpart of `TypeInferenceTest.precedenceOfMethodsOnAny`.
+  It verifies that the values returned by the methods are consistent with the types checked in the static analysis.
+  Thus, we verify that the runtime method resolution and type inference are consistent.
+  */
+  @Test
+  public void precedenceOfMethodsOnAny() throws URISyntaxException {
+    var module = ctx.eval(TypeInferenceTest.anyPrecedenceTestSource());
+    var result = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "foo");
+    var str = result.as(Object.class).toString();
+    // See TypeInferenceTest.precedenceOfMethodsOnAny for the dissection of each value and
+    // explanations.
+    assertEquals("[A_Value, B_Value, C_Value, A_Value, A_Value]", str);
   }
 
   /**


### PR DESCRIPTION
### Pull Request Description

- As followup of #[12048](https://github.com/enso-org/enso/pull/12048) I thought that it may be useful to add a test that verifies that method resolution precedence on Any is consistent between static analysis and runtime.
- I've added a test that gives 5 different types and checks which type the inference picks and compares that also with what the runtime returns.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
