### PR TITLE
Regex support in Expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - [Added DB_Table.Offset for Snowflake, Postgres, SQLite][12251]
 - [Support for key-pair authentication in Snowflake connector.][12247]
 - [Support for basic arithmetic operations as numbers in Expressions.][12297]
+- [Support for Regular Expressions in Enso Expressions.][12320]
 
 [11926]: https://github.com/enso-org/enso/pull/11926
 [12031]: https://github.com/enso-org/enso/pull/12031
@@ -72,6 +73,7 @@
 [12251]: https://github.com/enso-org/enso/pull/12251
 [12247]: https://github.com/enso-org/enso/pull/12247
 [12297]: https://github.com/enso-org/enso/pull/12297
+[12320]: https://github.com/enso-org/enso/pull/12320
 
 #### Enso Language & Runtime
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1650,10 +1650,7 @@ type DB_Column
             input_type = Meta.type_of term
             params = Replace_Params.Value input_type case_sensitivity only_first
             self.connection.dialect.if_replace_params_supports params <|
-                raw_term = case term of
-                    _ : Regex -> term.pattern
-                    _ -> term
-                new_name = self.naming_helper.function_name "replace" [self, raw_term, new_text]
+                new_name = self.naming_helper.function_name "replace" [self, term, new_text]
                 self.make_op "REPLACE" [raw_term, new_text] new_name [term, params]
 
     ## GROUP Standard.Base.Text

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1651,6 +1651,9 @@ type DB_Column
             params = Replace_Params.Value input_type case_sensitivity only_first
             self.connection.dialect.if_replace_params_supports params <|
                 new_name = self.naming_helper.function_name "replace" [self, term, new_text]
+                raw_term = case term of
+                    _ : Regex -> term.pattern
+                    _ -> term
                 self.make_op "REPLACE" [raw_term, new_text] new_name [term, params]
 
     ## GROUP Standard.Base.Text

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -1503,7 +1503,7 @@ type Column
             new_text_fn = wrap_text_argument_as_value_provider new_text
 
             term_fn.if_not_error <| new_text_fn.if_not_error <|
-                new_name = naming_helper.function_name "replace" [self, term.to_text, new_text]
+                new_name = naming_helper.function_name "replace" [self, term, new_text]
 
                 do_replace index input =
                     term = term_fn index

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
@@ -13,7 +13,7 @@ type Expression_Statics
     time -> Time_Of_Day =
         Time_Of_Day.now
 
-    ## Creates a regular expression (alternatively use r/expression/
+    ## Creates a regular expression (alternatively use r/expression/)
     regex expression = Regex.compile expression
 
     ## Multiples two values.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression_Statics.enso
@@ -13,6 +13,9 @@ type Expression_Statics
     time -> Time_Of_Day =
         Time_Of_Day.now
 
+    ## Creates a regular expression (alternatively use r/expression/
+    regex expression = Regex.compile expression
+
     ## Multiples two values.
     * this that = this * that
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -103,7 +103,8 @@ type Column_Naming_Helper
        For other objects, it will return its pretty-printed representation.
     to_expression_text self value =
         if is_column value then "[" + value.name + "]" else
-            value.pretty
+            if value.is_a Regex then "regex('" + value.pattern + "')" else
+                value.pretty
 
     ## PRIVATE
        Concatenates a vector of texts that are meant to make a single column

--- a/std-bits/table/src/main/antlr4/Expression.g4
+++ b/std-bits/table/src/main/antlr4/Expression.g4
@@ -19,6 +19,7 @@ expr:   expr op=POWER expr                                # Power
     |   MINUS expr                                        # UnaryMinus
     |   '..' IDENTIFIER                                   # Atom
     |   value                                             # Literal
+    |   REGEX_LITERAL                                     # RegexLiteral
     ;
 
 POWER : '^';
@@ -35,6 +36,9 @@ LESS_THAN : '<';
 GREATER_THAN : '>';
 
 WHITESPACE : [ \t\r\n]+ -> skip;
+
+REGEX_LITERAL : 'r/' REGEX_BODY '/' ;
+fragment REGEX_BODY : (~[/\r\n])+ ; // Match everything except '/' and newlines
 
 fragment A:[aA];
 fragment B:[bB];

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -425,6 +425,13 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   }
 
   @Override
