### PR TITLE
Move static expression methods to enso

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
@@ -1,0 +1,14 @@
+from Standard.Base import all
+
+type Expression_Statics
+    ## Obtains the current date from the system clock in the system timezone.
+    today -> Date =
+        Date.today
+    
+    ## Obtains the current date-time from the system clock in the system timezone.
+    now -> Date_Time =
+        Date_Time.now
+
+    ## Obtains the current time from the system clock in the default time-zone.
+    time -> Time_Of_Day =
+        Time_Of_Day.now

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -58,8 +59,10 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     private final boolean isVariableArgumentMethod;
     private final boolean isStaticMethod;
     private final Value staticsType;
+    private final String name;
 
     public Method(Value module, Value type, String name, boolean variableArgumentMethod) {
+      this.name = name;
       var context = Context.getCurrent().getBindings("enso");
       final Value staticsModule =
           context.invokeMember("get_module", "Standard.Table.Expression_Statics");
@@ -80,20 +83,40 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       }
     }
 
-    public Value getEnsoMethod() {
-      return ensoMethod;
+    public Value execute(Value[] args, Function<Value, Value> wrapAsColumn)
+    {
+      Object[] objects = prepareArguments(args, wrapAsColumn);
+      try {
+        var result = ensoMethod.execute(objects);
+        if (result.canExecute()) {
+          throw new IllegalArgumentException("Insufficient arguments for method " + name + ".");
+        }
+        return result;
+      } catch (PolyglotException e) {
+        if (e.getMessage().startsWith("Type error: expected a function")) {
+          throw new IllegalArgumentException("Too many arguments for method " + name + ".");
+        }
+        throw e;
+      }
     }
 
-    public boolean isVariableArgumentMethod() {
-      return isVariableArgumentMethod;
+    public Object[] prepareArguments(Value[] args, Function<Value, Value> wrapAsColumn) {
+    Object[] objects;
+    if (isVariableArgumentMethod) {
+      objects = new Object[2];
+      objects[0] = wrapAsColumn.apply(args[0]);
+      objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
+    } else if (isStaticMethod) {
+      // The static method takes the type as the synthetic 'self' argument, so we need to prepend
+      // it:
+      objects = new Object[args.length + 1];
+      objects[0] = staticsType;
+      System.arraycopy(args, 0, objects, 1, args.length);
+    } else {
+      objects = Arrays.copyOf(args, args.length, Object[].class);
+      objects[0] = wrapAsColumn.apply(args[0]);
     }
-
-    public boolean isStaticMethod() {
-      return isStaticMethod;
-    }
-
-    public Value getStaticsType() {
-      return staticsType;
+      return objects;
     }
   }
 
@@ -171,38 +194,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
 
   private Value executeMethod(String name, Value... args) {
     var method = getMethod.apply(name);
-    Object[] objects = prepareArguments(method, args);
-    try {
-      var result = method.getEnsoMethod().execute(objects);
-      if (result.canExecute()) {
-        throw new IllegalArgumentException("Insufficient arguments for method " + name + ".");
-      }
-      return makeConstantColumn.apply(result);
-    } catch (PolyglotException e) {
-      if (e.getMessage().startsWith("Type error: expected a function")) {
-        throw new IllegalArgumentException("Too many arguments for method " + name + ".");
-      }
-      throw e;
-    }
-  }
-
-  private Object[] prepareArguments(Method method, Value[] args) {
-    Object[] objects;
-    if (method.isVariableArgumentMethod()) {
-      objects = new Object[2];
-      objects[0] = wrapAsColumn(args[0]);
-      objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
-    } else if (method.isStaticMethod()) {
-      // The static method takes the type as the synthetic 'self' argument, so we need to prepend
-      // it:
-      objects = new Object[args.length + 1];
-      objects[0] = method.getStaticsType();
-      System.arraycopy(args, 0, objects, 1, args.length);
-    } else {
-      objects = Arrays.copyOf(args, args.length, Object[].class);
-      objects[0] = wrapAsColumn(args[0]);
-    }
-    return objects;
+    Value result = method.execute(args, c->wrapAsColumn(c));
+    return makeConstantColumn.apply(result);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -54,7 +53,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     }
   }
 
-    private static Value wrapAsColumn(Value value, Function<Object, Value> makeConstantColumn) {
+  private static Value wrapAsColumn(Value value, Function<Object, Value> makeConstantColumn) {
     if (value.isNull()) {
       return makeConstantColumn.apply(value);
     }
@@ -96,8 +95,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       }
     }
 
-    public Value execute(Value[] args, Function<Object, Value> makeConstantColumn)
-    {
+    public Value execute(Value[] args, Function<Object, Value> makeConstantColumn) {
       Object[] objects = prepareArguments(args, makeConstantColumn);
       try {
         var result = ensoMethod.execute(objects);
@@ -114,21 +112,21 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     }
 
     public Object[] prepareArguments(Value[] args, Function<Object, Value> makeConstantColumn) {
-    Object[] objects;
-    if (isVariableArgumentMethod) {
-      objects = new Object[2];
-      objects[0] = wrapAsColumn(args[0], makeConstantColumn);
-      objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
-    } else if (isStaticMethod) {
-      // The static method takes the type as the synthetic 'self' argument, so we need to prepend
-      // it:
-      objects = new Object[args.length + 1];
-      objects[0] = staticsType;
-      System.arraycopy(args, 0, objects, 1, args.length);
-    } else {
-      objects = Arrays.copyOf(args, args.length, Object[].class);
-      objects[0] = wrapAsColumn(args[0], makeConstantColumn);
-    }
+      Object[] objects;
+      if (isVariableArgumentMethod) {
+        objects = new Object[2];
+        objects[0] = wrapAsColumn(args[0], makeConstantColumn);
+        objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
+      } else if (isStaticMethod) {
+        // The static method takes the type as the synthetic 'self' argument, so we need to prepend
+        // it:
+        objects = new Object[args.length + 1];
+        objects[0] = staticsType;
+        System.arraycopy(args, 0, objects, 1, args.length);
+      } else {
+        objects = Arrays.copyOf(args, args.length, Object[].class);
+        objects[0] = wrapAsColumn(args[0], makeConstantColumn);
+      }
       return objects;
     }
   }

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -1,15 +1,13 @@
 package org.enso.table.expressions;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -56,6 +54,50 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     }
   }
 
