### PR TITLE
BenchmarksRunner does not override jvm args of forked processes.

### DIFF
--- a/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -27,7 +27,7 @@ public class BenchmarksRunner {
 
   public static void run(String[] args) throws RunnerException {
     if (args.length == 0) {
-      args = new String[] {"--jvmArgs=-Dbench.all=true"};
+      args = new String[] {"--jvmArgsPrepend=-Dbench.all=true"};
     }
     CommandLineOptions cmdOpts = null;
     try {


### PR DESCRIPTION
Fixes #11808

### Pull Request Description

Fixes "PolyglotException: No language of id epb found". Turns out that we have accidentally overridden all the arguments to forked JVMs of JMH to just `-Dbench.all=true`.

Now, `sbt std-benchmarks/bench` works also locally. Before this PR, they also failed locally.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