+  public Value visitRegexLiteral(ExpressionParser.RegexLiteralContext ctx) {
+    String regexPattern = ctx.REGEX_LITERAL().getText();
+    regexPattern = regexPattern.substring(2, regexPattern.length() - 1); // Remove leading 'r/' and trailing '/'
+    return executeMethod("regex", Value.asValue(regexPattern));
+  }
+
+  @Override
   public Value visitParen(ExpressionParser.ParenContext ctx) {
     return visit(ctx.expr());
   }

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -427,7 +427,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   @Override
   public Value visitRegexLiteral(ExpressionParser.RegexLiteralContext ctx) {
     String regexPattern = ctx.REGEX_LITERAL().getText();
-    regexPattern = regexPattern.substring(2, regexPattern.length() - 1); // Remove leading 'r/' and trailing '/'
+    // Remove leading 'r/' and trailing '/'
+    regexPattern = regexPattern.substring(2, regexPattern.length() - 1);
     return executeMethod("regex", Value.asValue(regexPattern));
   }
 

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1603,11 +1603,12 @@ add_column_operation_specs suite_builder setup =
 
             supported_replace_params = setup.test_selection.supported_replace_params
             if supported_replace_params.contains (Replace_Params.Value Text Case_Sensitivity.Default False) then
-                col.text_replace 'hello' 'bye' . name . should_equal 'replace([x], \'hello\', \'bye\')'
+                col.text_replace 'hello' 'bye' . name . should_equal "replace([x], 'hello', 'bye')"
             if supported_replace_params.contains (Replace_Params.Value Regex Case_Sensitivity.Default False) then
-                col.text_replace 'a[bcd]'.to_regex 'hey' . name . should_equal 'replace([x], \'a[bcd]\', \'hey\')'
+                col.text_replace 'a[bcd]'.to_regex 'hey' . name . should_equal "replace([x], regex('a[bcd]'), 'hey')"
+                col.text_replace (regex 'a[bcd]') 'hey' . name . should_equal "replace([x], regex('a[bcd]'), 'hey')"
             if supported_replace_params.contains (Replace_Params.Value DB_Column Case_Sensitivity.Default False) then
-                col.text_replace patterns replacements . name . should_equal 'replace([x], [patterns], [replacements])'
+                col.text_replace patterns replacements . name . should_equal "replace([x], [patterns], [replacements])"
 
     suite_builder.group prefix+"(Column_Operations_Spec) Column Operations - Text Replace (in-memory only)" group_builder->
 
@@ -1623,8 +1624,12 @@ add_column_operation_specs suite_builder setup =
                 data.a.text_replace data.b "#" Case_Sensitivity.Insensitive only_first=True . to_vector . should_equal ["#lpha", "Brav#", "Ch#rlie", "D#lta", "Ech#", "F#xtrot"]
 
             group_builder.specify "should allow regex based replacing" <|
-                data.a.text_replace "[aeiou]".to_regex "#" . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
-                data.a.text_replace "[aeiou]".to_regex "#" . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
+                r = data.a.text_replace "[aeiou]".to_regex "#" 
+                r . name . should_equal "replace([A], regex('[aeiou]'), '#')"
+                r . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
+                r2 = data.a.text_replace (regex "[aeiou]") "#" 
+                r2 . name . should_equal "replace([A], regex('[aeiou]'), '#')"
+                r2 . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
                 data.a.text_replace "([aeiou])(.*?)[aeiou]".to_regex "$1$2$1" . to_vector . should_equal ["Alpha", "Brava", "Charlae", "Delte", "Echo", "Foxtrot"]
 
             group_builder.specify "should handle unicode" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -7,6 +7,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Value_Type, expr
 from Standard.Table.Errors import all
 import Standard.Table.Expression.Expression_Error
+import Standard.Base.Data.Text.Regex.Regex_Syntax_Error
 
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Type
 import Standard.Database.Feature.Feature
@@ -438,7 +439,7 @@ add_expression_specs suite_builder detailed setup =
             expression_test "text_replace([C], regex('l{2}'), '')" ["Heo", "World", "Heo World!", "", Nothing]
             expression_test "text_replace([C], regex('L{2}'), '')" ["Hello", "World", "Hello World!", "", Nothing]
             expression_test "text_replace([C], r/l{2}/, '')" ["Heo", "World", "Heo World!", "", Nothing]