+  public static class Method {
+    private final Value ensoMethod;
+    private final boolean isVariableArgumentMethod;
+    private final boolean isStaticMethod;
+    private final Value staticsType;
+
+    public Method(Value module, Value type, String name, boolean variableArgumentMethod) {
+      var context = Context.getCurrent().getBindings("enso");
+      final Value staticsModule =
+          context.invokeMember("get_module", "Standard.Table.Expression_Statics");
+      this.staticsType = staticsModule.invokeMember("get_type", "Expression_Statics");
+      this.isVariableArgumentMethod = variableArgumentMethod;
+
+      var staticMethod = staticsModule.invokeMember("get_method", staticsType, name);
+      if (staticMethod.canExecute()) {
+        this.isStaticMethod = true;
+        this.ensoMethod = staticMethod;
+      } else {
+        var instanceMethod = module.invokeMember("get_method", type, name);
+        if (!instanceMethod.canExecute()) {
+          throw new UnsupportedOperationException("Method not found: " + name);
+        }
+        this.isStaticMethod = false;
+        this.ensoMethod = instanceMethod;
+      }
+    }
+
+    public Value getEnsoMethod() {
+      return ensoMethod;
+    }
+
+    public boolean isVariableArgumentMethod() {
+      return isVariableArgumentMethod;
+    }
+
+    public boolean isStaticMethod() {
+      return isStaticMethod;
+    }
+
+    public Value getStaticsType() {
+      return staticsType;
+    }
+  }
+
   public static Value evaluate(
       String expression,
       Function<String, Value> getColumn,
@@ -67,26 +109,22 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     var context = Context.getCurrent().getBindings("enso");
     final Value module = context.invokeMember("get_module", moduleName);
     final Value type = module.invokeMember("get_type", typeName);
-    Function<String, Value> getMethod = name -> module.invokeMember("get_method", type, name);
+    final var setVariableArgumentFunctions =
+        new HashSet<>(Arrays.asList(variableArgumentFunctions));
+    Function<String, Method> getMethod =
+        name -> new Method(module, type, name, setVariableArgumentFunctions.contains(name));
     Function<String, Value> makeConstructor =
         name -> module.invokeMember("eval_expression", ".." + name);
 
-    return evaluateImpl(
-        expression,
-        getColumn,
-        makeConstantColumn,
-        getMethod,
-        makeConstructor,
-        variableArgumentFunctions);
+    return evaluateImpl(expression, getColumn, makeConstantColumn, getMethod, makeConstructor);
   }
 
   public static Value evaluateImpl(
       String expression,
       Function<String, Value> getColumn,
       Function<Object, Value> makeConstantColumn,
-      Function<String, Value> getMethod,
-      Function<String, Value> makeConstructor,
-      String[] variableArgumentFunctions) {
+      Function<String, Method> getMethod,
+      Function<String, Value> makeConstructor) {
     var lexer = new ExpressionLexer(CharStreams.fromString(expression));
     lexer.removeErrorListeners();
     lexer.addErrorListener(ThrowOnErrorListener.INSTANCE);
@@ -97,8 +135,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     parser.addErrorListener(ThrowOnErrorListener.INSTANCE);
 
     var visitor =
-        new ExpressionVisitorImpl(
-            getColumn, makeConstantColumn, getMethod, makeConstructor, variableArgumentFunctions);
+        new ExpressionVisitorImpl(getColumn, makeConstantColumn, getMethod, makeConstructor);
 
     var expr = parser.prog();
     return visitor.visit(expr);
@@ -106,21 +143,18 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
 
   private final Function<String, Value> getColumn;
   private final Function<Object, Value> makeConstantColumn;
-  private final Function<String, Value> getMethod;
+  private final Function<String, Method> getMethod;
   private final Function<String, Value> makeConstructor;
-  private final Set<String> variableArgumentFunctions;
 
   private ExpressionVisitorImpl(
       Function<String, Value> getColumn,
       Function<Object, Value> makeConstantColumn,
-      Function<String, Value> getMethod,
-      Function<String, Value> makeConstructor,
-      String[] variableArgumentFunctions) {
+      Function<String, Method> getMethod,
+      Function<String, Value> makeConstructor) {
     this.getColumn = getColumn;
     this.makeConstantColumn = makeConstantColumn;
     this.getMethod = getMethod;
     this.makeConstructor = makeConstructor;
-    this.variableArgumentFunctions = new HashSet<>(Arrays.asList(variableArgumentFunctions));
   }
 
   private Value wrapAsColumn(Value value) {
@@ -137,23 +171,10 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   }
 
   private Value executeMethod(String name, Value... args) {
-    Value method = getMethod.apply(name);
-    if (!method.canExecute()) {
-      throw new UnsupportedOperationException(name);
-    }
-
-    Object[] objects;
-    if (this.variableArgumentFunctions.contains(name)) {
-      objects = new Object[2];
-      objects[0] = args[0];
-      objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
-    } else {
-      objects = Arrays.copyOf(args, args.length, Object[].class);
-    }
-    objects[0] = wrapAsColumn(args[0]);
-
+    var method = getMethod.apply(name);
+    Object[] objects = prepareArguments(method, args);
     try {
-      var result = method.execute(objects);
+      var result = method.getEnsoMethod().execute(objects);
       if (result.canExecute()) {
         throw new IllegalArgumentException("Insufficient arguments for method " + name + ".");
       }
@@ -164,6 +185,25 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       }
       throw e;
     }
+  }
+
+  private Object[] prepareArguments(Method method, Value[] args) {
+    Object[] objects;
+    if (method.isVariableArgumentMethod()) {
+      objects = new Object[2];
+      objects[0] = wrapAsColumn(args[0]);
+      objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
+    } else if (method.isStaticMethod()) {
+      // The static method takes the module as the synthetic 'self' argument, so we need to prepend
+      // it:
+      objects = new Object[args.length + 1];
+      objects[0] = method.getStaticsType();
+      System.arraycopy(args, 0, objects, 1, args.length);
+    } else {
+      objects = Arrays.copyOf(args, args.length, Object[].class);
+      objects[0] = wrapAsColumn(args[0]);
+    }
+    return objects;
   }
 
   @Override
