### PR TITLE
Enabling native launchers for the release

### DIFF
--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -202,19 +202,6 @@ impl RunContext {
         if self.config.build_native_runner {
             env::ENSO_LAUNCHER.set(&engine::EngineLauncher::TestNative)?;
         }
-
-        // TODO: Once the native image is production ready, we should switch to
-        // EngineLauncher::Native on release versions.
-        // See tasks in https://github.com/orgs/enso-org/discussions/10121
-        /*let version = versions_from_env()?.unwrap();
-        let is_release = version.release_mode;
-        let kind = Kind::deduce(&version)?;
-        if is_release {
-            env::ENSO_LAUNCHER.set(&engine::EngineLauncher::Native)?;
-        } else {
-            env::ENSO_LAUNCHER.set(&engine::EngineLauncher::Shell)?;
-        }*/
-
         prepare_simple_library_server.await??;
 
         Ok(())

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -14,8 +14,16 @@ object GraalVM {
 
     override def toString(): String = {
       val prop = System.getenv(VAR_NAME)
-      // default value is `shell`
-      return if (prop == null) "shell" else prop;
+      // default value is `shell` for development and `native` for the release
+      return if (prop != null) {
+        prop
+      } else {
+        if (BuildInfo.isReleaseMode) {
+          "native"
+        } else {
+          "shell"
+        }
+      }
     }
 
     private lazy val parsed


### PR DESCRIPTION
### Pull Request Description

Let's finish #10121 by enabling `native` Enso launcher during the release builds. 
- thanks to #12287 everyone needs to **opt-in** to use the _native mode_. 
- the _release bits_ are ready for the _native mode_ 
- turn the _native mode_ on by specifying `ENSO_LAUCHER=native` environment variable. 
- during the _development_ we continue to use `shell` launchers by default
- follow instructions in #12117 to develop within _native mode_
 
Nightly [release bits are built](https://github.com/enso-org/enso/actions/runs/13367730649). Thanks for testing them.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] Release [bits are tested](https://github.com/enso-org/enso/actions/runs/13367730649) manually
    - [x] Check is [OK on Linux](https://github.com/enso-org/enso/pull/12296#issuecomment-2663079436)
    - [x] Check on Windows
    - no check on Mac - IDE isn't built right now
- [x] Nightly extra tests [running](https://github.com/enso-org/enso/actions/runs/13371454537)
