### PR TITLE
Refactor Suggestion DB

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/component.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/component.test.ts
@@ -104,11 +104,10 @@ test.each`
   }
 
   const pattern = 'foo_bar'
-  const entry = {
-    ...makeModuleMethod(`local.Project.${name}`),
-    aliases: aliases ?? [],
-  }
+  const entry = makeModuleMethod(`local.Project.${name}`, { aliases: aliases ?? [] })
   const filtering = new Filtering({ pattern })
-  const componentInfo = { id: 0, entry, match: filtering.filter(entry)! }
+  const match = filtering.filter(entry, [])
+  expect(match).not.toBeNull()
+  const componentInfo = { id: 0, entry, match: match! }
   expect(replaceMatches(makeComponent(componentInfo))).toEqual(highlighted)
 })

--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -1,5 +1,5 @@
 import { Filtering, type MatchResult } from '@/components/ComponentBrowser/filtering'
-import { entryQn, SuggestionEntry } from '@/stores/suggestionDatabase/entry'
+import { SuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import {
   makeConstructor,
   makeFunction,
@@ -14,9 +14,9 @@ import { expect, test } from 'vitest'
 import { Opt } from 'ydoc-shared/util/data/opt'
 
 test.each([
-  { ...makeModuleMethod('Standard.Base.Data.read'), groupIndex: 0 },
-  { ...makeModuleMethod('Standard.Base.Data.write'), groupIndex: 0 },
-  { ...makeStaticMethod('Standard.Base.Data.Vector.Vector.new'), groupIndex: 1 },
+  makeModuleMethod('Standard.Base.Data.read', { group: 'Standard.Base.MockGroup1' }),
+  makeModuleMethod('Standard.Base.Data.write', { group: 'Standard.Base.MockGroup1' }),
+  makeStaticMethod('Standard.Base.Data.Vector.Vector.new', { group: 'Standard.Base.MockGroup2' }),
   makeModuleMethod('Standard.Base.Data.read_text'),
   makeStaticMethod('local.Project.Foo.new'),
   makeStaticMethod('local.Project.Internalization.internalize'),
@@ -27,7 +27,7 @@ test.each([
 
 test.each([
   makeModuleMethod('Standard.Base.Data.Vector.some_method'), // not in top group
-  { ...makeMethod('Standard.Base.Data.Vector.Vector.get'), groupIndex: 1 }, // not static method
+  makeMethod('Standard.Base.Data.Vector.Vector.get', { group: 'Standard.Base.MockGroup2' }), // not static method
   makeModule('Standard.Base.Data.Vector'), // Not top module
   makeModule('local.New_Project'), // Main module
   makeModule('Standard.Base.Data'), // Top module
@@ -118,12 +118,12 @@ function matchedText(ownerName: string, name: string, matchResult: MatchResult) 
 
 type MatchingTestCase = {
   pattern: string
-  matchedSorted: { module?: string; name: string; aliases: string[] }[]
-  notMatched: { module?: string; name: string; aliases: string[] }[]
+  matchedSorted: { module?: string; name: string; aliases?: string[] }[]
+  notMatched: { module?: string; name: string; aliases?: string[] }[]
 }
 
 // In this test, `matchedSorted` are specified in expected score ascending order.
-test.each([
+test.each<MatchingTestCase>([
   {
     pattern: 'foo',
     matchedSorted: [
@@ -210,29 +210,34 @@ test.each([
       { module: 'local.Pr', name: 'bar' },
     ],
   },
-] as MatchingTestCase[])('Matching pattern $pattern', ({ pattern, matchedSorted, notMatched }) => {
+])('Matching pattern $pattern', ({ pattern, matchedSorted, notMatched }) => {
   const filtering = new Filtering({ pattern })
-  const matchedSortedEntries = Array.from(matchedSorted, ({ name, aliases, module }) => ({
-    ...makeModuleMethod(`${module ?? 'local.Project'}.${name}`),
-    aliases: aliases ?? [],
-  }))
+  const matchedSortedEntries = Array.from(matchedSorted, ({ name, aliases, module }) =>
+    makeModuleMethod(`${module ?? 'local.Project'}.${name}`, { aliases: aliases ?? [] }),
+  )
   const matchResults = Array.from(matchedSortedEntries, (entry) => filtering.filter(entry, []))
   // Checking matching entries
   function checkResult(entry: SuggestionEntry, result: Opt<MatchResult>) {
-    expect(result, `Matching entry ${entryQn(entry)}`).not.toBeNull()
+    expect(result, `Matching entry ${entry.definitionPath}`).not.toBeNull()
     expect(
-      matchedText(entry.memberOf ? qnLastSegment(entry.memberOf) : '', entry.name, result!)
+      matchedText(
+        'memberOf' in entry && entry.memberOf ? qnLastSegment(entry.memberOf) : '',
+        entry.name,
+        result!,
+      )
         .toLowerCase()
         .replace(/ /g, '_'),
-      `Matched text of entry ${entryQn(entry)}`,
+      `Matched text of entry ${entry.definitionPath}`,
     ).toEqual(pattern.toLowerCase().replace(/ /g, '_'))
   }
+  expect(matchedSortedEntries.length).toBeGreaterThan(0)
+  expect(matchedSortedEntries[0]).not.toBeNull()
   checkResult(matchedSortedEntries[0]!, matchResults[0])
   for (let i = 1; i < matchResults.length; i++) {
     checkResult(matchedSortedEntries[i]!, matchResults[i])
     expect(
       matchResults[i]!.score,
-      `score('${entryQn(matchedSortedEntries[i]!)}') > score('${entryQn(matchedSortedEntries[i - 1]!)}')`,
+      `score('${matchedSortedEntries[i]!.definitionPath}') > score('${matchedSortedEntries[i - 1]!.definitionPath}')`,
     ).toBeGreaterThan(matchResults[i - 1]!.score)
   }
 
@@ -242,6 +247,6 @@ test.each([
       ...makeModuleMethod(`${module ?? 'local.Project'}.${name}`),
       aliases: aliases ?? [],
     }
-    expect(filtering.filter(entry, []), entryQn(entry)).toBeNull()
+    expect(filtering.filter(entry, []), entry.definitionPath).toBeNull()
   }
 })

--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -55,12 +55,26 @@ test('An Instance method is shown when self arg matches', () => {
   expect(filteringWithoutSelfType.filter(entry2, [])).toBeNull()
 })
 
-test('Additional self types are taken into account when filtering', () => {
+test('`Any` type methods taken into account when filtering', () => {
   const entry1 = makeMethod('Standard.Base.Data.Vector.Vector.get')
   const entry2 = makeMethod('Standard.Base.Any.Any.to_string')
-  const additionalSelfType = 'Standard.Base.Any.Any' as QualifiedName
   const filtering = new Filtering({
     selfArg: { type: 'known', typename: 'Standard.Base.Data.Vector.Vector' },
+  })
+  expect(filtering.filter(entry1, [])).not.toBeNull()
+  expect(filtering.filter(entry2, [])).not.toBeNull()
+
+  const filteringWithoutSelfType = new Filtering({})
+  expect(filteringWithoutSelfType.filter(entry1, [])).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry2, [])).toBeNull()
+})
+
+test('Additional self types are taken into account when filtering', () => {
+  const entry1 = makeMethod('Standard.Base.Data.Numbers.Float.abs')
+  const entry2 = makeMethod('Standard.Base.Data.Numbers.Number.sqrt')
+  const additionalSelfType = 'Standard.Base.Data.Numbers.Number' as QualifiedName
+  const filtering = new Filtering({
+    selfArg: { type: 'known', typename: 'Standard.Base.Data.Numbers.Float' },
   })
   expect(filtering.filter(entry1, [additionalSelfType])).not.toBeNull()
   expect(filtering.filter(entry2, [additionalSelfType])).not.toBeNull()

--- a/app/gui/src/project-view/components/ComponentBrowser/component.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/component.ts
@@ -1,6 +1,7 @@
 import { Filtering, type MatchResult } from '@/components/ComponentBrowser/filtering'
 import { SuggestionDb } from '@/stores/suggestionDatabase'
 import {
+  entryIsStatic,
   SuggestionKind,
   type SuggestionEntry,
   type SuggestionId,
@@ -8,11 +9,9 @@ import {
 import { compareOpt } from '@/util/compare'
 import { isSome } from '@/util/data/opt'
 import { Range } from '@/util/data/range'
-import { ANY_TYPE_QN } from '@/util/ensoTypes'
 import { displayedIconOf } from '@/util/getIconName'
 import type { Icon } from '@/util/iconMetadata/iconName'
-import type { QualifiedName } from '@/util/qualifiedName'
-import { qnLastSegmentIndex, tryQualifiedName } from '@/util/qualifiedName'
+import { qnJoin, qnLastSegment, tryQualifiedName, type QualifiedName } from '@/util/qualifiedName'
 
 interface ComponentLabelInfo {
   label: string
@@ -34,19 +33,18 @@ export interface Component extends ComponentLabel {
 
 /** @returns the displayed label of given suggestion entry with information of highlighted ranges. */
 export function labelOfEntry(entry: SuggestionEntry, match: MatchResult): ComponentLabelInfo {
-  if (entry.memberOf && entry.selfType == null) {
-    const ownerLastSegmentStart = qnLastSegmentIndex(entry.memberOf) + 1
-    const ownerName = entry.memberOf.substring(ownerLastSegmentStart)
-    const nameOffset = ownerName.length + '.'.length
+  if (entryIsStatic(entry) && entry.memberOf) {
+    const label = qnJoin(qnLastSegment(entry.memberOf), entry.name)
     if ((!match.ownerNameRanges && !match.nameRanges) || match.matchedAlias) {
       return {
-        label: `${ownerName}.${entry.name}`,
+        label,
         matchedAlias: match.matchedAlias,
         matchedRanges: match.nameRanges,
       }
     }
+    const nameOffset = label.length - entry.name.length
     return {
-      label: `${ownerName}.${entry.name}`,
+      label,
       matchedAlias: match.matchedAlias,
       matchedRanges: [
         ...(match.ownerNameRanges ?? []),
@@ -112,12 +110,13 @@ export function makeComponent({ id, entry, match }: ComponentInfo): Component {
 /** Create {@link Component} list from filtered suggestions. */
 export function makeComponentList(db: SuggestionDb, filtering: Filtering): Component[] {
   function* matchSuggestions() {
-    // All types are descendants of `Any`, so we can safely prepopulate it here.
-    // This way, we will use it even when `selfArg` is not a valid qualified name.
-    const additionalSelfTypes: QualifiedName[] = [ANY_TYPE_QN]
+    const additionalSelfTypes: QualifiedName[] = []
     if (filtering.selfArg?.type === 'known') {
       const maybeName = tryQualifiedName(filtering.selfArg.typename)
-      if (maybeName.ok) populateAdditionalSelfTypes(db, additionalSelfTypes, maybeName.value)
+      if (maybeName.ok) {
+        const entry = db.getEntryByQualifiedName(maybeName.value)
+        if (entry) additionalSelfTypes.push(...db.ancestors(entry))
+      }
     }
 
     for (const [id, entry] of db.entries()) {
@@ -129,17 +128,4 @@ export function makeComponentList(db: SuggestionDb, filtering: Filtering): Compo
   }
   const matched = Array.from(matchSuggestions()).sort(compareSuggestions)
   return Array.from(matched, (info) => makeComponent(info))
-}
-
-/**
- * Type can inherit methods from `parentType`, and it can do that recursively.
- * In practice, these hierarchies are at most two levels deep.
- */
-function populateAdditionalSelfTypes(db: SuggestionDb, list: QualifiedName[], name: QualifiedName) {
-  let entry = db.getEntryByQualifiedName(name)
-  // We don’t need to add `Any` to the list, because the caller already did that.
-  while (entry != null && entry.parentType != null && entry.parentType !== ANY_TYPE_QN) {
-    list.push(entry.parentType)
-    entry = db.getEntryByQualifiedName(entry.parentType)
-  }
 }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/__tests__/widgetFunctionCallInfo.test.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/__tests__/widgetFunctionCallInfo.test.ts
@@ -19,26 +19,25 @@ import {
   useWidgetFunctionCallInfo,
 } from '../widgetFunctionCallInfo'
 
-const moduleMethod = {
-  ...makeMethod('local.Project.module_method', 'Text'),
-  arguments: [makeArgument('arg')],
+const moduleMethod = makeMethod('local.Project.module_method', {
+  returnType: 'Text',
+  args: [makeArgument('arg')],
   annotations: ['arg'],
-}
-const con = {
-  ...makeConstructor('local.Project.Type.Con'),
-  arguments: [makeArgument('arg')],
+})
+const con = makeConstructor('local.Project.Type.Con', {
+  args: [makeArgument('arg')],
   annotations: ['arg'],
-}
-const method = {
-  ...makeMethod('local.Project.Type.method', 'Text'),
-  arguments: [makeArgument('self'), makeArgument('arg')],
+})
+const method = makeMethod('local.Project.Type.method', {
+  returnType: 'Text',
+  args: [makeArgument('self'), makeArgument('arg')],
   annotations: ['arg'],
-}
-const staticMethod = {
-  ...makeStaticMethod('local.Project.Type.static_method', 'Text'),
-  arguments: [makeArgument('arg')],
+})
+const staticMethod = makeStaticMethod('local.Project.Type.static_method', {
+  returnType: 'Text',
+  args: [makeArgument('arg')],
   annotations: ['arg'],
-}
+})
 
 test.each`
   code                                       | callSuggestion  | subjectSpan            | attachedSpan            | subjectType                  | methodName

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -6,7 +6,7 @@ import {
 import type { MethodCallInfo } from '@/stores/graph/graphDatabase'
 import type { ExpressionInfo } from '@/stores/project/computedValueRegistry'
 import type { NodeVisualizationConfiguration } from '@/stores/project/executionContext'
-import { entryQn } from '@/stores/suggestionDatabase/entry'
+import { entryIsAnnotatable } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
 import type { AstId } from '@/util/ast/abstract'
 import {
@@ -60,7 +60,7 @@ export function useWidgetFunctionCallInfo(
     if (analyzed.kind === 'infix') {
       return analyzed.lhs?.externalId
     }
-    const knownArguments = methodCallInfo.value?.suggestion?.arguments
+    const knownArguments = methodCallInfo.value?.suggestion.arguments
     const hasKnownSelfArgument = knownArguments?.[0]?.name === 'self'
 
     // First we always want to attach the visualization to the `self` argument,
@@ -90,8 +90,9 @@ export function useWidgetFunctionCallInfo(
 
     const info = methodCallInfo.value
     if (!info) return null
+    if (!entryIsAnnotatable(info.suggestion)) return null
     const annotatedArgs = info.suggestion.annotations
-    if (annotatedArgs.length === 0) return null
+    if (!annotatedArgs.length) return null
     const name = info.suggestion.name
     const positionalArgumentsExpressions = [
       `.${name}`,
@@ -134,7 +135,7 @@ export function useWidgetFunctionCallInfo(
     if (cfg.kind === 'FunctionCall') return cfg
     if (cfg.kind === 'OneOfFunctionCalls' && methodCallInfo.value != null) {
       const info = methodCallInfo.value
-      const fullName = entryQn(info?.suggestion)
+      const fullName = info?.suggestion.definitionPath
       const autoscopedName = '..' + info?.suggestion.name
       return cfg.possibleFunctions.get(fullName) ?? cfg.possibleFunctions.get(autoscopedName)
     }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -18,6 +18,8 @@ import { useGraphStore } from '@/stores/graph'
 import { requiredImports, type RequiredImport } from '@/stores/graph/imports'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import {
+  SuggestionKind,
+  entryIsStatic,
   type SuggestionEntry,
   type SuggestionEntryArgument,
 } from '@/stores/suggestionDatabase/entry'
@@ -26,7 +28,7 @@ import { targetIsOutside } from '@/util/autoBlur'
 import { ArgumentInfoKey } from '@/util/callTree'
 import { arrayEquals } from '@/util/data/array'
 import type { Opt } from '@/util/data/opt'
-import { qnLastSegment, tryQualifiedName } from '@/util/qualifiedName'
+import { qnJoin, qnLastSegment, tryQualifiedName } from '@/util/qualifiedName'
 import { autoUpdate, offset, shift, size, useFloating } from '@floating-ui/vue'
 import type { Ref, RendererNode, VNode } from 'vue'
 import { computed, proxyRefs, ref, shallowRef, watch } from 'vue'
@@ -119,8 +121,8 @@ class ExpressionTag {
 
   static FromEntry(entry: SuggestionEntry, label?: Opt<string>): ExpressionTag {
     const expression =
-      entry.selfType != null ? `_.${entry.name}`
-      : entry.memberOf ? `${qnLastSegment(entry.memberOf)}.${entry.name}`
+      entryIsStatic(entry) && entry.memberOf ? qnJoin(qnLastSegment(entry.memberOf), entry.name)
+      : entry.kind === SuggestionKind.Method ? `_.${entry.name}`
       : entry.name
     return new ExpressionTag(
       expression,

--- a/app/gui/src/project-view/stores/graph/graphDatabase.ts
+++ b/app/gui/src/project-view/stores/graph/graphDatabase.ts
@@ -1,7 +1,7 @@
 import { computeNodeColor } from '@/composables/nodeColors'
 import { ComputedValueRegistry, type ExpressionInfo } from '@/stores/project/computedValueRegistry'
 import { SuggestionDb, type Group } from '@/stores/suggestionDatabase'
-import type { SuggestionEntry } from '@/stores/suggestionDatabase/entry'
+import { type CallableSuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
 import type { AstId, NodeMetadata } from '@/util/ast/abstract'
@@ -49,7 +49,7 @@ import { isUuid, visMetadataEquals } from 'ydoc-shared/yjsModel'
 export interface MethodCallInfo {
   methodCall: MethodCall
   methodCallSource: Ast.AstId
-  suggestion: SuggestionEntry
+  suggestion: CallableSuggestionEntry
 }
 
 /** TODO: Add docs */
@@ -221,9 +221,7 @@ export class GraphDb {
   getMethodCallInfo(id: AstId): MethodCallInfo | undefined {
     const methodCall = this.getMethodCall(id)
     if (methodCall == null) return
-    const suggestionId = this.suggestionDb.findByMethodPointer(methodCall.methodPointer)
-    if (suggestionId == null) return
-    const suggestion = this.suggestionDb.get(suggestionId)
+    const suggestion = this.suggestionDb.entryByMethodPointer(methodCall.methodPointer)
     if (suggestion == null) return
     return { methodCall, methodCallSource: id, suggestion }
   }

--- a/app/gui/src/project-view/stores/graph/imports.ts
+++ b/app/gui/src/project-view/stores/graph/imports.ts
@@ -225,7 +225,10 @@ export function requiredImportsByFQN(
 }
 
 function selfTypeEntry(db: SuggestionDb, entry: SuggestionEntry): SuggestionEntry | undefined {
-  if (entry.memberOf) {
+  if (
+    (entry.kind === SuggestionKind.Method || entry.kind === SuggestionKind.Constructor) &&
+    entry.memberOf
+  ) {
     return db.getEntryByQualifiedName(entry.memberOf)
   }
 }

--- a/app/gui/src/project-view/stores/suggestionDatabase/__tests__/documentation.test.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/__tests__/documentation.test.ts
@@ -6,8 +6,8 @@ import { expect, test } from 'vitest'
 
 test.each([
   ['ALIAS Bar', 'Bar'],
-  ['Some one section\n   But not tags here', null],
-  ['GROUP different tag', null],
+  ['Some one section\n   But not tags here', undefined],
+  ['GROUP different tag', undefined],
   ['PRIVATE\nGROUP Input\nALIAS Foo\n\nSeveral tags', 'Foo'],
 ])('Getting tag from docs case %#.', (doc, expected) => {
   const sections = parseDocs(doc)
@@ -20,14 +20,14 @@ const groups = [
   { name: 'Another', project: unwrap(tryQualifiedName('local.Project')) },
 ]
 test.each([
-  ['From Base', 'local.Project.Main', null],
+  ['From Base', 'local.Project.Main', undefined],
   ['From Base', 'Standard.Base', 0],
   ['Standard.Base.From Base', 'local.Project.Main', 0],
   ['Other', 'local.Project.Main', 1],
   ['local.Project.Other', 'local.Project.Main', 1],
   ['Other', 'local.Project.Some.Deep.Submodule', 1],
   ['Another', 'local.Project.Main', 2],
-  ['Not Existing', 'local.Project.Main', null],
+  ['Not Existing', 'local.Project.Main', undefined],
 ])('Get group index case %#.', (name, definedIn, expected) => {
   const definedInQn = unwrap(tryQualifiedName(definedIn))
   expect(getGroupIndex(name, definedInQn, groups)).toBe(expected)

--- a/app/gui/src/project-view/stores/suggestionDatabase/documentation.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/documentation.ts
@@ -9,8 +9,10 @@ import { type DeepReadonly } from 'vue'
 export interface DocumentationData {
   documentation: Doc.Section[]
   aliases: string[]
-  iconName?: Icon
-  groupIndex?: number
+  /** A name of a custom icon to use when displaying the entry. */
+  iconName: Icon | undefined
+  /** An index of a group from group list in suggestionDb store this entry belongs to. */
+  groupIndex: number | undefined
   isPrivate: boolean
   isUnstable: boolean
 }
@@ -22,10 +24,9 @@ function isTagNamed(tag: string) {
 }
 
 /** @internal */
-export function tagValue(doc: Doc.Section[], tag: string): Opt<string> {
+export function tagValue(doc: Doc.Section[], tag: string): string | undefined {
   const tagSection = doc.find(isTagNamed(tag))
-  if (tagSection == null) return null
-  return tagSection.Tag.body
+  return tagSection?.Tag.body
 }
 
 /** @internal */
@@ -33,16 +34,17 @@ export function getGroupIndex(
   groupName: string,
   entryModule: QualifiedName,
   groups: DeepReadonly<Group[]>,
-): Opt<number> {
+): number | undefined {
   let normalized: string
   if (groupName.indexOf('.') >= 0) {
     normalized = groupName
   } else {
     const project = /^[^.]+\.[^.]+/.exec(entryModule)
-    if (project == null) return null
+    if (project == null) return
     normalized = `${project}.${groupName}`
   }
-  return findIndexOpt(groups, (group) => `${group.project}.${group.name}` == normalized)
+  const index = findIndexOpt(groups, (group) => `${group.project}.${group.name}` == normalized)
+  return index == null ? undefined : index
 }
 
 /** TODO: Add docs */
@@ -53,13 +55,13 @@ export function documentationData(
 ): DocumentationData {
   const parsed = documentation != null ? parseDocs(documentation) : []
   const groupName = tagValue(parsed, 'Group')
-  const groupIndex = groupName ? getGroupIndex(groupName, definedIn, groups) : null
-  const iconName = tagValue(parsed, 'Icon') as Opt<Icon>
+  const groupIndex = groupName ? getGroupIndex(groupName, definedIn, groups) : undefined
+  const iconName = tagValue(parsed, 'Icon')
 
   return {
     documentation: parsed,
-    ...(iconName != null ? { iconName } : {}),
-    ...(groupIndex != null ? { groupIndex } : {}),
+    iconName: iconName != null ? (iconName as Icon) : undefined,
+    groupIndex,
     aliases:
       tagValue(parsed, 'Alias')
         ?.trim()

--- a/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
@@ -1,11 +1,13 @@
-import type { Doc } from '@/util/docParser'
-import type { Icon } from '@/util/iconMetadata/iconName'
-import type { IdentifierOrOperatorIdentifier, QualifiedName } from '@/util/qualifiedName'
-import { qnJoin, qnParent, qnSegments } from '@/util/qualifiedName'
+import { type DocumentationData } from '@/stores/suggestionDatabase/documentation'
+import {
+  qnSegments,
+  type IdentifierOrOperatorIdentifier,
+  type QualifiedName,
+} from '@/util/qualifiedName'
 import type { MethodPointer } from 'ydoc-shared/languageServerTypes'
-import type {
-  SuggestionEntryArgument,
-  SuggestionEntryScope,
+import {
+  type SuggestionEntryArgument,
+  type SuggestionEntryScope,
 } from 'ydoc-shared/languageServerTypes/suggestions'
 
 export type {
@@ -32,48 +34,124 @@ export enum SuggestionKind {
   Local = 'Local',
 }
 
-export interface SuggestionEntry {
-  kind: SuggestionKind
+export interface SuggestionEntryCommon extends DocumentationData {
+  readonly kind: SuggestionKind
   /** A module where the suggested object is defined. */
   definedIn: QualifiedName
-  /** A type or module this method or constructor belongs to. */
-  memberOf?: QualifiedName
-  isPrivate: boolean
-  isUnstable: boolean
   name: IdentifierOrOperatorIdentifier
-  aliases: string[]
-  /** A type of the "self" argument. This field is present only for instance methods. */
-  selfType?: Typename
-  /**
-   * Argument lists of suggested object (atom or function). If the object does not take any
-   * arguments, the list is empty.
-   */
-  arguments: SuggestionEntryArgument[]
   /** A type returned by the suggested object. */
   returnType: Typename
-  /** Qualified name of the parent type. */
-  parentType?: QualifiedName
+  /** The fully qualified name of the `SuggestionEntry`, disregarding reexports. */
+  definitionPath: QualifiedName
+}
+
+interface Reexportable {
   /** A least-nested module reexporting this entity. */
-  reexportedIn?: QualifiedName
-  documentation: Doc.Section[]
+  reexportedIn: QualifiedName | undefined
+}
+
+interface Scoped {
   /** A scope where this suggestion is visible. */
-  scope?: SuggestionEntryScope
-  /** A name of a custom icon to use when displaying the entry. */
-  iconName?: Icon
-  /** An index of a group from group list in suggestionDb store this entry belongs to. */
-  groupIndex?: number
+  scope: SuggestionEntryScope | undefined
+}
+
+interface Annotatable {
   /** A list of annotations. They are present for methods and constructors only. */
   annotations: string[]
 }
 
-/** Get the fully qualified name of the `SuggestionEntry`, disregarding reexports. */
-export function entryQn(entry: SuggestionEntry): QualifiedName {
-  if (entry.kind == SuggestionKind.Module) {
-    return entry.definedIn
-  } else {
-    const owner = entryOwnerQn(entry)
-    return owner ? qnJoin(owner, entry.name) : entry.name
-  }
+interface TakesArguments {
+  /** Argument lists of suggested object (atom or function). */
+  arguments: SuggestionEntryArgument[]
+}
+
+interface IsMemberOf {
+  /**
+   * A type or module this method or constructor belongs to. This will not be `undefined` unless the value was an
+   * invalid qualified name.
+   */
+  memberOf: QualifiedName | undefined
+}
+
+export interface ModuleSuggestionEntry extends SuggestionEntryCommon, Reexportable {
+  readonly kind: SuggestionKind.Module
+}
+
+export interface TypeSuggestionEntry extends SuggestionEntryCommon, Reexportable, TakesArguments {
+  readonly kind: SuggestionKind.Type
+  /** Qualified name of the parent type. */
+  parentType: QualifiedName | undefined
+}
+
+export interface ConstructorSuggestionEntry
+  extends SuggestionEntryCommon,
+    Reexportable,
+    Annotatable,
+    TakesArguments,
+    IsMemberOf {
+  readonly kind: SuggestionKind.Constructor
+}
+
+export interface MethodSuggestionEntry
+  extends SuggestionEntryCommon,
+    Reexportable,
+    Annotatable,
+    TakesArguments,
+    IsMemberOf {
+  readonly kind: SuggestionKind.Method
+  /** Type of the "self" argument. */
+  selfType: Typename | undefined
+}
+
+export interface FunctionSuggestionEntry extends SuggestionEntryCommon, Scoped, TakesArguments {
+  readonly kind: SuggestionKind.Function
+}
+
+export interface LocalSuggestionEntry extends SuggestionEntryCommon, Scoped {
+  readonly kind: SuggestionKind.Local
+}
+
+export type SuggestionEntry =
+  | ModuleSuggestionEntry
+  | TypeSuggestionEntry
+  | ConstructorSuggestionEntry
+  | MethodSuggestionEntry
+  | FunctionSuggestionEntry
+  | LocalSuggestionEntry
+
+/**
+ * A type that can be called. This includes every suggestion kind that takes arguments, except
+ * {@link SuggestionKind.Type}.
+ */
+export type CallableSuggestionEntry =
+  | MethodSuggestionEntry
+  | ConstructorSuggestionEntry
+  | FunctionSuggestionEntry
+
+/** Type predicate for {@link CallableSuggestionEntry}. */
+export function entryIsCallable(entry: SuggestionEntry): entry is CallableSuggestionEntry {
+  return (
+    entry.kind === SuggestionKind.Method ||
+    entry.kind === SuggestionKind.Function ||
+    entry.kind === SuggestionKind.Constructor
+  )
+}
+
+/** Predicate for types that can have annotated arguments. */
+export function entryIsAnnotatable(
+  entry: SuggestionEntry,
+): entry is MethodSuggestionEntry | ConstructorSuggestionEntry {
+  return entry.kind === SuggestionKind.Method || entry.kind === SuggestionKind.Constructor
+}
+
+/** Predicate for members that can be called on a type. */
+export function entryIsStatic(
+  entry: SuggestionEntry,
+): entry is ConstructorSuggestionEntry | (MethodSuggestionEntry & { selfType: undefined }) {
+  return (
+    entry.kind === SuggestionKind.Constructor ||
+    (entry.kind === SuggestionKind.Method && entry.selfType == null)
+  )
 }
 
 /** Get the MethodPointer pointing to definition represented by the entry. */
@@ -86,29 +164,17 @@ export function entryMethodPointer(entry: SuggestionEntry): MethodPointer | unde
   }
 }
 
-/** TODO: Add docs */
-export function entryOwnerQn(entry: SuggestionEntry): QualifiedName | null {
-  if (entry.kind == SuggestionKind.Module) {
-    return qnParent(entry.definedIn)
-  } else {
-    return entry.memberOf ?? entry.definedIn
-  }
-}
-
 const DOCUMENTATION_ROOT = 'https://help.enso.org/docs/api'
 
 /** TODO: Add docs */
 export function suggestionDocumentationUrl(entry: SuggestionEntry): string | undefined {
   if (entry.kind !== SuggestionKind.Method && entry.kind !== SuggestionKind.Function) return
-  const location = entry.memberOf ?? entry.definedIn
+  const location = entry.definitionPath
   const segments: string[] = qnSegments(location)
   if (segments[0] !== 'Standard') return
   if (segments.length < 3) return
-  const namespace = segments[0]
-  segments[0] = DOCUMENTATION_ROOT
-  segments[1] = `${namespace}.${segments[1]}`
-  segments[segments.length - 1] += `.${entry.name}`
-  return segments.join('/')
+  const project = `${segments[0]}.${segments[1]}`
+  return [DOCUMENTATION_ROOT, project, ...segments.slice(2)].join('/')
 }
 
 /** `true` if calling the function without providing a value for this argument will result in an error. */

--- a/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
@@ -143,29 +143,6 @@ class FunctionSuggestionEntryImpl extends BaseSuggestionEntry implements Functio
   }
 }
 
-/*
-type GConstructor<T = {}> = new (...args: any[]) => T
-function AddReturnType<TBase extends GConstructor<FunctionSuggestionEntryImpl>>(Base: TBase) {
-  return class WithReturnType extends Base {
-    private constructor(...args: any[]) {
-      super(...args)
-    }
-
-    override setLsReturnType(returnType: Typename) {
-      this.returnType = returnType
-    }
-
-    static parse(
-      lsEntry: lsTypes.SuggestionEntry.Function,
-      groups: DeepReadonly<Group[]>,
-    ): Result<FunctionSuggestionEntry> {
-      return new this()
-      return FunctionSuggestionEntryImpl.parse(lsEntry, groups)
-    }
-  }
-}
- */
-
 class ModuleSuggestionEntryImpl extends BaseSuggestionEntry implements ModuleSuggestionEntry {
   readonly kind = SuggestionKind.Module
 

--- a/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
@@ -1,36 +1,521 @@
-import { SuggestionDb, type Group } from '@/stores/suggestionDatabase'
+import { type Group, SuggestionDb } from '@/stores/suggestionDatabase'
 import {
   documentationData,
   type DocumentationData,
 } from '@/stores/suggestionDatabase/documentation'
 import {
-  SuggestionKind,
+  type ConstructorSuggestionEntry,
+  type FunctionSuggestionEntry,
+  type LocalSuggestionEntry,
+  type MethodSuggestionEntry,
+  type ModuleSuggestionEntry,
   type SuggestionEntry,
   type SuggestionEntryArgument,
+  type SuggestionEntryCommon,
+  SuggestionKind,
   type Typename,
+  type TypeSuggestionEntry,
 } from '@/stores/suggestionDatabase/entry'
 import { assert, assertNever } from '@/util/assert'
 import { type Opt } from '@/util/data/opt'
-import { Err, Ok, withContext, type Result } from '@/util/data/result'
+import { Err, Ok, type Result, withContext } from '@/util/data/result'
+import { ANY_TYPE_QN } from '@/util/ensoTypes'
 import {
+  type IdentifierOrOperatorIdentifier,
+  isIdentifierOrOperatorIdentifier,
+  isQualifiedName,
   normalizeQualifiedName,
   qnJoin,
   qnLastSegment,
-  tryIdentifierOrOperatorIdentifier,
-  tryQualifiedName,
-  type IdentifierOrOperatorIdentifier,
   type QualifiedName,
+  tryQualifiedName,
 } from '@/util/qualifiedName'
 import { type ToValue } from '@/util/reactivity'
-import { toValue, type DeepReadonly } from 'vue'
+import { type DeepReadonly, toValue } from 'vue'
 import * as lsTypes from 'ydoc-shared/languageServerTypes/suggestions'
 import {
   SuggestionArgumentUpdate,
   SuggestionsDatabaseUpdate,
 } from 'ydoc-shared/languageServerTypes/suggestions'
 
-interface UnfinishedEntry extends Partial<SuggestionEntry> {
-  kind: SuggestionKind
+function isOptQN(optQn: string | undefined): optQn is QualifiedName | undefined {
+  if (optQn == null) return true
+  return isQualifiedName(optQn)
+}
+
+abstract class BaseSuggestionEntry implements SuggestionEntryCommon {
+  abstract readonly kind: SuggestionKind
+  private documentationData: DocumentationData
+  abstract name: IdentifierOrOperatorIdentifier
+  abstract returnType: Typename
+
+  protected constructor(
+    documentation: string | undefined,
+    public definedIn: QualifiedName,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    this.documentationData = documentationData(documentation, definedIn, groups)
+  }
+
+  get documentation() {
+    return this.documentationData.documentation
+  }
+  get aliases() {
+    return this.documentationData.aliases
+  }
+  get iconName() {
+    return this.documentationData.iconName
+  }
+  get groupIndex() {
+    return this.documentationData.groupIndex
+  }
+  get isPrivate() {
+    return this.documentationData.isPrivate
+  }
+  get isUnstable() {
+    return this.documentationData.isUnstable
+  }
+  get definitionPath() {
+    return qnJoin(this.definedIn, this.name)
+  }
+
+  setDocumentation(documentation: string | undefined, groups: DeepReadonly<Group[]>) {
+    this.documentationData = documentationData(documentation, this.definedIn, groups)
+  }
+  setLsModule(lsModule: string) {
+    const qn = tryQualifiedName(lsModule)
+    if (!qn.ok) return false
+    this.definedIn = normalizeQualifiedName(qn.value)
+    return true
+  }
+  setLsReturnType(_returnType: Typename) {
+    console.warn(`Cannot modify \`returnType\` of entry type ${this.kind}.`)
+  }
+  setLsReexported(_reexported: QualifiedName | undefined) {
+    console.warn(`Cannot modify \`reexported\` of entry type ${this.kind}.`)
+  }
+  setLsScope(_scope: lsTypes.SuggestionEntryScope | undefined) {
+    console.warn(`Cannot modify \`scope\` of entry type ${this.kind}.`)
+  }
+}
+
+class FunctionSuggestionEntryImpl extends BaseSuggestionEntry implements FunctionSuggestionEntry {
+  readonly kind = SuggestionKind.Function
+  arguments: lsTypes.SuggestionEntryArgument[]
+
+  private constructor(
+    readonly name: IdentifierOrOperatorIdentifier,
+    public scope: lsTypes.SuggestionEntryScope | undefined,
+    args: lsTypes.SuggestionEntryArgument[],
+    definedIn: QualifiedName,
+    public returnType: Typename,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+    this.arguments = args
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Function,
+    groups: DeepReadonly<Group[]>,
+  ): Result<FunctionSuggestionEntry> {
+    if (!isIdentifierOrOperatorIdentifier(lsEntry.name)) return Err('Invalid name')
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    return Ok(
+      new FunctionSuggestionEntryImpl(
+        lsEntry.name,
+        lsEntry.scope,
+        lsEntry.arguments,
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.returnType,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReturnType(returnType: Typename) {
+    this.returnType = returnType
+  }
+  override setLsScope(scope: lsTypes.SuggestionEntryScope | undefined) {
+    this.scope = scope
+  }
+}
+
+/*
+type GConstructor<T = {}> = new (...args: any[]) => T
+function AddReturnType<TBase extends GConstructor<FunctionSuggestionEntryImpl>>(Base: TBase) {
+  return class WithReturnType extends Base {
+    private constructor(...args: any[]) {
+      super(...args)
+    }
+
+    override setLsReturnType(returnType: Typename) {
+      this.returnType = returnType
+    }
+
+    static parse(
+      lsEntry: lsTypes.SuggestionEntry.Function,
+      groups: DeepReadonly<Group[]>,
+    ): Result<FunctionSuggestionEntry> {
+      return new this()
+      return FunctionSuggestionEntryImpl.parse(lsEntry, groups)
+    }
+  }
+}
+ */
+
+class ModuleSuggestionEntryImpl extends BaseSuggestionEntry implements ModuleSuggestionEntry {
+  readonly kind = SuggestionKind.Module
+
+  private constructor(
+    definedIn: QualifiedName,
+    public reexportedIn: QualifiedName | undefined,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+  }
+
+  get name() {
+    return qnLastSegment(this.definedIn)
+  }
+  get returnType() {
+    return this.definedIn
+  }
+  override get definitionPath() {
+    return this.definedIn
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Module,
+    groups: DeepReadonly<Group[]>,
+  ): Result<ModuleSuggestionEntry> {
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    if (!isOptQN(lsEntry.reexport)) return Err('Invalid reexport')
+    return Ok(
+      new ModuleSuggestionEntryImpl(
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.reexport,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReexported(reexported: QualifiedName | undefined) {
+    this.reexportedIn = reexported
+  }
+}
+
+class TypeSuggestionEntryImpl extends BaseSuggestionEntry implements TypeSuggestionEntry {
+  readonly kind = SuggestionKind.Type
+  arguments: lsTypes.SuggestionEntryArgument[]
+
+  private constructor(
+    readonly name: IdentifierOrOperatorIdentifier,
+    args: lsTypes.SuggestionEntryArgument[],
+    public parentType: QualifiedName | undefined,
+    definedIn: QualifiedName,
+    public reexportedIn: QualifiedName | undefined,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+    this.arguments = args
+  }
+
+  get returnType() {
+    return qnJoin(this.definedIn, this.name)
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Type,
+    groups: DeepReadonly<Group[]>,
+  ): Result<TypeSuggestionEntry> {
+    if (!isIdentifierOrOperatorIdentifier(lsEntry.name)) return Err('Invalid name')
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    if (!isOptQN(lsEntry.reexport)) return Err('Invalid reexport')
+    if (!isOptQN(lsEntry.parentType)) return Err('Invalid parent type')
+    return Ok(
+      new TypeSuggestionEntryImpl(
+        lsEntry.name,
+        lsEntry.params,
+        lsEntry.parentType === ANY_TYPE_QN ? undefined : lsEntry.parentType,
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.reexport,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReexported(reexported: QualifiedName | undefined) {
+    this.reexportedIn = reexported
+  }
+}
+
+class ConstructorSuggestionEntryImpl
+  extends BaseSuggestionEntry
+  implements ConstructorSuggestionEntry
+{
+  readonly kind = SuggestionKind.Constructor
+  arguments: lsTypes.SuggestionEntryArgument[]
+
+  private constructor(
+    readonly name: IdentifierOrOperatorIdentifier,
+    args: lsTypes.SuggestionEntryArgument[],
+    public reexportedIn: QualifiedName | undefined,
+    public annotations: string[],
+    definedIn: QualifiedName,
+    public returnType: Typename,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+    this.arguments = args
+  }
+
+  get memberOf() {
+    const qn = tryQualifiedName(this.returnType)
+    return qn.ok ? normalizeQualifiedName(qn.value) : undefined
+  }
+  override get definitionPath() {
+    return this.memberOf ? qnJoin(this.memberOf, this.name) : super.definitionPath
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Constructor,
+    groups: DeepReadonly<Group[]>,
+  ): Result<ConstructorSuggestionEntry> {
+    if (!isIdentifierOrOperatorIdentifier(lsEntry.name)) return Err('Invalid name')
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    if (!isOptQN(lsEntry.reexport)) return Err('Invalid reexport')
+    return Ok(
+      new ConstructorSuggestionEntryImpl(
+        lsEntry.name,
+        lsEntry.arguments,
+        lsEntry.reexport,
+        lsEntry.annotations,
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.returnType,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReturnType(returnType: Typename) {
+    this.returnType = returnType
+  }
+  override setLsReexported(reexported: QualifiedName | undefined) {
+    this.reexportedIn = reexported
+  }
+}
+
+class MethodSuggestionEntryImpl extends BaseSuggestionEntry implements MethodSuggestionEntry {
+  readonly kind = SuggestionKind.Method
+  arguments: lsTypes.SuggestionEntryArgument[]
+
+  private constructor(
+    readonly name: IdentifierOrOperatorIdentifier,
+    args: lsTypes.SuggestionEntryArgument[],
+    public reexportedIn: QualifiedName | undefined,
+    public annotations: string[],
+    private readonly isStatic: boolean,
+    private lsSelfType: string,
+    definedIn: QualifiedName,
+    public returnType: Typename,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+    this.arguments = args
+  }
+
+  get memberOf() {
+    const qn = tryQualifiedName(this.lsSelfType)
+    return qn.ok ? normalizeQualifiedName(qn.value) : undefined
+  }
+  override get definitionPath() {
+    return this.memberOf ? qnJoin(this.memberOf, this.name) : super.definitionPath
+  }
+  get selfType() {
+    if (this.isStatic) return undefined
+    return this.lsSelfType
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Method,
+    groups: DeepReadonly<Group[]>,
+  ): Result<MethodSuggestionEntry> {
+    if (!isIdentifierOrOperatorIdentifier(lsEntry.name)) return Err('Invalid name')
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    if (!isOptQN(lsEntry.reexport)) return Err('Invalid reexport')
+    return Ok(
+      new MethodSuggestionEntryImpl(
+        lsEntry.name,
+        lsEntry.arguments,
+        lsEntry.reexport,
+        lsEntry.annotations,
+        lsEntry.isStatic,
+        lsEntry.selfType,
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.returnType,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReturnType(returnType: Typename) {
+    this.returnType = returnType
+  }
+  override setLsReexported(reexported: QualifiedName | undefined) {
+    this.reexportedIn = reexported
+  }
+  setLsSelfType(selfType: string) {
+    this.lsSelfType = selfType
+  }
+}
+
+class LocalSuggestionEntryImpl extends BaseSuggestionEntry implements LocalSuggestionEntry {
+  readonly kind = SuggestionKind.Local
+
+  private constructor(
+    readonly name: IdentifierOrOperatorIdentifier,
+    public scope: lsTypes.SuggestionEntryScope | undefined,
+    definedIn: QualifiedName,
+    public returnType: Typename,
+    documentation: string | undefined,
+    groups: DeepReadonly<Group[]>,
+  ) {
+    super(documentation, definedIn, groups)
+  }
+
+  static parse(
+    lsEntry: lsTypes.SuggestionEntry.Local,
+    groups: DeepReadonly<Group[]>,
+  ): Result<LocalSuggestionEntry> {
+    if (!isIdentifierOrOperatorIdentifier(lsEntry.name)) return Err('Invalid name')
+    if (!isQualifiedName(lsEntry.module)) return Err('Invalid module name')
+    return Ok(
+      new LocalSuggestionEntryImpl(
+        lsEntry.name,
+        lsEntry.scope,
+        normalizeQualifiedName(lsEntry.module),
+        lsEntry.returnType,
+        lsEntry.documentation,
+        groups,
+      ),
+    )
+  }
+
+  override setLsReturnType(returnType: Typename) {
+    this.returnType = returnType
+  }
+  override setLsScope(scope: lsTypes.SuggestionEntryScope | undefined) {
+    this.scope = scope
+  }
+}
+
+function applyFieldUpdate<K extends string, T, R>(
+  name: K,
+  update: { [P in K]?: lsTypes.FieldUpdate<T> },
+  updater: (newValue: T) => R,
+): Result<Opt<R>> {
+  const field = update[name]
+  if (field == null) return Ok(null)
+  return withContext(
+    () => `when handling field "${name}" update`,
+    () => {
+      switch (field.tag) {
+        case 'Set':
+          if (field.value != null) {
+            return Ok(updater(field.value))
+          } else {
+            return Err('Received "Set" update with no value')
+          }
+        case 'Remove':
+          return Err(`Received "Remove" for non-optional field`)
+        default:
+          return Err(`Received field update with unknown value`)
+      }
+    },
+  )
+}
+
+function applyPropertyUpdate<K extends string, T>(
+  name: K,
+  obj: { [P in K]: T },
+  update: { [P in K]?: lsTypes.FieldUpdate<T> },
+): Result<void> {
+  const apply = applyFieldUpdate(name, update, (newValue) => {
+    obj[name] = newValue
+  })
+  if (!apply.ok) return apply
+  return Ok()
+}
+
+function applyOptPropertyUpdate<K extends string, T>(
+  name: K,
+  obj: { [P in K]?: T },
+  update: { [P in K]?: lsTypes.FieldUpdate<T> },
+) {
+  const field = update[name]
+  switch (field?.tag) {
+    case 'Set':
+      obj[name] = field.value
+      break
+    case 'Remove':
+      delete obj[name]
+      break
+  }
+}
+
+function applyArgumentsUpdate(
+  args: SuggestionEntryArgument[],
+  update: lsTypes.SuggestionArgumentUpdate,
+): Result<void> {
+  switch (update.type) {
+    case 'Add': {
+      args.splice(update.index, 0, update.argument)
+      return Ok()
+    }
+    case 'Remove': {
+      args.splice(update.index, 1)
+      return Ok()
+    }
+    case 'Modify': {
+      return withContext(
+        () => `when modifying argument with index ${update.index}`,
+        () => {
+          const arg = args[update.index]
+          if (arg == null) return Err(`Wrong argument index ${update.index}`)
+          return modifyArgument(arg, update)
+        },
+      )
+    }
+  }
+}
+
+function modifyArgument(
+  arg: SuggestionEntryArgument,
+  update: SuggestionArgumentUpdate.Modify,
+): Result<void> {
+  const nameUpdate = applyPropertyUpdate('name', arg, update)
+  if (!nameUpdate.ok) return nameUpdate
+  const typeUpdate = applyFieldUpdate('reprType', update, (type) => {
+    arg.reprType = type
+  })
+  if (!typeUpdate.ok) return typeUpdate
+  const isSuspendedUpdate = applyPropertyUpdate('isSuspended', arg, update)
+  if (!isSuspendedUpdate.ok) return isSuspendedUpdate
+  const hasDefaultUpdate = applyPropertyUpdate('hasDefault', arg, update)
+  if (!hasDefaultUpdate.ok) return hasDefaultUpdate
+  applyOptPropertyUpdate('defaultValue', arg, update)
+  return Ok()
 }
 
 /** Interprets language server messages to create and update suggestion database entries. */
@@ -38,294 +523,30 @@ export class SuggestionUpdateProcessor {
   /** Constructor. */
   constructor(private readonly groups: ToValue<DeepReadonly<Group[]>>) {}
 
-  private setLsName(
-    entry: UnfinishedEntry,
-    name: string,
-  ): entry is UnfinishedEntry & { name: IdentifierOrOperatorIdentifier } {
-    const ident = tryIdentifierOrOperatorIdentifier(name)
-    if (!ident.ok) return false
-    entry.name = ident.value
-    return true
-  }
-
-  private setLsModule(
-    entry: UnfinishedEntry & { name: IdentifierOrOperatorIdentifier },
-    module: string,
-  ): entry is UnfinishedEntry & { name: IdentifierOrOperatorIdentifier; definedIn: QualifiedName } {
-    const qn = tryQualifiedName(module)
-    if (!qn.ok) return false
-    const normalizedQn = normalizeQualifiedName(qn.value)
-    entry.definedIn = normalizedQn
-    switch (entry.kind) {
-      case SuggestionKind.Module:
-        entry.name = qnLastSegment(normalizedQn)
-        entry.returnType = normalizedQn
-        break
-      case SuggestionKind.Type:
-        entry.returnType = qnJoin(normalizedQn, entry.name)
-        break
-    }
-    return true
-  }
-
-  private setAsOwner(entry: UnfinishedEntry, type: string) {
-    const qn = tryQualifiedName(type)
-    if (qn.ok) {
-      entry.memberOf = normalizeQualifiedName(qn.value)
-    } else {
-      delete entry.memberOf
-    }
-  }
-
-  private setLsSelfType(entry: UnfinishedEntry, selfType: Typename, isStaticParam?: boolean) {
-    const isStatic = isStaticParam ?? entry.selfType == null
-    if (!isStatic) entry.selfType = selfType
-    this.setAsOwner(entry, selfType)
-  }
-
-  private setLsReturnType(
-    entry: UnfinishedEntry,
-    returnType: Typename,
-  ): asserts entry is UnfinishedEntry & { returnType: Typename } {
-    entry.returnType = returnType
-    if (entry.kind == SuggestionKind.Constructor) {
-      this.setAsOwner(entry, returnType)
-    }
-  }
-
-  private setLsReexported(
-    entry: UnfinishedEntry,
-    reexported: string,
-  ): entry is UnfinishedEntry & { reexprotedIn: QualifiedName } {
-    const qn = tryQualifiedName(reexported)
-    if (!qn.ok) return false
-    entry.reexportedIn = normalizeQualifiedName(qn.value)
-    return true
-  }
-
-  private setLsParentType(
-    entry: UnfinishedEntry,
-    parentType: string,
-  ): entry is UnfinishedEntry & { parentType: QualifiedName } {
-    const qn = tryQualifiedName(parentType)
-    if (!qn.ok) return false
-    entry.parentType = normalizeQualifiedName(qn.value)
-    return true
-  }
-
-  private setLsDocumentation(
-    entry: UnfinishedEntry & { definedIn: QualifiedName },
-    documentation: Opt<string>,
-  ): asserts entry is UnfinishedEntry & { definedIn: QualifiedName } & DocumentationData {
-    const data = documentationData(documentation, entry.definedIn, toValue(this.groups))
-    Object.assign(entry, data)
-    // Removing optional fields. I don't know a better way to do this.
-    if (data.groupIndex == null) delete entry.groupIndex
-    if (data.iconName == null) delete entry.iconName
-  }
-
   /** Create a suggestion DB entry from data provided by the given language server. */
   entryFromLs(lsEntry: lsTypes.SuggestionEntry): Result<SuggestionEntry> {
     return withContext(
       () => `when creating entry`,
-      () => {
+      (): Result<SuggestionEntry> => {
+        const groups = toValue(this.groups)
         switch (lsEntry.type) {
-          case 'function': {
-            const entry = {
-              kind: SuggestionKind.Function,
-              annotations: [],
-            }
-            if (!this.setLsName(entry, lsEntry.name)) return Err('Invalid name')
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            this.setLsReturnType(entry, lsEntry.returnType)
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            return Ok({
-              scope: lsEntry.scope,
-              arguments: lsEntry.arguments,
-              ...entry,
-            })
-          }
-          case 'module': {
-            const entry = {
-              kind: SuggestionKind.Module,
-              name: 'MODULE' as IdentifierOrOperatorIdentifier,
-              arguments: [],
-              returnType: '',
-              annotations: [],
-            }
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            if (lsEntry.reexport != null && !this.setLsReexported(entry, lsEntry.reexport))
-              return Err('Invalid reexported module name')
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            assert(entry.returnType !== '') // Should be overwriten
-            return Ok(entry)
-          }
-          case 'type': {
-            const entry = {
-              kind: SuggestionKind.Type,
-              returnType: '',
-              annotations: [],
-            }
-            if (!this.setLsName(entry, lsEntry.name)) return Err('Invalid name')
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            if (lsEntry.reexport != null && !this.setLsReexported(entry, lsEntry.reexport))
-              return Err('Invalid reexported module name')
-            if (lsEntry.parentType != null && !this.setLsParentType(entry, lsEntry.parentType))
-              return Err('Invalid parent type')
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            assert(entry.returnType !== '') // Should be overwriten
-            return Ok({
-              arguments: lsEntry.params,
-              ...entry,
-            })
-          }
-          case 'constructor': {
-            const entry = { kind: SuggestionKind.Constructor }
-            if (!this.setLsName(entry, lsEntry.name)) return Err('Invalid name')
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            if (lsEntry.reexport != null && !this.setLsReexported(entry, lsEntry.reexport))
-              return Err('Invalid reexported module name')
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            this.setLsReturnType(entry, lsEntry.returnType)
-            return Ok({
-              arguments: lsEntry.arguments,
-              annotations: lsEntry.annotations,
-              ...entry,
-            })
-          }
-          case 'method': {
-            const entry = { kind: SuggestionKind.Method }
-            if (!this.setLsName(entry, lsEntry.name)) return Err('Invalid name')
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            if (lsEntry.reexport != null && !this.setLsReexported(entry, lsEntry.reexport))
-              return Err('Invalid reexported module name')
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            this.setLsSelfType(entry, lsEntry.selfType, lsEntry.isStatic)
-            this.setLsReturnType(entry, lsEntry.returnType)
-            return Ok({
-              arguments: lsEntry.arguments,
-              annotations: lsEntry.annotations,
-              ...entry,
-            })
-          }
-          case 'local': {
-            const entry = {
-              kind: SuggestionKind.Local,
-              arguments: [],
-              annotations: [],
-            }
-            if (!this.setLsName(entry, lsEntry.name)) return Err('Invalid name')
-            if (!this.setLsModule(entry, lsEntry.module)) return Err('Invalid module name')
-            this.setLsReturnType(entry, lsEntry.returnType)
-            this.setLsDocumentation(entry, lsEntry.documentation)
-            return Ok({
-              scope: lsEntry.scope,
-              ...entry,
-            })
-          }
+          case 'function':
+            return FunctionSuggestionEntryImpl.parse(lsEntry, groups)
+          case 'module':
+            return ModuleSuggestionEntryImpl.parse(lsEntry, groups)
+          case 'type':
+            return TypeSuggestionEntryImpl.parse(lsEntry, groups)
+          case 'constructor':
+            return ConstructorSuggestionEntryImpl.parse(lsEntry, groups)
+          case 'method':
+            return MethodSuggestionEntryImpl.parse(lsEntry, groups)
+          case 'local':
+            return LocalSuggestionEntryImpl.parse(lsEntry, groups)
           default:
             assertNever(lsEntry)
         }
       },
     )
-  }
-
-  private applyFieldUpdate<K extends string, T, R>(
-    name: K,
-    update: { [P in K]?: lsTypes.FieldUpdate<T> },
-    updater: (newValue: T) => R,
-  ): Result<Opt<R>> {
-    const field = update[name]
-    if (field == null) return Ok(null)
-    return withContext(
-      () => `when handling field "${name}" update`,
-      () => {
-        switch (field.tag) {
-          case 'Set':
-            if (field.value != null) {
-              return Ok(updater(field.value))
-            } else {
-              return Err('Received "Set" update with no value')
-            }
-          case 'Remove':
-            return Err(`Received "Remove" for non-optional field`)
-          default:
-            return Err(`Received field update with unknown value`)
-        }
-      },
-    )
-  }
-
-  private applyPropertyUpdate<K extends string, T>(
-    name: K,
-    obj: { [P in K]: T },
-    update: { [P in K]?: lsTypes.FieldUpdate<T> },
-  ): Result<void> {
-    const apply = this.applyFieldUpdate(name, update, (newValue) => {
-      obj[name] = newValue
-    })
-    if (!apply.ok) return apply
-    return Ok()
-  }
-
-  private applyOptPropertyUpdate<K extends string, T>(
-    name: K,
-    obj: { [P in K]?: T },
-    update: { [P in K]?: lsTypes.FieldUpdate<T> },
-  ) {
-    const field = update[name]
-    switch (field?.tag) {
-      case 'Set':
-        obj[name] = field.value
-        break
-      case 'Remove':
-        delete obj[name]
-        break
-    }
-  }
-
-  private applyArgumentsUpdate(
-    args: SuggestionEntryArgument[],
-    update: lsTypes.SuggestionArgumentUpdate,
-  ): Result<void> {
-    switch (update.type) {
-      case 'Add': {
-        args.splice(update.index, 0, update.argument)
-        return Ok()
-      }
-      case 'Remove': {
-        args.splice(update.index, 1)
-        return Ok()
-      }
-      case 'Modify': {
-        return withContext(
-          () => `when modifying argument with index ${update.index}`,
-          () => {
-            const arg = args[update.index]
-            if (arg == null) return Err(`Wrong argument index ${update.index}`)
-            return this.modifyArgument(arg, update)
-          },
-        )
-      }
-    }
-  }
-
-  private modifyArgument(
-    arg: SuggestionEntryArgument,
-    update: SuggestionArgumentUpdate.Modify,
-  ): Result<void> {
-    const nameUpdate = this.applyPropertyUpdate('name', arg, update)
-    if (!nameUpdate.ok) return nameUpdate
-    const typeUpdate = this.applyFieldUpdate('reprType', update, (type) => {
-      arg.reprType = type
-    })
-    if (!typeUpdate.ok) return typeUpdate
-    const isSuspendedUpdate = this.applyPropertyUpdate('isSuspended', arg, update)
-    if (!isSuspendedUpdate.ok) return isSuspendedUpdate
-    const hasDefaultUpdate = this.applyPropertyUpdate('hasDefault', arg, update)
-    if (!hasDefaultUpdate.ok) return hasDefaultUpdate
-    this.applyOptPropertyUpdate('defaultValue', arg, update)
-    return Ok()
   }
 
   private applyUpdate(
@@ -369,39 +590,38 @@ export class SuggestionUpdateProcessor {
     entry: SuggestionEntry,
     update: SuggestionsDatabaseUpdate.Modify,
   ): Result<void> {
-    for (const argumentUpdate of update.arguments ?? []) {
-      const updateResult = this.applyArgumentsUpdate(entry.arguments, argumentUpdate)
-      if (!updateResult.ok) return updateResult
+    assert(entry instanceof BaseSuggestionEntry)
+
+    if ('arguments' in entry) {
+      for (const argumentUpdate of update.arguments ?? []) {
+        const updateResult = applyArgumentsUpdate(entry.arguments, argumentUpdate)
+        if (!updateResult.ok) return updateResult
+      }
     }
 
-    const moduleUpdate = this.applyFieldUpdate('module', update, (module) =>
-      this.setLsModule(entry, module),
-    )
+    const moduleUpdate = applyFieldUpdate('module', update, (module) => entry.setLsModule(module))
     if (!moduleUpdate.ok) return moduleUpdate
     if (moduleUpdate.value === false) return Err('Invalid module name')
 
-    const selfTypeUpdate = this.applyFieldUpdate('selfType', update, (selfType) =>
-      this.setLsSelfType(entry, selfType),
-    )
+    const selfTypeUpdate = applyFieldUpdate('selfType', update, (selfType) => {
+      if (!(entry instanceof MethodSuggestionEntryImpl)) return false
+      entry.setLsSelfType(selfType)
+    })
     if (!selfTypeUpdate.ok) return selfTypeUpdate
 
-    const returnTypeUpdate = this.applyFieldUpdate('returnType', update, (returnType) => {
-      this.setLsReturnType(entry, returnType)
+    const returnTypeUpdate = applyFieldUpdate('returnType', update, (returnType) => {
+      entry.setLsReturnType(returnType)
     })
     if (!returnTypeUpdate.ok) return returnTypeUpdate
 
-    if (update.documentation != null) this.setLsDocumentation(entry, update.documentation.value)
+    if (update.documentation)
+      entry.setDocumentation(update.documentation.value, toValue(this.groups))
 
-    this.applyOptPropertyUpdate('scope', entry, update)
+    if (update.scope) entry.setLsScope(update.scope.value)
 
-    if (update.reexport != null) {
-      if (update.reexport.value != null) {
-        const reexport = tryQualifiedName(update.reexport.value)
-        if (!reexport.ok) return reexport
-        entry.reexportedIn = reexport.value
-      } else {
-        delete entry.reexportedIn
-      }
+    if (update.reexport) {
+      if (!isOptQN(update.reexport.value)) return Err('Invalid reexport')
+      entry.setLsReexported(update.reexport.value)
     }
 
     return Ok()

--- a/app/gui/src/project-view/util/callTree.ts
+++ b/app/gui/src/project-view/util/callTree.ts
@@ -6,7 +6,7 @@ import { DisplayMode } from '@/providers/widgetRegistry/configuration'
 import type { MethodCallInfo } from '@/stores/graph/graphDatabase'
 import {
   isRequiredArgument,
-  type SuggestionEntry,
+  type CallableSuggestionEntry,
   type SuggestionEntryArgument,
 } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
@@ -213,7 +213,7 @@ export function interpretCall(callRoot: Ast.Expression): InterpretedCall {
 
 interface CallInfo {
   notAppliedArguments?: number[] | undefined
-  suggestion?: SuggestionEntry | undefined
+  suggestion?: CallableSuggestionEntry | undefined
   widgetCfg?: widgetCfg.FunctionCall | undefined
   subjectAsSelf?: boolean | undefined
 }
@@ -225,7 +225,7 @@ export class ArgumentApplication {
     public target: ArgumentApplication | Ast.Expression | ArgumentPlaceholder | ArgumentAst,
     public infixOperator: Ast.Token | undefined,
     public argument: ArgumentAst | ArgumentPlaceholder,
-    public calledFunction: SuggestionEntry | undefined,
+    public calledFunction: CallableSuggestionEntry | undefined,
     public isInnermost: boolean,
   ) {}
 

--- a/app/ydoc-shared/src/languageServerTypes/suggestions.ts
+++ b/app/ydoc-shared/src/languageServerTypes/suggestions.ts
@@ -44,19 +44,19 @@ export interface SuggestionEntryScope {
 // A type of suggestion entries.
 export type SuggestionEntry =
   // A module
-  | suggestionEntryVariant.Module
+  | SuggestionEntry.Module
   // A type
-  | suggestionEntryVariant.Type
+  | SuggestionEntry.Type
   // A type constructor
-  | suggestionEntryVariant.Constructor
+  | SuggestionEntry.Constructor
   // A method defined on a type
-  | suggestionEntryVariant.Method
+  | SuggestionEntry.Method
   // A function
-  | suggestionEntryVariant.Function
+  | SuggestionEntry.Function
   // A local value
-  | suggestionEntryVariant.Local
+  | SuggestionEntry.Local
 
-namespace suggestionEntryVariant {
+export namespace SuggestionEntry {
   export interface Module {
     type: 'module'
     /** The fully qualified module name. */


### PR DESCRIPTION
### Pull Request Description

Allow different suggestion DB types to have different properties, instead of assigning placeholder values; move type-specific entry logic into entry definitions. The `Any` type is now implicit: It is no longer stored as a parent of every type. When filtering by self-type, `Any` is treated as unknown.

Part of #11815.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
