### PR TITLE
Include Standard.Google_Api in NI

### DIFF
--- a/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/jni-config.json
+++ b/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/jni-config.json
@@ -1,0 +1,249 @@
+[
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.ChannelException"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion",
+        "fields": [
+            {
+                "name": "file"
+            },
+            {
+                "name": "transferred"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.LinuxSocket"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.Native"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+        "fields": [
+            {
+                "name": "count"
+            },
+            {
+                "name": "memoryAddress"
+            },
+            {
+                "name": "recipientAddr"
+            },
+            {
+                "name": "recipientAddrLen"
+            },
+            {
+                "name": "recipientPort"
+            },
+            {
+                "name": "recipientScopeId"
+            },
+            {
+                "name": "segmentSize"
+            },
+            {
+                "name": "senderAddr"
+            },
+            {
+                "name": "senderAddrLen"
+            },
+            {
+                "name": "senderPort"
+            },
+            {
+                "name": "senderScopeId"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeStaticallyReferencedJniMethods"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.Buffer"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "byte[]",
+                    "int",
+                    "int",
+                    "int",
+                    "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "byte[]",
+                    "int",
+                    "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "int",
+                    "int",
+                    "int[]"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.Socket"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.ssl.OpenSslClientSessionCache"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.ssl.OpenSslSessionCache",
+        "methods": [
+            {
+                "name": "getSession",
+                "parameterTypes": [
+                    "long",
+                    "byte[]"
+                ]
+            },
+            {
+                "name": "sessionCreated",
+                "parameterTypes": [
+                    "long",
+                    "long"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.ssl.ReferenceCountedOpenSslClientContext$ExtendedTrustManagerVerifyCallback"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.ssl.ReferenceCountedOpenSslContext$AbstractCertificateVerifier",
+        "methods": [
+            {
+                "name": "verify",
+                "parameterTypes": [
+                    "long",
+                    "byte[][]",
+                    "java.lang.String"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.Buffer"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCallbackTask",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "long",
+                    "byte[]",
+                    "byte[][]",
+                    "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCallback"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifierTask",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "long",
+                    "byte[][]",
+                    "java.lang.String",
+                    "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.Library"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSL"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLContext"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "long",
+                    "byte[]",
+                    "io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "long",
+                    "int",
+                    "byte[]",
+                    "io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
+        "fields": [
+            {
+                "name": "resultBytes"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLSession"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLTask",
+        "fields": [
+            {
+                "name": "complete"
+            },
+            {
+                "name": "returnValue"
+            }
+        ]
+    }
+]

--- a/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/reflect-config.json
+++ b/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/reflect-config.json
@@ -1,0 +1,951 @@
+[
+    {
+        "name": "com.google.api.client.googleapis.javanet.GoogleNetHttpTransport"
+    },
+    {
+        "name": "com.google.api.client.json.gson.GsonFactory"
+    },
+    {
+        "name": "com.google.api.services.sheets.v4.Sheets",
+        "methods": [
+            {
+                "name": "spreadsheets"
+            }
+        ]
+    },
+    {
+        "name": "com.google.api.services.sheets.v4.Sheets.Builder"
+    },
+    {
+        "name": "com.google.api.services.sheets.v4.Sheets$Builder",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "com.google.api.client.http.HttpTransport",
+                    "com.google.api.client.json.JsonFactory",
+                    "com.google.api.client.http.HttpRequestInitializer"
+                ]
+            },
+            {
+                "name": "setApplicationName",
+                "parameterTypes": [
+                    "java.lang.String"
+                ]
+            },
+            {
+                "name": "build"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.census.InternalCensusStatsAccessor"
+    },
+    {
+        "name": "io.grpc.census.InternalCensusTracingAccessor"
+    },
+    {
+        "name": "io.grpc.internal.DnsNameResolverProvider"
+    },
+    {
+        "name": "io.grpc.internal.JndiResourceResolverFactory",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.internal.PickFirstLoadBalancerProvider"
+    },
+    {
+        "name": "io.grpc.internal.SerializingExecutor",
+        "fields": [
+            {
+                "name": "runState"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.NettyChannelProvider"
+    },
+    {
+        "name": "io.grpc.netty.UdsNettyChannelProvider"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.AbstractNettyHandler",
+        "methods": [
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler",
+        "methods": [
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "close",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "write",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.ProtocolNegotiators"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ClientTlsHandler"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$GrpcNegotiationHandler",
+        "methods": [
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ProtocolNegotiationHandler",
+        "methods": [
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$WaitUntilActiveHandler",
+        "methods": [
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.grpc.netty.WriteBufferingAndExceptionHandler",
+        "methods": [
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRead",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "close",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "connect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            },
+            {
+                "name": "flush",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "write",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.buffer.AbstractByteBufAllocator",
+        "queryAllDeclaredMethods": true
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.buffer.AbstractReferenceCountedByteBuf",
+        "fields": [
+            {
+                "name": "refCnt"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext",
+        "fields": [
+            {
+                "name": "handlerState"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.ChannelDuplexHandler",
+        "methods": [
+            {
+                "name": "bind",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "close",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "connect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "deregister",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "disconnect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "flush",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "read",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "write",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.ChannelInboundHandlerAdapter",
+        "methods": [
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRead",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "channelReadComplete",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRegistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelUnregistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelWritabilityChanged",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            },
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.ChannelOutboundBuffer",
+        "fields": [
+            {
+                "name": "totalPendingSize"
+            },
+            {
+                "name": "unwritable"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultChannelConfig",
+        "fields": [
+            {
+                "name": "autoRead"
+            },
+            {
+                "name": "writeBufferWaterMark"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline",
+        "fields": [
+            {
+                "name": "estimatorHandle"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext",
+        "methods": [
+            {
+                "name": "bind",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRead",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "channelReadComplete",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRegistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelUnregistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelWritabilityChanged",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "close",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "connect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "deregister",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "disconnect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            },
+            {
+                "name": "flush",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "read",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "write",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$TailContext",
+        "methods": [
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRead",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "channelReadComplete",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelRegistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelUnregistered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelWritabilityChanged",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            },
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.Epoll",
+        "methods": [
+            {
+                "name": "isAvailable",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "int",
+                    "java.util.concurrent.ThreadFactory"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollServerSocketChannel",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor",
+        "fields": [
+            {
+                "name": "state"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder",
+        "methods": [
+            {
+                "name": "channelRead",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            },
+            {
+                "name": "userEventTriggered",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler",
+        "methods": [
+            {
+                "name": "bind",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "channelReadComplete",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelWritabilityChanged",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "connect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "deregister",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "disconnect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "flush",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "read",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler",
+        "methods": [
+            {
+                "name": "bind",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "channelActive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelInactive",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "channelReadComplete",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "close",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "connect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.net.SocketAddress",
+                    "java.net.SocketAddress",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "deregister",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "disconnect",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            },
+            {
+                "name": "exceptionCaught",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Throwable"
+                ]
+            },
+            {
+                "name": "flush",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "read",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"
+                ]
+            },
+            {
+                "name": "write",
+                "parameterTypes": [
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext",
+                    "java.lang.Object",
+                    "io.grpc.netty.shaded.io.netty.channel.ChannelPromise"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCallback"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCallbackTask"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLContext"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodTask"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLTask"
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.AbstractReferenceCounted",
+        "fields": [
+            {
+                "name": "refCnt"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.DefaultAttributeMap",
+        "fields": [
+            {
+                "name": "attributes"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.Recycler$DefaultHandle",
+        "fields": [
+            {
+                "name": "state"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil",
+        "queryAllDeclaredMethods": true
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.concurrent.DefaultPromise",
+        "fields": [
+            {
+                "name": "result"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor",
+        "fields": [
+            {
+                "name": "state"
+            },
+            {
+                "name": "threadProperties"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryUtil",
+        "methods": [
+            {
+                "name": "loadLibrary",
+                "parameterTypes": [
+                    "java.lang.String",
+                    "boolean"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+        "fields": [
+            {
+                "name": "producerLimit"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+        "fields": [
+            {
+                "name": "consumerIndex"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+        "fields": [
+            {
+                "name": "producerIndex"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+        "fields": [
+            {
+                "name": "consumerIndex"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+        "fields": [
+            {
+                "name": "producerIndex"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+        "fields": [
+            {
+                "name": "producerLimit"
+            }
+        ]
+    },
+    {
+        "name": "io.grpc.okhttp.OkHttpChannelProvider"
+    },
+    {
+        "name": "io.grpc.override.ContextStorageOverride"
+    },
+    {
+        "name": "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": []
+            }
+        ]
+    }
+]

--- a/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/resource-config.json
+++ b/std-bits/google-api/src/main/resources/META-INF/native-image/org/enso/google/resource-config.json
@@ -1,0 +1,25 @@
+{
+    "resources": {
+        "includes": [
+            {
+                "pattern": "\\QMETA-INF/services/com.google.auth.http.HttpTransportFactory\\E"
+            },
+            {
+                "pattern": "\\QMETA-INF/services/io.grpc.LoadBalancerProvider\\E"
+            },
+            {
+                "pattern": "\\QMETA-INF/services/io.grpc.ManagedChannelProvider\\E"
+            },
+            {
+                "pattern": "\\QMETA-INF/services/io.grpc.NameResolverProvider\\E"
+            },
+            {
+                "pattern": "\\Qcom/google/api/client/googleapis/google-api-client.properties\\E"
+            },
+            {
+                "pattern": "\\Qcom/google/api/client/googleapis/google.p12\\E"
+            }
+        ]
+    },
+    "bundles": []
+}

--- a/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/resource-config.json
+++ b/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/resource-config.json
@@ -1,7 +1,7 @@
 {
   "resources":{
   "includes":[{
-    "pattern":"\\QMETA-INF/java.sql.Driver\\E"
+    "pattern":"\\QMETA-INF/services/java.sql.Driver\\E"
   }]},
   "bundles":[{
     "name": "com.microsoft.sqlserver.jdbc.SQLServerResource"

--- a/test/Google_Api_Test/src/Main.enso
+++ b/test/Google_Api_Test/src/Main.enso
@@ -1,9 +1,7 @@
 from Standard.Base import all
-import Standard.Google_Api
+from Standard.Google_Api import all
 
 from Standard.Test import all
-
-
 
 main filter=Nothing =
     suite = Test.build suite_builder->
@@ -12,11 +10,10 @@ main filter=Nothing =
 
 
 add_specs suite_builder =
-    secret = enso_project.data / 'secret.json'
-    api = Google_Api.initialize secret
-
     suite_builder.group "Google Spreadsheets" group_builder->
         group_builder.specify "should allow downloading a spreadsheet" <|
+            secret = enso_project.data / 'secret.json'
+            api = Google_Sheets.initialize secret
             sheet_id = '1WjVQhYdc04RwdWB22RNLgfQiLeWYhxiij1_xj22RDq0'
             sheet_range = 'Sheet1!A1:B6'
             table = api.spreadsheets.get_table sheet_id sheet_range
@@ -24,3 +21,8 @@ add_specs suite_builder =
             table.at 'Foo' . to_vector . should_equal [1,2,3,4,5]
             table.at 'Bar' . to_vector . should_equal ["hello", "world", "foo", "bar", "baz"]
 
+    suite_builder.group "Google Analytics" group_builder->
+        group_builder.specify "should allow downloading a spreadsheet" <|
+            secret = enso_project.data / 'secret.json'
+            accounts = Google_Analytics.list_accounts secret
+            accounts.length . should_equal 1


### PR DESCRIPTION
### Pull Request Description

This change adds the last remaining Standard library to Native Image. We extract native libraries from `grpc-netty-shaded` jar to minimize the size of the resulting jar. NI test is not run on purpose as test/Google_Api_Test is currently semi-working.

### Important Notes

Including `Google_Api` adds ~90MB to Native Image.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
