### PR TITLE
Fix spurious imports, clean up tests

### DIFF
--- a/app/gui/src/project-view/stores/graph/__tests__/imports.test.ts
+++ b/app/gui/src/project-view/stores/graph/__tests__/imports.test.ts
@@ -19,107 +19,116 @@ import {
 } from '@/stores/suggestionDatabase/mockSuggestion'
 import { Ast } from '@/util/ast'
 import { unwrap } from '@/util/data/result'
-import { tryIdentifier, tryQualifiedName } from '@/util/qualifiedName'
+import { tryIdentifier, tryQualifiedName, type Identifier } from '@/util/qualifiedName'
 import { expect, test } from 'vitest'
+import { assertDefined } from 'ydoc-shared/util/assert'
 
-test.each([
+const qn = (s: string) => unwrap(tryQualifiedName(s))
+
+interface CoverCase {
+  description: string
+  existing: Import
+  required: RequiredImport
+  expected: boolean
+}
+test.each<CoverCase>([
   {
     description: 'Direct import of a module',
     existing: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'Module' },
-    } as Import,
+    },
     required: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base')),
-    } as RequiredImport,
+      module: qn('Standard.Base'),
+    },
     expected: true,
   },
   {
     description: 'Module imported by alias',
     existing: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'Module', alias: unwrap(tryIdentifier('MyBase')) },
-    } as Import,
+    },
     required: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base')),
-    } as RequiredImport,
+      module: qn('Standard.Base'),
+    },
     expected: true,
   },
   {
     description: 'Module imported from parent',
     existing: {
-      from: unwrap(tryQualifiedName('Standard')),
+      from: qn('Standard'),
       imported: { kind: 'List', names: [unwrap(tryIdentifier('Base'))] },
-    } as Import,
+    },
     required: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base')),
-    } as RequiredImport,
+      module: qn('Standard.Base'),
+    },
     expected: true,
   },
   {
     description: 'Module imported from parent with all',
     existing: {
-      from: unwrap(tryQualifiedName('Standard')),
+      from: qn('Standard'),
       imported: { kind: 'All', except: [] },
-    } as Import,
+    },
     required: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base')),
-    } as RequiredImport,
+      module: qn('Standard.Base'),
+    },
     expected: true,
   },
   {
     description: 'Module hidden when importing all from parent',
     existing: {
-      from: unwrap(tryQualifiedName('Standard')),
+      from: qn('Standard'),
       imported: { kind: 'All', except: [unwrap(tryIdentifier('Base'))] },
-    } as Import,
+    },
     required: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base')),
-    } as RequiredImport,
+      module: qn('Standard.Base'),
+    },
     expected: false,
   },
   {
     description: 'Type imported from module by name',
     existing: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'List', names: [unwrap(tryIdentifier('Table'))] },
-    } as Import,
+    },
     required: {
       kind: 'Unqualified',
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       import: unwrap(tryIdentifier('Table')),
-    } as RequiredImport,
+    },
     expected: true,
   },
   {
     description: 'Type imported from module by all',
     existing: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'All', except: [] },
-    } as Import,
+    },
     required: {
       kind: 'Unqualified',
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       import: unwrap(tryIdentifier('Table')),
-    } as RequiredImport,
+    },
     expected: true,
   },
   {
     description: 'Type hidden when importing all',
     existing: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'All', except: [unwrap(tryIdentifier('Table'))] },
