### PR TITLE
Address common issues after bazel merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,11 +138,7 @@ project/metals.sbt
 ## Build Cache ##
 #################
 
-bazel-bin
-bazel-bazel
-bazel-enso
-bazel-out
-bazel-testlogs
+bazel-*
 build-cache
 
 ##################

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -10,7 +10,6 @@ import * as path from 'node:path'
 import * as tar from 'tar'
 import * as yaml from 'yaml'
 
-import { COOP_COEP_CORP_HEADERS } from 'enso-common'
 import GLOBAL_CONFIG from 'enso-common/src/config.json' with { type: 'json' }
 
 import * as projectManagement from './projectManagement'
@@ -23,6 +22,11 @@ const HTTP_STATUS_OK = 200
 const HTTP_STATUS_BAD_REQUEST = 400
 const HTTP_STATUS_NOT_FOUND = 404
 const PROJECTS_ROOT_DIRECTORY = projectManagement.getProjectsDirectory()
+
+const COMMON_HEADERS = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Resource-Policy': 'same-origin',
+}
 
 // =============
 // === Types ===
@@ -139,7 +143,7 @@ export default function projectManagerShimMiddleware(
         const directory = url.searchParams.get('directory') ?? PROJECTS_ROOT_DIRECTORY
         if (fileName == null) {
           response
-            .writeHead(HTTP_STATUS_BAD_REQUEST, COOP_COEP_CORP_HEADERS)
+            .writeHead(HTTP_STATUS_BAD_REQUEST, COMMON_HEADERS)
             .end('Request is missing search parameter `file_name`.')
         } else {
           const filePath = path.join(directory, fileName)
@@ -147,16 +151,16 @@ export default function projectManagerShimMiddleware(
             .writeFile(filePath, request)
             .then(() => {
               response
-                .writeHead(HTTP_STATUS_OK, [
-                  ['Content-Length', String(filePath.length)],
-                  ['Content-Type', 'text/plain'],
-                  ...COOP_COEP_CORP_HEADERS,
-                ])
+                .writeHead(HTTP_STATUS_OK, {
+                  'Content-Length': String(filePath.length),
+                  'Content-Type': 'text/plain',
+                  ...COMMON_HEADERS,
+                })
                 .end(filePath)
             })
             .catch((e) => {
               console.error(e)
-              response.writeHead(HTTP_STATUS_BAD_REQUEST, COOP_COEP_CORP_HEADERS).end()
+              response.writeHead(HTTP_STATUS_BAD_REQUEST, COMMON_HEADERS).end()
             })
         }
         break
@@ -172,15 +176,15 @@ export default function projectManagerShimMiddleware(
           .uploadBundle(request, directory, name)
           .then((id) => {
             response
-              .writeHead(HTTP_STATUS_OK, [
-                ['Content-Length', String(id.length)],
-                ['Content-Type', 'text/plain'],
-                ...COOP_COEP_CORP_HEADERS,
-              ])
+              .writeHead(HTTP_STATUS_OK, {
+                'Content-Length': String(id.length),
+                'Content-Type': 'text/plain',
+                ...COMMON_HEADERS,
+              })
               .end(id)
           })
           .catch(() => {
-            response.writeHead(HTTP_STATUS_BAD_REQUEST, COOP_COEP_CORP_HEADERS).end()
+            response.writeHead(HTTP_STATUS_BAD_REQUEST, COMMON_HEADERS).end()
           })
         break
       }
@@ -193,7 +197,7 @@ export default function projectManagerShimMiddleware(
           !cliArguments.every((item): item is string => typeof item === 'string')
         ) {
           response
-            .writeHead(HTTP_STATUS_BAD_REQUEST, COOP_COEP_CORP_HEADERS)
+            .writeHead(HTTP_STATUS_BAD_REQUEST, COMMON_HEADERS)
             .end('Command arguments must be an array of strings.')
         } else {
           void (async () => {
@@ -335,11 +339,11 @@ export default function projectManagerShimMiddleware(
             }
             const buffer = Buffer.from(result)
             response
-              .writeHead(HTTP_STATUS_OK, [
-                ['Content-Length', String(buffer.byteLength)],
-                ['Content-Type', 'application/json'],
-                ...COOP_COEP_CORP_HEADERS,
-              ])
+              .writeHead(HTTP_STATUS_OK, {
+                'Content-Length': String(buffer.byteLength),
+                'Content-Type': 'application/json',
+                ...COMMON_HEADERS,
+              })
               .end(buffer)
           })()
         }
@@ -370,10 +374,10 @@ export default function projectManagerShimMiddleware(
                     'id' in metadata &&
                     metadata.id === uuid
                   ) {
-                    response.writeHead(HTTP_STATUS_OK, [
-                      ['Content-Type', 'application/gzip+x-enso-project'],
-                      ...COOP_COEP_CORP_HEADERS,
-                    ])
+                    response.writeHead(HTTP_STATUS_OK, {
+                      'Content-Type': 'application/gzip+x-enso-project',
+                      ...COMMON_HEADERS,
+                    })
                     tar
                       .create({ gzip: true, cwd: projectRoot }, [projectRoot])
                       .pipe(response, { end: true })
@@ -386,22 +390,22 @@ export default function projectManagerShimMiddleware(
               }
             }
             if (!success) {
-              response.writeHead(HTTP_STATUS_NOT_FOUND, COOP_COEP_CORP_HEADERS).end()
+              response.writeHead(HTTP_STATUS_NOT_FOUND, COMMON_HEADERS).end()
             }
           })
           break
         }
