### PR TITLE
Display component evaluating status

### DIFF
--- a/app/gui/integration-test/project-view/graphRenderNodes.spec.ts
+++ b/app/gui/integration-test/project-view/graphRenderNodes.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
+import { mockExpressionUpdate } from './expressionUpdates'
 import * as locate from './locate'
 
 test('graph can open and render nodes', async ({ page }) => {
@@ -15,4 +16,13 @@ test('graph can open and render nodes', async ({ page }) => {
   // check documented node's content
   const finalNode = locate.graphNodeByBinding(page, 'final')
   await expect(finalNode.locator('.WidgetToken')).toHaveText(['Main', '.', 'func1', 'prod'])
+})
+
+test('Component icon indicates evaluation in progress', async ({ page }) => {
+  await actions.goToGraph(page)
+
+  const node = locate.graphNodeByBinding(page, 'final')
+  await expect(node.locator('.WidgetIcon .LoadingSpinner')).not.toBeVisible()
+  await mockExpressionUpdate(page, 'final', { payload: { type: 'Pending', progress: 0.1 } })
+  await expect(node.locator('.WidgetIcon .LoadingSpinner')).toBeVisible()
 })

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetIcon.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetIcon.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
+import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { Score, defineWidget, widgetProps } from '@/providers/widgetRegistry'
-import type { URLString } from '@/util/data/urlString'
-import type { Icon } from '@/util/iconMetadata/iconName'
-import NodeWidget from '../NodeWidget.vue'
+import { type URLString } from '@/util/data/urlString'
+import { type Icon } from '@/util/iconMetadata/iconName'
+import { computed } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
+
+const icon = computed(() => props.input[DisplayIcon].icon)
 </script>
 
 <script lang="ts">
@@ -13,7 +17,7 @@ export const DisplayIcon: unique symbol = Symbol.for('WidgetInput:DisplayIcon')
 declare module '@/providers/widgetRegistry' {
   export interface WidgetInput {
     [DisplayIcon]?: {
-      icon: Icon | URLString
+      icon: Icon | URLString | '$evaluating'
       allowChoice?: boolean
       showContents?: boolean
     }
@@ -32,7 +36,16 @@ export const widgetDefinition = defineWidget(
 
 <template>
   <div class="WidgetIcon">
-    <SvgIcon class="nodeCategoryIcon grab-handle" :name="props.input[DisplayIcon].icon" />
+    <div class="iconContainer">
+      <Transition>
+        <LoadingSpinner
+          v-if="icon === '$evaluating'"
+          class="nodeCategoryIcon grab-handle"
+          :size="16"
+        />
+        <SvgIcon v-else class="nodeCategoryIcon grab-handle" :name="icon" />
+      </Transition>
+    </div>
     <NodeWidget v-if="props.input[DisplayIcon].showContents === true" :input="props.input" />
   </div>
 </template>
@@ -43,10 +56,33 @@ export const widgetDefinition = defineWidget(
   flex-direction: row;
   align-items: center;
   gap: var(--widget-token-pad-unit);
-
-  > .SvgIcon {
-    margin: 0 calc((var(--node-port-height) - 16px) / 2);
-    display: flex;
+}
+.iconContainer {
+  position: relative;
+  height: 16px;
+  width: 16px;
+  margin: 0 calc((var(--node-port-height) - 16px) / 2);
+}
+.nodeCategoryIcon {
+  position: absolute;
+}
+.LoadingSpinner {
+  border: 4px solid;
+  border-radius: 100%;
+  border-color: rgba(255, 255, 255, 90%) #0000;
+  animation: s1 0.8s infinite;
+}
+@keyframes s1 {
+  to {
+    transform: rotate(0.5turn);
   }
+}
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.1s ease;
+}
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelfAccessChain.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelfAccessChain.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import { DisplayIcon } from '@/components/GraphEditor/widgets/WidgetIcon.vue'
 import { injectFunctionInfo } from '@/providers/functionInfo'
 import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { injectWidgetTree } from '@/providers/widgetTree'
+import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
-import { displayedIconOf } from '@/util/getIconName'
-import { computed } from 'vue'
-import { DisplayIcon } from './WidgetIcon.vue'
+import { displayedIconOf, useDisplayedIcon } from '@/util/getIconName'
+import { computed, toRef } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
 const functionInfo = injectFunctionInfo(true)
+const graph = useGraphStore()
+const tree = injectWidgetTree()
 
-const displayedIcon = computed(() => {
+const baseIcon = computed(() => {
   const callInfo = functionInfo?.callInfo
   return displayedIconOf(
     callInfo?.suggestion,
@@ -19,13 +22,13 @@ const displayedIcon = computed(() => {
     functionInfo?.outputType ?? 'Unknown',
   )
 })
+const { displayedIcon } = useDisplayedIcon(graph.db, toRef(tree, 'externalId'), baseIcon)
 
 const iconInput = computed(() => {
   const lhs = props.input.value.lhs
   if (!lhs) return
   const input = WidgetInput.WithPort(WidgetInput.FromAst(lhs))
-  const icon = displayedIcon.value
-  if (icon) input[DisplayIcon] = { icon, showContents: showFullAccessChain.value }
+  input[DisplayIcon] = { icon: displayedIcon.value, showContents: showFullAccessChain.value }
   return input
 })
 

--- a/app/gui/src/project-view/util/getIconName.ts
+++ b/app/gui/src/project-view/util/getIconName.ts
@@ -83,8 +83,8 @@ export function useDisplayedIcon(
   baseIcon: ToValue<Icon | URLString>,
 ) {
   const evaluating = computed(() => {
-    const status = graphDb.getExpressionInfo(toValue(externalId))?.payload.type
-    return status === 'Pending' || status === undefined
+    const payload = graphDb.getExpressionInfo(toValue(externalId))?.payload
+    return payload?.type === 'Pending' && payload.progress
   })
   return {
     displayedIcon: computed(() => (evaluating.value ? '$evaluating' : toValue(baseIcon))),

--- a/app/gui/src/project-view/util/getIconName.ts
+++ b/app/gui/src/project-view/util/getIconName.ts
@@ -1,12 +1,16 @@
-import type { NodeId } from '@/stores/graph'
-import { GraphDb } from '@/stores/graph/graphDatabase'
+import { type NodeId } from '@/stores/graph'
+import { type GraphDb } from '@/stores/graph/graphDatabase'
 import {
   SuggestionKind,
   type SuggestionEntry,
   type Typename,
 } from '@/stores/suggestionDatabase/entry'
-import type { Icon } from '@/util/iconMetadata/iconName'
+import { type URLString } from '@/util/data/urlString'
+import { type Icon } from '@/util/iconMetadata/iconName'
 import { type MethodPointer } from '@/util/methodPointer'
+import { type ToValue } from '@/util/reactivity'
+import { computed, toValue } from 'vue'
+import { type ExternalId } from 'ydoc-shared/yjsModel'
 
 const typeNameToIconLookup: Record<string, Icon> = {
   'Standard.Base.Data.Text.Text': 'text_input',
@@ -66,5 +70,23 @@ export function iconOfNode(node: NodeId, graphDb: GraphDb) {
       return 'data_output'
     case 'input':
       return 'data_input'
+  }
+}
+
+/**
+ * Returns the icon to show on a component, using either the provided base icon or an icon representing its current
+ * status.
+ */
+export function useDisplayedIcon(
+  graphDb: GraphDb,
+  externalId: ToValue<ExternalId>,
+  baseIcon: ToValue<Icon | URLString>,
+) {
+  const evaluating = computed(() => {
+    const status = graphDb.getExpressionInfo(toValue(externalId))?.payload.type
+    return status === 'Pending' || status === undefined
+  })
+  return {
+    displayedIcon: computed(() => (evaluating.value ? '$evaluating' : toValue(baseIcon))),
   }
 }


### PR DESCRIPTION
### Pull Request Description

Components being evaluated show loading animation in icon position.

https://github.com/user-attachments/assets/157fd056-7269-46f4-abc0-a4f6b6c19047

(Video demonstrates UI, but progress updates triggering this state are not sent by backend yet.)

Fixes #7577.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
