### PR TITLE
Include Mac OS X aarch64 version of native lib of opencv

### DIFF
--- a/project/StdBits.scala
+++ b/project/StdBits.scala
@@ -198,7 +198,9 @@ object StdBits {
     */
   private def arch(): String = {
     val arch = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH)
-    arch.replace("amd64", "x86_64")
+    arch
+      .replace("amd64", "x86_64")
+      .replace("aarch64", "ARMv8")
   }
 
   private def updateDependency(


### PR DESCRIPTION
Fixes #12178 

### Pull Request Description

Include Mac OS X aarch64 version of native library in OpenCV. Previously, it was accidentally dropped from the distribution.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.f
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
