### PR TITLE
Component status colors

### DIFF
--- a/app/gui/integration-test/project-view/edgeRendering.spec.ts
+++ b/app/gui/integration-test/project-view/edgeRendering.spec.ts
@@ -65,8 +65,8 @@ test('Hover behaviour of edges', async ({ page }) => {
 
   // Expect the top edge part to be dimmed
   const topEdge = page.locator('svg.behindNodes g:nth-child(2) path:nth-child(1)')
-  await expect(topEdge).toHaveClass('edge visible dimmed')
+  await expect(topEdge).toHaveClass('edge define-node-colors visible dimmed pending')
   // Expect the bottom edge part not to be dimmed
   const bottomEdge = page.locator('svg.behindNodes g:nth-child(2) path:nth-child(3)')
-  await expect(bottomEdge).toHaveClass('edge visible')
+  await expect(bottomEdge).toHaveClass('edge define-node-colors visible pending')
 })

--- a/app/gui/src/project-view/assets/base.css
+++ b/app/gui/src/project-view/assets/base.css
@@ -90,7 +90,7 @@
   --color-node-text-missing-value: white;
 
   &.pending {
-    --color-node-primary: var(--color-node-pending);
+    --color-node-background: var(--color-node-pending);
   }
 
   &.selected {

--- a/app/gui/src/project-view/assets/base.css
+++ b/app/gui/src/project-view/assets/base.css
@@ -88,9 +88,15 @@
     #aaa 40%
   );
   --color-node-text-missing-value: white;
+  --color-edge-from-node: color-mix(
+    in oklab,
+    var(--node-group-color) 85%,
+    white 15%
+  );
 
   &.pending {
     --color-node-background: var(--color-node-pending);
+    --color-edge-from-node: var(--color-node-pending);
   }
 
   &.selected {
@@ -108,6 +114,11 @@
       in oklab,
       var(--color-node-primary) 70%,
       black 30%
+    );
+    --color-edge-from-node: color-mix(
+      in oklab,
+      var(--color-node-primary) 40%,
+      white 60%
     );
   }
 }

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -18,6 +18,7 @@ import GraphVisualization from '@/components/GraphEditor/GraphVisualization.vue'
 import type { NodeCreationOptions } from '@/components/GraphEditor/nodeCreation'
 import PointFloatingMenu from '@/components/PointFloatingMenu.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
+import { useComponentColors } from '@/composables/componentColors'
 import { useDoubleClick } from '@/composables/doubleClick'
 import { usePointer, useResizeObserver } from '@/composables/events'
 import { provideComponentButtons } from '@/providers/componentButtons'
@@ -158,8 +159,6 @@ const visibleMessage = computed(
 )
 
 const nodeHovered = ref(false)
-
-const selected = computed(() => nodeSelection?.isSelected(nodeId.value) ?? false)
 
 const isOnlyOneSelected = computed(
   () =>
@@ -307,9 +306,9 @@ const isRecordingOverridden = computed({
   },
 })
 
-const expressionInfo = computed(() => graph.db.getExpressionInfo(props.node.innerExpr.externalId))
-const executionState = computed(() => expressionInfo.value?.payload.type ?? 'Unknown')
-const color = computed(() => graph.db.getNodeColorStyle(nodeId.value))
+const typename = computed(
+  () => graph.db.getExpressionInfo(props.node.innerExpr.externalId)?.rawTypename,
+)
 
 const nodeEditHandler = nodeEditBindings.handler({
   cancel(e) {
@@ -362,16 +361,6 @@ const dataSource = computed(
   () => ({ type: 'node', nodeId: props.node.rootExpr.externalId }) as const,
 )
 
-const pending = computed(() => {
-  switch (executionState.value) {
-    case 'Unknown':
-    case 'Pending':
-      return true
-    default:
-      return false
-  }
-})
-
 // === Recompute node expression ===
 
 function useRecomputation() {
@@ -394,13 +383,15 @@ const nodeStyle = computed(() => {
   return {
     transform: transform.value,
     minWidth: isVisualizationEnabled.value ? `${visualizationWidth.value ?? 200}px` : undefined,
-    '--node-group-color': color.value,
+    '--node-group-color': baseColor.value,
     ...(props.node.zIndex ? { 'z-index': props.node.zIndex } : {}),
     '--viz-below-node': `${graphSelectionSize.value.y - nodeSize.value.y}px`,
     '--node-size-x': `${nodeSize.value.x}px`,
     '--node-size-y': `${nodeSize.value.y}px`,
   }
 })
+
+const { baseColor, selected, pending } = useComponentColors(graph.db, nodeSelection, nodeId)
 
 const nodeClass = computed(() => {
   return {
@@ -499,7 +490,7 @@ const showMenuAt = ref<{ x: number; y: number }>()
       :isComponentMenuVisible="menuVisible"
       :currentType="props.node.vis?.identifier"
       :dataSource="dataSource"
-      :typename="expressionInfo?.rawTypename"
+      :typename="typename"
       :width="visualizationWidth"
       :height="visualizationHeight"
       :isFocused="isOnlyOneSelected"

--- a/app/gui/src/project-view/composables/componentColors.ts
+++ b/app/gui/src/project-view/composables/componentColors.ts
@@ -1,0 +1,27 @@
+import { type NodeId } from '@/stores/graph'
+import { type GraphDb } from '@/stores/graph/graphDatabase'
+import { type ToValue } from '@/util/reactivity'
+import { computed, toValue } from 'vue'
+
+/** Returns the component's base color, and information about state that may modify it. */
+export function useComponentColors(
+  graphDb: GraphDb,
+  nodeSelection: { isSelected: (nodeId: NodeId) => boolean } | undefined,
+  nodeId: ToValue<NodeId | undefined>,
+) {
+  const nodeIdValue = computed(() => toValue(nodeId))
+  const node = computed(() => nodeIdValue.value && graphDb.nodeIdToNode.get(nodeIdValue.value))
+  const expressionInfo = computed(
+    () => node.value && graphDb.getExpressionInfo(node.value.innerExpr.externalId),
+  )
+  const executionState = computed(() => expressionInfo.value?.payload.type ?? 'Unknown')
+  return {
+    baseColor: computed(() => nodeIdValue.value && graphDb.getNodeColorStyle(nodeIdValue.value)),
+    selected: computed(
+      () => (nodeIdValue.value && nodeSelection?.isSelected(nodeIdValue.value)) ?? false,
+    ),
+    pending: computed(
+      () => executionState.value === 'Unknown' || executionState.value === 'Pending',
+    ),
+  }
+}

--- a/app/gui/src/project-view/stores/graph/unconnectedEdges.ts
+++ b/app/gui/src/project-view/stores/graph/unconnectedEdges.ts
@@ -14,8 +14,6 @@ interface AnyUnconnectedEdge {
   disconnectedEdgeTarget?: PortId
   /** Identifies what the disconnected end should be attached to. */
   anchor: UnconnectedEdgeAnchor
-  /** CSS value; if provided, overrides any color calculation. */
-  color?: string
 }
 export interface UnconnectedSource extends AnyUnconnectedEdge {
   source: undefined


### PR DESCRIPTION
### Pull Request Description

https://github.com/user-attachments/assets/865f3be3-e963-4f27-97aa-419a66d04d73

Fixes #12001
- Component color reflects pending status
- Edges from component reflect pending/selected status

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
