### PR TITLE
Avoiding duplicated code inside of the with index and `-NoIndex` tasks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5125,9 +5125,9 @@ launcherDistributionRoot := packageBuilder.localArtifact("launcher") / "enso"
 projectManagerDistributionRoot :=
   packageBuilder.localArtifact("project-manager") / "enso"
 
-lazy val createEngineIndex =
+lazy val createStdLibsIndexes =
   taskKey[Unit]("Creates index files for standard libraries")
-createEnginePackage := {
+createStdLibsIndexes := {
   updateLibraryManifests.value
   buildEngineDistributionNoIndex.value
   val modulesToCopy    = componentModulesPaths.value
@@ -5143,11 +5143,11 @@ createEnginePackage := {
     cacheFactory   = cacheFactory.sub("stdlib"),
     log            = log
   )
-  log.info(s"Standard library indexes create for $root")
+  log.info(s"Standard library indexes create for $distributionRoot")
 }
 
-ThisBuild / createEngineIndex := {
-  createEngineIndex.result.value
+ThisBuild / createStdLibsIndexes := {
+  createStdLibsIndexes.result.value
 }
 
 lazy val createEnginePackageNoIndex =
@@ -5169,8 +5169,7 @@ createEnginePackageNoIndex := {
     editionName         = currentEdition,
     sourceStdlibVersion = stdLibVersion,
     targetStdlibVersion = targetStdlibVersion,
-    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value,
-    generateIndex       = false
+    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value
   )
   log.info(s"Engine package created at $root")
 }
@@ -5194,7 +5193,7 @@ buildEngineDistributionNoIndex := Def.taskIf {
 // of other tasks.
 ThisBuild / buildEngineDistributionNoIndex := {
   updateLibraryManifests.value
-  createEnginePackage.value
+  createEnginePackageNoIndex.value
 }
 
 lazy val shouldBuildNativeImage = taskKey[Boolean](
@@ -5233,8 +5232,8 @@ lazy val buildEngineDistribution =
   taskKey[Unit]("Builds the engine distribution")
 buildEngineDistribution := {
   buildEngineDistributionNoIndex.value
-  createEnginePackage.value
-  createEngineIndex.value
+  createEnginePackageNoIndex.value
+  createStdLibsIndexes.value
 }
 
 // This makes the buildEngineDistributionNoIndex task usable as a dependency

--- a/build.sbt
+++ b/build.sbt
@@ -5125,34 +5125,29 @@ launcherDistributionRoot := packageBuilder.localArtifact("launcher") / "enso"
 projectManagerDistributionRoot :=
   packageBuilder.localArtifact("project-manager") / "enso"
 
-lazy val createEnginePackage =
-  taskKey[Unit]("Creates the engine distribution package")
+lazy val createEngineIndex =
+  taskKey[Unit]("Creates index files for standard libraries")
 createEnginePackage := {
   updateLibraryManifests.value
   buildEngineDistributionNoIndex.value
-  val modulesToCopy = componentModulesPaths.value
-  val root          = engineDistributionRoot.value
-  val log           = streams.value.log
-  val cacheFactory  = streams.value.cacheStoreFactory
-  DistributionPackage.createEnginePackage(
-    distributionRoot    = root,
-    cacheFactory        = cacheFactory,
-    log                 = log,
-    jarModulesToCopy    = modulesToCopy,
-    graalVersion        = graalMavenPackagesVersion,
-    javaVersion         = graalVersion,
-    ensoVersion         = ensoVersion,
-    editionName         = currentEdition,
-    sourceStdlibVersion = stdLibVersion,
-    targetStdlibVersion = targetStdlibVersion,
-    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value,
-    generateIndex       = true
+  val modulesToCopy    = componentModulesPaths.value
+  val distributionRoot = engineDistributionRoot.value
+  val log              = streams.value.log
+  val cacheFactory     = streams.value.cacheStoreFactory
+
+  DistributionPackage.indexStdLibs(
+    stdLibVersion  = targetStdlibVersion,
+    ensoVersion    = ensoVersion,
+    stdLibRoot     = distributionRoot / "lib",
+    ensoExecutable = distributionRoot / "bin" / "enso",
+    cacheFactory   = cacheFactory.sub("stdlib"),
+    log            = log
   )
-  log.info(s"Engine package created at $root")
+  log.info(s"Standard library indexes create for $root")
 }
 
-ThisBuild / createEnginePackage := {
-  createEnginePackage.result.value
+ThisBuild / createEngineIndex := {
+  createEngineIndex.result.value
 }
 
 lazy val createEnginePackageNoIndex =
@@ -5199,25 +5194,7 @@ buildEngineDistributionNoIndex := Def.taskIf {
 // of other tasks.
 ThisBuild / buildEngineDistributionNoIndex := {
   updateLibraryManifests.value
-  val modulesToCopy = componentModulesPaths.value
-  val root          = engineDistributionRoot.value
-  val log           = streams.value.log
-  val cacheFactory  = streams.value.cacheStoreFactory
-  DistributionPackage.createEnginePackage(
-    distributionRoot    = root,
-    cacheFactory        = cacheFactory,
-    log                 = log,
-    jarModulesToCopy    = modulesToCopy,
-    graalVersion        = graalMavenPackagesVersion,
-    javaVersion         = graalVersion,
-    ensoVersion         = ensoVersion,
-    editionName         = currentEdition,
-    sourceStdlibVersion = stdLibVersion,
-    targetStdlibVersion = targetStdlibVersion,
-    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value,
-    generateIndex       = false
-  )
-  log.info(s"Engine package created at $root")
+  createEnginePackage.value
 }
 
 lazy val shouldBuildNativeImage = taskKey[Boolean](
@@ -5257,6 +5234,7 @@ lazy val buildEngineDistribution =
 buildEngineDistribution := {
   buildEngineDistributionNoIndex.value
   createEnginePackage.value
+  createEngineIndex.value
 }
 
 // This makes the buildEngineDistributionNoIndex task usable as a dependency

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -137,8 +137,7 @@ object DistributionPackage {
     editionName: String,
     sourceStdlibVersion: String,
     targetStdlibVersion: String,
-    targetDir: File,
-    generateIndex: Boolean
+    targetDir: File
   ): Unit = {
     copyDirectoryIncremental(
       file("distribution/engine/THIRD-PARTY"),
@@ -195,17 +194,6 @@ object DistributionPackage {
       graalVersion = graalVersion,
       javaVersion  = javaVersion
     )
-
-    if (generateIndex) {
-      indexStdLibs(
-        stdLibVersion  = targetStdlibVersion,
-        ensoVersion    = ensoVersion,
-        stdLibRoot     = distributionRoot / "lib",
-        ensoExecutable = distributionRoot / "bin" / "enso",
-        cacheFactory   = cacheFactory.sub("stdlib"),
-        log            = log
-      )
-    }
   }
 
   def indexStdLibs(


### PR DESCRIPTION
### Pull Request Description

I am seeing [CI failures like this one](https://github.com/enso-org/enso/actions/runs/13010150839/job/36285908565?pr=12163#step:8:1085):
```
java.io.FileNotFoundException: built-distribution/enso-engine-2025.1.1-dev-linux-amd64/enso-2025.1.1-dev/lib/Standard/Base/2025.1.1-dev/package.yaml (No such file or directory)
at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
at sbt.io.IO$.read(IO.scala:973)
at DistributionPackage$.fixLibraryManifest(DistributionPackage.scala:492)
at DistributionPackage$.$anonfun$copyLibraryCacheIncremental$2(DistributionPackage.scala:535)
at DistributionPackage$.$anonfun$copyLibraryCacheIncremental$2$adapted(DistributionPackage.scala:527)
at DistributionPackage$.$anonfun$copyLibraryCacheIncremental$1(DistributionPackage.scala:527)
at DistributionPackage$.$anonfun$copyLibraryCacheIncremental$1$adapted(DistributionPackage.scala:526)
at DistributionPackage$.copyLibraryCacheIncremental(DistributionPackage.scala:526)
at DistributionPackage$.createEnginePackage(DistributionPackage.scala:177)
```
I believe it was introduced recently when [bunch of tasks got duplicated](https://github.com/enso-org/enso/pull/12117/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R5145) in `build.sbt`. This change removes the duplication:
- `DistributionPackage.createEnginePackage` no longer build the indexes
- there is separete `DistributionPackage.indexStdLibs` function for that wrapped in `createStdLibsIndexes` task
- `buildEngineDistribution` just depends on all three sub tasks:
    - `buildEngineDistributionNoIndex`
    - `createEnginePackageNoIndex`
    - `createStdLibsIndexes`

This shall avoid a situation when two different tasks are mangling with the same package/libraries structure.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
     style guides.
- [x] CI will be green
