### PR TITLE
Adapt `parse` test for Snowflake edge case

### DIFF
--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -572,8 +572,8 @@ add_conversion_specs suite_builder setup =
             ## On most backends, existing_type will be Integer,
                but e.g. on Snowflake it will be Decimal, so to make this test universal
                we need to set the actual type as target for parse.
+            setup.expect_integer_type (t2.at "X")
             existing_type = t2.at "X" . value_type
-            setup.expect_integer_type existing_type
 
             c3 = t2.parse ["X"] existing_type . at "X"
             setup.expect_integer_type c3

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -567,8 +567,15 @@ add_conversion_specs suite_builder setup =
             setup.expect_integer_type c2
             c2.to_vector . should_equal v
 
+            # Testing that `parse` on a column that already has the right type also works (no-op).
             t2 = table_builder [["X", v]]
-            c3 = t2.parse ["X"] Value_Type.Integer . at "X"
+            ## On most backends, existing_type will be Integer,
+               but e.g. on Snowflake it will be Decimal, so to make this test universal
+               we need to set the actual type as target for parse.
+            existing_type = t2.at "X" . value_type
+            setup.expect_integer_type existing_type
+
+            c3 = t2.parse ["X"] existing_type . at "X"
             setup.expect_integer_type c3
             c3.to_vector . should_equal v
 


### PR DESCRIPTION
### Pull Request Description

Fixing a regression in Snowflake tests.

- In Snowflake, the Integer type is superseded by Decimal.
- Thus, a `parse` test that was checking that parsing a column that already has the right type is na no-op was failing, because on Snowflake the column did not have the 'right type' - we were asking for Integer, but on Snowflake the column had Decimal.
- To fix this, we change the test to ask exactly for the type that the column has:
	- On most backends this will still ask for Integer.
	- On Snowflake this will ask for Decimal and ensure the conversion is still a no-op.
- Due to Snowflake's differences, `parse Integer` won't work as easily as on other platforms, the user has to ask for Decimal.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
