### PR TITLE
Expect failure when parsing external Qualified Names

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -10,8 +10,8 @@ import {
   makeStaticMethod,
 } from '@/stores/suggestionDatabase/mockSuggestion'
 import { assert } from '@/util/assert'
-import { parseAbsoluteProjectPath } from '@/util/projectPath'
-import { qnLastSegment, tryQualifiedName } from '@/util/qualifiedName'
+import { parseAbsoluteProjectPathRaw } from '@/util/projectPath'
+import { qnLastSegment } from '@/util/qualifiedName'
 import { expect, test } from 'vitest'
 import { type Opt } from 'ydoc-shared/util/data/opt'
 import { unwrap } from 'ydoc-shared/util/data/result'
@@ -42,7 +42,7 @@ test.each([
 
 function stdPath(path: string) {
   assert(path.startsWith('Standard.'))
-  return parseAbsoluteProjectPath(unwrap(tryQualifiedName(path)))
+  return unwrap(parseAbsoluteProjectPathRaw(path))
 }
 
 test('An Instance method is shown when self arg matches', () => {

--- a/app/gui/src/project-view/components/DocumentationPanel.vue
+++ b/app/gui/src/project-view/components/DocumentationPanel.vue
@@ -20,7 +20,7 @@ import { type Opt } from '@/util/data/opt'
 import { Ok } from '@/util/data/result'
 import type { Icon as IconName } from '@/util/iconMetadata/iconName'
 import { ProjectPath } from '@/util/projectPath'
-import { qnSlice } from '@/util/qualifiedName'
+import { qnSegments, qnSlice } from '@/util/qualifiedName'
 import { computed, watch } from 'vue'
 
 const props = defineProps<{ selectedEntry: SuggestionId | undefined; aiMode?: boolean }>()
@@ -99,7 +99,7 @@ watch(historyStack.current, (current) => {
 
 const breadcrumbs = computed<Breadcrumb[]>(() => {
   if (name.value) {
-    const segments = [...projectNames.pathSegments(name.value)]
+    const segments = [...qnSegments(projectNames.printProjectPath(name.value))]
     return segments.slice(1).map((s) => ({ label: s.toLowerCase() }))
   } else {
     return []
@@ -110,8 +110,8 @@ function handleBreadcrumbClick(index: number) {
   if (name.value) {
     const pathSlice = name.value.path ? qnSlice(name.value.path, 0, index) : Ok(undefined)
     if (pathSlice.ok) {
-      const qName = name.value.withPath(pathSlice.value)
-      const id = db.entries.findByProjectPath(qName)
+      const projectPathSlice = name.value.withPath(pathSlice.value)
+      const id = db.entries.findByProjectPath(projectPathSlice)
       if (id != null) {
         historyStack.record(id)
       }

--- a/app/gui/src/project-view/components/DocumentationPanel.vue
+++ b/app/gui/src/project-view/components/DocumentationPanel.vue
@@ -17,9 +17,10 @@ import type { SuggestionId } from '@/stores/suggestionDatabase/entry'
 import { suggestionDocumentationUrl } from '@/stores/suggestionDatabase/entry'
 import { tryGetIndex } from '@/util/data/array'
 import { type Opt } from '@/util/data/opt'
+import { Ok } from '@/util/data/result'
 import type { Icon as IconName } from '@/util/iconMetadata/iconName'
-import type { QualifiedName } from '@/util/qualifiedName'
-import { qnSegments, qnSlice } from '@/util/qualifiedName'
+import { ProjectPath } from '@/util/projectPath'
+import { qnSlice } from '@/util/qualifiedName'
 import { computed, watch } from 'vue'
 
 const props = defineProps<{ selectedEntry: SuggestionId | undefined; aiMode?: boolean }>()
@@ -58,9 +59,9 @@ const isPlaceholder = computed(() => documentation.value.kind === 'Placeholder')
 
 const projectNames = injectProjectNames()
 
-const name = computed<Opt<QualifiedName>>(() => {
+const name = computed<Opt<ProjectPath>>(() => {
   const docs = documentation.value
-  return docs.kind === 'Placeholder' ? null : projectNames.printProjectPath(docs.name)
+  return docs.kind === 'Placeholder' ? null : docs.name
 })
 
 // === Breadcrumbs ===
@@ -98,7 +99,7 @@ watch(historyStack.current, (current) => {
 
 const breadcrumbs = computed<Breadcrumb[]>(() => {
   if (name.value) {
-    const segments = qnSegments(name.value)
+    const segments = [...projectNames.pathSegments(name.value)]
     return segments.slice(1).map((s) => ({ label: s.toLowerCase() }))
   } else {
     return []
@@ -107,9 +108,10 @@ const breadcrumbs = computed<Breadcrumb[]>(() => {
 
 function handleBreadcrumbClick(index: number) {
   if (name.value) {
-    const qName = qnSlice(name.value, 0, index + 2)
-    if (qName.ok) {
-      const id = db.entries.findByProjectPath(projectNames.parseProjectPath(qName.value))
+    const pathSlice = name.value.path ? qnSlice(name.value.path, 0, index) : Ok(undefined)
+    if (pathSlice.ok) {
+      const qName = name.value.withPath(pathSlice.value)
+      const id = db.entries.findByProjectPath(qName)
       if (id != null) {
         historyStack.record(id)
       }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/__tests__/widgetFunctionCallInfo.test.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/__tests__/widgetFunctionCallInfo.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@/stores/suggestionDatabase/mockSuggestion'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
+import { unwrap } from '@/util/data/result'
 import { expect, test } from 'vitest'
 import { ref, type Ref } from 'vue'
 import { type Opt } from 'ydoc-shared/util/data/opt'
@@ -92,7 +93,7 @@ test.each`
         getExpressionInfo(astId) {
           if (subjectSpan != null && astId === id('subject')) {
             return {
-              typename: projectNames.parseProjectPath(subjectType),
+              typename: unwrap(projectNames.parseProjectPath(subjectType)),
               rawTypename: subjectType,
               methodCall: undefined,
               payload: { type: 'Value' },

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetTableEditor/__tests__/tableInputArgument.test.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetTableEditor/__tests__/tableInputArgument.test.ts
@@ -15,8 +15,7 @@ import { makeType } from '@/stores/suggestionDatabase/mockSuggestion'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
 import { type Identifier } from '@/util/ast/abstract'
-import { parseAbsoluteProjectPath } from '@/util/projectPath'
-import { tryQualifiedName } from '@/util/qualifiedName'
+import { parseAbsoluteProjectPathRaw } from '@/util/projectPath'
 import { GetContextMenuItems, GetMainMenuItems } from 'ag-grid-enterprise'
 import { expect, test, vi } from 'vitest'
 import { assertDefined } from 'ydoc-shared/util/assert'
@@ -43,7 +42,7 @@ assert(CELLS_LIMIT_SQRT === Math.floor(CELLS_LIMIT_SQRT))
 
 function stdPath(path: string) {
   assert(path.startsWith('Standard.'))
-  return parseAbsoluteProjectPath(unwrap(tryQualifiedName(path)))
+  return unwrap(parseAbsoluteProjectPathRaw(path))
 }
 
 test.each([

--- a/app/gui/src/project-view/stores/graph/__tests__/imports.test.ts
+++ b/app/gui/src/project-view/stores/graph/__tests__/imports.test.ts
@@ -29,7 +29,7 @@ const qn = (s: string) => unwrap(tryQualifiedName(s))
 const projectNames = mockProjectNameStore('local', 'Project')
 
 function projectPath(path: string) {
-  return projectNames.parseProjectPath(unwrap(tryQualifiedName(path)))
+  return unwrap(projectNames.parseProjectPath(unwrap(tryQualifiedName(path))))
 }
 
 interface CoverCase {
@@ -142,7 +142,7 @@ test.each<CoverCase>([
   expect(
     covers(
       {
-        from: projectNames.parseProjectPath(existing.from),
+        from: unwrap(projectNames.parseProjectPath(existing.from)),
         imported: existing.imported,
       },
       required,
@@ -222,7 +222,7 @@ test.each<ConflictCase>([
   const conflicts = detectImportConflicts(
     db,
     alreadyImported.map(({ from, imported }) => ({
-      from: projectNames.parseProjectPath(from),
+      from: unwrap(projectNames.parseProjectPath(from)),
       imported,
     })),
     importing,

--- a/app/gui/src/project-view/stores/graph/index.ts
+++ b/app/gui/src/project-view/stores/graph/index.ts
@@ -276,7 +276,7 @@ export const [provideGraphStore, useGraphStore] = createContextStore(
         return
       }
       const topLevel = edit.getVersion(moduleRoot.value)
-      const existingImports = analyzeImports(topLevel, projectNames)
+      const existingImports = [...analyzeImports(topLevel, projectNames)]
 
       const conflicts = []
       const nonConflictingImports = []
@@ -306,7 +306,7 @@ export const [provideGraphStore, useGraphStore] = createContextStore(
         return
       }
       const topLevel = edit.getVersion(moduleRoot.value)
-      const existingImports_ = existingImports ?? analyzeImports(topLevel, projectNames)
+      const existingImports_ = existingImports ?? [...analyzeImports(topLevel, projectNames)]
 
       const importsToAdd = filterOutRedundantImports(existingImports_, imports)
       if (!importsToAdd.length) return

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from '@/stores/project/executionContext'
 import { mockProjectNameStore, type ProjectNameStore } from '@/stores/projectNames'
-import { unwrapOr } from '@/util/data/result'
+import { Ok, Result, unwrapOr } from '@/util/data/result'
 import { ReactiveDb, ReactiveIndex } from '@/util/database/reactiveDb'
 import { ANY_TYPE_QN } from '@/util/ensoTypes'
 import { parseMethodPointer, type MethodCall } from '@/util/methodPointer'
@@ -84,11 +84,21 @@ function updateInfo(
   if (newInfo.profilingInfo !== info.profilingInfo) info.profilingInfo = update.profilingInfo
 }
 
-function translateMethodCall(ls: LSMethodCall, projectNames: ProjectNameStore): MethodCall {
-  return {
-    methodPointer: parseMethodPointer(ls.methodPointer, projectNames),
+/**
+ * Translate the MethodCall retrieved from language server to our structure.
+ *
+ * The qualified names are validated and stored as {@link ProjectPath}s.
+ */
+export function translateMethodCall(
+  ls: LSMethodCall,
+  projectNames: ProjectNameStore,
+): Result<MethodCall> {
+  const methodPointer = parseMethodPointer(ls.methodPointer, projectNames)
+  if (!methodPointer.ok) return methodPointer
+  return Ok({
+    methodPointer: methodPointer.value,
     notAppliedArguments: ls.notAppliedArguments,
-  }
+  })
 }
 
 function combineInfo(
@@ -107,11 +117,16 @@ function combineInfo(
   if (typename && !typename.ok) {
     typename.error.log('Discarding invalid type in expression update')
   }
+  const newMethodCall =
+    update.methodCall ? translateMethodCall(update.methodCall, projectNames) : undefined
+  if (newMethodCall && !newMethodCall.ok) {
+    newMethodCall.error.log('Discarding invalid methodCall in expression update')
+  }
   return {
     typename: typename ? unwrapOr(typename, undefined) : undefined,
     rawTypename,
     methodCall:
-      update.methodCall ? translateMethodCall(update.methodCall, projectNames)
+      newMethodCall?.ok ? newMethodCall.value
       : isPending ? info?.methodCall
       : undefined,
     payload: update.payload,

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -109,7 +109,8 @@ function combineInfo(
   const isPending = update.payload.type === 'Pending'
   const updateSingleValueType = update.type.at(0) // TODO: support multi-value (aka intersection) types
   const rawTypename = updateSingleValueType ?? (isPending ? info?.rawTypename : undefined)
-  // TODO[ao]: why do we discard Any type here?
+  // As all objects descend from Any, we can treat Any as implicit. This reduces the depth of all type
+  // hierarchies that have to be stored and have to be walked when filtering.
   const typename =
     rawTypename && rawTypename !== ANY_TYPE_QN ?
       projectNames.parseProjectPathRaw(rawTypename)

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -1,10 +1,10 @@
 import type { ExecutionContext } from '@/stores/project/executionContext'
 import { mockProjectNameStore, type ProjectNameStore } from '@/stores/projectNames'
+import { unwrapOr } from '@/util/data/result'
 import { ReactiveDb, ReactiveIndex } from '@/util/database/reactiveDb'
 import { ANY_TYPE_QN } from '@/util/ensoTypes'
 import { parseMethodPointer, type MethodCall } from '@/util/methodPointer'
 import { type ProjectPath } from '@/util/projectPath'
-import { isQualifiedName } from '@/util/qualifiedName'
 import { markRaw } from 'vue'
 import type {
   ExpressionId,
@@ -99,11 +99,16 @@ function combineInfo(
   const isPending = update.payload.type === 'Pending'
   const updateSingleValueType = update.type.at(0) // TODO: support multi-value (aka intersection) types
   const rawTypename = updateSingleValueType ?? (isPending ? info?.rawTypename : undefined)
+  // TODO[ao]: why do we discard Any type here?
+  const typename =
+    rawTypename && rawTypename !== ANY_TYPE_QN ?
+      projectNames.parseProjectPathRaw(rawTypename)
+    : undefined
+  if (typename && !typename.ok) {
+    typename.error.log('Discarding invalid type in expression update')
+  }
   return {
-    typename:
-      rawTypename && isQualifiedName(rawTypename) && rawTypename !== ANY_TYPE_QN ?
-        projectNames.parseProjectPath(rawTypename)
-      : undefined,
+    typename: typename ? unwrapOr(typename, undefined) : undefined,
     rawTypename,
     methodCall:
       update.methodCall ? translateMethodCall(update.methodCall, projectNames)

--- a/app/gui/src/project-view/stores/projectNames.ts
+++ b/app/gui/src/project-view/stores/projectNames.ts
@@ -1,9 +1,8 @@
 import { createContextStore } from '@/providers'
 import { Ok, Result } from '@/util/data/result'
 import { parseAbsoluteProjectPath, ProjectPath } from '@/util/projectPath'
-import { normalizeQualifiedName, qnJoin, qnSegments, tryQualifiedName } from '@/util/qualifiedName'
+import { normalizeQualifiedName, qnJoin, tryQualifiedName } from '@/util/qualifiedName'
 import { type ToValue } from '@/util/reactivity'
-import { chain } from 'enso-common/src/utilities/data/iter'
 import { computed, readonly, ref, toRef, toValue } from 'vue'
 import { type Identifier, type QualifiedName } from 'ydoc-shared/ast'
 
@@ -78,12 +77,6 @@ function useProjectNameStore(
     return path.path ? qnJoin(project, path.path) : project
   }
 
-  function pathSegments(projectPath: ProjectPath) {
-    const project = projectPath.project ?? outboundProject.value
-    const pathSegments = projectPath.path ? qnSegments(projectPath.path) : []
-    return chain(qnSegments(project), pathSegments)
-  }
-
   return {
     parseProjectPath,
     parseProjectPathRaw,
@@ -99,7 +92,6 @@ function useProjectNameStore(
       }
     },
     displayName: readonly(toRef(displayName)),
-    pathSegments,
   }
 }
 

--- a/app/gui/src/project-view/stores/projectNames.ts
+++ b/app/gui/src/project-view/stores/projectNames.ts
@@ -1,7 +1,9 @@
 import { createContextStore } from '@/providers'
+import { Ok, Result } from '@/util/data/result'
 import { parseAbsoluteProjectPath, ProjectPath } from '@/util/projectPath'
-import { normalizeQualifiedName, qnJoin } from '@/util/qualifiedName'
+import { normalizeQualifiedName, qnJoin, qnSegments, tryQualifiedName } from '@/util/qualifiedName'
 import { type ToValue } from '@/util/reactivity'
+import { chain } from 'enso-common/src/utilities/data/iter'
 import { computed, readonly, ref, toRef, toValue } from 'vue'
 import { type Identifier, type QualifiedName } from 'ydoc-shared/ast'
 
@@ -36,11 +38,23 @@ function useProjectNameStore(
    * To ensure that QNs are interpreted correctly during and after project renames, this should be applied to data
    * from the backend as it is received.
    */
-  function parseProjectPath(path: QualifiedName): ProjectPath {
+  function parseProjectPath(path: QualifiedName): Result<ProjectPath> {
     const parsed = parseAbsoluteProjectPath(path)
-    return parsed.project === inboundProject.value ?
-        ProjectPath.create(undefined, parsed.path)
+    if (!parsed.ok) return parsed
+    return parsed.value.project === inboundProject.value ?
+        Ok(ProjectPath.create(undefined, parsed.value.path))
       : parsed
+  }
+
+  /**
+   * Interpret a string as a project path.
+   *
+   * Same as {@link parseProjectPath}, but the path is also checked for being an actual Qualified Name.
+   */
+  function parseProjectPathRaw(path: string): Result<ProjectPath> {
+    const qn = tryQualifiedName(path)
+    if (!qn.ok) return qn
+    return parseProjectPath(qn.value)
   }
 
   /**
@@ -64,8 +78,15 @@ function useProjectNameStore(
     return path.path ? qnJoin(project, path.path) : project
   }
 
+  function pathSegments(projectPath: ProjectPath) {
+    const project = projectPath.project ?? outboundProject.value
+    const pathSegments = projectPath.path ? qnSegments(projectPath.path) : []
+    return chain(qnSegments(project), pathSegments)
+  }
+
   return {
     parseProjectPath,
+    parseProjectPathRaw,
     printProjectPath,
     serializeProjectPathForBackend,
     onProjectRenameRequested: (newName: Identifier) => {
@@ -78,6 +99,7 @@ function useProjectNameStore(
       }
     },
     displayName: readonly(toRef(displayName)),
+    pathSegments,
   }
 }
 

--- a/app/gui/src/project-view/stores/suggestionDatabase/__tests__/documentation.test.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/__tests__/documentation.test.ts
@@ -2,8 +2,8 @@ import { mockProjectNameStore } from '@/stores/projectNames'
 import { getGroupIndex, tagValue } from '@/stores/suggestionDatabase/documentation'
 import { unwrap } from '@/util/data/result'
 import { parseDocs } from '@/util/docParser'
-import { parseAbsoluteProjectPath } from '@/util/projectPath'
-import { tryQualifiedName, type QualifiedName } from '@/util/qualifiedName'
+import { parseAbsoluteProjectPathRaw } from '@/util/projectPath'
+import { type QualifiedName } from '@/util/qualifiedName'
 import { expect, test } from 'vitest'
 
 test.each([
@@ -24,7 +24,7 @@ const groups = [
   { name: 'Another', project: 'local.Project' },
 ].map(({ name, project }) => ({
   name,
-  project: parseAbsoluteProjectPath(unwrap(tryQualifiedName(project))).project as QualifiedName,
+  project: unwrap(parseAbsoluteProjectPathRaw(project)).project as QualifiedName,
 }))
 test.each([
   ['From Base', 'local.Project.Main', undefined],
@@ -37,7 +37,7 @@ test.each([
   ['Not Existing', 'local.Project.Main', undefined],
 ])('Get group index case %#.', (name, definedIn, expected) => {
   const definedInQn =
-    projectNames.parseProjectPath(unwrap(tryQualifiedName(definedIn))).project ??
+    unwrap(projectNames.parseProjectPathRaw(definedIn)).project ??
     ('local.Project' as QualifiedName)
   expect(getGroupIndex(name, definedInQn, groups)).toBe(expected)
 })

--- a/app/gui/src/project-view/stores/suggestionDatabase/__tests__/lsUpdate.test.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/__tests__/lsUpdate.test.ts
@@ -5,7 +5,7 @@ import { SuggestionUpdateProcessor } from '@/stores/suggestionDatabase/lsUpdate'
 import { assert, assertDefined } from '@/util/assert'
 import { unwrap } from '@/util/data/result'
 import { parseDocs } from '@/util/docParser'
-import { parseAbsoluteProjectPath, ProjectPath } from '@/util/projectPath'
+import { parseAbsoluteProjectPathRaw, ProjectPath } from '@/util/projectPath'
 import {
   tryIdentifier,
   tryQualifiedName,
@@ -18,7 +18,7 @@ import { type SuggestionsDatabaseUpdate } from 'ydoc-shared/languageServerTypes/
 
 function stdPath(path: string) {
   assert(path.startsWith('Standard.'))
-  return parseAbsoluteProjectPath(unwrap(tryQualifiedName(path)))
+  return unwrap(parseAbsoluteProjectPathRaw(path))
 }
 
 const projectNames = mockProjectNameStore()

--- a/app/gui/src/project-view/util/__tests__/callTree.test.ts
+++ b/app/gui/src/project-view/util/__tests__/callTree.test.ts
@@ -389,7 +389,7 @@ test.each<ArgsTestCase>([
 
 function stdPath(path: string) {
   assert(path.startsWith('Standard.'))
-  return parseAbsoluteProjectPath(unwrap(tryQualifiedName(path)))
+  return unwrap(parseAbsoluteProjectPath(unwrap(tryQualifiedName(path))))
 }
 
 function prepareMocksForGetMethodCallTest(): {

--- a/app/gui/src/project-view/util/__tests__/projectPath.test.ts
+++ b/app/gui/src/project-view/util/__tests__/projectPath.test.ts
@@ -1,4 +1,5 @@
 import { mockProjectNameStore } from '@/stores/projectNames'
+import { unwrap } from '@/util/data/result'
 import { ProjectPath } from '@/util/projectPath'
 import { type QualifiedName } from '@/util/qualifiedName'
 import { expect, test } from 'vitest'
@@ -29,7 +30,7 @@ const cases = [
 const projectNames = mockProjectNameStore()
 
 test.each(cases)('Parse', ({ qn, path }) => {
-  expect(projectNames.parseProjectPath(qn).toJSON()).toStrictEqual(path.toJSON())
+  expect(unwrap(projectNames.parseProjectPath(qn)).toJSON()).toStrictEqual(path.toJSON())
 })
 
 test.each(cases)('Normalize', ({ path, normalized }) => {

--- a/app/gui/src/project-view/util/__tests__/qualifiedName.test.ts
+++ b/app/gui/src/project-view/util/__tests__/qualifiedName.test.ts
@@ -81,7 +81,7 @@ test.each([
   ['local.Project.elem', true],
   ['local.Project.Module.elem', false],
 ])('pathIsTopElement(%s) returns %s', (name, result) => {
-  expect(projectNames.parseProjectPath(unwrap(tryQualifiedName(name))).isTopElement()).toBe(result)
+  expect(unwrap(projectNames.parseProjectPathRaw(name)).isTopElement()).toBe(result)
 })
 
 test.each([

--- a/app/gui/src/project-view/util/methodPointer.ts
+++ b/app/gui/src/project-view/util/methodPointer.ts
@@ -1,4 +1,5 @@
 import { type ProjectNameStore } from '@/stores/projectNames'
+import { Ok, Result } from '@/util/data/result'
 import { type ProjectPath } from '@/util/projectPath'
 import { type QualifiedName } from '@/util/qualifiedName'
 import * as encoding from 'lib0/encoding'
@@ -40,13 +41,17 @@ export function methodPointerEquals(left: MethodPointer, right: MethodPointer): 
 export function parseMethodPointer(
   ptr: LSMethodPointer,
   projectNames: ProjectNameStore,
-): MethodPointer {
+): Result<MethodPointer> {
   const { module, definedOnType, name } = ptr
-  return {
-    module: projectNames.parseProjectPath(module as QualifiedName),
-    definedOnType: projectNames.parseProjectPath(definedOnType as QualifiedName),
+  const parsedModule = projectNames.parseProjectPath(module as QualifiedName)
+  if (!parsedModule.ok) return parsedModule
+  const parsedDefinedOnType = projectNames.parseProjectPath(definedOnType as QualifiedName)
+  if (!parsedDefinedOnType.ok) return parsedDefinedOnType
+  return Ok({
+    module: parsedModule.value,
+    definedOnType: parsedDefinedOnType.value,
     name: name as Identifier,
-  }
+  })
 }
 
 export type StackItem = ExplicitCall | LocalCall

--- a/app/gui/src/project-view/util/projectPath.ts
+++ b/app/gui/src/project-view/util/projectPath.ts
@@ -2,6 +2,7 @@ import { Err, Ok, Result } from '@/util/data/result'
 import {
   qnJoin,
   qnSplit,
+  tryQualifiedName,
   type IdentifierOrOperatorIdentifier,
   type QualifiedName,
 } from '@/util/qualifiedName'
@@ -20,6 +21,13 @@ export function parseAbsoluteProjectPath(path: QualifiedName): Result<ProjectPat
       parts[2] ? (parts[2] as QualifiedName) : undefined,
     ),
   )
+}
+
+/** Parses the string as a literal project path. */
+export function parseAbsoluteProjectPathRaw(path: string): Result<ProjectPath> {
+  const qn = tryQualifiedName(path)
+  if (!qn.ok) return qn
+  return parseAbsoluteProjectPath(qn.value)
 }
 
 /** Prints a literal project path. */

--- a/app/gui/src/project-view/util/projectPath.ts
+++ b/app/gui/src/project-view/util/projectPath.ts
@@ -1,21 +1,24 @@
+import { Err, Ok, Result } from '@/util/data/result'
 import {
   qnJoin,
   qnSplit,
   type IdentifierOrOperatorIdentifier,
   type QualifiedName,
 } from '@/util/qualifiedName'
-import { assert, assertDefined } from 'ydoc-shared/util/assert'
+import { assertDefined } from 'ydoc-shared/util/assert'
 
 export type ProjectName = QualifiedName
 
 /** Parses the qualified name as a literal project path. */
-export function parseAbsoluteProjectPath(path: QualifiedName): ProjectPath {
+export function parseAbsoluteProjectPath(path: QualifiedName): Result<ProjectPath> {
   const parts = /^([^.]+\.[^.]+)(?:\.(.+))?$/.exec(path)
-  assert(parts != null)
+  if (parts == null) return Err(`${path} is not absolute project path`)
   assertDefined(parts[1])
-  return ProjectPath.create(
-    parts[1] as QualifiedName,
-    parts[2] ? (parts[2] as QualifiedName) : undefined,
+  return Ok(
+    ProjectPath.create(
+      parts[1] as QualifiedName,
+      parts[2] ? (parts[2] as QualifiedName) : undefined,
+    ),
   )
 }
 


### PR DESCRIPTION
### Pull Request Description

Fixes #12168 

Change `parseProjectPath` family of functions, so they return `Result`. Handle all translators from LS to handle cases when qualified names are not actual qualified name.

Fixed WildgetSelection, so it accepts qualified names which are not absolute.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
