### PR TITLE
Disable bazel remote cache on self-hosted runners

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,11 +24,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,10 +23,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/engine-benchmark.yml
+++ b/.github/workflows/engine-benchmark.yml
@@ -25,10 +25,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/engine-benchmark.yml
+++ b/.github/workflows/engine-benchmark.yml
@@ -26,11 +26,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -27,11 +27,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -81,11 +76,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -133,11 +123,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -186,11 +171,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -239,11 +219,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -292,11 +267,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -357,11 +327,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -420,11 +385,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -484,11 +444,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -548,11 +503,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -612,11 +562,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -680,11 +625,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -746,11 +686,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -813,11 +748,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -880,11 +810,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -26,10 +26,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -83,10 +80,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -138,10 +132,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -194,10 +185,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -250,10 +238,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -306,10 +291,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -374,10 +356,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -440,10 +419,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -507,10 +483,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -574,10 +547,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -641,10 +611,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -712,10 +679,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -781,10 +745,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -851,10 +812,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -921,10 +879,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -84,10 +81,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -151,10 +145,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -29,11 +29,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -82,11 +77,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -146,11 +136,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -29,11 +29,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -82,11 +77,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -135,11 +125,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -199,11 +184,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -263,11 +243,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -330,11 +305,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -397,11 +367,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -84,10 +81,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -140,10 +134,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -207,10 +198,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -274,10 +262,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -344,10 +329,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -414,10 +396,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -26,11 +26,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -101,11 +96,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -25,10 +25,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -103,10 +100,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/gui-checks.yml
+++ b/.github/workflows/gui-checks.yml
@@ -116,8 +116,8 @@ jobs:
       fail-fast: false
       max-parallel: 24
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ide-packaging-optional.yml
+++ b/.github/workflows/ide-packaging-optional.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -82,10 +79,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -151,10 +145,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/ide-packaging-optional.yml
+++ b/.github/workflows/ide-packaging-optional.yml
@@ -29,11 +29,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -80,11 +75,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -146,11 +136,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/ide-packaging.yml
+++ b/.github/workflows/ide-packaging.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -82,10 +79,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -136,10 +130,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -203,10 +194,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -272,10 +260,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -358,10 +343,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/ide-packaging.yml
+++ b/.github/workflows/ide-packaging.yml
@@ -29,11 +29,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -80,11 +75,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -131,11 +121,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -195,11 +180,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -261,11 +241,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -344,11 +319,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -48,11 +48,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -47,10 +47,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -86,11 +81,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -147,11 +137,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -208,11 +193,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -261,11 +241,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -318,11 +293,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -373,11 +343,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -429,11 +394,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -490,11 +450,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -550,11 +505,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -624,11 +574,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -703,11 +648,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -783,11 +723,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -88,10 +85,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -152,10 +146,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -216,10 +207,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -272,10 +260,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -332,10 +317,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -390,10 +372,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -449,10 +428,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -513,10 +489,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -576,10 +549,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -653,10 +623,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -735,10 +702,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -818,10 +782,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/std-libs-benchmark.yml
+++ b/.github/workflows/std-libs-benchmark.yml
@@ -25,10 +25,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/std-libs-benchmark.yml
+++ b/.github/workflows/std-libs-benchmark.yml
@@ -26,11 +26,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/wasm-checks.yml
+++ b/.github/workflows/wasm-checks.yml
@@ -29,11 +29,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -80,11 +75,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -131,11 +121,6 @@ jobs:
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
-        name: Installing wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.12.1
       - name: Expose Artifact API and context information.
         uses: actions/github-script@v7
         with:
@@ -154,6 +139,11 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.12.1
       - run: ./run wasm test --no-native
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wasm-checks.yml
+++ b/.github/workflows/wasm-checks.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -82,10 +79,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -136,10 +130,7 @@ jobs:
       - name: Setup bazel environment
         uses: bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85
         with:
-          bazelisk-cache: true
-          disk-cache: true
           output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
