### PR TITLE
Fix benchmark comparison in `bench_download.py` tool

### DIFF
--- a/tools/performance/engine-benchmarks/README.md
+++ b/tools/performance/engine-benchmarks/README.md
@@ -35,6 +35,11 @@ Run local tests with:
 python -m unittest --verbose bench_tool/test*.py
 ```
 
+Run a single test with:
+```bash
+python -m unittest --verbose bench_tool/test*.py -k <test_name>
+```
+
 ## Relation to GH Actions
 
 The `bench_download.py` script is used in

--- a/tools/performance/engine-benchmarks/bench_tool/__init__.py
+++ b/tools/performance/engine-benchmarks/bench_tool/__init__.py
@@ -58,9 +58,9 @@ class Source(Enum):
 
     def artifact_names(self) -> List[str]:
         if self == Source.ENGINE:
-            return ["Runtime Benchmark Report"]
+            return ["Runtime Benchmark Report", "benchmark-results.xml"]
         elif self == Source.STDLIB:
-            return ["Enso JMH Benchmark Report"]
+            return ["Enso JMH Benchmark Report", "benchmark-results.xml"]
         else:
             raise ValueError(f"Unknown source {self}")
 

--- a/tools/performance/engine-benchmarks/bench_tool/test_bench_results.py
+++ b/tools/performance/engine-benchmarks/bench_tool/test_bench_results.py
@@ -69,5 +69,21 @@ class TestBenchResults(unittest.IsolatedAsyncioTestCase):
             bench_report = await get_bench_report(bench_run, temp_dir, remote_cache)
             self.assertIsNotNone(bench_report)
             self.assertEqual(bench_run, bench_report.bench_run)
-            self.assertEqual(64, len(bench_report.label_score_dict))
+            self.assertEqual(70, len(bench_report.label_score_dict))
+    
+    async def test_get_new_bench_report(self):
+        # Artifact names changed on 2025-02-03 - in PR https://github.com/enso-org/enso/pull/12226
+        # This test ensures that the artifact names were correctly updated
+        since = datetime.fromisoformat("2025-02-03")
+        until = datetime.fromisoformat("2025-02-05")
+        bench_runs = await get_bench_runs(since, until, "develop", ENGINE_BENCH_WORKFLOW_ID)
+        self.assertGreater(len(bench_runs), 0)
+        bench_run = bench_runs[0]
+        remote_cache = ReadonlyRemoteCache()
+        with WithTempDir("test_get_bench_report") as temp_dir:
+            bench_report = await get_bench_report(bench_run, temp_dir, remote_cache)
+            self.assertIsNotNone(bench_report)
+            self.assertEqual(bench_run, bench_report.bench_run)
+            self.assertEqual(80, len(bench_report.label_score_dict))
+
 

--- a/tools/performance/engine-benchmarks/bench_tool/test_bench_results.py
+++ b/tools/performance/engine-benchmarks/bench_tool/test_bench_results.py
@@ -46,8 +46,8 @@ class TestBenchResults(unittest.IsolatedAsyncioTestCase):
         Bench run does not need remote cache - it fetches just some metadata about GH artifacts.
         :return:
         """
-        since = datetime.fromisoformat("2023-10-01")
-        until = datetime.fromisoformat("2023-10-05")
+        since = datetime.fromisoformat("2024-10-01")
+        until = datetime.fromisoformat("2024-10-05")
         bench_runs = await get_bench_runs(since, until, "develop", ENGINE_BENCH_WORKFLOW_ID)
         self.assertGreater(len(bench_runs), 0)
         bench_run = bench_runs[0]
@@ -58,9 +58,9 @@ class TestBenchResults(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_bench_report(self):
         # We choose an old date on purpose, so that the remote cache must be used, and is thus
-        # transitively tested.
-        since = datetime.fromisoformat("2023-10-01")
-        until = datetime.fromisoformat("2023-10-05")
+        # transitively tested. Note that GH deletes workflow runs that are older than 2 years.
+        since = datetime.fromisoformat("2024-10-01")
+        until = datetime.fromisoformat("2024-10-05")
         bench_runs = await get_bench_runs(since, until, "develop", ENGINE_BENCH_WORKFLOW_ID)
         self.assertGreater(len(bench_runs), 0)
         bench_run = bench_runs[0]

--- a/tools/performance/engine-benchmarks/bench_tool/test_website_regen.py
+++ b/tools/performance/engine-benchmarks/bench_tool/test_website_regen.py
@@ -17,8 +17,8 @@ class TestWebsiteRegen(unittest.IsolatedAsyncioTestCase):
         remote_cache = SyncRemoteCache(self.LOCAL_REPO_ROOT)
         # Pull the repo if necessary
         await remote_cache.initialize()
-        since = datetime.fromisoformat("2023-10-01")
-        until = datetime.fromisoformat("2023-10-25")
+        since = datetime.fromisoformat("2024-10-01")
+        until = datetime.fromisoformat("2024-10-25")
         with WithTempDir("test_engine_website_regen") as temp_dir:
             temp_dir_path = Path(temp_dir)
             html_out = temp_dir_path.joinpath("engine-benchs.html")


### PR DESCRIPTION
### Pull Request Description

`./bench_download.py` tool stopped working after https://github.com/enso-org/enso/pull/12226. Because the artifacts on benchmark workflow runs were renamed. This PR just renames the artifacts (suggested in https://github.com/enso-org/enso/pull/12201#issuecomment-2635659249) and also adds some unit tests.

In many unit tests, I had to bump the date of the fetched data, because GH seems to delete workflow runs that are older than 2 years.

Note that yesterday, [Benchmark Upload](https://github.com/enso-org/enso/actions/workflows/bench-upload.yml) workflow started printing a [warning that there is an unknown artifact name](https://github.com/enso-org/enso/actions/runs/13152367074/job/36701982751#step:6:1116)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
