### PR TITLE
Make submodule URL relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "app/gui/.dev-env"]
 	path = app/gui/.dev-env
-	url = https://github.com/enso-org/dev-env
+	url = ../dev-env.git


### PR DESCRIPTION
### Pull Request Description

Addresses https://github.com/enso-org/enso/pull/12264#issuecomment-2667675941

If someone was surprised that it works (as I was), here is an excerpt from the git docs (emphasis mine):

> <repository> is the URL of the new submodule’s origin repository. This may be either an absolute URL, or (if it begins with ./ or ../), the location relative to the superproject’s default **remote repository**

