### PR TITLE
Enable NI with IDE

### DIFF
--- a/lib/scala/runtime-version-manager/src/main/resources/META-INF/native-image/org/enso/runtimeversionmanager/resource-config.json
+++ b/lib/scala/runtime-version-manager/src/main/resources/META-INF/native-image/org/enso/runtimeversionmanager/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":{
+  "includes":[{
+    "pattern":"\\Qorg/apache/tika/mime/tika-mimetypes.xml\\E"
+  }]},
+  "bundles":[]
+}

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -21,6 +21,9 @@ case class NativeExecCommand(executablePath: Path) extends ExecCommand {
 }
 
 object NativeExecCommand {
+
+  private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
+
   def apply(
     version: String,
     engine: Engine,
@@ -31,10 +34,11 @@ object NativeExecCommand {
     val execName = OS.executableName("enso")
     val fullExecPath =
       dm.paths.engines.resolve(version).resolve("bin").resolve(execName)
+    val ensoLauncher = Option(System.getenv(LAUNCHER_ENV_NAME))
 
     if (fullExecPath.toFile.exists() && isBinary(fullExecPath, logger)) {
       Some(NativeExecCommand(fullExecPath))
-    } else {
+    } else if (ensoLauncher.map(_.equals("native")).getOrElse(false)) {
       val component =
         engine.componentDirPath.resolve("..").toAbsolutePath.normalize
       val fallbackExecPath = component.resolve("bin").resolve("enso")
@@ -43,8 +47,14 @@ object NativeExecCommand {
       ) {
         Some(NativeExecCommand(fallbackExecPath))
       } else {
+        logger.debug(
+          "Failed to find native launcher at a pre-determined location: {}",
+          fallbackExecPath
+        )
         None
       }
+    } else {
+      None
     }
   }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -3,10 +3,9 @@ package org.enso.runtimeversionmanager.runner
 import org.enso.cli.OS
 import org.enso.distribution.{DistributionManager, Environment}
 import org.enso.runtimeversionmanager.components.Engine
-
 import org.apache.tika.config.TikaConfig
 import org.apache.tika.Tika
-
+import org.slf4j.Logger
 import java.nio.file.Path
 
 case class NativeExecCommand(executablePath: Path) extends ExecCommand {
@@ -22,19 +21,34 @@ case class NativeExecCommand(executablePath: Path) extends ExecCommand {
 }
 
 object NativeExecCommand {
-  def apply(version: String): Option[NativeExecCommand] = {
+  def apply(
+    version: String,
+    engine: Engine,
+    logger: Logger
+  ): Option[NativeExecCommand] = {
     val env      = new Environment() {}
     val dm       = new DistributionManager(env)
     val execName = OS.executableName("enso")
     val fullExecPath =
       dm.paths.engines.resolve(version).resolve("bin").resolve(execName)
 
-    if (fullExecPath.toFile.exists() && isBinary(fullExecPath)) {
+    if (fullExecPath.toFile.exists() && isBinary(fullExecPath, logger)) {
       Some(NativeExecCommand(fullExecPath))
-    } else None
+    } else {
+      val component =
+        engine.componentDirPath.resolve("..").toAbsolutePath.normalize
+      val fallbackExecPath = component.resolve("bin").resolve("enso")
+      if (
+        fallbackExecPath.toFile.exists() && isBinary(fallbackExecPath, logger)
+      ) {
+        Some(NativeExecCommand(fallbackExecPath))
+      } else {
+        None
+      }
+    }
   }
 
-  private def isBinary(path: Path): Boolean = {
+  private def isBinary(path: Path, logger: Logger): Boolean = {
     try {
       val config    = TikaConfig.getDefaultConfig()
       val tika      = new Tika(config)
@@ -43,7 +57,8 @@ object NativeExecCommand {
       val tpe       = mimeTypes.forName(mime).getType.getType
       tpe != null && tpe == "application"
     } catch {
-      case _: Throwable =>
+      case e: Throwable =>
+        logger.warn("Failed to infer mimetype for path {}", path, e)
         false
     }
   }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -1,6 +1,5 @@
 package org.enso.runtimeversionmanager.runner
 
-import com.typesafe.scalalogging.Logger
 import org.enso.semver.SemVer
 import org.enso.distribution.{DistributionManager, Environment}
 import org.enso.editions.updater.EditionManager
@@ -9,17 +8,14 @@ import org.enso.logger.masking.MaskedString
 import org.slf4j.event.Level
 
 import java.net.URI
-import org.enso.runtimeversionmanager.components.{
-  Engine,
-  GraalRuntime,
-  RuntimeVersionManager
-}
+import org.enso.runtimeversionmanager.components.{Engine, RuntimeVersionManager}
 import org.enso.runtimeversionmanager.config.GlobalRunnerConfigurationManager
 
 import java.nio.file.Path
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future, TimeoutException}
 import scala.util.Try
+import org.slf4j.LoggerFactory
 
 /** A helper class that prepares settings for running Enso components and
   * converts these settings to actual commands that launch the component inside
@@ -40,6 +36,8 @@ class Runner(
     * Can be overridden in tests.
     */
   protected val currentWorkingDirectory: Path = Path.of(".")
+
+  private lazy val logger = LoggerFactory.getLogger(classOf[Runner])
 
   def newProject(
     path: Path,
@@ -71,7 +69,7 @@ class Runner(
         ) ++ templateOption ++ normalizedNameOption ++ authorNameOption ++ authorEmailOption ++ additionalArguments
       // TODO [RW] reporting warnings to the IDE (#1710)
       if (Engine.isNightly(engineVersion)) {
-        Logger[Runner].warn(
+        logger.warn(
           "Creating a new project using a nightly build [{}]. " +
           "Nightly builds may disappear after a while, so you may need to " +
           "upgrade. Consider using a stable version.",
@@ -167,7 +165,7 @@ class Runner(
     def prepareAndRunCommand(engine: Engine, cmd: ExecCommand): R = {
       val jvmOptsFromEnvironment = environment.getEnvVar(JVM_OPTIONS_ENV_VAR)
       jvmOptsFromEnvironment.foreach { opts =>
-        Logger[Runner].debug(
+        logger.debug(
           "Picking up additional JVM options [{}] from the " +
           "[{}] environment variable.",
           MaskedString(opts),
@@ -196,7 +194,7 @@ class Runner(
       val javaHome: Option[String] = environment
         .getEnvPath(JVM_PATH_ENV_VAR)
         .map { p =>
-          Logger[Runner].info(
+          logger.info(
             "Using explicit " + JVM_PATH_ENV_VAR + " JVM: " + p
           )
           p.toString()
@@ -224,7 +222,11 @@ class Runner(
       case None =>
         runtimeVersionManager.withEngineAndRuntime(engineVersion) {
           (engine, runtime) =>
-            NativeExecCommand.apply(engineVersion.toString) match {
+            NativeExecCommand.apply(
+              engineVersion.toString,
+              engine,
+              logger
+            ) match {
               case Some(cmd) =>
                 prepareAndRunCommand(engine, cmd)
               case None =>
@@ -254,7 +256,7 @@ class Runner(
         Await.result(loggerConnection, 3.seconds)
       } catch {
         case exception: TimeoutException =>
-          Logger[GraalRuntime].warn(
+          logger.warn(
             "The logger has not been set up within the 3 second time limit, " +
             "the launched component will be started but it will not be " +
             "connected to the logging service.",


### PR DESCRIPTION
If Enso's native image of runner is present **and** `ENSO_LAUNCHER=native` env var is set, IDE will invoke native image.
In all other cases, old jvm runner is being used.
