### PR TITLE
 Unhandled Java Exceptions not handled in same way as Enso panics

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -532,25 +532,26 @@ public final class ExecutionService {
    * @param panic the panic to display.
    * @return a human-readable version of its contents.
    */
-  public String getExceptionMessage(PanicException panic) {
+  public String getExceptionMessage(AbstractTruffleException panic) {
     var iop = InteropLibrary.getUncached();
     var p = context.getThreadManager().enter();
+    var payload = panic instanceof PanicException ex ? ex.getPayload() : panic;
     try {
       // Invoking a member on an Atom that does not have a method `to_display_text` will not
       // contrary to what is
       // expected from the documentation, throw an `UnsupportedMessageException`.
       // Instead it will crash with some internal assertion deep inside runtime. Hence the check.
-      if (iop.isMemberInvocable(panic.getPayload(), "to_display_text")) {
-        return iop.asString(iop.invokeMember(panic.getPayload(), "to_display_text"));
+      if (iop.isMemberInvocable(payload, "to_display_text")) {
+        return iop.asString(iop.invokeMember(payload, "to_display_text"));
       } else throw UnsupportedMessageException.create();
     } catch (UnsupportedMessageException
         | ArityException
         | UnknownIdentifierException
         | UnsupportedTypeException e) {
-      return TypeToDisplayTextNode.getUncached().execute(panic.getPayload());
+      return TypeToDisplayTextNode.getUncached().execute(payload);
     } catch (Throwable e) {
       if (iop.isException(e)) {
-        return TypeToDisplayTextNode.getUncached().execute(panic.getPayload());
+        return TypeToDisplayTextNode.getUncached().execute(payload);
       } else {
         throw e;
       }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -96,13 +96,9 @@ object ProgramExecutionSupport {
       if (callStack.isEmpty) {
         logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
 
-        val panicValue = value.getValue match {
-          case panicSentinel: PanicSentinel => panicSentinel.getPanic
-          case other                        => other
-        }
-        if (VisualizationResult.isInterruptedException(panicValue)) {
-          panicValue match {
-            case e: AbstractTruffleException =>
+        value.getValue match {
+          case sentinel: PanicSentinel =>
+            if (VisualizationResult.isInterruptedException(sentinel.getPanic)) {
               sendInterruptedExpressionUpdate(
                 contextId,
                 executionFrame.syncState,
@@ -110,9 +106,9 @@ object ProgramExecutionSupport {
               )
               // Bail out early. Any references to this value that do not expect
               // Interrupted error will likely return `No_Such_Method` otherwise.
-              throw new ThreadInterruptedException(e);
-            case _ =>
-          }
+              throw new ThreadInterruptedException(sentinel.getPanic)
+            }
+          case _ =>
         }
         sendExpressionUpdate(contextId, executionFrame.syncState, value)
         sendVisualizationUpdates(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -96,8 +96,12 @@ object ProgramExecutionSupport {
       if (callStack.isEmpty) {
         logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
 
-        if (VisualizationResult.isInterruptedException(value.getValue)) {
-          value.getValue match {
+        val panicValue = value.getValue match {
+          case panicSentinel: PanicSentinel => panicSentinel.getPanic
+          case other                        => other
+        }
+        if (VisualizationResult.isInterruptedException(panicValue)) {
+          panicValue match {
             case e: AbstractTruffleException =>
               sendInterruptedExpressionUpdate(
                 contextId,

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/id/execution/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/id/execution/IdExecutionInstrument.java
@@ -267,8 +267,8 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
       public void onReturnExceptional(VirtualFrame frame, Throwable exception) {
         if (exception instanceof TailCallException) {
           onTailCallReturn(exception, Function.ArgumentsHelper.getState(frame.getArguments()));
-        } else if (exception instanceof PanicSentinel sentinel) {
-          onReturnValue(frame, sentinel);
+        } else if (exception instanceof PanicSentinel) {
+          onReturnValue(frame, exception);
         } else if (exception instanceof AbstractTruffleException ex) {
           onReturnValue(frame, new PanicSentinel(ex, context.getInstrumentedNode()));
         }

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/id/execution/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/id/execution/IdExecutionInstrument.java
@@ -35,7 +35,6 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.control.TailCallException;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
-import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.instrument.Timer;
 import org.enso.interpreter.runtime.state.ExecutionEnvironment;
@@ -268,10 +267,10 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
       public void onReturnExceptional(VirtualFrame frame, Throwable exception) {
         if (exception instanceof TailCallException) {
           onTailCallReturn(exception, Function.ArgumentsHelper.getState(frame.getArguments()));
-        } else if (exception instanceof PanicException panicException) {
-          onReturnValue(frame, new PanicSentinel(panicException, context.getInstrumentedNode()));
-        } else if (exception instanceof AbstractTruffleException) {
-          onReturnValue(frame, exception);
+        } else if (exception instanceof PanicSentinel sentinel) {
+          onReturnValue(frame, sentinel);
+        } else if (exception instanceof AbstractTruffleException ex) {
+          onReturnValue(frame, new PanicSentinel(ex, context.getInstrumentedNode()));
         }
       }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
@@ -496,7 +496,7 @@ object TestMessages {
         expressionIds.toSet.map { expressionId =>
           Api.ExpressionUpdate(
             expressionId,
-            None,
+            Some(Vector(ConstantsGen.PANIC)),
             methodCall,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             false,

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
@@ -14,7 +14,8 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
  */
 @ExportLibrary(TypesLibrary.class)
 public final class PanicSentinel extends AbstractTruffleException {
-  final PanicException panic;
+
+  private final AbstractTruffleException panic;
 
   /**
    * Create an instance of the panic sentinel, wrapping the provided panic.
@@ -22,7 +23,7 @@ public final class PanicSentinel extends AbstractTruffleException {
    * @param panic the panic to wrap
    * @param location the location from where the sentinel was thrown
    */
-  public PanicSentinel(PanicException panic, Node location) {
+  public PanicSentinel(AbstractTruffleException panic, Node location) {
     super(location);
     this.panic = panic;
   }
@@ -32,7 +33,7 @@ public final class PanicSentinel extends AbstractTruffleException {
    *
    * @return the underlying panic object
    */
-  public PanicException getPanic() {
+  public AbstractTruffleException getPanic() {
     return panic;
   }
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #11881 

Handle Java exceptions the same way as Enso panics.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
