### PR TITLE
Enable ydoc-server tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -390,6 +390,7 @@ lazy val enso = (project in file("."))
     `text-buffer`,
     `version-output`,
     `ydoc-polyfill`,
+    `ydoc-server`,
     `zio-wrapper`
   )
   .settings(Global / concurrentRestrictions += Tags.exclusive(Exclusive))

--- a/project/Ydoc.scala
+++ b/project/Ydoc.scala
@@ -5,8 +5,11 @@ import scala.sys.process.*
 
 object Ydoc {
 
+  private val corepackCommand =
+    if (Platform.isWindows) "corepack.cmd" else "corepack"
+
   private val pnpmCommand =
-    if (Platform.isWindows) "corepack.cmd pnpm" else "corepack pnpm"
+    s"$corepackCommand pnpm"
 
   /** Generates the bundled JS source of the Ydoc server.
     *
@@ -53,10 +56,11 @@ object Ydoc {
           ydocServerResourceManaged / "org" / "enso" / "ydoc" / "server" / "ydoc.cjs"
 
         if (changed) {
-          val command = s"$pnpmCommand build:ydoc-server-polyglot"
-          streams.log.info(command)
-          val exitCode = command ! streams.log
+          runCommand(s"$corepackCommand --version", streams)
+          runCommand(s"$pnpmCommand --version", streams)
 
+          val command = s"$pnpmCommand build:ydoc-server-polyglot"
+          val exitCode = runCommand(command, streams)
           if (exitCode != 0) {
             throw new CommandFailed(command, exitCode)
           }
@@ -87,9 +91,11 @@ object Ydoc {
       case (changed, _) =>
         val nodeModules = base / "node_modules"
         if (changed || !nodeModules.isDirectory) {
+          runCommand(s"$corepackCommand --version", streams)
+          runCommand(s"$pnpmCommand --version", streams)
+
           val command = s"$pnpmCommand i --frozen-lockfile"
-          streams.log.info(command)
-          val exitCode = command ! streams.log
+          val exitCode = runCommand(command, streams)
           if (exitCode != 0) {
             throw new CommandFailed(command, exitCode)
           }
@@ -99,6 +105,17 @@ object Ydoc {
     val inputFile = base / "pnpm-lock.json"
 
     generator(inputFile)
+  }
+
+  /** Run command printing the output to the log stream.
+    *
+    * @param command the command to run
+    * @param streams the build streams
+    * @return exit code
+    */
+  private def runCommand(command: String, streams: TaskStreams): Int = {
+    streams.log.info(command)
+    command ! streams.log
   }
 
   final private class CommandFailed(command: String, exitCode: Int)

--- a/project/Ydoc.scala
+++ b/project/Ydoc.scala
@@ -59,7 +59,7 @@ object Ydoc {
           runCommand(s"$corepackCommand --version", streams)
           runCommand(s"$pnpmCommand --version", streams)
 
-          val command = s"$pnpmCommand build:ydoc-server-polyglot"
+          val command  = s"$pnpmCommand build:ydoc-server-polyglot"
           val exitCode = runCommand(command, streams)
           if (exitCode != 0) {
             throw new CommandFailed(command, exitCode)
@@ -94,7 +94,7 @@ object Ydoc {
           runCommand(s"$corepackCommand --version", streams)
           runCommand(s"$pnpmCommand --version", streams)
 
-          val command = s"$pnpmCommand i --frozen-lockfile"
+          val command  = s"$pnpmCommand i --frozen-lockfile"
           val exitCode = runCommand(command, streams)
           if (exitCode != 0) {
             throw new CommandFailed(command, exitCode)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Enable `ydoc-server` tests after `corepack` is fixed in #12249

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
