### PR TITLE
Enable Standard.AWS and Standard.Microsoft in native image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3670,7 +3670,7 @@ lazy val `engine-runner` = project
     run / connectInput := true
   )
   .settings(
-    NativeImage.smallJdk := None, //Some(buildSmallJdk.value),
+    NativeImage.smallJdk := Some(buildSmallJdk.value),
     NativeImage.additionalCp := {
       val runnerDeps =
         (Compile / fullClasspath).value.map(_.data.getAbsolutePath)
@@ -3813,13 +3813,11 @@ lazy val `engine-runner` = project
               // "-H:-DeleteLocalSymbols",
               // you may need to set smallJdk := None to use following flags:
               // "--trace-class-initialization=org.enso.syntax2.Parser",
-              "--diagnostics-mode",
-              "--verbose",
+              // "--diagnostics-mode",
+              // "--verbose",
               "-Dnic=nic",
               "-Dorg.enso.feature.native.lib.output=" + (engineDistributionRoot.value / "bin"),
-              "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin"),
-              "--trace-class-initialization=org.apache.commons.logging.LogFactory",
-              "--trace-class-initialization=com.amazonaws.auth.profile.internal.BasicProfileConfigFileLoader,org.apache.commons.logging.impl.LogFactoryImpl"
+              "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin")
             ),
             mainClass = Some("org.enso.runner.Main"),
             initializeAtRuntime = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3670,7 +3670,7 @@ lazy val `engine-runner` = project
     run / connectInput := true
   )
   .settings(
-    NativeImage.smallJdk := Some(buildSmallJdk.value),
+    NativeImage.smallJdk := None, //Some(buildSmallJdk.value),
     NativeImage.additionalCp := {
       val runnerDeps =
         (Compile / fullClasspath).value.map(_.data.getAbsolutePath)
@@ -3719,7 +3719,9 @@ lazy val `engine-runner` = project
         `base-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `database-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
+        `database-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+        `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
+
       core ++ stdLibsJars
     },
     buildSmallJdk := {
@@ -3810,11 +3812,13 @@ lazy val `engine-runner` = project
               // "-H:-DeleteLocalSymbols",
               // you may need to set smallJdk := None to use following flags:
               // "--trace-class-initialization=org.enso.syntax2.Parser",
-              // "--diagnostics-mode",
-              // "--verbose",
+              "--diagnostics-mode",
+              "--verbose",
               "-Dnic=nic",
               "-Dorg.enso.feature.native.lib.output=" + (engineDistributionRoot.value / "bin"),
-              "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin")
+              "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin"),
+              "--trace-class-initialization=org.apache.commons.logging.LogFactory",
+              "--trace-class-initialization=com.amazonaws.auth.profile.internal.BasicProfileConfigFileLoader,org.apache.commons.logging.impl.LogFactoryImpl"
             ),
             mainClass = Some("org.enso.runner.Main"),
             initializeAtRuntime = Seq(
@@ -3837,7 +3841,8 @@ lazy val `engine-runner` = project
               "org.enso.image",
               "org.enso.table",
               "org.enso.database",
-              "org.eclipse.jgit"
+              "org.eclipse.jgit",
+              "com.amazonaws"
             )
           )
       }

--- a/build.sbt
+++ b/build.sbt
@@ -3720,7 +3720,8 @@ lazy val `engine-runner` = project
         `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `database-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
+        `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+        `std-microsoft-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
 
       core ++ stdLibsJars
     },

--- a/build.sbt
+++ b/build.sbt
@@ -3721,7 +3721,9 @@ lazy val `engine-runner` = project
         `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `database-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
         `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `std-microsoft-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
+        `std-microsoft-polyglot-root`
+          .listFiles("*.jar")
+          .map(_.getAbsolutePath())
 
       core ++ stdLibsJars
     },

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -702,6 +702,18 @@ pub async fn runner_sanity_test(
             .run_ok()
             .await;
 
+        let test_aws = Command::new(&enso)
+                    .args(["--run", repo_root.test.join("AWS_Tests").as_str()])
+                    .set_env(ENSO_DATA_DIRECTORY, engine_package)?
+                    .run_ok()
+                    .await;
+
+        let test_microsoft = Command::new(&enso)
+                    .args(["--run", repo_root.test.join("Microsoft_Tests").as_str()])
+                    .set_env(ENSO_DATA_DIRECTORY, engine_package)?
+                    .run_ok()
+                    .await;
+
         let test_geo = Command::new(&enso)
             .args(["--run", repo_root.test.join("Geo_Tests").as_str()])
             .set_env(ENSO_DATA_DIRECTORY, engine_package)?
@@ -714,7 +726,7 @@ pub async fn runner_sanity_test(
             .run_ok()
             .await;
 
-        let all_cmds = test_base.and(test_internal_base).and(test_table).and(test_geo).and(test_image);
+        let all_cmds = test_base.and(test_internal_base).and(test_table).and(test_aws).and(test_microsoft).and(test_geo).and(test_image);
 
         // The following test does not actually run anything, it just checks if the engine
         // can accept `--jvm` argument and evaluates something.

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -703,16 +703,16 @@ pub async fn runner_sanity_test(
             .await;
 
         let test_aws = Command::new(&enso)
-                    .args(["--run", repo_root.test.join("AWS_Tests").as_str()])
-                    .set_env(ENSO_DATA_DIRECTORY, engine_package)?
-                    .run_ok()
-                    .await;
+            .args(["--run", repo_root.test.join("AWS_Tests").as_str()])
+            .set_env(ENSO_DATA_DIRECTORY, engine_package)?
+            .run_ok()
+            .await;
 
         let test_microsoft = Command::new(&enso)
-                    .args(["--run", repo_root.test.join("Microsoft_Tests").as_str()])
-                    .set_env(ENSO_DATA_DIRECTORY, engine_package)?
-                    .run_ok()
-                    .await;
+            .args(["--run", repo_root.test.join("Microsoft_Tests").as_str()])
+            .set_env(ENSO_DATA_DIRECTORY, engine_package)?
+            .run_ok()
+            .await;
 
         let test_geo = Command::new(&enso)
             .args(["--run", repo_root.test.join("Geo_Tests").as_str()])

--- a/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/resource-config.json
+++ b/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\QMETA-INF/java.sql.Driver\\E"
+  }]},
+  "bundles":[{
+    "name": "com.microsoft.sqlserver.jdbc.SQLServerResource"
+  }]
+}

--- a/test/Microsoft_Tests/README.md
+++ b/test/Microsoft_Tests/README.md
@@ -10,7 +10,7 @@ Please set the following environment variables:
 - 'ENSO_SQLSERVER_HOST' - the name of the server hosting SQLServer,
 - 'ENSO_SQLSERVER_PORT' - the port SQLServer is on,
 - 'ENSO_SQLSERVER_USER' - the user name to use to connect,
-- 'ENSO_SQLSERVER_PASSWORD' - the pasword for that user,
+- 'ENSO_SQLSERVER_PASSWORD' - the password for that user,
 - 'ENSO_SQLSERVER_DATABASE' - the database on the SQLServer to use.
 
 ## Docker


### PR DESCRIPTION
### Pull Request Description

`com.amazonaws` was required to be initialized at runtime due to logging being already present on that list.

Closes #12149 and #12150.
