### PR TITLE
Always attempt to resolve to a default edition

### DIFF
--- a/lib/scala/editions/src/main/scala/org/enso/editions/EditionResolver.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/EditionResolver.scala
@@ -6,7 +6,6 @@ import org.enso.editions.EditionResolutionError.{
 }
 import org.enso.editions.Editions.{RawEdition, ResolvedEdition}
 import org.enso.editions.provider.EditionProvider
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 
@@ -27,15 +26,7 @@ case class EditionResolver(provider: EditionProvider) {
   def resolve(
     edition: RawEdition
   ): Either[EditionResolutionError, ResolvedEdition] =
-    resolveEdition(edition, Nil).left.flatMap { err =>
-      LoggerFactory
-        .getLogger(classOf[EditionResolver])
-        .warn(
-          "Failed to resolve original edition. Trying fallback to the default one",
-          err
-        )
-      resolveEdition(DefaultEdition.getDefaultEdition, Nil).left.map(_ => err)
-    }
+    resolveEdition(edition, Nil)
 
   /** A helper method that resolves an edition and keeps a list of already
     * visited edition names to avoid cycles.

--- a/lib/scala/editions/src/main/scala/org/enso/editions/EditionResolver.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/EditionResolver.scala
@@ -6,6 +6,7 @@ import org.enso.editions.EditionResolutionError.{
 }
 import org.enso.editions.Editions.{RawEdition, ResolvedEdition}
 import org.enso.editions.provider.EditionProvider
+import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 
@@ -26,7 +27,15 @@ case class EditionResolver(provider: EditionProvider) {
   def resolve(
     edition: RawEdition
   ): Either[EditionResolutionError, ResolvedEdition] =
-    resolveEdition(edition, Nil)
+    resolveEdition(edition, Nil).left.flatMap { err =>
+      LoggerFactory
+        .getLogger(classOf[EditionResolver])
+        .warn(
+          "Failed to resolve original edition. Trying fallback to the default one",
+          err
+        )
+      resolveEdition(DefaultEdition.getDefaultEdition, Nil).left.map(_ => err)
+    }
 
   /** A helper method that resolves an edition and keeps a list of already
     * visited edition names to avoid cycles.

--- a/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
+++ b/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
@@ -1,7 +1,10 @@
 package org.enso.editions
 
 import org.enso.semver.SemVer
-import org.enso.editions.EditionResolutionError.EditionResolutionCycle
+import org.enso.editions.EditionResolutionError.{
+  CannotLoadEdition,
+  EditionResolutionCycle
+}
 import org.enso.editions.Editions.{RawEdition, Repository}
 import org.enso.editions.provider.{
   EditionLoadingError,
@@ -209,7 +212,7 @@ class EditionResolverSpec
       }
     }
 
-    "defer to default version when parent is missing" in new WithDefaultContext {
+    "not defer to default version when parent is missing" in new WithDefaultContext {
       ctx =>
       val localRepo = Repository("main", "http://example.com/local")
 
@@ -229,12 +232,9 @@ class EditionResolverSpec
         )
       )
 
-      inside(ctx.resolver.resolve(edition)) { case Right(resolved) =>
-        resolved.parent should be(defined)
-        resolved.engineVersion should not be defined
-        resolved.parent.get.engineVersion should equal(
-          Some(SemVer.of(0, 0, 0, "dev"))
-        )
+      inside(ctx.resolver.resolve(edition)) {
+        case Left(CannotLoadEdition(name, _)) =>
+          name shouldEqual "2020.2"
       }
     }
 

--- a/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
+++ b/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
@@ -2,7 +2,7 @@ package org.enso.editions
 
 import org.enso.semver.SemVer
 import org.enso.editions.EditionResolutionError.EditionResolutionCycle
-import org.enso.editions.Editions.Repository
+import org.enso.editions.Editions.{RawEdition, Repository}
 import org.enso.editions.provider.{
   EditionLoadingError,
   EditionNotFound,
@@ -17,9 +17,9 @@ class EditionResolverSpec
     with Matchers
     with Inside
     with OptionValues {
-  object FakeEditionProvider extends EditionProvider {
+  class FakeEditionProvider extends EditionProvider {
     val mainRepo = Repository("main", "https://example.com/main")
-    val editions: Map[String, Editions.RawEdition] = Map(
+    val _editions: Map[String, Editions.RawEdition] = Map(
       "2021.0" -> Editions.Raw.Edition(
         parent        = None,
         engineVersion = Some(SemVer.of(1, 2, 3)),
@@ -48,6 +48,7 @@ class EditionResolverSpec
         libraries     = Map()
       )
     )
+    def editions = _editions
 
     override def findEditionForName(
       name: String
@@ -58,7 +59,25 @@ class EditionResolverSpec
       editions.keys.toSeq
   }
 
-  val resolver = EditionResolver(FakeEditionProvider)
+  object FakeEditionProvider {
+    val mainRepo = Repository("main", "https://example.com/main")
+  }
+
+  class FakeEditionProviderWithDefault extends FakeEditionProvider {
+    override lazy val editions: Map[String, RawEdition] =
+      super.editions + ("0.0.0-dev" -> Editions.Raw.Edition(
+        parent        = None,
+        engineVersion = Some(SemVer.of(0, 0, 0, "dev")),
+        repositories  = Map(),
+        libraries     = Map()
+      ))
+  }
+
+  class WithDefaultContext {
+    val resolver = EditionResolver(new FakeEditionProviderWithDefault)
+  }
+
+  val resolver = EditionResolver(new FakeEditionProvider)
 
   "EditionResolver" should {
     "resolve a simple edition" in {
@@ -189,5 +208,35 @@ class EditionResolverSpec
         editions shouldEqual Seq("cycleA", "cycleB", "cycleA")
       }
     }
+
+    "defer to default version when parent is missing" in new WithDefaultContext {
+      ctx =>
+      val localRepo = Repository("main", "http://example.com/local")
+
+      localRepo should not equal FakeEditionProvider.mainRepo
+
+      val edition = Editions.Raw.Edition(
+        parent        = Some("2020.2"),
+        engineVersion = None,
+        repositories  = Map("main" -> localRepo),
+        libraries = Map(
+          LibraryName("foo", "bar") -> Editions.Raw
+            .PublishedLibrary(
+              LibraryName("foo", "bar"),
+              SemVer.of(1, 2, 3),
+              "main"
+            )
+        )
+      )
+
+      inside(ctx.resolver.resolve(edition)) { case Right(resolved) =>
+        resolved.parent should be(defined)
+        resolved.engineVersion should not be defined
+        resolved.parent.get.engineVersion should equal(
+          Some(SemVer.of(0, 0, 0, "dev"))
+        )
+      }
+    }
+
   }
 }


### PR DESCRIPTION
### Pull Request Description

It appears that we still fail when some old edition is requested and ignore the default editions.
This changes adds (a last one?) fallback to the default edition.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
