### PR TITLE
Fix artifact upload in benchmark jobs

### DIFF
--- a/.github/workflows/engine-benchmark.yml
+++ b/.github/workflows/engine-benchmark.yml
@@ -48,6 +48,11 @@ jobs:
       - run: ./run backend benchmark runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results.xml
+          path: engine/runtime-benchmarks/bench-report.xml
       - if: (always())
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/std-libs-benchmark.yml
+++ b/.github/workflows/std-libs-benchmark.yml
@@ -48,6 +48,11 @@ jobs:
       - run: ./run backend benchmark enso-jmh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results.xml
+          path: std-bits/benchmarks/bench-report.xml
       - if: (always())
         name: Clean after
         run: ./run git-clean

--- a/build_tools/build/src/ci_gen.rs
+++ b/build_tools/build/src/ci_gen.rs
@@ -831,16 +831,33 @@ pub fn extra_nightly_tests() -> Result<Workflow> {
 }
 
 pub fn engine_benchmark() -> Result<Workflow> {
-    benchmark_workflow("Benchmark Engine", "backend benchmark runtime", Some(4 * 60))
+    let report_path = "engine/runtime-benchmarks/bench-report.xml";
+    benchmark_workflow(
+        "Benchmark Engine",
+        "backend benchmark runtime",
+        report_path,
+        Some(4 * 60),
+    )
 }
 
 pub fn std_libs_benchmark() -> Result<Workflow> {
-    benchmark_workflow("Benchmark Standard Libraries", "backend benchmark enso-jmh", Some(4 * 60))
+    let report_path = "std-bits/benchmarks/bench-report.xml";
+    benchmark_workflow(
+        "Benchmark Standard Libraries",
+        "backend benchmark enso-jmh",
+        report_path,
+        Some(4 * 60),
+    )
 }
 
+/// #parameters
+/// - `name` - name of the workflow
+/// - `command_line` - command line to run the benchmarks
+/// - `artifact_to_upload` - Path to the artifact to upload
 fn benchmark_workflow(
     name: &str,
     command_line: &str,
+    artifact_to_upload: &str,
     timeout_minutes: Option<u32>,
 ) -> Result<Workflow> {
     let just_check_input_name = "just-check";
@@ -865,7 +882,8 @@ fn benchmark_workflow(
 
     let graal_edition = graalvm::Edition::Community;
     let job_name = format!("{name} ({graal_edition})");
-    let job = benchmark_job(&job_name, command_line, timeout_minutes, graal_edition);
+    let job =
+        benchmark_job(&job_name, command_line, artifact_to_upload, timeout_minutes, graal_edition);
     workflow.add_job(job);
 
     Ok(workflow)
@@ -874,11 +892,16 @@ fn benchmark_workflow(
 fn benchmark_job(
     job_name: &str,
     command_line: &str,
+    artifact_to_upload: &str,
     timeout_minutes: Option<u32>,
     graal_edition: graalvm::Edition,
 ) -> Job {
+    let upload_artifact_step = step::upload_artifact("Upload benchmark results")
+        .with_custom_argument("name", "benchmark-results.xml")
+        .with_custom_argument("path", artifact_to_upload);
     let mut job = RunStepsBuilder::new(command_line)
         .cleaning(CleaningCondition::Always)
+        .customize(move |step| vec![step, upload_artifact_step])
         .build_job(job_name, BenchmarkRunner);
     job.timeout_minutes = timeout_minutes;
     match graal_edition {

--- a/build_tools/build/src/ci_gen.rs
+++ b/build_tools/build/src/ci_gen.rs
@@ -832,12 +832,7 @@ pub fn extra_nightly_tests() -> Result<Workflow> {
 
 pub fn engine_benchmark() -> Result<Workflow> {
     let report_path = "engine/runtime-benchmarks/bench-report.xml";
-    benchmark_workflow(
-        "Benchmark Engine",
-        "backend benchmark runtime",
-        report_path,
-        Some(4 * 60),
-    )
+    benchmark_workflow("Benchmark Engine", "backend benchmark runtime", report_path, Some(4 * 60))
 }
 
 pub fn std_libs_benchmark() -> Result<Workflow> {

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -415,7 +415,9 @@ impl RunContext {
         }
 
         if is_in_env() {
-            // If we were running any benchmarks, they are complete by now. Upload the report.
+            // If we were running any benchmarks, they are complete by now.
+            // Just check whether the reports exist, the artifact upload is done in a
+            // separate step.
             for bench in &self.config.execute_benchmarks {
                 match bench {
                     Benchmarks::Runtime => {
@@ -425,13 +427,7 @@ impl RunContext {
                             .engine
                             .join("runtime-benchmarks")
                             .join("bench-report.xml");
-                        if runtime_bench_report.exists() {
-                            ide_ci::actions::artifacts::upload_single_file(
-                                runtime_bench_report,
-                                "Runtime Benchmark Report",
-                            )
-                            .await?;
-                        } else {
+                        if !runtime_bench_report.exists() {
                             warn!(
                                 "No Runtime Benchmark Report file found at {}, nothing to upload.",
                                 runtime_bench_report.display()
@@ -441,13 +437,7 @@ impl RunContext {
                     Benchmarks::EnsoJMH => {
                         let enso_jmh_report =
                             &self.paths.repo_root.std_bits.benchmarks.bench_report_xml;
-                        if enso_jmh_report.exists() {
-                            ide_ci::actions::artifacts::upload_single_file(
-                                enso_jmh_report,
-                                "Enso JMH Benchmark Report",
-                            )
-                            .await?;
-                        } else {
+                        if !enso_jmh_report.exists() {
                             warn!(
                                 "No Enso JMH Benchmark Report file found at {}, nothing to upload.",
                                 enso_jmh_report.display()

--- a/build_tools/ci_utils/src/actions/artifacts.rs
+++ b/build_tools/ci_utils/src/actions/artifacts.rs
@@ -84,7 +84,7 @@ fn upload(
     .boxed()
 }
 
-pub fn upload_single_file(
+fn upload_single_file(
     file: impl Into<PathBuf>,
     artifact_name: impl Into<String>,
 ) -> BoxFuture<'static, Result> {


### PR DESCRIPTION
Follow-up of #12210 - Remove call to deprecated upload_artifact from benchmark jobs

### Pull Request Description

Fixes benchmark jobs. Example of a recent failure is at https://github.com/enso-org/enso/actions/runs/13063541131/job/36451661359

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Ensure benchmarks run and upload their artifacts
- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