@@ -410,11 +450,6 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   public Value visitFunction(ExpressionParser.FunctionContext ctx) {
     var name = ctx.IDENTIFIER().getText().toLowerCase();
     var args = ctx.expr().stream().map(this::visit).toArray(Value[]::new);
-    return switch (name) {
-      case "today" -> Value.asValue(LocalDate.now());
-      case "now" -> Value.asValue(LocalDateTime.now().atZone(ZoneId.systemDefault()));
-      case "time" -> Value.asValue(LocalTime.now());
-      default -> executeMethod(name, args);
-    };
+    return executeMethod(name, args);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -66,32 +66,36 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
         : value;
   }
 
-  public static class Method {
-    private final Value ensoMethod;
-    private final boolean isVariableArgumentMethod;
-    private final boolean isStaticMethod;
-    private final Value staticsType;
-    private final String name;
+  public interface MethodInterface {
+    Value execute(Value[] args, Function<Object, Value> makeConstantColumn);
 
-    public Method(Value module, Value type, String name, boolean variableArgumentMethod) {
-      this.name = name;
+    Object[] prepareArguments(Value[] args, Function<Object, Value> makeConstantColumn);
+  }
+
+  public record Method(
+      Value ensoMethod, boolean isVariableArgumentMethod, boolean isStaticMethod, String name)
+      implements MethodInterface {
+
+    private static final Value STATICS_MODULE;
+    private static final Value STATICS_TYPE;
+
+    static {
       var context = Context.getCurrent().getBindings("enso");
-      final Value staticsModule =
-          context.invokeMember("get_module", "Standard.Table.Expression_Statics");
-      this.staticsType = staticsModule.invokeMember("get_type", "Expression_Statics");
-      this.isVariableArgumentMethod = variableArgumentMethod;
+      STATICS_MODULE = context.invokeMember("get_module", "Standard.Table.Expression_Statics");
+      STATICS_TYPE = STATICS_MODULE.invokeMember("get_type", "Expression_Statics");
+    }
 
-      var staticMethod = staticsModule.invokeMember("get_method", staticsType, name);
+    public static Method create(
+        Value module, Value type, String name, boolean variableArgumentMethod) {
+      var staticMethod = STATICS_MODULE.invokeMember("get_method", STATICS_TYPE, name);
       if (staticMethod.canExecute()) {
-        this.isStaticMethod = true;
-        this.ensoMethod = staticMethod;
+        return new Method(staticMethod, variableArgumentMethod, true, name);
       } else {
         var instanceMethod = module.invokeMember("get_method", type, name);
         if (!instanceMethod.canExecute()) {
           throw new UnsupportedOperationException("Method not found: " + name);
         }
-        this.isStaticMethod = false;
-        this.ensoMethod = instanceMethod;
+        return new Method(instanceMethod, variableArgumentMethod, false, name);
       }
     }
 
@@ -118,10 +122,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
         objects[0] = wrapAsColumn(args[0], makeConstantColumn);
         objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
       } else if (isStaticMethod) {
-        // The static method takes the type as the synthetic 'self' argument, so we need to prepend
-        // it:
         objects = new Object[args.length + 1];
-        objects[0] = staticsType;
+        objects[0] = STATICS_TYPE;
         System.arraycopy(args, 0, objects, 1, args.length);
       } else {
         objects = Arrays.copyOf(args, args.length, Object[].class);
@@ -144,8 +146,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     final Value type = module.invokeMember("get_type", typeName);
     final var setVariableArgumentFunctions =
         new HashSet<>(Arrays.asList(variableArgumentFunctions));
-    Function<String, Method> getMethod =
-        name -> new Method(module, type, name, setVariableArgumentFunctions.contains(name));
+    Function<String, MethodInterface> getMethod =
+        name -> Method.create(module, type, name, setVariableArgumentFunctions.contains(name));
     Function<String, Value> makeConstructor =
         name -> module.invokeMember("eval_expression", ".." + name);
 
@@ -156,7 +158,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       String expression,
       Function<String, Value> getColumn,
       Function<Object, Value> makeConstantColumn,
-      Function<String, Method> getMethod,
+      Function<String, MethodInterface> getMethod,
       Function<String, Value> makeConstructor) {
     var lexer = new ExpressionLexer(CharStreams.fromString(expression));
     lexer.removeErrorListeners();
@@ -176,13 +178,13 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
 
   private final Function<String, Value> getColumn;
   private final Function<Object, Value> makeConstantColumn;
-  private final Function<String, Method> getMethod;
+  private final Function<String, MethodInterface> getMethod;
   private final Function<String, Value> makeConstructor;
 
   private ExpressionVisitorImpl(
       Function<String, Value> getColumn,
       Function<Object, Value> makeConstantColumn,
-      Function<String, Method> getMethod,
+      Function<String, MethodInterface> getMethod,
       Function<String, Value> makeConstructor) {
     this.getColumn = getColumn;
     this.makeConstantColumn = makeConstantColumn;

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -54,6 +54,19 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     }
   }
 
+    private static Value wrapAsColumn(Value value, Function<Object, Value> makeConstantColumn) {
+    if (value.isNull()) {
+      return makeConstantColumn.apply(value);
+    }
+
+    var metaObject = value.getMetaObject();
+    return metaObject != null
+            && metaObject.isHostObject()
+            && metaObject.asHostObject() instanceof Class<?>
+        ? makeConstantColumn.apply(value)
+        : value;
+  }
+
   public static class Method {
     private final Value ensoMethod;
     private final boolean isVariableArgumentMethod;
@@ -83,9 +96,9 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       }
     }
 
-    public Value execute(Value[] args, Function<Value, Value> wrapAsColumn)
+    public Value execute(Value[] args, Function<Object, Value> makeConstantColumn)
     {
-      Object[] objects = prepareArguments(args, wrapAsColumn);
+      Object[] objects = prepareArguments(args, makeConstantColumn);
       try {
         var result = ensoMethod.execute(objects);
         if (result.canExecute()) {
@@ -100,11 +113,11 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       }
     }
 
-    public Object[] prepareArguments(Value[] args, Function<Value, Value> wrapAsColumn) {
+    public Object[] prepareArguments(Value[] args, Function<Object, Value> makeConstantColumn) {
     Object[] objects;
     if (isVariableArgumentMethod) {
       objects = new Object[2];
-      objects[0] = wrapAsColumn.apply(args[0]);
+      objects[0] = wrapAsColumn(args[0], makeConstantColumn);
       objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
     } else if (isStaticMethod) {
       // The static method takes the type as the synthetic 'self' argument, so we need to prepend
@@ -114,7 +127,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       System.arraycopy(args, 0, objects, 1, args.length);
     } else {
       objects = Arrays.copyOf(args, args.length, Object[].class);
-      objects[0] = wrapAsColumn.apply(args[0]);
+      objects[0] = wrapAsColumn(args[0], makeConstantColumn);
     }
       return objects;
     }
@@ -179,29 +192,16 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     this.makeConstructor = makeConstructor;
   }
 
-  private Value wrapAsColumn(Value value) {
-    if (value.isNull()) {
-      return makeConstantColumn.apply(value);
-    }
-
-    var metaObject = value.getMetaObject();
-    return metaObject != null
-            && metaObject.isHostObject()
-            && metaObject.asHostObject() instanceof Class<?>
-        ? makeConstantColumn.apply(value)
-        : value;
-  }
-
   private Value executeMethod(String name, Value... args) {
     var method = getMethod.apply(name);
-    Value result = method.execute(args, c->wrapAsColumn(c));
+    Value result = method.execute(args, makeConstantColumn);
     return makeConstantColumn.apply(result);
   }
 
   @Override
   public Value visitProg(ExpressionParser.ProgContext ctx) {
     Value base = visit(ctx.expr());
-    return wrapAsColumn(base);
+    return wrapAsColumn(base, makeConstantColumn);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -194,7 +193,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
       objects[0] = wrapAsColumn(args[0]);
       objects[1] = Arrays.copyOfRange(args, 1, args.length, Object[].class);
     } else if (method.isStaticMethod()) {
-      // The static method takes the module as the synthetic 'self' argument, so we need to prepend
+      // The static method takes the type as the synthetic 'self' argument, so we need to prepend
       // it:
       objects = new Object[args.length + 1];
       objects[0] = method.getStaticsType();

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -52,3 +52,17 @@ public class ExpressionVisitorImplTest {
     assertEquals(mockedResult, result);
   }
 }
+
+@Test
+public void testSimpleStaticMethod() {
+    Value mockedMethodToday = mock(Value.class);
+    Value mockedResult = mock(Value.class);
+
+    when(getMethod.apply("today")).thenReturn(mockedMethodToday);
+    when(mockedMethodToday.canExecute()).thenReturn(true);
+    when(mockedMethodToday.execute()).thenReturn(mockedResult);
+    when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
+
+    Value result = evaluate("today()");
+    assertEquals(mockedResult, result);
+}

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -1,16 +1,18 @@
 package org.enso.table.expressions;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.function.Function;
+
 import org.enso.table.expressions.ExpressionVisitorImpl.Method;
 import org.graalvm.polyglot.Value;
+import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,18 +40,15 @@ public class ExpressionVisitorImplTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testSimpleMethodOnColumn() {
     Value mockedColumn1 = mock(Value.class);
     Method mockedMethodTextLength = mock(Method.class);
-    Value mockedEnsoMethodTextLength = mock(Value.class);
     Value mockedResult = mock(Value.class);
-
+    
     when(getColumn.apply("Column 1")).thenReturn(mockedColumn1);
     when(getMethod.apply("text_length")).thenReturn(mockedMethodTextLength);
-    when(mockedMethodTextLength.isVariableArgumentMethod()).thenReturn(false);
-    when(mockedMethodTextLength.isStaticMethod()).thenReturn(false);
-    when(mockedMethodTextLength.getEnsoMethod()).thenReturn(mockedEnsoMethodTextLength);
-    when(mockedEnsoMethodTextLength.execute(mockedColumn1)).thenReturn(mockedResult);
+    when(mockedMethodTextLength.execute(eq(new Value[]{mockedColumn1}), any(Function.class))).thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
 
     Value result = evaluate("text_length([Column 1])");
@@ -57,19 +56,13 @@ public class ExpressionVisitorImplTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testSimpleStaticMethod() {
     Method mockedMethodToday = mock(Method.class);
-    Value mockedEnsoMethodToday = mock(Value.class);
     Value mockedResult = mock(Value.class);
-    Value mockedStaticsType = mock(Value.class);
 
     when(getMethod.apply("today")).thenReturn(mockedMethodToday);
-    when(mockedMethodToday.getEnsoMethod()).thenReturn(mockedEnsoMethodToday);
-    when(mockedMethodToday.isVariableArgumentMethod()).thenReturn(false);
-    when(mockedMethodToday.isStaticMethod()).thenReturn(true);
-    when(mockedMethodToday.getStaticsType()).thenReturn(mockedStaticsType);
-    // Static method require passing their type as the synthetic 'self' argument
-    when(mockedEnsoMethodToday.execute(mockedStaticsType)).thenReturn(mockedResult);
+    when(mockedMethodToday.execute(eq(new Value[]{}), any(Function.class))).thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
 
     Value result = evaluate("today()");

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -1,16 +1,16 @@
 package org.enso.table.expressions;
 
-import java.util.function.Function;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.function.Function;
 import org.enso.table.expressions.ExpressionVisitorImpl.Method;
 import org.graalvm.polyglot.Value;
-import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -43,10 +43,11 @@ public class ExpressionVisitorImplTest {
     Method mockedMethodTextLength = mock(Method.class);
     Value mockedResult = mock(Value.class);
     Value mockedColumnResult = mock(Value.class);
-    
+
     when(getColumn.apply("Column 1")).thenReturn(mockedColumn1);
     when(getMethod.apply("text_length")).thenReturn(mockedMethodTextLength);
-    when(mockedMethodTextLength.execute(new Value[]{mockedColumn1}, makeConstantColumn)).thenReturn(mockedResult);
+    when(mockedMethodTextLength.execute(new Value[] {mockedColumn1}, makeConstantColumn))
+        .thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedColumnResult);
 
     Value result = evaluate("text_length([Column 1])");
@@ -60,7 +61,7 @@ public class ExpressionVisitorImplTest {
     Value mockedColumnResult = mock(Value.class);
 
     when(getMethod.apply("today")).thenReturn(mockedMethodToday);
-    when(mockedMethodToday.execute(new Value[]{}, makeConstantColumn)).thenReturn(mockedResult);
+    when(mockedMethodToday.execute(new Value[] {}, makeConstantColumn)).thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedColumnResult);
 
     Value result = evaluate("today()");

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,32 +38,32 @@ public class ExpressionVisitorImplTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testSimpleMethodOnColumn() {
     Value mockedColumn1 = mock(Value.class);
     Method mockedMethodTextLength = mock(Method.class);
     Value mockedResult = mock(Value.class);
+    Value mockedColumnResult = mock(Value.class);
     
     when(getColumn.apply("Column 1")).thenReturn(mockedColumn1);
     when(getMethod.apply("text_length")).thenReturn(mockedMethodTextLength);
-    when(mockedMethodTextLength.execute(eq(new Value[]{mockedColumn1}), any(Function.class))).thenReturn(mockedResult);
-    when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
+    when(mockedMethodTextLength.execute(new Value[]{mockedColumn1}, makeConstantColumn)).thenReturn(mockedResult);
+    when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedColumnResult);
 
     Value result = evaluate("text_length([Column 1])");
-    assertEquals(mockedResult, result);
+    assertEquals(mockedColumnResult, result);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testSimpleStaticMethod() {
     Method mockedMethodToday = mock(Method.class);
     Value mockedResult = mock(Value.class);
+    Value mockedColumnResult = mock(Value.class);
 
     when(getMethod.apply("today")).thenReturn(mockedMethodToday);
-    when(mockedMethodToday.execute(eq(new Value[]{}), any(Function.class))).thenReturn(mockedResult);
-    when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
+    when(mockedMethodToday.execute(new Value[]{}, makeConstantColumn)).thenReturn(mockedResult);
+    when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedColumnResult);
 
     Value result = evaluate("today()");
-    assertEquals(mockedResult, result);
+    assertEquals(mockedColumnResult, result);
   }
 }

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Function;
-import org.enso.table.expressions.ExpressionVisitorImpl.Method;
+import org.enso.table.expressions.ExpressionVisitorImpl.MethodInterface;
 import org.graalvm.polyglot.Value;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,7 +23,7 @@ public class ExpressionVisitorImplTest {
 
   @Mock private Function<String, Value> getColumn;
   @Mock private Function<Object, Value> makeConstantColumn;
-  @Mock private Function<String, Method> getMethod;
+  @Mock private Function<String, MethodInterface> getMethod;
   @Mock private Function<String, Value> makeConstructor;
 
   private Value evaluate(String expr) {
@@ -40,7 +40,7 @@ public class ExpressionVisitorImplTest {
   @Test
   public void testSimpleMethodOnColumn() {
     Value mockedColumn1 = mock(Value.class);
-    Method mockedMethodTextLength = mock(Method.class);
+    MethodInterface mockedMethodTextLength = mock(MethodInterface.class);
     Value mockedResult = mock(Value.class);
     Value mockedColumnResult = mock(Value.class);
 
@@ -56,7 +56,7 @@ public class ExpressionVisitorImplTest {
 
   @Test
   public void testSimpleStaticMethod() {
-    Method mockedMethodToday = mock(Method.class);
+    MethodInterface mockedMethodToday = mock(MethodInterface.class);
     Value mockedResult = mock(Value.class);
     Value mockedColumnResult = mock(Value.class);
 

--- a/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/expressions/ExpressionVisitorImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Function;
+import org.enso.table.expressions.ExpressionVisitorImpl.Method;
 import org.graalvm.polyglot.Value;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,12 +23,12 @@ public class ExpressionVisitorImplTest {
 
   @Mock private Function<String, Value> getColumn;
   @Mock private Function<Object, Value> makeConstantColumn;
-  @Mock private Function<String, Value> getMethod;
+  @Mock private Function<String, Method> getMethod;
   @Mock private Function<String, Value> makeConstructor;
 
   private Value evaluate(String expr) {
     return ExpressionVisitorImpl.evaluateImpl(
-        expr, getColumn, makeConstantColumn, getMethod, makeConstructor, new String[] {});
+        expr, getColumn, makeConstantColumn, getMethod, makeConstructor);
   }
 
   @Test
@@ -39,30 +40,39 @@ public class ExpressionVisitorImplTest {
   @Test
   public void testSimpleMethodOnColumn() {
     Value mockedColumn1 = mock(Value.class);
-    Value mockedMethodTextLength = mock(Value.class);
+    Method mockedMethodTextLength = mock(Method.class);
+    Value mockedEnsoMethodTextLength = mock(Value.class);
     Value mockedResult = mock(Value.class);
 
     when(getColumn.apply("Column 1")).thenReturn(mockedColumn1);
     when(getMethod.apply("text_length")).thenReturn(mockedMethodTextLength);
-    when(mockedMethodTextLength.canExecute()).thenReturn(true);
-    when(mockedMethodTextLength.execute(mockedColumn1)).thenReturn(mockedResult);
+    when(mockedMethodTextLength.isVariableArgumentMethod()).thenReturn(false);
+    when(mockedMethodTextLength.isStaticMethod()).thenReturn(false);
+    when(mockedMethodTextLength.getEnsoMethod()).thenReturn(mockedEnsoMethodTextLength);
+    when(mockedEnsoMethodTextLength.execute(mockedColumn1)).thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
 
     Value result = evaluate("text_length([Column 1])");
     assertEquals(mockedResult, result);
   }
-}
 
-@Test
-public void testSimpleStaticMethod() {
-    Value mockedMethodToday = mock(Value.class);
+  @Test
+  public void testSimpleStaticMethod() {
+    Method mockedMethodToday = mock(Method.class);
+    Value mockedEnsoMethodToday = mock(Value.class);
     Value mockedResult = mock(Value.class);
+    Value mockedStaticsType = mock(Value.class);
 
     when(getMethod.apply("today")).thenReturn(mockedMethodToday);
-    when(mockedMethodToday.canExecute()).thenReturn(true);
-    when(mockedMethodToday.execute()).thenReturn(mockedResult);
+    when(mockedMethodToday.getEnsoMethod()).thenReturn(mockedEnsoMethodToday);
+    when(mockedMethodToday.isVariableArgumentMethod()).thenReturn(false);
+    when(mockedMethodToday.isStaticMethod()).thenReturn(true);
+    when(mockedMethodToday.getStaticsType()).thenReturn(mockedStaticsType);
+    // Static method require passing their type as the synthetic 'self' argument
+    when(mockedEnsoMethodToday.execute(mockedStaticsType)).thenReturn(mockedResult);
     when(makeConstantColumn.apply(mockedResult)).thenReturn(mockedResult);
 
     Value result = evaluate("today()");
     assertEquals(mockedResult, result);
+  }
 }

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -419,6 +419,9 @@ add_expression_specs suite_builder detailed setup =
             expression_test "cast([A], ..Char)" ["1", "2", "3", "4", "5"]
             expression_test "starts_WITH([C], 'HELLO', ..INSENSITIVE)" [True, False, True, False, Nothing]
 
+        specify_test "should be able to call static expression methods" group_builder expression_test->
+            expression_test "today()" Date.today
+
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         expect_error ctor expr =
             expr.should_fail_with Expression_Error

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -419,7 +419,7 @@ add_expression_specs suite_builder detailed setup =
             expression_test "cast([A], ..Char)" ["1", "2", "3", "4", "5"]
             expression_test "starts_WITH([C], 'HELLO', ..INSENSITIVE)" [True, False, True, False, Nothing]
 
-        specify_test "should be able to call static expression methods" group_builder expression_test->
+        if setup.flagged ..Date_Time then specify_test "should be able to call static expression methods" group_builder expression_test->
             expression_test "today()" Date.today
 
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->


### PR DESCRIPTION
### Pull Request Description

Adds distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso and removes the previous implementations of date, now and today from the java code. This gives us the benefit of a consistent implementation and also gives the GUI somewhere it can get all of the supported static methods for the expression auto-complete.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