-    } as Import,
+    },
     required: {
       kind: 'Unqualified',
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       import: unwrap(tryIdentifier('Table')),
-    } as RequiredImport,
+    },
     expected: false,
   },
 ])('Existing imports cover required, $description', ({ existing, required, expected }) => {
@@ -128,21 +137,30 @@ test.each([
 
 const mockDb = () => {
   const db = new SuggestionDb()
-  const reexportedModule = makeModule('Standard.AWS.Connections')
-  reexportedModule.reexportedIn = unwrap(tryQualifiedName('Standard.Base'))
-  const reexportedType = makeModule('Standard.Database.DB_Table.DB_Table')
-  reexportedType.reexportedIn = unwrap(tryQualifiedName('Standard.Base'))
-  const extensionMethod = makeMethod('Standard.Network.URI.fetch')
-  extensionMethod.definedIn = unwrap(tryQualifiedName('Standard.Base'))
   db.set(1, makeModule('Standard.Base'))
   db.set(2, makeType('Standard.Base.Type'))
-  db.set(3, reexportedModule)
-  db.set(4, reexportedType)
+  db.set(
+    3,
+    makeModule('Standard.AWS.Connections', {
+      reexport: 'Standard.Base',
+    }),
+  )
+  db.set(
+    4,
+    makeModule('Standard.Database.DB_Table.DB_Table', {
+      reexport: 'Standard.Base',
+    }),
+  )
   db.set(5, makeConstructor('Standard.Base.Type.Constructor'))
-  db.set(6, makeStaticMethod('Standard.Base.Type.staticMethod'))
+  db.set(6, makeStaticMethod('Standard.Base.Type.static_method'))
   db.set(7, makeMethod('Standard.Base.Type.method'))
   db.set(8, makeType('Standard.Network.URI'))
-  db.set(9, extensionMethod)
+  db.set(
+    9,
+    makeMethod('Standard.Network.URI.fetch', {
+      module: 'Standard.Base',
+    }),
+  )
   db.set(10, makeType('Standard.Base.Vector'))
   db.set(11, makeStaticMethod('Standard.Base.Vector.new'))
   db.set(12, makeModule('Project.Foo'))
@@ -153,17 +171,23 @@ const mockDb = () => {
   return db
 }
 
-const qn = (s: string) => unwrap(tryQualifiedName(s))
-test.each([
+interface ConflictCase {
+  description: string
+  importing: RequiredImport
+  alreadyImported: Import[]
+  expected: { name: 'Vector'; fullyQualified: 'Project.Foo.Vector' }
+}
+
+test.each<ConflictCase>([
   {
     description: 'Conflicting Vector',
     importing: {
       kind: 'Unqualified',
       from: qn('Project.Foo'),
-      import: 'Vector',
-    } as RequiredImport,
+      import: 'Vector' as Identifier,
+    },
     alreadyImported: [
-      { from: qn('Standard.Base'), imported: { kind: 'List', names: ['Vector'] } } as Import,
+      { from: qn('Standard.Base'), imported: { kind: 'List', names: ['Vector' as Identifier] } },
     ],
     expected: { name: 'Vector', fullyQualified: 'Project.Foo.Vector' },
   },
@@ -172,23 +196,20 @@ test.each([
     importing: {
       kind: 'Unqualified',
       from: qn('Project.Foo'),
-      import: 'Vector',
-    } as RequiredImport,
-    alreadyImported: [
-      { from: qn('Standard.Base'), imported: { kind: 'All', except: [] } } as Import,
-    ],
+      import: 'Vector' as Identifier,
+    },
+    alreadyImported: [{ from: qn('Standard.Base'), imported: { kind: 'All', except: [] } }],
     expected: { name: 'Vector', fullyQualified: 'Project.Foo.Vector' },
   },
 ])('Conflicting imports: $description', ({ importing, alreadyImported, expected }) => {
   const db = mockDb()
 
-  const existingImports: Import[] = alreadyImported
-  const conflicts = detectImportConflicts(db, existingImports, importing)
+  const conflicts = detectImportConflicts(db, alreadyImported, importing)
   expect(conflicts).toEqual({
     detected: true,
-    pattern: expected.name,
-    fullyQualified: expected.fullyQualified,
-  } as ConflictInfo)
+    pattern: qn(expected.name),
+    fullyQualified: qn(expected.fullyQualified),
+  } satisfies ConflictInfo)
 })
 
 test.each([
@@ -197,7 +218,7 @@ test.each([
     expected: [
       {
         kind: 'Qualified',
-        module: unwrap(tryQualifiedName('Standard.Base')),
+        module: qn('Standard.Base'),
       },
     ],
   },
@@ -206,7 +227,7 @@ test.each([
     expected: [
       {
         kind: 'Unqualified',
-        from: unwrap(tryQualifiedName('Standard.Base')),
+        from: qn('Standard.Base'),
         import: unwrap(tryIdentifier('Type')),
       },
     ],
@@ -216,7 +237,7 @@ test.each([
     expected: [
       {
         kind: 'Unqualified',
-        from: unwrap(tryQualifiedName('Standard.Base')),
+        from: qn('Standard.Base'),
         import: unwrap(tryIdentifier('Connections')),
       },
     ],
@@ -226,7 +247,7 @@ test.each([
     expected: [
       {
         kind: 'Unqualified',
-        from: unwrap(tryQualifiedName('Standard.Base')),
+        from: qn('Standard.Base'),
         import: unwrap(tryIdentifier('DB_Table')),
       },
     ],
@@ -236,7 +257,7 @@ test.each([
     expected: [
       {
         kind: 'Unqualified',
-        from: unwrap(tryQualifiedName('Standard.Base')),
+        from: qn('Standard.Base'),
         import: unwrap(tryIdentifier('Type')),
       },
     ],
@@ -246,7 +267,7 @@ test.each([
     expected: [
       {
         kind: 'Unqualified',
-        from: unwrap(tryQualifiedName('Standard.Base')),
+        from: qn('Standard.Base'),
         import: unwrap(tryIdentifier('Type')),
       },
     ],
@@ -260,13 +281,15 @@ test.each([
     expected: [
       {
         kind: 'Qualified',
-        module: unwrap(tryQualifiedName('Standard.Base')),
+        module: qn('Standard.Base'),
       },
     ],
   },
 ])('Required imports $id', ({ id, expected }) => {
   const db = mockDb()
-  expect(requiredImports(db, db.get(id)!)).toStrictEqual(expected)
+  const entry = db.get(id)
+  assertDefined(entry)
+  expect(requiredImports(db, entry)).toStrictEqual(expected)
 })
 
 const parseImport = (code: string): Import | null => {
@@ -280,42 +303,42 @@ test.each([
   {
     code: 'from Standard.Base import all',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: { kind: 'All', except: [] },
     },
   },
   {
     code: 'from Standard.Base.Table import Table',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base.Table')),
+      from: qn('Standard.Base.Table'),
       imported: { kind: 'List', names: [unwrap(tryIdentifier('Table'))] },
     },
   },
   {
     code: 'import AWS.Connection as Backend',
     expected: {
-      from: unwrap(tryQualifiedName('AWS.Connection')),
+      from: qn('AWS.Connection'),
       imported: { kind: 'Module', alias: 'Backend' },
     },
   },
   {
     code: 'import Standard.Base.Data',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base.Data')),
+      from: qn('Standard.Base.Data'),
       imported: { kind: 'Module' },
     },
   },
   {
     code: 'import local',
     expected: {
-      from: unwrap(tryQualifiedName('local')),
+      from: qn('local'),
       imported: { kind: 'Module' },
     },
   },
   {
     code: 'from Standard.Base import Foo, Bar',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: {
         kind: 'List',
         names: [unwrap(tryIdentifier('Foo')), unwrap(tryIdentifier('Bar'))],
@@ -325,7 +348,7 @@ test.each([
   {
     code: 'from   Standard  . Base import  Foo ,  Bar ,Buz',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: {
         kind: 'List',
         names: [
@@ -339,7 +362,7 @@ test.each([
   {
     code: 'from Standard.Base import all hiding Foo, Bar',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: {
         kind: 'All',
         except: [unwrap(tryIdentifier('Foo')), unwrap(tryIdentifier('Bar'))],
@@ -349,7 +372,7 @@ test.each([
   {
     code: 'from   Standard  . Base import  all  hiding  Foo ,  Bar ,Buz',
     expected: {
-      from: unwrap(tryQualifiedName('Standard.Base')),
+      from: qn('Standard.Base'),
       imported: {
         kind: 'All',
         except: [
@@ -364,27 +387,30 @@ test.each([
   expect(parseImport(code)).toStrictEqual(expected)
 })
 
-test.each([
+test.each<{
+  import: RequiredImport
+  expected: string
+}>([
   {
     import: {
       kind: 'Unqualified',
-      from: unwrap(tryQualifiedName('Standard.Base.Table')),
+      from: qn('Standard.Base.Table'),
       import: unwrap(tryIdentifier('Table')),
-    } satisfies RequiredImport,
+    },
     expected: 'from Standard.Base.Table import Table',
   },
   {
     import: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('Standard.Base.Data')),
-    } satisfies RequiredImport,
+      module: qn('Standard.Base.Data'),
+    },
     expected: 'import Standard.Base.Data',
   },
   {
     import: {
       kind: 'Qualified',
-      module: unwrap(tryQualifiedName('local')),
-    } satisfies RequiredImport,
+      module: qn('local'),
+    },
     expected: 'import local',
   },
 ])('Generating import $expected', ({ import: import_, expected }) => {

--- a/app/gui/src/project-view/stores/graph/imports.ts
+++ b/app/gui/src/project-view/stores/graph/imports.ts
@@ -302,8 +302,7 @@ export interface DetectedConflict {
 
 export type ConflictInfo = DetectedConflict | undefined
 
-/* Detect possible name clash when adding `importsForEntry` with `existingImports` present. */
-/** TODO: Add docs */
+/** Detect possible name clash when adding `importsForEntry` with `existingImports` present. */
 export function detectImportConflicts(
   suggestionDb: SuggestionDb,
   existingImports: Import[],

--- a/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/lsUpdate.ts
@@ -174,7 +174,7 @@ class ModuleSuggestionEntryImpl extends BaseSuggestionEntry implements ModuleSug
     return Ok(
       new ModuleSuggestionEntryImpl(
         normalizeQualifiedName(lsEntry.module),
-        lsEntry.reexport,
+        lsEntry.reexport && normalizeQualifiedName(lsEntry.reexport),
         lsEntry.documentation,
         groups,
       ),
@@ -221,7 +221,7 @@ class TypeSuggestionEntryImpl extends BaseSuggestionEntry implements TypeSuggest
         lsEntry.params,
         lsEntry.parentType === ANY_TYPE_QN ? undefined : lsEntry.parentType,
         normalizeQualifiedName(lsEntry.module),
-        lsEntry.reexport,
+        lsEntry.reexport && normalizeQualifiedName(lsEntry.reexport),
         lsEntry.documentation,
         groups,
       ),
@@ -273,7 +273,7 @@ class ConstructorSuggestionEntryImpl
       new ConstructorSuggestionEntryImpl(
         lsEntry.name,
         lsEntry.arguments,
-        lsEntry.reexport,
+        lsEntry.reexport && normalizeQualifiedName(lsEntry.reexport),
         lsEntry.annotations,
         normalizeQualifiedName(lsEntry.module),
         lsEntry.returnType,
@@ -334,7 +334,7 @@ class MethodSuggestionEntryImpl extends BaseSuggestionEntry implements MethodSug
       new MethodSuggestionEntryImpl(
         lsEntry.name,
         lsEntry.arguments,
-        lsEntry.reexport,
+        lsEntry.reexport && normalizeQualifiedName(lsEntry.reexport),
         lsEntry.annotations,
         lsEntry.isStatic,
         lsEntry.selfType,
@@ -598,7 +598,7 @@ export class SuggestionUpdateProcessor {
 
     if (update.reexport) {
       if (!isOptQN(update.reexport.value)) return Err('Invalid reexport')
-      entry.setLsReexported(update.reexport.value)
+      entry.setLsReexported(update.reexport.value && normalizeQualifiedName(update.reexport.value))
     }
 
     return Ok()


### PR DESCRIPTION
### Pull Request Description

Fix unnecessary imports including `Main` path component caused by missed QN normalization in #12065; clean up some tests that were working but had type errors.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
