### PR TITLE
Fix "Run all benchmarks" configuration

### DIFF
--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -159,13 +159,15 @@ impl Benchmarks {
         match &self.bench_type {
             BenchmarkType::All => Some("bench".to_string()),
             BenchmarkType::Runtime => match &self.bench_name {
-                None => Some("runtime-benchmarks/bench".to_string()),
-                Some(name) => Some(format!("runtime-benchmarks/benchOnly {}", name)),
+                Some(name) if !name.is_empty() =>
+                    Some(format!("runtime-benchmarks/benchOnly {}", name)),
+                _ => Some("runtime-benchmarks/bench".to_string()),
             },
             BenchmarkType::Enso => None,
             BenchmarkType::EnsoJMH => match &self.bench_name {
-                None => Some("std-benchmarks/bench".to_string()),
-                Some(name) => Some(format!("std-benchmarks/benchOnly {}", name)),
+                Some(name) if !name.is_empty() =>
+                    Some(format!("std-benchmarks/benchOnly {}", name)),
+                _ => Some("std-benchmarks/bench".to_string()),
             },
         }
     }


### PR DESCRIPTION
Follow-up of #12324

### Pull Request Description

When an empty text field for `input.bench_name` is specified, all the benchmarks should be run. This fixes the failure in https://github.com/enso-org/enso/actions/runs/13418873236/job/37486422641

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
