### PR TITLE
Next step in In-Memory tidy up work.

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Fan_Out.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Fan_Out.enso
@@ -268,7 +268,7 @@ map_columns_to_multiple input_column function column_count column_builder=make_s
                 ## Add `output_values` to builders; if there are more builders
                    than `output_values`, pad with null.
                 0.up_to builders.length . each i->
-                    builders.at i . appendNoGrow (output_values.get i Nothing)
+                    builders.at i . append (output_values.get i Nothing)
 
             builders.to_vector
 
@@ -282,7 +282,7 @@ map_columns_to_multiple input_column function column_count column_builder=make_s
                 ## Add `output_values` to builders; if there are more builders
                    than `output_values`, pad with null.
                 0.up_to builders.length . each i->
-                    builders.at i . appendNoGrow (output_values.get i Nothing)
+                    builders.at i . append (output_values.get i Nothing)
 
                 output_values.length
 

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
@@ -57,10 +57,7 @@ public class SnowflakeIntegerColumnMaterializer implements Builder {
 
   @Override
   public void append(Object o) {
-    if (currentSize >= capacity()) {
-      grow();
-    }
-
+    ensureSpaceToAppend();
     switch (o) {
       case BigInteger bigInteger -> {
         switch (mode) {
@@ -135,24 +132,21 @@ public class SnowflakeIntegerColumnMaterializer implements Builder {
     return mode == Mode.LONG ? ints.length : bigInts.length;
   }
 
-  private void grow() {
-    int desiredCapacity = 3;
-    if (capacity() > 1) {
-      desiredCapacity = (capacity() * 3 / 2);
+  private void ensureSpaceToAppend() {
+    // Check current size. If there is space, we don't need to grow.
+    int dataLength = capacity();
+    if (currentSize < dataLength) {
+      return;
     }
 
-    // It is possible for the `currentSize` to grow arbitrarily larger than
-    // the capacity, because when nulls are being added the array is not
-    // resized, only the counter is incremented. Thus, we need to ensure
-    // that we have allocated enough space for at least one element.
-    if (currentSize >= desiredCapacity) {
-      desiredCapacity = currentSize + 1;
-    }
-
+    int desiredCapacity = Math.max(currentSize + 1, dataLength > 1 ? dataLength * 3 / 2 : 3);
     resize(desiredCapacity);
   }
 
   private void resize(int desiredCapacity) {
+    if (capacity() == desiredCapacity) {
+      return;
+    }
     switch (mode) {
       case LONG -> ints = Arrays.copyOf(ints, desiredCapacity);
       case BIG_INTEGER -> bigInts = Arrays.copyOf(bigInts, desiredCapacity);

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
@@ -56,12 +56,15 @@ public class SnowflakeIntegerColumnMaterializer implements Builder {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    if (currentSize >= capacity()) {
+      grow();
+    }
+
     switch (o) {
       case BigInteger bigInteger -> {
         switch (mode) {
           case BIG_INTEGER -> bigInts[currentSize++] = bigInteger;
-
           case LONG -> {
             if (fitsInLong(bigInteger)) {
               ints[currentSize++] = bigInteger.longValue();
@@ -72,19 +75,8 @@ public class SnowflakeIntegerColumnMaterializer implements Builder {
           }
         }
       }
-
-      case null -> appendNulls(1);
       default -> throw new ValueTypeMismatchException(BigIntegerType.INSTANCE, o);
     }
-  }
-
-  @Override
-  public void append(Object o) {
-    if (currentSize >= capacity()) {
-      grow();
-    }
-
-    appendNoGrow(o);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -4,7 +4,6 @@ import java.math.BigInteger;
 import java.util.List;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.Builder;
-import org.enso.table.data.column.builder.InferredIntegerBuilder;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.List;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.builder.InferredIntegerBuilder;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
@@ -31,7 +32,7 @@ public class Sum extends Aggregator {
   @Override
   public Builder makeBuilder(int size, ProblemAggregator problemAggregator) {
     return switch (inputType) {
-      case IntegerType integerType -> Builder.getInferredBuilder(size, problemAggregator);
+      case IntegerType integerType -> new InferredIntegerBuilder(size, problemAggregator);
       case BigIntegerType bigIntegerType -> Builder.getForType(
           bigIntegerType, size, problemAggregator);
       case FloatType floatType -> Builder.getForDouble(floatType, size, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -32,7 +32,7 @@ public class Sum extends Aggregator {
   @Override
   public Builder makeBuilder(int size, ProblemAggregator problemAggregator) {
     return switch (inputType) {
-      case IntegerType integerType -> new InferredIntegerBuilder(size, problemAggregator);
+      case IntegerType integerType -> Builder.getInferredBuilder(size, problemAggregator);
       case BigIntegerType bigIntegerType -> Builder.getForType(
           bigIntegerType, size, problemAggregator);
       case FloatType floatType -> Builder.getForDouble(floatType, size, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
@@ -13,7 +13,8 @@ public class BigDecimalBuilder extends TypedBuilder<BigDecimal> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
     try {
       data[currentSize++] = (BigDecimal) o;
     } catch (ClassCastException e) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -72,8 +72,9 @@ public class BigIntegerBuilder extends TypedBuilder<BigInteger> {
   @Override
   public void append(Object o) {
     ensureSpaceToAppend();
-    if (o instanceof BigInteger value) {
-      data[currentSize++] = value;
+
+    if (o == null) {
+      appendNulls(1);
     } else {
       try {
         data[currentSize++] = NumericConverter.coerceToBigInteger(o);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -83,7 +83,7 @@ public class BigIntegerBuilder extends TypedBuilder<BigInteger> {
     }
   }
 
-  public static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
+  static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
     var res = new BigIntegerBuilder(longBuilder.data.length, longBuilder.problemAggregator);
     int n = longBuilder.currentSize;
     Context context = Context.getCurrent();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -50,7 +50,7 @@ public class BigIntegerBuilder extends TypedBuilder<BigInteger> {
           if (data[i] == null) {
             res.appendNulls(1);
           } else {
-            res.appendNoGrow(data[i]);
+            res.append(data[i]);
           }
         }
         return res;
@@ -70,10 +70,9 @@ public class BigIntegerBuilder extends TypedBuilder<BigInteger> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
-    if (o == null) {
-      data[currentSize++] = null;
-    } else if (o instanceof BigInteger value) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
+    if (o instanceof BigInteger value) {
       data[currentSize++] = value;
     } else {
       try {
@@ -89,7 +88,7 @@ public class BigIntegerBuilder extends TypedBuilder<BigInteger> {
     int n = longBuilder.currentSize;
     Context context = Context.getCurrent();
     for (int i = 0; i < n; i++) {
-      res.appendNoGrow(BigInteger.valueOf(longBuilder.data[i]));
+      res.append(BigInteger.valueOf(longBuilder.data[i]));
       context.safepoint();
     }
     return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -21,7 +21,7 @@ public class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
     if (o == null) {
       isNothing.set(size);
     } else {
@@ -39,11 +39,6 @@ public class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   @Override
   public boolean accepts(Object o) {
     return o instanceof Boolean;
-  }
-
-  @Override
-  public void append(Object o) {
-    appendNoGrow(o);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -32,8 +32,8 @@ public class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
       } else {
         throw new ValueTypeMismatchException(getType(), o);
       }
+      size++;
     }
-    size++;
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -23,7 +23,7 @@ public class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   @Override
   public void append(Object o) {
     if (o == null) {
-      isNothing.set(size);
+      appendNulls(1);
     } else {
       if (o instanceof Boolean b) {
         if (b) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoundCheckedIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoundCheckedIntegerBuilder.java
@@ -34,18 +34,13 @@ public class BoundCheckedIntegerBuilder extends LongBuilder {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
     if (o == null) {
-      isNothing.set(currentSize++);
+      appendNulls(1);
     } else {
       Long x = NumericConverter.tryConvertingToLong(o);
       if (x != null) {
-        if (type.fits(x)) {
-          this.data[currentSize++] = x;
-        } else {
-          isNothing.set(currentSize++);
-          castProblemAggregator.reportNumberOutOfRange(x);
-        }
+        appendLong(x);
       } else {
         throw new ValueTypeMismatchException(type, o);
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -28,12 +28,14 @@ public interface Builder {
    * Currently, just the maximum value of an integer, but should be tested and limited.
    * For array based builders, must be less than the maximum array size.
    * */
-  long MAX_SIZE = Integer.MAX_VALUE;
+  int MAX_SIZE = Integer.MAX_VALUE;
 
-  private static void checkSize(long size) {
+  private static int checkSize(long size) {
     if (size > MAX_SIZE) {
       throw new IllegalArgumentException("Columns cannot exceed " + MAX_SIZE + " rows.");
     }
+
+    return (int)size;
   }
 
   /**
@@ -45,10 +47,7 @@ public interface Builder {
   static Builder getForType(StorageType type, long size, ProblemAggregator problemAggregator) {
     Builder builder =
         switch (type) {
-          case AnyObjectType _ -> {
-            checkSize(size);
-            yield new MixedBuilder((int)size);
-          }
+          case AnyObjectType _ -> new MixedBuilder(checkSize(size));
           case BooleanType _ -> getForBoolean(size);
           case DateType _ -> getForDate(size);
           case DateTimeType _ -> getForDateTime(size);
@@ -71,8 +70,8 @@ public interface Builder {
    * @param size the initial size of the builder.
    */
   static Builder getInferredBuilder(long size, ProblemAggregator problemAggregator) {
-    checkSize(size);
-    return new InferredBuilder((int)size, problemAggregator, false);
+    int checkedSize = checkSize(size);
+    return new InferredBuilder(checkedSize, problemAggregator, false);
   }
 
   /**
@@ -81,8 +80,8 @@ public interface Builder {
    * @param size the initial size of the builder.
    */
   static BuilderForBoolean getForBoolean(long size) {
-    checkSize(size);
-    return new BoolBuilder((int)size);
+    int checkedSize = checkSize(size);
+    return new BoolBuilder(checkedSize);
   }
 
   /**
@@ -95,8 +94,8 @@ public interface Builder {
    */
   static BuilderForLong getForLong(
       IntegerType integerType, long size, ProblemAggregator problemAggregator) {
-    checkSize(size);
-    return LongBuilder.make((int)size, integerType, problemAggregator);
+    int checkedSize = checkSize(size);
+    return LongBuilder.make(checkedSize, integerType, problemAggregator);
   }
 
   /**
@@ -113,8 +112,8 @@ public interface Builder {
       throw new IllegalArgumentException("Only 64-bit floats are currently supported.");
     }
 
-    checkSize(size);
-    return new DoubleBuilder((int)size, problemAggregator);
+    int checkedSize = checkSize(size);
+    return new DoubleBuilder(checkedSize, problemAggregator);
   }
 
   /**
@@ -124,38 +123,38 @@ public interface Builder {
    * @param size the initial size of the builder.
    */
   static Builder getObjectBuilder(long size) {
-    checkSize(size);
-    return new ObjectBuilder((int)size);
+    int checkedSize = checkSize(size);
+    return new ObjectBuilder(checkedSize);
   }
 
   static BuilderForType<BigDecimal> getForBigDecimal(long size) {
-    checkSize(size);
-    return new BigDecimalBuilder((int)size);
+    int checkedSize = checkSize(size);
+    return new BigDecimalBuilder(checkedSize);
   }
 
   static BuilderForType<BigInteger> getForBigInteger(long size, ProblemAggregator problemAggregator) {
-    checkSize(size);
-    return new BigIntegerBuilder((int)size, problemAggregator);
+    int checkedSize = checkSize(size);
+    return new BigIntegerBuilder(checkedSize, problemAggregator);
   }
 
   static BuilderForType<LocalDate> getForDate(long size) {
-    checkSize(size);
-    return new DateBuilder((int)size, false);
+    int checkedSize = checkSize(size);
+    return new DateBuilder(checkedSize, false);
   }
 
   static BuilderForType<ZonedDateTime> getForDateTime(long size) {
-    checkSize(size);
-    return new DateTimeBuilder((int)size, false);
+    int checkedSize = checkSize(size);
+    return new DateTimeBuilder(checkedSize, false);
   }
 
   static BuilderForType<String> getForText(long size, TextType textType) {
-    checkSize(size);
-    return new StringBuilder((int)size, textType);
+    int checkedSize = checkSize(size);
+    return new StringBuilder(checkedSize, textType);
   }
 
   static BuilderForType<LocalTime> getForTime(long size) {
-    checkSize(size);
-    return new TimeOfDayBuilder((int)size);
+    int checkedSize = checkSize(size);
+    return new TimeOfDayBuilder(checkedSize);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -131,16 +131,6 @@ public interface Builder {
   }
 
   /**
-   * Append a new item to this builder, assuming that it has enough allocated space.
-   *
-   * <p>This function should only be used when it is guaranteed that the builder has enough
-   * capacity, for example if it was initialized with an initial capacity known up-front.
-   *
-   * @param o the item to append
-   */
-  void appendNoGrow(Object o);
-
-  /**
    * Append a new item to this builder, increasing the capacity if necessary.
    *
    * @param o the item to append

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -24,15 +24,31 @@ import java.time.ZonedDateTime;
 /** Interface defining a builder for creating columns dynamically. */
 public interface Builder {
   /**
+   * The maximum size of a builder.
+   * Currently, just the maximum value of an integer, but should be tested and limited.
+   * For array based builders, must be less than the maximum array size.
+   * */
+  long MAX_SIZE = Integer.MAX_VALUE;
+
+  private static void checkSize(long size) {
+    if (size > MAX_SIZE) {
+      throw new IllegalArgumentException("Columns cannot exceed " + MAX_SIZE + " rows.");
+    }
+  }
+
+  /**
    * Constructs a builder accepting values of a specific type.
    *
    * <p>If {@code type} is {@code null}, it will return an {@link InferredBuilder} that will infer
    * the type from the data.
    */
-  static Builder getForType(StorageType type, int size, ProblemAggregator problemAggregator) {
+  static Builder getForType(StorageType type, long size, ProblemAggregator problemAggregator) {
     Builder builder =
         switch (type) {
-          case AnyObjectType _ -> new MixedBuilder(size);
+          case AnyObjectType _ -> {
+            checkSize(size);
+            yield new MixedBuilder((int)size);
+          }
           case BooleanType _ -> getForBoolean(size);
           case DateType _ -> getForDate(size);
           case DateTimeType _ -> getForDateTime(size);
@@ -44,6 +60,7 @@ public interface Builder {
           case BigIntegerType _ -> getForBigInteger(size, problemAggregator);
           case null -> getInferredBuilder(size, problemAggregator);
         };
+
     assert java.util.Objects.equals(builder.getType(), type);
     return builder;
   }
@@ -53,8 +70,9 @@ public interface Builder {
    *
    * @param size the initial size of the builder.
    */
-  static Builder getInferredBuilder(int size, ProblemAggregator problemAggregator) {
-    return new InferredBuilder(size, problemAggregator, false);
+  static Builder getInferredBuilder(long size, ProblemAggregator problemAggregator) {
+    checkSize(size);
+    return new InferredBuilder((int)size, problemAggregator, false);
   }
 
   /**
@@ -62,8 +80,9 @@ public interface Builder {
    *
    * @param size the initial size of the builder.
    */
-  static BuilderForBoolean getForBoolean(int size) {
-    return new BoolBuilder(size);
+  static BuilderForBoolean getForBoolean(long size) {
+    checkSize(size);
+    return new BoolBuilder((int)size);
   }
 
   /**
@@ -75,8 +94,9 @@ public interface Builder {
    * @param problemAggregator the problem aggregator to use for this builder.
    */
   static BuilderForLong getForLong(
-      IntegerType integerType, int size, ProblemAggregator problemAggregator) {
-    return LongBuilder.make(size, integerType, problemAggregator);
+      IntegerType integerType, long size, ProblemAggregator problemAggregator) {
+    checkSize(size);
+    return LongBuilder.make((int)size, integerType, problemAggregator);
   }
 
   /**
@@ -88,12 +108,13 @@ public interface Builder {
    * @param problemAggregator the problem aggregator to use for this builder.
    */
   static BuilderForDouble getForDouble(
-      FloatType floatType, int size, ProblemAggregator problemAggregator) {
+      FloatType floatType, long size, ProblemAggregator problemAggregator) {
     if (floatType.bits() != Bits.BITS_64) {
       throw new IllegalArgumentException("Only 64-bit floats are currently supported.");
     }
 
-    return new DoubleBuilder(size, problemAggregator);
+    checkSize(size);
+    return new DoubleBuilder((int)size, problemAggregator);
   }
 
   /**
@@ -102,32 +123,39 @@ public interface Builder {
    *
    * @param size the initial size of the builder.
    */
-  static Builder getObjectBuilder(int size) {
-    return new ObjectBuilder(size);
+  static Builder getObjectBuilder(long size) {
+    checkSize(size);
+    return new ObjectBuilder((int)size);
   }
 
-  static BuilderForType<BigDecimal> getForBigDecimal(int size) {
-    return new BigDecimalBuilder(size);
+  static BuilderForType<BigDecimal> getForBigDecimal(long size) {
+    checkSize(size);
+    return new BigDecimalBuilder((int)size);
   }
 
-  static BuilderForType<BigInteger> getForBigInteger(int size, ProblemAggregator problemAggregator) {
-    return new BigIntegerBuilder(size, problemAggregator);
+  static BuilderForType<BigInteger> getForBigInteger(long size, ProblemAggregator problemAggregator) {
+    checkSize(size);
+    return new BigIntegerBuilder((int)size, problemAggregator);
   }
 
-  static BuilderForType<LocalDate> getForDate(int size) {
-    return new DateBuilder(size, false);
+  static BuilderForType<LocalDate> getForDate(long size) {
+    checkSize(size);
+    return new DateBuilder((int)size, false);
   }
 
-  static BuilderForType<ZonedDateTime> getForDateTime(int size) {
-    return new DateTimeBuilder(size, false);
+  static BuilderForType<ZonedDateTime> getForDateTime(long size) {
+    checkSize(size);
+    return new DateTimeBuilder((int)size, false);
   }
 
-  static BuilderForType<String> getForText(int size, TextType textType) {
-    return new StringBuilder(size, textType);
+  static BuilderForType<String> getForText(long size, TextType textType) {
+    checkSize(size);
+    return new StringBuilder((int)size, textType);
   }
 
-  static BuilderForType<LocalTime> getForTime(int size) {
-    return new TimeOfDayBuilder(size);
+  static BuilderForType<LocalTime> getForTime(long size) {
+    checkSize(size);
+    return new TimeOfDayBuilder((int)size);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateBuilder.java
@@ -19,7 +19,8 @@ public class DateBuilder extends TypedBuilder<LocalDate> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
     try {
       data[currentSize++] = (LocalDate) o;
     } catch (ClassCastException e) {
@@ -50,7 +51,7 @@ public class DateBuilder extends TypedBuilder<LocalDate> {
     if (allowDateToDateTimeConversion && Objects.equals(type, DateTimeType.INSTANCE)) {
       var res = new DateTimeBuilder(data.length, true);
       for (int i = 0; i < currentSize; i++) {
-        res.appendNoGrow(data[i]);
+        res.append(data[i]);
       }
       return res;
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -32,7 +32,8 @@ public class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
     try {
       if (allowDateToDateTimeConversion && o instanceof LocalDate localDate) {
         data[currentSize++] = convertDate(localDate);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -57,12 +57,7 @@ public class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
-    if (o == null) {
-      isNothing.set(currentSize++);
-      return;
-    }
-
+  public void append(Object o) {
     double value;
     if (NumericConverter.isFloatLike(o)) {
       value = NumericConverter.coerceToDouble(o);
@@ -77,6 +72,7 @@ public class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
       throw new ValueTypeMismatchException(getType(), o);
     }
 
+    ensureSpaceToAppend();
     data[currentSize++] = value;
   }
 
@@ -153,9 +149,7 @@ public class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
    * @param value the double to append
    */
   public void appendDouble(double value) {
-    if (currentSize >= data.length) {
-      grow();
-    }
+    ensureSpaceToAppend();
     data[currentSize++] = value;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -58,6 +58,11 @@ public class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
 
   @Override
   public void append(Object o) {
+    if (o == null) {
+      appendNulls(1);
+      return;
+    }
+
     double value;
     if (NumericConverter.isFloatLike(o)) {
       value = NumericConverter.coerceToDouble(o);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -171,8 +171,8 @@ public class InferredBuilder implements Builder {
 
   private void retypeToMixed() {
     // The new internal builder must be at least `currentSize` so it can store
-    // all the current values. Make it the same as the `initialSize` to avoid
-    // unnecessary reallocation.
+    // all the current values. In order to avoid any extra reallocations, we
+    // also make it at least as big as the initial size.
     int capacity = Math.max(initialSize, currentSize);
     currentBuilder = MixedBuilder.fromBuilder(currentBuilder, capacity);
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -48,28 +48,6 @@ public class InferredBuilder implements Builder {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
-    if (currentBuilder == null) {
-      if (o == null) {
-        currentSize++;
-        return;
-      } else {
-        initBuilderFor(o);
-      }
-    }
-    if (o == null) {
-      currentBuilder.appendNulls(1);
-    } else {
-      if (currentBuilder.accepts(o)) {
-        currentBuilder.appendNoGrow(o);
-      } else {
-        retypeAndAppend(o);
-      }
-    }
-    currentSize++;
-  }
-
-  @Override
   public void append(Object o) {
     // ToDo: This a workaround for an issue with polyglot layer. #5590 is related.
     o = Polyglot_Utils.convertPolyglotValue(o);
@@ -193,9 +171,8 @@ public class InferredBuilder implements Builder {
 
   private void retypeToMixed() {
     // The new internal builder must be at least `currentSize` so it can store
-    // all the current values. It must also be at least 'initialSize' since the
-    // caller might be using appendNoGrow and is expecting to write at least
-    // that many values.
+    // all the current values. Make it the same as the `initialSize` to avoid
+    // unnecessary reallocation.
     int capacity = Math.max(initialSize, currentSize);
     currentBuilder = MixedBuilder.fromBuilder(currentBuilder, capacity);
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -54,7 +54,7 @@ public class InferredBuilder implements Builder {
 
     if (currentBuilder == null) {
       if (o == null) {
-        currentSize++;
+        appendNulls(1);
         return;
       } else {
         initBuilderFor(o);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -24,7 +24,7 @@ public class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithR
         new InferredDoubleBuilder(longBuilder.getDataSize(), longBuilder.problemAggregator);
 
     for (int i = 0; i < currentSize; i++) {
-      newBuilder.appendLongNoGrow(longBuilder.data[i]);
+      newBuilder.appendLong(longBuilder.data[i]);
     }
     newBuilder.isNothing = longBuilder.isNothing;
 
@@ -86,11 +86,7 @@ public class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithR
   }
 
   @Override
-  public void appendLong(long value) {
-    super.appendLong(value);
-  }
-
-  private void appendLongNoGrow(long integer) {
+  public void appendLong(long integer) {
     double convertedFloatValue = (double) integer;
     boolean isLossy = integer != (long) convertedFloatValue;
     if (isLossy) {
@@ -99,27 +95,18 @@ public class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithR
     } else {
       isLongCompactedAsDouble.set(currentSize, true);
     }
-
-    data[currentSize++] = convertedFloatValue;
+    appendDouble(convertedFloatValue);
   }
 
   @Override
-  public void appendNoGrow(Object o) {
-    if (o == null) {
-      isNothing.set(currentSize++);
-      return;
-    }
-
+  public void append(Object o) {
     if (NumericConverter.isFloatLike(o)) {
-      data[currentSize++] = NumericConverter.coerceToDouble(o);
+      appendDouble(NumericConverter.coerceToDouble(o));
     } else if (NumericConverter.isCoercibleToLong(o)) {
-      appendLongNoGrow(NumericConverter.coerceToLong(o));
+      appendLong(NumericConverter.coerceToLong(o));
     } else if (o instanceof BigInteger bigInteger) {
       setRaw(currentSize, bigInteger);
-      data[currentSize++] = convertBigIntegerToDouble(bigInteger);
-    } else if (o instanceof BigDecimal bigDecimal) {
-      setRaw(currentSize, bigDecimal);
-      data[currentSize++] = convertBigDecimalToDouble(bigDecimal);
+      appendDouble(convertBigIntegerToDouble(bigInteger));
     } else {
       throw new ValueTypeMismatchException(getType(), o);
     }
@@ -159,7 +146,7 @@ public class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithR
           res.appendNulls(1);
         } else {
           BigDecimal bigDecimal = BigDecimal.valueOf(data[i]);
-          res.appendNoGrow(bigDecimal);
+          res.append(bigDecimal);
         }
       }
       return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -100,6 +100,11 @@ public class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithR
 
   @Override
   public void append(Object o) {
+    if (o == null) {
+      appendNulls(1);
+      return;
+    }
+
     if (NumericConverter.isFloatLike(o)) {
       appendDouble(NumericConverter.coerceToDouble(o));
     } else if (NumericConverter.isCoercibleToLong(o)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
@@ -72,7 +72,9 @@ public class InferredIntegerBuilder implements Builder {
 
   @Override
   public int getCurrentSize() {
-    return bigIntegerBuilder != null ? bigIntegerBuilder.getCurrentSize() : longBuilder.getCurrentSize();
+    return bigIntegerBuilder != null
+        ? bigIntegerBuilder.getCurrentSize()
+        : longBuilder.getCurrentSize();
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
@@ -17,7 +17,6 @@ import org.enso.table.problems.ProblemAggregator;
 public class InferredIntegerBuilder implements Builder {
   private BuilderWithRetyping longBuilder;
   private Builder bigIntegerBuilder = null;
-  private int currentSize = 0;
 
   /** Creates a new instance of this builder, with the given known result length. */
   public InferredIntegerBuilder(int initialSize, ProblemAggregator problemAggregator) {
@@ -29,31 +28,6 @@ public class InferredIntegerBuilder implements Builder {
           "InferredIntegerBuilder must be able to retype to BigIntegerBuilder, but the base "
               + "builder does not support retyping.");
     }
-  }
-
-  @Override
-  public void appendNoGrow(Object o) {
-    if (o == null) {
-      appendNulls(1);
-    } else if (o instanceof BigInteger bi) {
-      retypeToBigIntegerMaybe();
-      bigIntegerBuilder.appendNoGrow(bi);
-    } else {
-      Long lng = NumericConverter.tryConvertingToLong(o);
-      if (lng == null) {
-        throw new IllegalStateException(
-            "Unexpected value added to InferredIntegerBuilder "
-                + o.getClass()
-                + ". This is a bug in the Table library.");
-      } else {
-        if (bigIntegerBuilder != null) {
-          bigIntegerBuilder.appendNoGrow(BigInteger.valueOf(lng));
-        } else {
-          longBuilder.appendNoGrow(lng);
-        }
-      }
-    }
-    currentSize++;
   }
 
   @Override
@@ -78,7 +52,6 @@ public class InferredIntegerBuilder implements Builder {
         }
       }
     }
-    currentSize++;
   }
 
   @Override
@@ -88,7 +61,6 @@ public class InferredIntegerBuilder implements Builder {
     } else {
       longBuilder.appendNulls(count);
     }
-    currentSize += count;
   }
 
   @Override
@@ -100,7 +72,7 @@ public class InferredIntegerBuilder implements Builder {
 
   @Override
   public int getCurrentSize() {
-    return currentSize;
+    return bigIntegerBuilder != null ? bigIntegerBuilder.getCurrentSize() : longBuilder.getCurrentSize();
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -151,8 +151,7 @@ public class LongBuilder extends NumericBuilder implements BuilderForLong, Build
 
     Long x = NumericConverter.tryConvertingToLong(o);
     if (x != null) {
-      ensureSpaceToAppend();
-      this.data[currentSize++] = x;
+      appendLong(x);
     } else {
       throw new ValueTypeMismatchException(getType(), o);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -26,7 +26,7 @@ public class LongBuilder extends NumericBuilder implements BuilderForLong, Build
   }
 
   static LongBuilder make(int initialSize, IntegerType type, ProblemAggregator problemAggregator) {
-    if (type.equals(IntegerType.INT_64)) {
+    if (type == null || type.equals(IntegerType.INT_64)) {
       return new LongBuilder(initialSize, problemAggregator);
     } else {
       return new BoundCheckedIntegerBuilder(initialSize, type, problemAggregator);
@@ -144,6 +144,11 @@ public class LongBuilder extends NumericBuilder implements BuilderForLong, Build
 
   @Override
   public void append(Object o) {
+    if (o == null) {
+      appendNulls(1);
+      return;
+    }
+
     Long x = NumericConverter.tryConvertingToLong(o);
     if (x != null) {
       ensureSpaceToAppend();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -138,24 +138,18 @@ public class LongBuilder extends NumericBuilder implements BuilderForLong, Build
    * @param value the integer to append
    */
   public void appendLong(long value) {
-    if (currentSize >= this.data.length) {
-      grow();
-    }
-
-    assert currentSize < this.data.length;
+    ensureSpaceToAppend();
     this.data[currentSize++] = value;
   }
 
-  public void appendNoGrow(Object o) {
-    if (o == null) {
-      isNothing.set(currentSize++);
+  @Override
+  public void append(Object o) {
+    Long x = NumericConverter.tryConvertingToLong(o);
+    if (x != null) {
+      ensureSpaceToAppend();
+      this.data[currentSize++] = x;
     } else {
-      Long x = NumericConverter.tryConvertingToLong(o);
-      if (x != null) {
-        this.data[currentSize++] = x;
-      } else {
-        throw new ValueTypeMismatchException(getType(), o);
-      }
+      throw new ValueTypeMismatchException(getType(), o);
     }
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/MixedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/MixedBuilder.java
@@ -24,14 +24,8 @@ public class MixedBuilder extends ObjectBuilder implements BuilderWithRetyping {
   }
 
   @Override
-  public Storage<Object> seal() {
-    resize(currentSize);
+  public Storage<Object> doSeal() {
     return new MixedStorage(data, currentSize);
-  }
-
-  @Override
-  public boolean accepts(Object o) {
-    return true;
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -19,14 +19,6 @@ public abstract class NumericBuilder implements Builder {
   }
 
   @Override
-  public void append(Object o) {
-    if (currentSize >= getDataSize()) {
-      grow();
-    }
-    appendNoGrow(o);
-  }
-
-  @Override
   public int getCurrentSize() {
     return currentSize;
   }
@@ -44,8 +36,14 @@ public abstract class NumericBuilder implements Builder {
    * appends. It tries to keep the invariant that after calling `grow` the array has at least one
    * free slot.
    */
-  protected void grow() {
+  protected void ensureSpaceToAppend() {
     int dataLength = getDataSize();
+
+    // Check current size. If there is space, we don't need to grow.
+    if (currentSize < dataLength) {
+      return;
+    }
+
     int desiredCapacity = Math.max(currentSize + 1, dataLength > 1 ? dataLength * 3 / 2 : 3);
     resize(desiredCapacity);
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/ObjectBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/ObjectBuilder.java
@@ -1,49 +1,25 @@
 package org.enso.table.data.column.builder;
 
-import java.util.Arrays;
 import org.enso.table.data.column.storage.ObjectStorage;
 import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
-import org.enso.table.data.column.storage.type.StorageType;
 
 /** A builder for boxed object columns. */
-public class ObjectBuilder implements Builder {
-  protected Object[] data;
-  protected int currentSize = 0;
-
+public class ObjectBuilder extends TypedBuilder<Object> {
   public ObjectBuilder(int size) {
-    this.data = new Object[size];
+    super(AnyObjectType.INSTANCE, new Object[size]);
   }
 
   @Override
-  public void copyDataTo(Object[] items) {
-    if (currentSize >= 0) {
-      System.arraycopy(data, 0, items, 0, currentSize);
-    }
-  }
-
-  @Override
-  public StorageType getType() {
-    return AnyObjectType.INSTANCE;
-  }
-
-  @Override
-  public void appendNoGrow(Object o) {
-    data[currentSize++] = o;
+  public boolean accepts(Object o) {
+    return true;
   }
 
   @Override
   public void append(Object o) {
-    if (currentSize >= data.length) {
-      grow();
-    }
+    ensureSpaceToAppend();
     data[currentSize++] = o;
-  }
-
-  @Override
-  public void appendNulls(int count) {
-    currentSize += count;
   }
 
   @Override
@@ -64,45 +40,7 @@ public class ObjectBuilder implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
-    return currentSize;
-  }
-
-  @Override
-  public Storage<Object> seal() {
-    resize(currentSize);
+  public Storage<Object> doSeal() {
     return new ObjectStorage(data, currentSize);
-  }
-
-  public Object[] getData() {
-    return data;
-  }
-
-  /**
-   * Grows the underlying array.
-   *
-   * <p>The method grows the array by 50% by default to amortize the re-allocation time over
-   * appends. It tries to keep the invariant that after calling `grow` the array has at least one
-   * free slot.
-   */
-  private void grow() {
-    int desiredCapacity = 3;
-    if (data.length > 1) {
-      desiredCapacity = (data.length * 3 / 2);
-    }
-
-    // It is possible for the `currentSize` to grow arbitrarily larger than
-    // the capacity, because when nulls are being added the array is not
-    // resized, only the counter is incremented. Thus, we need to ensure
-    // that we have allocated enough space for at least one element.
-    if (currentSize >= desiredCapacity) {
-      desiredCapacity = currentSize + 1;
-    }
-
-    resize(desiredCapacity);
-  }
-
-  protected void resize(int desiredCapacity) {
-    this.data = Arrays.copyOf(data, desiredCapacity);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -16,7 +16,8 @@ public class StringBuilder extends TypedBuilder<String> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
     try {
       String str = (String) o;
       if (type.fits(str)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/TimeOfDayBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/TimeOfDayBuilder.java
@@ -13,7 +13,8 @@ public class TimeOfDayBuilder extends TypedBuilder<LocalTime> {
   }
 
   @Override
-  public void appendNoGrow(Object o) {
+  public void append(Object o) {
+    ensureSpaceToAppend();
     try {
       data[currentSize++] = (LocalTime) o;
     } catch (ClassCastException e) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
@@ -38,15 +38,6 @@ public abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderFor
   }
 
   @Override
-  public void append(Object o) {
-    if (currentSize >= data.length) {
-      grow();
-    }
-
-    appendNoGrow(o);
-  }
-
-  @Override
   public void appendNulls(int count) {
     currentSize += count;
   }
@@ -79,30 +70,27 @@ public abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderFor
   }
 
   /**
-   * Grows the underlying array.
+   * Checks if space to append single element, grows the underlying array if
+   * needed.
    *
-   * <p>The method grows the array by 50% by default to amortize the re-allocation time over
-   * appends. It tries to keep the invariant that after calling `grow` the array has at least one
-   * free slot.
+   * <p>The method grows the array by 50% by default to amortize the
+   * re-allocation time over appends. It tries to keep the invariant that
+   * after calling `grow` the array has at least one free slot.
    */
-  private void grow() {
-    int desiredCapacity = 3;
-    if (data.length > 1) {
-      desiredCapacity = (data.length * 3 / 2);
+  protected void ensureSpaceToAppend() {
+    // Check current size. If there is space, we don't need to grow.
+    if (currentSize < data.length) {
+      return;
     }
 
-    // It is possible for the `currentSize` to grow arbitrarily larger than
-    // the capacity, because when nulls are being added the array is not
-    // resized, only the counter is incremented. Thus, we need to ensure
-    // that we have allocated enough space for at least one element.
-    if (currentSize >= desiredCapacity) {
-      desiredCapacity = currentSize + 1;
-    }
-
+    int desiredCapacity = Math.max(currentSize + 1, data.length > 1 ? data.length * 3 / 2 : 3);
     resize(desiredCapacity);
   }
 
   private void resize(int desiredCapacity) {
+    if (data.length == desiredCapacity) {
+      return;
+    }
     this.data = Arrays.copyOf(data, desiredCapacity);
   }
 
@@ -110,7 +98,7 @@ public abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderFor
 
   @Override
   public Storage<T> seal() {
-    // We grow the array to the exact size, because we want to avoid index out of bounds errors.
+    // We set the array to the exact size, because we want to avoid index out of bounds errors.
     // Most of the time, the builder was initialized with the right size anyway - the only
     // exceptions are e.g. reading results from a database, where the count is unknown.
     // In the future we may rely on smarter storage for sparse columns.

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
@@ -87,7 +87,7 @@ public abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderFor
     resize(desiredCapacity);
   }
 
-  private void resize(int desiredCapacity) {
+  protected void resize(int desiredCapacity) {
     if (data.length == desiredCapacity) {
       return;
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
@@ -70,12 +70,11 @@ public abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderFor
   }
 
   /**
-   * Checks if space to append single element, grows the underlying array if
-   * needed.
+   * Checks if space to append single element, grows the underlying array if needed.
    *
-   * <p>The method grows the array by 50% by default to amortize the
-   * re-allocation time over appends. It tries to keep the invariant that
-   * after calling `grow` the array has at least one free slot.
+   * <p>The method grows the array by 50% by default to amortize the re-allocation time over
+   * appends. It tries to keep the invariant that after calling `grow` the array has at least one
+   * free slot.
    */
   protected void ensureSpaceToAppend() {
     // Check current size. If there is space, we don't need to grow.

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/UnaryOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/UnaryOperation.java
@@ -78,7 +78,7 @@ public interface UnaryOperation {
         i -> {
           Value result = function.apply(column.getStorage().getItemAsObject(i));
           Object converted = Polyglot_Utils.convertPolyglotValue(result);
-          storageBuilder.appendNoGrow(converted);
+          storageBuilder.append(converted);
         });
     return new Column(newColumnName, storageBuilder.seal());
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/StorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/StorageConverter.java
@@ -1,6 +1,6 @@
 package org.enso.table.data.column.operation.cast;
 
-import java.util.function.IntFunction;
+import java.util.function.LongFunction;
 import org.enso.table.data.column.builder.BuilderForType;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
@@ -39,16 +39,11 @@ public interface StorageConverter<T> {
   }
 
   static <T> Storage<T> innerLoop(
-      BuilderForType<T> builder, ColumnStorage storage, IntFunction<T> converter) {
+      BuilderForType<T> builder, ColumnStorage storage, LongFunction<T> converter) {
     Context context = Context.getCurrent();
 
     long n = storage.getSize();
-    if (n > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    for (int i = 0; i < n; i++) {
+    for (long i = 0; i < n; i++) {
       if (storage.isNothing(i)) {
         builder.appendNulls(1);
       } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/StorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/StorageConverter.java
@@ -52,7 +52,7 @@ public interface StorageConverter<T> {
       if (storage.isNothing(i)) {
         builder.appendNulls(1);
       } else {
-        builder.appendNoGrow(converter.apply(i));
+        builder.append(converter.apply(i));
       }
 
       context.safepoint();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBigDecimalConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBigDecimalConverter.java
@@ -4,6 +4,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnDoubleStorage;
+import org.enso.table.data.column.storage.ColumnLongStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.BigDecimalStorage;
@@ -33,23 +36,23 @@ public class ToBigDecimalConverter implements StorageConverter<BigDecimal> {
   }
 
   private Storage<BigDecimal> convertDoubleStorage(
-      DoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
+      ColumnDoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigDecimal(doubleStorage.size()),
+        Builder.getForBigDecimal(doubleStorage.getSize()),
         doubleStorage,
         (i) -> {
-          double x = doubleStorage.getItemAsDouble(i);
+          double x = doubleStorage.get(i);
           return BigDecimal.valueOf(x);
         });
   }
 
   private Storage<BigDecimal> convertLongStorage(
-      AbstractLongStorage longStorage, CastProblemAggregator problemAggregator) {
+      ColumnLongStorage longStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigDecimal(longStorage.size()),
+        Builder.getForBigDecimal(longStorage.getSize()),
         longStorage,
         (i) -> {
-          long x = longStorage.getItem(i);
+          long x = longStorage.get(i);
           return BigDecimal.valueOf(x);
         });
   }
@@ -77,12 +80,12 @@ public class ToBigDecimalConverter implements StorageConverter<BigDecimal> {
   }
 
   private Storage<BigDecimal> castFromMixed(
-      Storage<?> storage, CastProblemAggregator problemAggregator) {
+      ColumnStorage storage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigDecimal(storage.size()),
+        Builder.getForBigDecimal(storage.getSize()),
         storage,
         (i) -> {
-          Object o = storage.getItemBoxed(i);
+          Object o = storage.getItemAsObject(i);
           return switch (o) {
             case Boolean b -> booleanAsBigDecimal(b);
             case Long l -> BigDecimal.valueOf(l);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBigIntegerConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBigIntegerConverter.java
@@ -4,6 +4,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnDoubleStorage;
+import org.enso.table.data.column.storage.ColumnLongStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.BigDecimalStorage;
@@ -33,23 +36,23 @@ public class ToBigIntegerConverter implements StorageConverter<BigInteger> {
   }
 
   private Storage<BigInteger> convertDoubleStorage(
-      DoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
+      ColumnDoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigInteger(doubleStorage.size(), problemAggregator),
+        Builder.getForBigInteger(doubleStorage.getSize(), problemAggregator),
         doubleStorage,
         (i) -> {
-          double x = doubleStorage.getItemAsDouble(i);
+          double x = doubleStorage.get(i);
           return BigDecimal.valueOf(x).toBigInteger();
         });
   }
 
   private Storage<BigInteger> convertLongStorage(
-      AbstractLongStorage longStorage, CastProblemAggregator problemAggregator) {
+      ColumnLongStorage longStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigInteger(longStorage.size(), problemAggregator),
+        Builder.getForBigInteger(longStorage.getSize(), problemAggregator),
         longStorage,
         (i) -> {
-          long x = longStorage.getItem(i);
+          long x = longStorage.get(i);
           return BigInteger.valueOf(x);
         });
   }
@@ -60,7 +63,7 @@ public class ToBigIntegerConverter implements StorageConverter<BigInteger> {
         Builder.getForBigInteger(boolStorage.size(), problemAggregator),
         boolStorage,
         (i) -> {
-          boolean x = boolStorage.getItem(i);
+          boolean x = boolStorage.getItem((int) i);
           return booleanAsBigInteger(x);
         });
   }
@@ -71,18 +74,18 @@ public class ToBigIntegerConverter implements StorageConverter<BigInteger> {
         Builder.getForBigInteger(bigDecimalStorage.size(), problemAggregator),
         bigDecimalStorage,
         (i) -> {
-          BigDecimal x = bigDecimalStorage.getItemBoxed(i);
+          BigDecimal x = bigDecimalStorage.getItemBoxed((int) i);
           return x.toBigInteger();
         });
   }
 
   private Storage<BigInteger> castFromMixed(
-      Storage<?> storage, CastProblemAggregator problemAggregator) {
+      ColumnStorage storage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForBigInteger(storage.size(), problemAggregator),
+        Builder.getForBigInteger(storage.getSize(), problemAggregator),
         storage,
         (i) -> {
-          Object o = storage.getItemBoxed(i);
+          Object o = storage.getItemAsObject(i);
           return switch (o) {
             case Boolean b -> booleanAsBigInteger(b);
             case Long l -> BigInteger.valueOf(l);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBooleanStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToBooleanStorageConverter.java
@@ -2,6 +2,7 @@ package org.enso.table.data.column.operation.cast;
 
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 
@@ -19,13 +20,13 @@ public class ToBooleanStorageConverter implements StorageConverter<Boolean> {
   }
 
   private Storage<Boolean> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     // As mixed storage is already boxed, use the standard inner loop.
     return StorageConverter.innerLoop(
-        Builder.getForBoolean(mixedStorage.size()),
+        Builder.getForBoolean(mixedStorage.getSize()),
         mixedStorage,
         (i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           if (o instanceof Boolean b) {
             return b;
           } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToDateStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToDateStorageConverter.java
@@ -3,6 +3,7 @@ package org.enso.table.data.column.operation.cast;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.datetime.DateTimeStorage;
@@ -24,12 +25,12 @@ public class ToDateStorageConverter implements StorageConverter<LocalDate> {
   }
 
   private Storage<LocalDate> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForDate(mixedStorage.size()),
+        Builder.getForDate(mixedStorage.getSize()),
         mixedStorage,
         (i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           return switch (o) {
             case LocalDate d -> d;
             case ZonedDateTime d -> d.toLocalDate();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToDateTimeStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToDateTimeStorageConverter.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.datetime.DateTimeStorage;
@@ -25,12 +26,12 @@ public class ToDateTimeStorageConverter implements StorageConverter<ZonedDateTim
   }
 
   public Storage<ZonedDateTime> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForDateTime(mixedStorage.size()),
+        Builder.getForDateTime(mixedStorage.getSize()),
         mixedStorage,
         (i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           return switch (o) {
             case ZonedDateTime d -> d;
             case LocalDate d -> convertDate(d);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
@@ -2,11 +2,13 @@ package org.enso.table.data.column.operation.cast;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.BuilderForDouble;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnBooleanStorage;
+import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
@@ -48,16 +50,11 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
 
   /** Specialised innerLoop so that we can avoid boxing. */
   static Storage<Double> innerLoop(
-      BuilderForDouble builder, ColumnStorage storage, ObjIntConsumer<BuilderForDouble> converter) {
+      BuilderForDouble builder, ColumnStorage storage, ObjLongConsumer<BuilderForDouble> converter) {
     Context context = Context.getCurrent();
 
     long n = storage.getSize();
-    if (n > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    for (int i = 0; i < n; i++) {
+    for (long i = 0; i < n; i++) {
       if (storage.isNothing(i)) {
         builder.appendNulls(1);
       } else {
@@ -71,12 +68,12 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
   }
 
   private Storage<Double> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForDouble(FloatType.FLOAT_64, mixedStorage.size(), problemAggregator),
+        Builder.getForDouble(FloatType.FLOAT_64, mixedStorage.getSize(), problemAggregator),
         mixedStorage,
         (builder, i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
 
           if (NumericConverter.isCoercibleToLong(o)) {
             builder.appendLong(NumericConverter.coerceToLong(o));
@@ -97,23 +94,23 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
   }
 
   private Storage<Double> convertLongStorage(
-      AbstractLongStorage longStorage, CastProblemAggregator problemAggregator) {
+      ColumnLongStorage longStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForDouble(FloatType.FLOAT_64, longStorage.size(), problemAggregator),
+        Builder.getForDouble(FloatType.FLOAT_64, longStorage.getSize(), problemAggregator),
         longStorage,
         (builder, i) -> {
-          long value = longStorage.getItem(i);
+          long value = longStorage.get(i);
           builder.appendLong(value);
         });
   }
 
   private Storage<Double> convertBoolStorage(
-      BoolStorage boolStorage, CastProblemAggregator problemAggregator) {
+      ColumnBooleanStorage boolStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForDouble(FloatType.FLOAT_64, boolStorage.size(), problemAggregator),
+        Builder.getForDouble(FloatType.FLOAT_64, boolStorage.getSize(), problemAggregator),
         boolStorage,
         (builder, i) -> {
-          boolean value = boolStorage.getItem(i);
+          boolean value = boolStorage.get(i);
           builder.appendDouble(booleanAsDouble(value));
         });
   }
@@ -127,7 +124,7 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
     return innerLoop(
         Builder.getForDouble(FloatType.FLOAT_64, storage.size(), problemAggregator),
         storage,
-        (builder, i) -> builder.append(storage.getItemBoxed(i)));
+        (builder, i) -> builder.append(storage.getItemBoxed((int)i)));
   }
 
   private Storage<Double> convertBigDecimalStorage(
@@ -135,6 +132,6 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
     return innerLoop(
         Builder.getForDouble(FloatType.FLOAT_64, storage.size(), problemAggregator),
         storage,
-        (builder, i) -> builder.append(storage.getItemBoxed(i)));
+        (builder, i) -> builder.append(storage.getItemBoxed((int)i)));
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
@@ -50,7 +50,9 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
 
   /** Specialised innerLoop so that we can avoid boxing. */
   static Storage<Double> innerLoop(
-      BuilderForDouble builder, ColumnStorage storage, ObjLongConsumer<BuilderForDouble> converter) {
+      BuilderForDouble builder,
+      ColumnStorage storage,
+      ObjLongConsumer<BuilderForDouble> converter) {
     Context context = Context.getCurrent();
 
     long n = storage.getSize();
@@ -124,7 +126,7 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
     return innerLoop(
         Builder.getForDouble(FloatType.FLOAT_64, storage.size(), problemAggregator),
         storage,
-        (builder, i) -> builder.append(storage.getItemBoxed((int)i)));
+        (builder, i) -> builder.append(storage.getItemBoxed((int) i)));
   }
 
   private Storage<Double> convertBigDecimalStorage(
@@ -132,6 +134,6 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
     return innerLoop(
         Builder.getForDouble(FloatType.FLOAT_64, storage.size(), problemAggregator),
         storage,
-        (builder, i) -> builder.append(storage.getItemBoxed((int)i)));
+        (builder, i) -> builder.append(storage.getItemBoxed((int) i)));
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
@@ -153,7 +153,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, longStorage.size(), problemAggregator),
         longStorage,
         (builder, i) -> {
-          long value = longStorage.getItem((int)i);
+          long value = longStorage.getItem((int) i);
           builder.appendLong(value);
         });
   }
@@ -164,7 +164,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, storage.size(), problemAggregator),
         storage,
         (builder, i) -> {
-          BigInteger value = storage.getItemBoxed((int)i);
+          BigInteger value = storage.getItemBoxed((int) i);
           if (targetType.fits(value)) {
             builder.appendLong(value.longValue());
           } else {
@@ -180,7 +180,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, storage.size(), problemAggregator),
         storage,
         (builder, i) -> {
-          BigDecimal value = storage.getItemBoxed((int)i);
+          BigDecimal value = storage.getItemBoxed((int) i);
           BigInteger bigInteger = value.toBigInteger();
           if (targetType.fits(bigInteger)) {
             builder.appendLong(bigInteger.longValue());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
@@ -2,11 +2,13 @@ package org.enso.table.data.column.operation.cast;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.BuilderForLong;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnBooleanStorage;
+import org.enso.table.data.column.storage.ColumnDoubleStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
@@ -50,16 +52,11 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
 
   /** Specialised innerLoop so that we can avoid boxing. */
   static Storage<Long> innerLoop(
-      BuilderForLong builder, ColumnStorage storage, ObjIntConsumer<BuilderForLong> converter) {
+      BuilderForLong builder, ColumnStorage storage, ObjLongConsumer<BuilderForLong> converter) {
     Context context = Context.getCurrent();
 
     long n = storage.getSize();
-    if (n > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    for (int i = 0; i < n; i++) {
+    for (long i = 0; i < n; i++) {
       if (storage.isNothing(i)) {
         builder.appendNulls(1);
       } else {
@@ -73,12 +70,12 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
   }
 
   private Storage<Long> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForLong(targetType, mixedStorage.size(), problemAggregator),
+        Builder.getForLong(targetType, mixedStorage.getSize(), problemAggregator),
         mixedStorage,
         (builder, i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           if (o instanceof Boolean b) {
             builder.appendLong(booleanAsLong(b));
           } else if (NumericConverter.isCoercibleToLong(o)) {
@@ -116,23 +113,23 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
   }
 
   private Storage<Long> convertBoolStorage(
-      BoolStorage boolStorage, CastProblemAggregator problemAggregator) {
+      ColumnBooleanStorage boolStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForLong(targetType, boolStorage.size(), problemAggregator),
+        Builder.getForLong(targetType, boolStorage.getSize(), problemAggregator),
         boolStorage,
         (builder, i) -> {
-          boolean value = boolStorage.getItem(i);
+          boolean value = boolStorage.get(i);
           builder.appendLong(booleanAsLong(value));
         });
   }
 
   private Storage<Long> convertDoubleStorage(
-      DoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
+      ColumnDoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
     return innerLoop(
-        Builder.getForLong(targetType, doubleStorage.size(), problemAggregator),
+        Builder.getForLong(targetType, doubleStorage.getSize(), problemAggregator),
         doubleStorage,
         (builder, i) -> {
-          double value = doubleStorage.getItemAsDouble(i);
+          double value = doubleStorage.get(i);
           if (targetType.fits(value)) {
             long converted = (long) value;
             builder.appendLong(converted);
@@ -156,7 +153,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, longStorage.size(), problemAggregator),
         longStorage,
         (builder, i) -> {
-          long value = longStorage.getItem(i);
+          long value = longStorage.getItem((int)i);
           builder.appendLong(value);
         });
   }
@@ -167,7 +164,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, storage.size(), problemAggregator),
         storage,
         (builder, i) -> {
-          BigInteger value = storage.getItemBoxed(i);
+          BigInteger value = storage.getItemBoxed((int)i);
           if (targetType.fits(value)) {
             builder.appendLong(value.longValue());
           } else {
@@ -183,7 +180,7 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
         Builder.getForLong(targetType, storage.size(), problemAggregator),
         storage,
         (builder, i) -> {
-          BigDecimal value = storage.getItemBoxed(i);
+          BigDecimal value = storage.getItemBoxed((int)i);
           BigInteger bigInteger = value.toBigInteger();
           if (targetType.fits(bigInteger)) {
             builder.appendLong(bigInteger.longValue());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
@@ -7,9 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
 import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.enso.table.data.column.builder.Builder;
-import org.enso.table.data.column.storage.BoolStorage;
-import org.enso.table.data.column.storage.Storage;
-import org.enso.table.data.column.storage.StringStorage;
+import org.enso.table.data.column.storage.*;
 import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.datetime.DateTimeStorage;
 import org.enso.table.data.column.storage.datetime.TimeOfDayStorage;
@@ -55,12 +53,12 @@ public class ToTextStorageConverter implements StorageConverter<String> {
   }
 
   private Storage<String> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForText(mixedStorage.size(), targetType),
+        Builder.getForText(mixedStorage.getSize(), targetType),
         mixedStorage,
         (i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           return switch (o) {
             case LocalTime d -> adapt(convertTime(d), problemAggregator);
             case LocalDate d -> adapt(convertDate(d), problemAggregator);
@@ -72,34 +70,34 @@ public class ToTextStorageConverter implements StorageConverter<String> {
   }
 
   private Storage<String> castLongStorage(
-      AbstractLongStorage longStorage, CastProblemAggregator problemAggregator) {
+      ColumnLongStorage longStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForText(longStorage.size(), targetType),
+        Builder.getForText(longStorage.getSize(), targetType),
         longStorage,
         (i) -> {
-          long value = longStorage.getItem(i);
+          long value = longStorage.get(i);
           return adapt(Long.toString(value), problemAggregator);
         });
   }
 
   private Storage<String> castBoolStorage(
-      BoolStorage boolStorage, CastProblemAggregator problemAggregator) {
+      ColumnBooleanStorage boolStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForText(boolStorage.size(), targetType),
+        Builder.getForText(boolStorage.getSize(), targetType),
         boolStorage,
         (i) -> {
-          boolean value = boolStorage.getItem(i);
+          boolean value = boolStorage.get(i);
           return adapt(convertBoolean(value), problemAggregator);
         });
   }
 
   private Storage<String> castDoubleStorage(
-      DoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
+      ColumnDoubleStorage doubleStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForText(doubleStorage.size(), targetType),
+        Builder.getForText(doubleStorage.getSize(), targetType),
         doubleStorage,
         (i) -> {
-          double value = doubleStorage.getItem(i);
+          double value = doubleStorage.get(i);
           return adapt(Double.toString(value), problemAggregator);
         });
   }
@@ -110,7 +108,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
         Builder.getForText(storage.size(), targetType),
         storage,
         (i) -> {
-          var value = storage.getItemBoxed(i);
+          var value = storage.getItemBoxed((int) i);
           return adapt(converter.apply(value), problemAggregator);
         });
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTimeOfDayStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTimeOfDayStorageConverter.java
@@ -3,6 +3,7 @@ package org.enso.table.data.column.operation.cast;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.datetime.DateTimeStorage;
 import org.enso.table.data.column.storage.datetime.TimeOfDayStorage;
@@ -24,12 +25,12 @@ public class ToTimeOfDayStorageConverter implements StorageConverter<LocalTime> 
   }
 
   private Storage<LocalTime> castFromMixed(
-      Storage<?> mixedStorage, CastProblemAggregator problemAggregator) {
+      ColumnStorage mixedStorage, CastProblemAggregator problemAggregator) {
     return StorageConverter.innerLoop(
-        Builder.getForTime(mixedStorage.size()),
+        Builder.getForTime(mixedStorage.getSize()),
         mixedStorage,
         (i) -> {
-          Object o = mixedStorage.getItemBoxed(i);
+          Object o = mixedStorage.getItemAsObject(i);
           return switch (o) {
             case LocalTime d -> d;
             case ZonedDateTime d -> convertDateTime(d);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/GenericBinaryObjectMapOperation.java
@@ -46,7 +46,7 @@ public abstract class GenericBinaryObjectMapOperation<
           builder.appendNulls(1);
         } else {
           OutputType result = run(storage.getItemBoxed(i), casted);
-          builder.appendNoGrow(result);
+          builder.append(result);
         }
 
         context.safepoint();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/datetime/TimeLikeCoalescingOperation.java
@@ -37,7 +37,7 @@ public abstract class TimeLikeCoalescingOperation<T>
         Context context = Context.getCurrent();
         for (int i = 0; i < size; i++) {
           T r = storage.isNothing(i) ? casted : doOperation(storage.getItemBoxed(i), casted);
-          builder.appendNoGrow(r);
+          builder.append(r);
           context.safepoint();
         }
 
@@ -76,7 +76,7 @@ public abstract class TimeLikeCoalescingOperation<T>
             }
           }
 
-          builder.appendNoGrow(r);
+          builder.append(r);
           context.safepoint();
         }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/BigDecimalRoundOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/BigDecimalRoundOp.java
@@ -47,7 +47,7 @@ public class BigDecimalRoundOp
       if (!storage.isNothing(i)) {
         BigDecimal value = storage.getItem(i);
         BigDecimal result = Decimal_Utils.round(value, (int) decimalPlaces.longValue(), useBankers);
-        builder.appendNoGrow(result);
+        builder.append(result);
       } else {
         builder.appendNulls(1);
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryBooleanOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryBooleanOperation.java
@@ -20,11 +20,7 @@ abstract class AbstractUnaryBooleanOperation extends AbstractUnaryOperation {
   @Override
   protected BuilderForBoolean createBuilder(
       ColumnStorage storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage.getSize() > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-    return Builder.getForBoolean((int) storage.getSize());
+    return Builder.getForBoolean(storage.getSize());
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryLongOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryLongOperation.java
@@ -27,11 +27,7 @@ abstract class AbstractUnaryLongOperation extends AbstractUnaryOperation {
   @Override
   protected BuilderForLong createBuilder(
       ColumnStorage storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage.getSize() > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-    return Builder.getForLong(returnType, (int) storage.getSize(), problemAggregator);
+    return Builder.getForLong(returnType, storage.getSize(), problemAggregator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/AbstractUnaryOperation.java
@@ -54,12 +54,7 @@ abstract class AbstractUnaryOperation implements UnaryOperation {
 
   protected Builder createBuilder(
       ColumnStorage storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage.getSize() > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    return Builder.getInferredBuilder((int) storage.getSize(), problemAggregator);
+    return Builder.getInferredBuilder(storage.getSize(), problemAggregator);
   }
 
   /** Apply the operation to a Boolean Storage. */

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/DateTruncateOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/DateTruncateOperation.java
@@ -24,12 +24,7 @@ public class DateTruncateOperation extends AbstractUnaryOperation {
   @Override
   protected Builder createBuilder(
       ColumnStorage storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage.getSize() > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    return Builder.getForType(DateType.INSTANCE, (int) storage.getSize(), problemAggregator);
+    return Builder.getForType(DateType.INSTANCE, storage.getSize(), problemAggregator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/UnaryRoundOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/UnaryRoundOperation.java
@@ -47,12 +47,7 @@ public class UnaryRoundOperation extends AbstractUnaryOperation {
 
   protected Builder createBuilder(
       ColumnStorage storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage.getSize() > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          "Cannot currently operate on columns larger than " + Integer.MAX_VALUE + ".");
-    }
-
-    return new InferredIntegerBuilder((int) storage.getSize(), problemAggregator);
+    return Builder.getInferredBuilder(storage.getSize(), problemAggregator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/UnaryRoundOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/UnaryRoundOperation.java
@@ -6,7 +6,6 @@ import java.util.function.DoubleToLongFunction;
 import java.util.function.Function;
 import org.enso.base.numeric.Decimal_Utils;
 import org.enso.table.data.column.builder.Builder;
-import org.enso.table.data.column.builder.InferredIntegerBuilder;
 import org.enso.table.data.column.operation.UnaryOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.ColumnLongStorage;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -215,7 +215,7 @@ public final class BoolStorage extends Storage<Boolean>
     Builder builder = Builder.getForType(resultStorageType, size, problemAggregator);
     for (int i = 0; i < size; i++) {
       if (isNothing.get(i)) {
-        builder.append(null);
+        builder.appendNulls(1);
       } else if (getItem(i)) {
         builder.append(on_true.apply(i));
       } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/MixedStorage.java
@@ -135,7 +135,7 @@ public final class MixedStorage extends ObjectStorage implements ColumnStorageWi
         Builder builder =
             Builder.getForType(inferredType, size(), BlackholeProblemAggregator.INSTANCE);
         for (int i = 0; i < size(); i++) {
-          builder.appendNoGrow(getItemBoxed(i));
+          builder.append(getItemBoxed(i));
         }
         cachedInferredStorage = builder.seal();
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -164,7 +164,7 @@ public abstract class Storage<T> implements ColumnStorage {
       } else {
         Object result = function.apply(it, argument);
         Object converted = Polyglot_Utils.convertPolyglotValue(result);
-        storageBuilder.appendNoGrow(converted);
+        storageBuilder.append(converted);
       }
 
       context.safepoint();
@@ -197,7 +197,7 @@ public abstract class Storage<T> implements ColumnStorage {
       } else {
         Object result = function.apply(it1, it2);
         Object converted = Polyglot_Utils.convertPolyglotValue(result);
-        storageBuilder.appendNoGrow(converted);
+        storageBuilder.append(converted);
       }
 
       context.safepoint();
@@ -332,12 +332,7 @@ public abstract class Storage<T> implements ColumnStorage {
     Context context = Context.getCurrent();
     for (int i = 0; i < size(); i++) {
       Object it = getItemBoxed(i);
-      if (it == null) {
-        builder.appendNoGrow(convertedFallback);
-      } else {
-        builder.appendNoGrow(it);
-      }
-
+      builder.append(it == null ? convertedFallback : it);
       context.safepoint();
     }
 
@@ -356,12 +351,7 @@ public abstract class Storage<T> implements ColumnStorage {
     var builder = Builder.getForType(commonType, size(), problemAggregator);
     Context context = Context.getCurrent();
     for (int i = 0; i < size(); i++) {
-      if (isNothing(i)) {
-        builder.appendNoGrow(other.getItemBoxed(i));
-      } else {
-        builder.appendNoGrow(getItemBoxed(i));
-      }
-
+      builder.append(isNothing(i) ? other.getItemBoxed(i) : getItemBoxed(i));
       context.safepoint();
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -23,8 +23,10 @@ import org.enso.table.data.column.operation.map.numeric.comparisons.LessOrEqualC
 import org.enso.table.data.column.operation.map.numeric.helpers.DoubleArrayAdapter;
 import org.enso.table.data.column.operation.map.numeric.isin.DoubleIsInOp;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnDoubleStorage;
 import org.enso.table.data.column.storage.ColumnStorageWithNothingMap;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.ValueIsNothingException;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
@@ -37,7 +39,7 @@ import org.graalvm.polyglot.Value;
 
 /** A column containing floating point numbers. */
 public final class DoubleStorage extends NumericStorage<Double>
-    implements DoubleArrayAdapter, ColumnStorageWithNothingMap {
+    implements DoubleArrayAdapter, ColumnStorageWithNothingMap, ColumnDoubleStorage {
   private final double[] data;
   private final BitSet isNothing;
   private final int size;
@@ -414,5 +416,13 @@ public final class DoubleStorage extends NumericStorage<Double>
   @Override
   public BitSet getIsNothingMap() {
     return isNothing;
+  }
+
+  @Override
+  public double get(long index) throws ValueIsNothingException {
+    if (isNothing(index)) {
+      throw new ValueIsNothingException(index);
+    }
+    return getItem((int) index);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -423,6 +423,6 @@ public final class DoubleStorage extends NumericStorage<Double>
     if (isNothing(index)) {
       throw new ValueIsNothingException(index);
     }
-    return getItem((int) index);
+    return getItem(Math.toIntExact(index));
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -130,15 +130,9 @@ public final class LongStorage extends AbstractLongStorage {
     final var builder = Builder.getForType(BigIntegerType.INSTANCE, size, problemAggregator);
     Context context = Context.getCurrent();
     for (int i = 0; i < size(); i++) {
-      if (isNothing.get(i)) {
-        builder.appendNoGrow(bigInteger);
-      } else {
-        builder.appendNoGrow(BigInteger.valueOf(data[i]));
-      }
-
+      builder.append(isNothing.get(i) ? bigInteger : BigInteger.valueOf(data[i]));
       context.safepoint();
     }
-
     return builder.seal();
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/index/CrossTabIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/CrossTabIndex.java
@@ -149,7 +149,7 @@ public class CrossTabIndex {
     for (UnorderedMultiValueKey ySubKey : getYKeys()) {
 
       // Fill the y key columns.
-      IntStream.range(0, yColumns.length).forEach(i -> storage[i].appendNoGrow(ySubKey.get(i)));
+      IntStream.range(0, yColumns.length).forEach(i -> storage[i].append(ySubKey.get(i)));
 
       int offset = yColumns.length;
 
@@ -161,7 +161,7 @@ public class CrossTabIndex {
         }
 
         for (int i = 0; i < aggregates.length; i++) {
-          storage[offset + i].appendNoGrow(aggregates[i].aggregate(rowIds, problemAggregator));
+          storage[offset + i].append(aggregates[i].aggregate(rowIds, problemAggregator));
         }
 
         offset += aggregates.length;

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -122,14 +122,14 @@ public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
       // No grouping and no data
       List<Integer> empty = new ArrayList<>();
       for (int i = 0; i < length; i++) {
-        storage[i].appendNoGrow(columns[i].aggregate(empty, problemAggregator));
+        storage[i].append(columns[i].aggregate(empty, problemAggregator));
         context.safepoint();
       }
     } else {
       for (List<Integer> group_locs : this.locs.values()) {
         for (int i = 0; i < length; i++) {
           Object value = columns[i].aggregate(group_locs, problemAggregator);
-          storage[i].appendNoGrow(value);
+          storage[i].append(value);
           context.safepoint();
         }
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
@@ -113,9 +113,9 @@ public class Column {
     for (Object item : items) {
       if (item instanceof Value v) {
         Object converted = Polyglot_Utils.convertPolyglotValue(v);
-        builder.appendNoGrow(converted);
+        builder.append(converted);
       } else {
-        builder.appendNoGrow(item);
+        builder.append(item);
       }
 
       context.safepoint();
@@ -142,7 +142,7 @@ public class Column {
     var builder = Builder.getForType(expectedType, n, problemAggregator);
 
     for (Object item : items) {
-      builder.appendNoGrow(item);
+      builder.append(item);
       context.safepoint();
     }
 
@@ -174,7 +174,7 @@ public class Column {
     Builder builder = Builder.getForType(storageType, repeat, problemAggregator);
     Context context = Context.getCurrent();
     for (int i = 0; i < repeat; i++) {
-      builder.appendNoGrow(converted);
+      builder.append(converted);
       context.safepoint();
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/lookup/LookupJoin.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/lookup/LookupJoin.java
@@ -114,7 +114,7 @@ public class LookupJoin {
         } else {
           itemToAdd = mergeColumns.original.getItemBoxed(i);
         }
-        mergeColumns.builder.appendNoGrow(itemToAdd);
+        mergeColumns.builder.append(itemToAdd);
       }
 
       // Prepare order mask for new columns / fully-replaced columns

--- a/std-bits/table/src/main/java/org/enso/table/parsing/IncrementalDatatypeParser.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/IncrementalDatatypeParser.java
@@ -16,8 +16,8 @@ public abstract class IncrementalDatatypeParser extends DatatypeParser {
   /**
    * Creates a new column builder expecting the specific datatype, with a specified capacity.
    *
-   * <p>The {@code parseColumn} method will use {@code appendNoGrow} function, so the initial
-   * capacity should be set properly so that the builder can hold all expected elements.
+   * <p>The {@code parseColumn} knows the expected size, so the initial capacity should be set
+   * properly to avoid reallocations.
    *
    * <p>The type returned from {@code parseSingleValue} should be consistent with the types that the
    * builder returned here expects - it should never return a value that cannot be accepted by the
@@ -40,7 +40,7 @@ public abstract class IncrementalDatatypeParser extends DatatypeParser {
       String cell = sourceStorage.getItemBoxed(i);
       if (cell != null) {
         Object parsed = parseSingleValue(cell, problemAggregator);
-        builder.appendNoGrow(parsed);
+        builder.append(parsed);
       } else {
         builder.appendNulls(1);
       }

--- a/std-bits/table/src/main/java/org/enso/table/parsing/TypeInferringParser.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/TypeInferringParser.java
@@ -65,7 +65,7 @@ public class TypeInferringParser extends DatatypeParser {
             innerAggregator.detachFromParent();
             continue parsers;
           }
-          builder.appendNoGrow(parsed);
+          builder.append(parsed);
         } else {
           builder.appendNulls(1);
         }

--- a/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.stream.Collectors;
 import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.builder.BuilderForType;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.table.Column;
@@ -67,7 +68,7 @@ public class DelimitedReader {
   /** The line number of the start of the current row in the input file. */
   private long currentLine = 0;
 
-  private Builder[] builders = null;
+  private List<BuilderForType<String>> builders = null;
   private final DelimitedReaderProblemAggregator problemAggregator;
 
   /**
@@ -264,27 +265,27 @@ public class DelimitedReader {
     assert builders != null;
     assert canFitMoreRows();
 
-    if (row.length != builders.length) {
+    if (row.length != builders.size()) {
       problemAggregator.reportInvalidRow(
-          currentLine, keepInvalidRows ? targetTableIndex : null, row, builders.length);
+          currentLine, keepInvalidRows ? targetTableIndex : null, row, builders.size());
 
       if (keepInvalidRows) {
-        for (int i = 0; i < builders.length && i < row.length; i++) {
-          builders[i].append(row[i]);
+        for (int i = 0; i < builders.size() && i < row.length; i++) {
+          builders.get(i).append(row[i]);
         }
 
         // If the current row had fewer columns than expected, nulls are inserted for the missing
         // values.
         // If it had more columns, the excess columns are discarded.
-        for (int i = row.length; i < builders.length; i++) {
-          builders[i].append(null);
+        for (int i = row.length; i < builders.size(); i++) {
+          builders.get(i).append(null);
         }
 
         targetTableIndex++;
       }
     } else {
-      for (int i = 0; i < builders.length; i++) {
-        builders[i].append(row[i]);
+      for (int i = 0; i < builders.size(); i++) {
+        builders.get(i).append(row[i]);
       }
 
       targetTableIndex++;
@@ -458,17 +459,17 @@ public class DelimitedReader {
       parser.stopParsing();
     }
 
-    Column[] columns = new Column[builders.length];
-    for (int i = 0; i < builders.length; i++) {
+    Column[] columns = new Column[builders.size()];
+    for (int i = 0; i < builders.size(); i++) {
       String columnName = effectiveColumnNames[i];
-      var col = (Storage<String>) builders[i].seal();
+      var stringStorage = builders.get(i).seal();
 
       // We don't expect InvalidFormat to be propagated back to Enso, there is no particular type
       // that we expect, so it can safely be null.
       Value expectedEnsoValueType = Value.asValue(null);
       CommonParseProblemAggregator parseProblemAggregator =
           ParseProblemAggregator.make(problemAggregator, columnName, expectedEnsoValueType);
-      Storage<?> storage = valueParser.parseColumn(col, parseProblemAggregator);
+      Storage<?> storage = valueParser.parseColumn(stringStorage, parseProblemAggregator);
       columns[i] = new Column(columnName, storage);
       context.safepoint();
     }
@@ -490,9 +491,9 @@ public class DelimitedReader {
   private static final int INITIAL_ROW_CAPACITY = 100;
 
   private void initBuilders(int count) {
-    builders = new Builder[count];
+    builders = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
-      builders[i] = Builder.getForType(TextType.VARIABLE_LENGTH, INITIAL_ROW_CAPACITY, null);
+      builders.add(Builder.getForText(INITIAL_ROW_CAPACITY, TextType.VARIABLE_LENGTH));
     }
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
@@ -278,7 +278,7 @@ public class DelimitedReader {
         // values.
         // If it had more columns, the excess columns are discarded.
         for (int i = row.length; i < builders.size(); i++) {
-          builders.get(i).append(null);
+          builders.get(i).appendNulls(1);
         }
 
         targetTableIndex++;

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -398,7 +398,7 @@ public class ExcelReader {
       int rows,
       ProblemAggregator problemAggregator) {
     for (int i = builders.size(); i <= columnCount; i++) {
-      Builder builder = new InferredBuilder(size, problemAggregator, true);
+      var builder = new InferredBuilder(size, problemAggregator, true);
       builder.appendNulls(rows);
       builders.add(builder);
     }

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -354,7 +354,7 @@ public class ExcelReader {
     while (row <= endRow && (row - startRow) < rowCount) {
       ExcelRow currentRow = sheet.get(row);
       if (currentRow == null) {
-        builders.forEach(b -> b.append(null));
+        builders.forEach(b -> b.appendNulls(1));
       } else {
         int currentEndCol =
             endCol == -1

--- a/test/Exploratory_Benchmarks/src/Table/Column_Bi_Map.enso
+++ b/test/Exploratory_Benchmarks/src/Table/Column_Bi_Map.enso
@@ -9,8 +9,8 @@ import project.Table.Helpers
 
 polyglot java import org.enso.exploratory_benchmark_helpers.MapHelpers
 polyglot java import org.enso.table.data.column.builder.Builder
-polyglot java import org.enso.table.data.column.storage.type.IntegerType;
-polyglot java import org.enso.table.data.column.storage.type.TextType;
+polyglot java import org.enso.table.data.column.storage.type.IntegerType
+polyglot java import org.enso.table.data.column.storage.type.TextType
 
 # Adding two String columns
 type Boxed_Bi_Map_Test

--- a/test/Exploratory_Benchmarks/src/Table/Column_Map.enso
+++ b/test/Exploratory_Benchmarks/src/Table/Column_Map.enso
@@ -9,7 +9,7 @@ import project.Table.Helpers
 
 polyglot java import org.enso.exploratory_benchmark_helpers.MapHelpers
 polyglot java import org.enso.table.data.column.builder.Builder
-polyglot java import org.enso.table.data.column.storage.type.IntegerType;
+polyglot java import org.enso.table.data.column.storage.type.IntegerType
 
 ## This tests an operation on a boxed value (e.g. ends_with on a String).
    It is the basic benchmark for comparing the performance between the vectorized Java op and approaches relying on Enso.

--- a/test/Exploratory_Benchmarks/src/Table/Column_Map_2.enso
+++ b/test/Exploratory_Benchmarks/src/Table/Column_Map_2.enso
@@ -43,20 +43,6 @@ type Boxed_Map_Test_2
                     builder.appendLong date.year
         Column.from_storage "result" builder.seal
 
-    ## This is the same as above, but uses `appendNoGrow` instead of
-       `appendLong`. I suspect it could be more efficient, so I'm testing it.
-    enso_map_with_builder_append_object self =
-        n = self.date_column.length
-        builder = Builder.getForLong IntegerType.INT_64 n Nothing
-        storage = get_storage_for_column self.date_column
-        0.up_to n . each i->
-            case storage.getItemBoxed i of
-                Nothing ->
-                    builder.appendNulls 1
-                date ->
-                    builder.appendNoGrow date.year
-        Column.from_storage "result" builder.seal
-
     verify_correctness self =
         Helpers.check_results [self.current_implementation, self.java_map, self.enso_map_as_vector convert_polyglot_dates=True, self.enso_map_as_vector convert_polyglot_dates=False, self.enso_map_with_builder_append_long, self.enso_map_with_builder_append_object]
 

--- a/test/Exploratory_Benchmarks/src/Table/Enso_Callback.enso
+++ b/test/Exploratory_Benchmarks/src/Table/Enso_Callback.enso
@@ -11,8 +11,8 @@ import project.Table.Helpers
 
 polyglot java import org.enso.exploratory_benchmark_helpers.MapHelpers
 polyglot java import org.enso.table.data.column.builder.Builder
-polyglot java import org.enso.table.data.column.storage.type.IntegerType;
-polyglot java import org.enso.table.data.column.storage.type.TextType;
+polyglot java import org.enso.table.data.column.storage.type.IntegerType
+polyglot java import org.enso.table.data.column.storage.type.TextType
 polyglot java import org.enso.table.data.table.Column as Java_Column
 
 ## This tests an operation that executes an Enso function on each element of a column.


### PR DESCRIPTION
### Pull Request Description

- Remove `appendNoGrow` method and use `append`.
  - While not a full benchmark, tested on reading 1m row Hyper file, calling `date_part ..Year` and `text_length`.
  - Original time was 0.939s, following PR changes time taken was 0.836s.
- Added `ColumnDoubleStorage` interface to `DoubleStorage`.
- Move cast operations to work through `ColumnStorage` interfaces where possible.
- Builder statics now take a `long` for the size and check against a maximum size.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