-
+            
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         expect_error ctor expr =
             expr.should_fail_with Expression_Error
@@ -457,6 +458,16 @@ add_expression_specs suite_builder detailed setup =
 
         group_builder.specify "should fail with Argument_Mismatch if too many arguments" <|
             expect_error Expression_Error.Argument_Mismatch <| test_table.get.evaluate_expression "is_empty([C], 'Hello')"
+            
+        group_builder.specify "should fail with bad regex" <|
+            ## Unclosed regex literal
+            expect_error Expression_Error.Syntax_Error <| test_table.get.evaluate_expression "text_replace([C], r/l{2}, '')"
+            ## Bad regex
+            r = test_table.get.evaluate_expression "text_replace([C], regex('l{2'), '')"
+            r.catch.should_be_a Regex_Syntax_Error.Error
+            ## Bad regex in a literal
+            r2 = test_table.get.evaluate_expression "text_replace([C], r/l{2/, '')"
+            r2.catch.should_be_a Regex_Syntax_Error.Error
 
     suite_builder.group prefix+"Expression Warnings should be reported" group_builder->
         group_builder.specify "should report floating point equality" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -435,7 +435,7 @@ add_expression_specs suite_builder detailed setup =
         specify_test "should be able to perform comparisons to get boolean results" group_builder expression_test->
             expression_test "text_replace([C], 'o', '', ..Sensitive, 3<5)" ["Hell", "Wrld", "Hell World!", "", Nothing]
 
-        specify_test "should be able to use regex" group_builder expression_test->
+        if setup.is_database.not then specify_test "should be able to use regex" group_builder expression_test->
             expression_test "text_replace([C], regex('l{2}'), '')" ["Heo", "World", "Heo World!", "", Nothing]
             expression_test "text_replace([C], regex('L{2}'), '')" ["Hello", "World", "Hello World!", "", Nothing]
             expression_test "text_replace([C], r/l{2}/, '')" ["Heo", "World", "Heo World!", "", Nothing]
@@ -459,7 +459,7 @@ add_expression_specs suite_builder detailed setup =
         group_builder.specify "should fail with Argument_Mismatch if too many arguments" <|
             expect_error Expression_Error.Argument_Mismatch <| test_table.get.evaluate_expression "is_empty([C], 'Hello')"
             
-        group_builder.specify "should fail with bad regex" <|
+        if setup.is_database.not then group_builder.specify "should fail with bad regex" <|
             ## Unclosed regex literal
             expect_error Expression_Error.Syntax_Error <| test_table.get.evaluate_expression "text_replace([C], r/l{2}, '')"
             ## Bad regex

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -434,6 +434,11 @@ add_expression_specs suite_builder detailed setup =
         specify_test "should be able to perform comparisons to get boolean results" group_builder expression_test->
             expression_test "text_replace([C], 'o', '', ..Sensitive, 3<5)" ["Hell", "Wrld", "Hell World!", "", Nothing]
 
+        specify_test "should be able to use regex" group_builder expression_test->
+            expression_test "text_replace([C], regex('l{2}'), '')" ["Heo", "World", "Heo World!", "", Nothing]
+            expression_test "text_replace([C], regex('L{2}'), '')" ["Hello", "World", "Hello World!", "", Nothing]
+            expression_test "text_replace([C], r/l{2}/, '')" ["Heo", "World", "Heo World!", "", Nothing]
+
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         expect_error ctor expr =
             expr.should_fail_with Expression_Error


### PR DESCRIPTION
### Pull Request Description

Adds regex support to the expression language in the form of:

- regex(.*)
- r/.*/

e.g.

text_replace([C], regex('l{2}'), '')
or
text_replace([C], r/l{2}/, '')

I need to update the documentation site (help.ensoanalytics.com) in a separate MR

### Important Notes

- I fixed the column name generation for text_replace using a regex which is technically a breaking change. However the old name was so poor I think I am happy to call it a defect.
- I went for r/ / rather than the js style / / mainly for ease of parsing to be able to differentiate from a / divide.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
