### PR TITLE
Fix DB maintenance actions broken by #7117

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -65,7 +65,11 @@ type JDBC_Connection
        `synchronized` critical section (including the current thread).
     run_maintenance_action_if_possible : (Nothing -> Any) -> Nothing
     run_maintenance_action_if_possible self callback =
-        self.operation_synchronizer.runMaintenanceActionIfPossible callback
+        # TODO The wrapping is a workaround for https://github.com/enso-org/enso/issues/7117
+        wrapped_callback x =
+            Context.Output.with_enabled <|
+                callback x
+        self.operation_synchronizer.runMaintenanceActionIfPossible wrapped_callback
 
     ## PRIVATE
 


### PR DESCRIPTION
### Pull Request Description

Running some tests I noticed logs like
```
sty 21, 2025 10:12:30 PM org.enso.database.dryrun.OperationSynchronizer runMaintenanceActionIfPossible
SEVERE: A maintenance action failed with exception: As writing is disabled, cannot execute an update query. Press the Write button ▶ to perform the operation.
```

They appear rather randomly. This PR should provide a workaround until #7117 is fixed.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