-          repository-cache: true
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/build_tools/build/src/ci_gen.rs
+++ b/build_tools/build/src/ci_gen.rs
@@ -19,7 +19,6 @@ use ide_ci::actions::workflow::definition::run;
 use ide_ci::actions::workflow::definition::setup_artifact_api;
 use ide_ci::actions::workflow::definition::setup_bazel;
 use ide_ci::actions::workflow::definition::setup_bazel_env;
-use ide_ci::actions::workflow::definition::setup_wasm_pack_step;
 use ide_ci::actions::workflow::definition::shell;
 use ide_ci::actions::workflow::definition::wrap_expression;
 use ide_ci::actions::workflow::definition::Branches;
@@ -377,13 +376,8 @@ pub fn runs_on(os: OS, runner_type: RunnerType) -> Vec<RunnerLabel> {
 
 /// Initial CI job steps: check out the source code and set up the environment.
 pub fn setup_script_steps() -> Vec<Step> {
-    let mut ret = vec![
-        setup_bazel_env(),
-        setup_bazel(),
-        setup_wasm_pack_step(),
-        setup_artifact_api(),
-        checkout_repo_step(),
-    ];
+    let mut ret =
+        vec![setup_bazel_env(), setup_bazel(), setup_artifact_api(), checkout_repo_step()];
     // We run `./run --help` so:
     // * The build-script is build in a separate step. This allows us to monitor its build-time and
     //   not affect timing of the actual build.

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -15,6 +15,7 @@ use crate::ide::web::env as ide_env;
 use core::panic;
 use ide_ci::actions::workflow::definition::cancel_workflow_action;
 use ide_ci::actions::workflow::definition::get_input_expression;
+use ide_ci::actions::workflow::definition::setup_wasm_pack_step;
 use ide_ci::actions::workflow::definition::shell;
 use ide_ci::actions::workflow::definition::step::Argument;
 use ide_ci::actions::workflow::definition::Access;
@@ -453,7 +454,9 @@ pub struct WasmTest;
 
 impl JobArchetype for WasmTest {
     fn job(&self, target: Target) -> Job {
-        plain_job(target, "WASM tests", "wasm test --no-native")
+        RunStepsBuilder::new("wasm test --no-native")
+            .customize(|step| vec![setup_wasm_pack_step(), step])
+            .build_job("WASM tests", target)
     }
 }
 

--- a/build_tools/ci_utils/src/actions/workflow/definition.rs
+++ b/build_tools/ci_utils/src/actions/workflow/definition.rs
@@ -98,12 +98,10 @@ pub fn setup_bazel() -> Step {
     Step {
         name: Some("Setup bazel environment".into()),
         uses: Some("bazel-contrib/setup-bazel@09f3a72d13a081857b0ee94e986ffa84caef7c85".into()),
-        with: Some(step::Argument::Other(BTreeMap::from([
-            (
-                "output-base".to_string(),
-                Value::String(format!("${{{{ {} && 'c:/_bazel' || '' }}}}", is_windows_runner())),
-            ),
-        ]))),
+        with: Some(step::Argument::Other(BTreeMap::from([(
+            "output-base".to_string(),
+            Value::String(format!("${{{{ {} && 'c:/_bazel' || '' }}}}", is_windows_runner())),
+        )]))),
         ..default()
     }
 }

--- a/build_tools/ci_utils/src/actions/workflow/definition.rs
+++ b/build_tools/ci_utils/src/actions/workflow/definition.rs
@@ -103,9 +103,6 @@ pub fn setup_bazel() -> Step {
                 "output-base".to_string(),
                 Value::String(format!("${{{{ {} && 'c:/_bazel' || '' }}}}", is_windows_runner())),
             ),
-            ("bazelisk-cache".to_string(), Value::Bool(true)),
-            ("disk-cache".to_string(), Value::Bool(true)),
-            ("repository-cache".to_string(), Value::Bool(true)),
         ]))),
         ..default()
     }


### PR DESCRIPTION
### Pull Request Description

Bazel cache download is taking significant time on self-hosted github actions runners, pretty much negating any benefit of caching in the first place. Disabling them should speed up many workflows. Since we don't clear the local bazel directory between builds, we still have effective local caching as long as the runners are not recreated.

Additionally removed wasm-pack installation from most jobs, since it is only used in wasm testing target.
