### PR TITLE
Fix detection of bundled runtime with --jvm option

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
+++ b/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
 import org.enso.distribution.DistributionManager;
 import org.enso.distribution.Environment;
+import org.enso.distribution.PortableDistributionManager;
 import org.enso.runtimeversionmanager.components.GraalRuntime;
 import org.enso.runtimeversionmanager.components.GraalVMVersion;
 import org.enso.runtimeversionmanager.components.GraalVersionManager;
@@ -68,7 +69,10 @@ final class JavaFinder {
    */
   private static Path findJavaExecutableInDistributionRuntimes() {
     var env = new Environment() {};
-    var distributionManager = new DistributionManager(env);
+    var distributionManager = new PortableDistributionManager(env);
+    if (distributionManager.isRunningPortable()) {
+      logger.trace("Running in portable distribution");
+    }
     var graalVersionManager = new GraalVersionManager(distributionManager, env);
     var versionUsedForBuild =
         new GraalVMVersion(BuildVersion.graalVersion(), BuildVersion.javaVersion());
@@ -89,6 +93,9 @@ final class JavaFinder {
           versionUsedForBuild);
       return newerRuntime.get().javaExecutable();
     }
+    logger.trace("No appropriate runtime found in the distribution.");
+    logger.trace("graalVersionManager.getAllRuntimes() = {}", graalVersionManager.getAllRuntimes());
+    logger.trace("Paths of distributionManager = {}", distributionManager.paths());
     return null;
   }
 

--- a/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
+++ b/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
@@ -93,9 +93,11 @@ final class JavaFinder {
           versionUsedForBuild);
       return newerRuntime.get().javaExecutable();
     }
-    logger.trace("No appropriate runtime found in the distribution.");
-    logger.trace("graalVersionManager.getAllRuntimes() = {}", graalVersionManager.getAllRuntimes());
-    logger.trace("Paths of distributionManager = {}", distributionManager.paths());
+    logger.trace(
+        "No appropriate runtime found in the distribution. "
+            + "graalVersionManager.getAllRuntimes() = {}, Paths of distributionManager = {}",
+        graalVersionManager.getAllRuntimes(),
+        distributionManager.paths());
     return null;
   }
 

--- a/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/DistributionManager.scala
+++ b/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/DistributionManager.scala
@@ -245,26 +245,21 @@ class DistributionManager(val env: Environment) {
     */
   private val BUNDLE_MARK_FILENAME = ".enso.bundle"
 
-  /** Root directory of a bundle.
-    *
-    * If the bundle is present, it will be located next to the `bin/` directory
-    * that contains the executable that we are currently running.
-    */
-  private def possibleBundleRoot =
-    env.getPathToRunningExecutable.getParent.getParent
-
-  /** Checks if [[possibleBundleRoot]] contains the bundle mark file and returns
-    * directories for the bundle if it was found.
-    */
-  private def detectBundle(): Option[Bundle] =
-    if (Files.exists(possibleBundleRoot / BUNDLE_MARK_FILENAME))
-      Some(
-        Bundle(
-          engines  = possibleBundleRoot / ENGINES_DIRECTORY,
-          runtimes = possibleBundleRoot / RUNTIMES_DIRECTORY
+  private def detectBundle(): Option[Bundle] = {
+    var curPath = env.getPathToRunningExecutable
+    while (curPath != null) {
+      if (Files.exists(curPath / BUNDLE_MARK_FILENAME)) {
+        return Some(
+          Bundle(
+            engines  = curPath / ENGINES_DIRECTORY,
+            runtimes = curPath / RUNTIMES_DIRECTORY
+          )
         )
-      )
-    else None
+      }
+      curPath = curPath.getParent
+    }
+    None
+  }
 
   /** Removes unused lockfiles. */
   def tryCleaningUnusedLockfiles(): Unit = {


### PR DESCRIPTION
Fixes #12302

### Pull Request Description

Running
```
$ ./enso-linux-x86_64-2025.1.1-nightly.2025.2.18.AppImage --appimage-extract
$ ./squashfs-root/resources/enso/dist/2025.1.1-nightly.2025.2.18/bin/enso --jvm --run tmp.enso
```
from the extracted AppImage correctly finds the bundled runtime.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
