### PR TITLE
[WIP] Implement IRComparator in tests

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparator.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparator.java
@@ -5,13 +5,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.Empty;
+import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Name;
 import org.enso.test.utils.IRDumperTestWrapper;
+import scala.jdk.javaapi.CollectionConverters;
 
 public final class IRComparator {
   private final String name;
   private final boolean compareMeta;
   private final IRDumperTestWrapper dumper = new IRDumperTestWrapper();
+  private IR expectedRoot;
+  private IR actualRoot;
 
   private IRComparator(String name, boolean compareMeta) {
     this.name = name;
@@ -24,8 +29,8 @@ public final class IRComparator {
 
   /**
    * Compares IRs and dumps the diff the {@code actualIR} IR does not match the {@code expectedIR}
-   * one. IRs are compared recursively. {@code expectedIR} IR can have {@link SkipIR} nodes. When
-   * the {@link IRComparator} encounters {@link SkipIR} node in the {@code expectedIR} IR, the
+   * one. IRs are compared recursively. {@code expectedIR} IR can have {@link org.enso.compiler.core.ir.Empty} nodes. When
+   * the {@link IRComparator} encounters {@link org.enso.compiler.core.ir.Empty} node in the {@code expectedIR} IR, the
    * corresponding subtree in the {@code actualIR} IR is skipped.
    *
    * <p>Traverses the IRs in the BFS order.
@@ -37,13 +42,15 @@ public final class IRComparator {
    * @param actualIR
    */
   public void compare(IR expectedIR, IR actualIR) throws IRComparisonFailure {
+    expectedRoot = expectedIR;
+    actualRoot = actualIR;
     var nodesToProcess = new ArrayDeque<NodePair>();
     nodesToProcess.add(new NodePair(expectedIR, actualIR));
     while (!nodesToProcess.isEmpty()) {
       var nodePairToProcess = nodesToProcess.poll();
       var expected = nodePairToProcess.expected;
       var actual = nodePairToProcess.actual;
-      if (expected instanceof SkipIR) {
+      if (expected instanceof Empty) {
         continue;
       }
       compareTwoNodes(expected, actual);
@@ -106,10 +113,37 @@ public final class IRComparator {
   }
 
   private IRComparisonFailure fail(String msg, IR expected, IR actual) {
-    dumper.dump(expected, name, "expected");
-    dumper.dump(actual, name, "actual");
+    dumper.dump(expectedRoot, name, "expected");
+    dumper.dump(actualRoot, name, "actual");
     System.err.println("Dumped expected and actual IRs to IGV with name " + name);
     return new IRComparisonFailure(msg, expected, actual);
+  }
+
+  private IR copyRootWithSwap(IR root, Expression node, Expression replacement) {
+    var duplRoot = root.duplicate(false, false, false, false);
+    var nodesToProcess = new ArrayDeque<IR>();
+    nodesToProcess.add(duplRoot);
+    while (!nodesToProcess.isEmpty()) {
+      var nodeToProcess = nodesToProcess.poll();
+      if (nodeToProcess == node) {
+
+      }
+    }
+  }
+
+  private IR replaceChild(IR node, int childIdx, IR replacement) {
+    var children = node.children();
+    var newChildren = new ArrayList<IR>();
+    for (var i = 0; i < children.size(); i++) {
+      if (childIdx == i) {
+        newChildren.add(replacement);
+      } else {
+        newChildren.add(children.apply(i));
+      }
+    }
+    // Replace via reflection
+    var newChildrenList = CollectionConverters.asScala(newChildren).toList();
+    throw new UnsupportedOperationException("unimplemented");
   }
 
   private record NodePair(IR expected, IR actual) {}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparator.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparator.java
@@ -1,0 +1,139 @@
+package org.enso.compiler.test.ircompare;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.Name;
+import org.enso.test.utils.IRDumperTestWrapper;
+
+public final class IRComparator {
+  private final String name;
+  private final boolean compareMeta;
+  private final IRDumperTestWrapper dumper = new IRDumperTestWrapper();
+
+  private IRComparator(String name, boolean compareMeta) {
+    this.name = name;
+    this.compareMeta = compareMeta;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Compares IRs and dumps the diff the {@code actualIR} IR does not match the {@code expectedIR}
+   * one. IRs are compared recursively. {@code expectedIR} IR can have {@link SkipIR} nodes. When
+   * the {@link IRComparator} encounters {@link SkipIR} node in the {@code expectedIR} IR, the
+   * corresponding subtree in the {@code actualIR} IR is skipped.
+   *
+   * <p>Traverses the IRs in the BFS order.
+   *
+   * <p>If the comparison fails, the diff is dumped to the {@link IRDumperTestWrapper IGV}. And
+   * {@link IRComparisonFailure} is thrown.
+   *
+   * @param expectedIR Can have {@link SkipIR} nodes.
+   * @param actualIR
+   */
+  public void compare(IR expectedIR, IR actualIR) throws IRComparisonFailure {
+    var nodesToProcess = new ArrayDeque<NodePair>();
+    nodesToProcess.add(new NodePair(expectedIR, actualIR));
+    while (!nodesToProcess.isEmpty()) {
+      var nodePairToProcess = nodesToProcess.poll();
+      var expected = nodePairToProcess.expected;
+      var actual = nodePairToProcess.actual;
+      if (expected instanceof SkipIR) {
+        continue;
+      }
+      compareTwoNodes(expected, actual);
+      var children = zipChildren(expected, actual);
+      nodesToProcess.addAll(children);
+    }
+  }
+
+  private void compareTwoNodes(IR expectedNode, IR actualNode) throws IRComparisonFailure {
+    assert !(expectedNode instanceof SkipIR);
+    var expectedClass = expectedNode.getClass().getName();
+    var actualClass = actualNode.getClass().getName();
+    if (!expectedClass.equals(actualClass)) {
+      throw fail(
+          "Expected node class " + expectedClass + " but got " + actualClass,
+          expectedNode,
+          actualNode);
+    }
+    var expectedChildrenCnt = expectedNode.children().size();
+    var actualChildrenCnt = actualNode.children().size();
+    if (expectedChildrenCnt != actualChildrenCnt) {
+      throw fail(
+          "Expected node to have " + expectedChildrenCnt + " children but got " + actualChildrenCnt,
+          expectedNode,
+          actualNode);
+    }
+    switch (expectedNode) {
+      case Name lit -> compareTwoNodes(lit, (Name) actualNode);
+      default -> {}
+    }
+  }
+
+  private void compareTwoNodes(Name expectedName, Name actualName) {
+    if (!expectedName.name().equals(actualName.name())) {
+      throw fail(
+          "Expected Name " + expectedName.name() + " but got " + actualName.name(),
+          expectedName,
+          actualName);
+    }
+    if (expectedName.isMethod() != actualName.isMethod()) {
+      throw fail(
+          "isMethod is different: expected: "
+              + expectedName.isMethod()
+              + " vs actual: "
+              + actualName.isMethod(),
+          expectedName,
+          actualName);
+    }
+  }
+
+  private static List<NodePair> zipChildren(IR expected, IR actual) {
+    assert expected.children().size() == actual.children().size();
+    var children = new ArrayList<NodePair>();
+    for (var i = 0; i < expected.children().size(); i++) {
+      var expectedChild = expected.children().apply(i);
+      var actualChild = actual.children().apply(i);
+      children.add(new NodePair(expectedChild, actualChild));
+    }
+    return children;
+  }
+
+  private IRComparisonFailure fail(String msg, IR expected, IR actual) {
+    dumper.dump(expected, name, "expected");
+    dumper.dump(actual, name, "actual");
+    System.err.println("Dumped expected and actual IRs to IGV with name " + name);
+    return new IRComparisonFailure(msg, expected, actual);
+  }
+
+  private record NodePair(IR expected, IR actual) {}
+
+  public static final class Builder {
+    private String name;
+    private boolean compareMeta = false;
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder compareMeta(boolean value) {
+      this.compareMeta = value;
+      return this;
+    }
+
+    public IRComparator build() {
+      Objects.requireNonNull(name);
+      if (compareMeta) {
+        throw new IllegalArgumentException("Meta comparison is not supported yet");
+      }
+      return new IRComparator(name, compareMeta);
+    }
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparisonFailure.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/IRComparisonFailure.java
@@ -1,0 +1,22 @@
+package org.enso.compiler.test.ircompare;
+
+import org.enso.compiler.core.IR;
+
+public final class IRComparisonFailure extends AssertionError {
+  private final IR expected;
+  private final IR actual;
+
+  public IRComparisonFailure(String message, IR expected, IR actual) {
+    super(message);
+    this.expected = expected;
+    this.actual = actual;
+  }
+
+  public IR getExpected() {
+    return expected;
+  }
+
+  public IR getActual() {
+    return actual;
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/SkipIR.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/SkipIR.java
@@ -1,0 +1,75 @@
+package org.enso.compiler.test.ircompare;
+
+import java.util.UUID;
+import java.util.function.Function;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.Identifier;
+import org.enso.compiler.core.ir.DiagnosticStorage;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.IdentifiedLocation;
+import org.enso.compiler.core.ir.MetadataStorage;
+import scala.Option;
+import scala.collection.immutable.List;
+
+/**
+ * An IR node, whose subtree is skipped by {@link IRComparator}.
+ */
+public final class SkipIR implements Expression {
+  public static final SkipIR INSTANCE = new SkipIR();
+
+  private SkipIR() {}
+
+  @Override
+  public MetadataStorage passData() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public IdentifiedLocation identifiedLocation() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public Expression setLocation(Option<IdentifiedLocation> location) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public Expression mapExpressions(Function<Expression, Expression> fn) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public List<IR> children() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public @Identifier UUID getId() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public DiagnosticStorage diagnostics() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public DiagnosticStorage getDiagnostics() {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public Expression duplicate(
+      boolean keepLocations,
+      boolean keepMetadata,
+      boolean keepDiagnostics,
+      boolean keepIdentifiers) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public String showCode(int indent) {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/TestComparator.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ircompare/TestComparator.java
@@ -1,0 +1,49 @@
+package org.enso.compiler.test.ircompare;
+
+import static scala.jdk.javaapi.CollectionConverters.asScala;
+
+import java.util.List;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.MetadataStorage;
+import org.enso.compiler.core.ir.Name;
+import org.junit.Test;
+import scala.Option;
+
+public final class TestComparator {
+  @Test
+  public void compareSingleNodes() {
+    var expectedLit = lit("foo", false);
+    var actualLit = lit("foo", false);
+    var comparator = buildComparator("compareSingleNodes");
+    comparator.compare(expectedLit, actualLit);
+  }
+
+  @Test
+  public void compareBlocks() {
+    var expectedBlock = block(List.of(), lit("foo", false));
+    var actualBlock = block(List.of(), lit("foo", false));
+    var comparator = buildComparator("compareBLocks");
+    comparator.compare(expectedBlock, actualBlock);
+  }
+
+  @Test
+  public void compareBlocksWithSkip() {
+    var expected = block(List.of(SkipIR.INSTANCE), lit("foo", false));
+    var actual = block(List.of(lit("XXX", false)), lit("foo", false));
+    var comparator = buildComparator("compareBlocksWithSkip");
+    comparator.compare(expected, actual);
+  }
+
+  private static Name.Literal lit(String name, boolean isMethod) {
+    return new Name.Literal(name, isMethod, null, Option.empty(), new MetadataStorage());
+  }
+
+  private static Expression.Block block(List<Expression> expressions, Expression returnExpr) {
+    return new Expression.Block(
+        asScala(expressions).toList(), returnExpr, null, false, new MetadataStorage());
+  }
+
+  private static IRComparator buildComparator(String name) {
+    return IRComparator.builder().name(name).build();
+  }
+}

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/NestedPatternMatchTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/NestedPatternMatchTest.scala
@@ -3,10 +3,11 @@ package org.enso.compiler.test.pass.desugar
 import org.enso.compiler.Passes
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
 import org.enso.compiler.core.ir.expression.Case
-import org.enso.compiler.core.ir.{Expression, Literal, Module, Name, Pattern}
+import org.enso.compiler.core.ir.{Empty, Expression, Literal, Module, Name, Pattern}
 import org.enso.compiler.pass.desugar.NestedPatternMatch
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
-import org.enso.compiler.test.CompilerTest
+import org.enso.compiler.test.ircompare.{IRComparator}
+import org.enso.compiler.test.{CompilerTest}
 
 class NestedPatternMatchTest extends CompilerTest {
 
@@ -341,5 +342,88 @@ class NestedPatternMatchTest extends CompilerTest {
         .name shouldEqual "Nil"
       consANilBranch2Expr.branches.head.terminalBranch shouldBe true
     }
+  }
+
+  "Simple nested pattern desugaring" should {
+    implicit val ctx: InlineContext = mkInlineContext
+
+    // IGV graph: https://github.com/user-attachments/assets/b5387e61-e577-4b03-8a4a-ca05e27f2462
+    "One nested pattern" in {
+      val ir =
+        """
+          |case x of
+          |    Cons (Nested a) -> num
+          |""".stripMargin.preprocessExpression.get
+      val processed = ir.desugar
+
+      val expectedIR = Expression.Block(
+        expressions = List(
+          Expression.Binding(
+            name = lit("<internal-0>"),
+            expression = emptyIR(),
+            identifiedLocation = null
+          )
+        ),
+        returnValue = Case.Expr(
+          scrutinee = lit("<internal-10>"),
+          branches = List(
+            Case.Branch(
+              pattern = Pattern.Constructor(
+                constructor = lit("Cons"),
+                fields = List(
+                  Pattern.Name(lit("<internal-1>"), identifiedLocation = null)
+                ),
+                identifiedLocation = null
+              ),
+              expression = Expression.Block(
+                expressions = List(
+                  Expression.Binding(
+                    name = lit("<internal-2>"),
+                    expression = emptyIR(),
+                    identifiedLocation = null
+                  ),
+                ),
+                returnValue = Case.Expr(
+                  scrutinee = lit("<internal-2>"),
+                  branches = List(
+                    Case.Branch(
+                      pattern = Pattern.Constructor(
+                        constructor = lit("Nested"),
+                        fields = List(
+                          Pattern.Name(lit("a"), identifiedLocation = null)
+                        ),
+                        identifiedLocation = null
+                      ),
+                      expression = lit("num"),
+                      terminalBranch = true,
+                      identifiedLocation = null
+                    )
+                  ),
+                  isNested = true,
+                  identifiedLocation = null
+                ),
+                identifiedLocation = null
+              ),
+              identifiedLocation = null,
+              terminalBranch = false
+            ),
+          ),
+          isNested = false,
+          identifiedLocation = null
+        ),
+        identifiedLocation = null
+      )
+
+      val comparator = IRComparator.builder().name("One nested pattern").build()
+      comparator.compare(expectedIR, processed)
+    }
+  }
+
+  private def lit(name: String): Name.Literal = {
+    Name.Literal(name = name, isMethod = false, identifiedLocation = null)
+  }
+
+  private def emptyIR(): Empty = {
+    new Empty(null)
   }
 }


### PR DESCRIPTION
### Pull Request Description

All over the compiler tests, we are testing the compiled IR with something like https://github.com/enso-org/enso/blob/24638b7ec9a2412611f5265e4b5c589369f86ddd/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/NestedPatternMatchTest.scala#L155-L183 which seems very cryptic.

When working on #11717 and #12061, it struck me that it could be useful to have a better IR comparison functionality in tests. More specifically, we could provide an expected IR object, compare it to the actual IR, and in case of a failure, we could dump the difference to IGV with #12061. In this PR, I have attempted to provide such functionality.

The problem is that the difference dumped to IGV when there is a test failure on 24638b7ec9a2412611f5265e4b5c589369f86ddd is not useful:
![image](https://github.com/user-attachments/assets/fe684dae-379b-4039-a9fb-3057355df7cb)

In these two graphs, there is actually a single node different - `Name.Literal('<internal-10>')`, but the diff shows us that the whole graph is different. To make this better and only highlight a single changed node, we need a functionality to replace children. More specifically, we need to duplicate the expected IR, and only replace a single node in the IR. That is, currently, impossible. But it could be possible after all our IR definitions are [generated by an annotation processor](https://github.com/enso-org/enso/pull/11770).

This PR is pushed to the repo, so that this idea is not forgotten.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