-        response.writeHead(HTTP_STATUS_NOT_FOUND, COOP_COEP_CORP_HEADERS).end()
+        response.writeHead(HTTP_STATUS_NOT_FOUND, COMMON_HEADERS).end()
         break
       }
     }
   } else if (request.method === 'GET' && requestPath === '/api/root-directory') {
     response
-      .writeHead(HTTP_STATUS_OK, [
-        ['Content-Length', String(PROJECTS_ROOT_DIRECTORY.length)],
-        ['Content-Type', 'text/plain'],
-        ...COOP_COEP_CORP_HEADERS,
-      ])
+      .writeHead(HTTP_STATUS_OK, {
+        'Content-Length': String(PROJECTS_ROOT_DIRECTORY.length),
+        'Content-Type': 'text/plain',
+        ...COMMON_HEADERS,
+      })
       .end(PROJECTS_ROOT_DIRECTORY)
   } else {
     next()

--- a/app/gui/vite.config.ts
+++ b/app/gui/vite.config.ts
@@ -1,7 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import react from '@vitejs/plugin-react'
 import vue from '@vitejs/plugin-vue'
-import { COOP_COEP_CORP_HEADERS } from 'enso-common'
 import { fileURLToPath } from 'node:url'
 import postcssNesting from 'postcss-nesting'
 import tailwindcss from 'tailwindcss'
@@ -75,10 +74,14 @@ export default defineConfig({
   ],
   optimizeDeps: {
     entries: fileURLToPath(new URL('./index.html', import.meta.url)),
+    exclude: ['enso-common'],
     holdUntilCrawlEnd: true,
   },
   server: {
-    headers: Object.fromEntries(COOP_COEP_CORP_HEADERS),
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+    },
     ...(process.env.GUI_HOSTNAME ? { host: process.env.GUI_HOSTNAME } : {}),
   },
   resolve: {

--- a/build_tools/build/src/project/gui.rs
+++ b/build_tools/build/src/project/gui.rs
@@ -81,7 +81,7 @@ impl IsTarget for Gui {
                 .current_dir(repo_root)
                 .set_env(ide_env::ENSO_IDE_COMMIT_HASH, &commit_hash)?
                 .set_env(ide_env::ENSO_IDE_VERSION, &version_string)?
-                .run("build:ide")
+                .run("build:gui")
                 .run_ok()
                 .await?;
 

--- a/build_tools/build/src/project/gui.rs
+++ b/build_tools/build/src/project/gui.rs
@@ -4,6 +4,7 @@
 
 use crate::prelude::*;
 
+use crate::ide::web::env as ide_env;
 use crate::ide::web::IdeDesktop;
 use crate::paths::generated::RepoRootAppGuiDist;
 use crate::paths::generated::RepoRootDistGuiAssets;
@@ -11,8 +12,8 @@ use crate::project::Context;
 use crate::project::IsArtifact;
 use crate::project::IsTarget;
 use crate::source::WithDestination;
-
 use ide_ci::ok_ready_boxed;
+use ide_ci::programs::Pnpm;
 
 
 
@@ -46,8 +47,15 @@ impl Artifact {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Gui;
 
+#[derive_where(Debug)]
+pub struct BuildInput {
+    pub version:     Version,
+    #[derive_where(skip)]
+    pub commit_hash: BoxFuture<'static, Result<String>>,
+}
+
 impl IsTarget for Gui {
-    type BuildInput = ();
+    type BuildInput = BuildInput;
     type Artifact = Artifact;
 
     fn artifact_name(&self) -> String {
@@ -63,11 +71,20 @@ impl IsTarget for Gui {
         context: Context,
         job: WithDestination<Self::BuildInput>,
     ) -> BoxFuture<'static, Result<Self::Artifact>> {
-        let WithDestination { inner: _, destination } = job;
+        let WithDestination { inner: BuildInput { version, commit_hash }, destination } = job;
         async move {
             let repo_root = &context.repo_root;
+            let version_string = version.to_string();
             crate::web::install(repo_root).await?;
-            crate::web::run_script(repo_root, crate::web::Script::Build).await?;
+            let commit_hash = commit_hash.await?;
+            Pnpm.cmd()?
+                .current_dir(repo_root)
+                .set_env(ide_env::ENSO_IDE_COMMIT_HASH, &commit_hash)?
+                .set_env(ide_env::ENSO_IDE_VERSION, &version_string)?
+                .run("build:ide")
+                .run_ok()
+                .await?;
+
             ide_ci::fs::mirror_directory(
                 &repo_root.app.gui.dist,
                 &destination.join(RepoRootDistGuiAssets::segment_name()),

--- a/build_tools/build/src/web.rs
+++ b/build_tools/build/src/web.rs
@@ -66,8 +66,6 @@ pub fn assume_installed() {
 #[strum(serialize_all = "kebab-case")]
 pub enum Script {
     CiCheck,
-    #[strum(serialize = "build:gui")]
-    Build,
     Format,
     #[strum(serialize = "format:workflows")]
     FormatWorkflows,

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -583,10 +583,14 @@ impl Resolvable for Gui {
     }
 
     fn resolve(
-        _ctx: &Processor,
-        _from: <Self as IsTargetSource>::BuildInput,
+        ctx: &Processor,
+        from: <Self as IsTargetSource>::BuildInput,
     ) -> BoxFuture<'static, Result<<Self as IsTarget>::BuildInput>> {
-        ok_ready_boxed(())
+        let arg::gui::BuildInput {} = from;
+        ok_ready_boxed(project::gui::BuildInput {
+            version:     ctx.triple.versions.version.clone(),
+            commit_hash: ctx.commit(),
+        })
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

- Added all `bazel-*` directories to .gitignore, so any project directory base names are supported.
- Removed usages of `enso-common` from vite configuration script, to avoid the need to run `compile` prior to starting dev server. The in-bundle references are working correctly regardless.
- Fixed version env propagation through IDE rust build script, which hopefully will fix wrong visible version in the nightly build title.
