### PR TITLE
Enable escaping forwardslash in regex expressions

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -103,7 +103,7 @@ type Column_Naming_Helper
        For other objects, it will return its pretty-printed representation.
     to_expression_text self value =
         if is_column value then "[" + value.name + "]" else
-            if value.is_a Regex then "regex('" + value.pattern + "')" else
+            if value.is_a Regex then "r/" + (value.pattern.replace "/" "\/") + "/" else
                 value.pretty
 
     ## PRIVATE

--- a/std-bits/table/src/main/antlr4/Expression.g4
+++ b/std-bits/table/src/main/antlr4/Expression.g4
@@ -38,7 +38,7 @@ GREATER_THAN : '>';
 WHITESPACE : [ \t\r\n]+ -> skip;
 
 REGEX_LITERAL : 'r/' REGEX_BODY '/' ;
-fragment REGEX_BODY : (~[/\r\n])+ ; // Match everything except '/' and newlines
+fragment REGEX_BODY : ( '\\/' | ~[/\r\n] )+ ; 
 
 fragment A:[aA];
 fragment B:[bB];

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1605,8 +1605,9 @@ add_column_operation_specs suite_builder setup =
             if supported_replace_params.contains (Replace_Params.Value Text Case_Sensitivity.Default False) then
                 col.text_replace 'hello' 'bye' . name . should_equal "replace([x], 'hello', 'bye')"
             if supported_replace_params.contains (Replace_Params.Value Regex Case_Sensitivity.Default False) then
-                col.text_replace 'a[bcd]'.to_regex 'hey' . name . should_equal "replace([x], regex('a[bcd]'), 'hey')"
-                col.text_replace (regex 'a[bcd]') 'hey' . name . should_equal "replace([x], regex('a[bcd]'), 'hey')"
+                col.text_replace 'a[bcd]'.to_regex 'hey' . name . should_equal "replace([x], r/a[bcd]/, 'hey')"
+                col.text_replace (regex 'a[bcd]') 'hey' . name . should_equal "replace([x], r/a[bcd]/, 'hey')"
+                col.text_replace (regex 'a[/bcd]') 'hey' . name . should_equal "replace([x], r/a[\/bcd]/, 'hey')"
             if supported_replace_params.contains (Replace_Params.Value DB_Column Case_Sensitivity.Default False) then
                 col.text_replace patterns replacements . name . should_equal "replace([x], [patterns], [replacements])"
 
@@ -1625,12 +1626,14 @@ add_column_operation_specs suite_builder setup =
 
             group_builder.specify "should allow regex based replacing" <|
                 r = data.a.text_replace "[aeiou]".to_regex "#" 
-                r . name . should_equal "replace([A], regex('[aeiou]'), '#')"
+                r . name . should_equal "replace([A], r/[aeiou]/, '#')"
                 r . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
                 r2 = data.a.text_replace (regex "[aeiou]") "#" 
-                r2 . name . should_equal "replace([A], regex('[aeiou]'), '#')"
+                r2 . name . should_equal "replace([A], r/[aeiou]/, '#')"
                 r2 . to_vector . should_equal ["Alph#", "Br#v#", "Ch#rl##", "D#lt#", "Ech#", "F#xtr#t"]
                 data.a.text_replace "([aeiou])(.*?)[aeiou]".to_regex "$1$2$1" . to_vector . should_equal ["Alpha", "Brava", "Charlae", "Delte", "Echo", "Foxtrot"]
+                r3 = data.a.text_replace (regex "[/aei\tou]") "#" 
+                r3 . name . should_equal "replace([A], r/[\/aei\tou]/, '#')"
 
             group_builder.specify "should handle unicode" <|
                 table = table_builder [["x", ["śćxx", "ąąasdfąą", "aﬃb"]], ["patterns", ["ć", "ąą", "ﬃ"]], ["replacements", ["abc", "def", "ghi"]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -33,7 +33,8 @@ add_expression_specs suite_builder detailed setup =
     test_table = Lazy_Ref.Value <|
         column_b = ["B", [1.0, 1.5, 2.5, 4, 6]]
         column_c = ["C", ["Hello", "World", "Hello World!", "", Nothing]]
-        table_builder [column_a_description, column_b, column_c, column_odd_description]
+        column_d = ["D", ["A/B", "C//D", "E\F", "", Nothing]]
+        table_builder [column_a_description, column_b, column_c, column_d, column_odd_description]
 
     pending_datetime = if (setup.flagged ..Date_Time).not then "Date/Time operations are not supported by this backend."
 
@@ -439,6 +440,14 @@ add_expression_specs suite_builder detailed setup =
             expression_test "text_replace([C], regex('l{2}'), '')" ["Heo", "World", "Heo World!", "", Nothing]
             expression_test "text_replace([C], regex('L{2}'), '')" ["Hello", "World", "Hello World!", "", Nothing]
             expression_test "text_replace([C], r/l{2}/, '')" ["Heo", "World", "Heo World!", "", Nothing]
+
+        if setup.is_database.not then specify_test "can use forward slash in regex literal by escaping it" group_builder expression_test->
+            expression_test "text_replace([D], r/\//, '*')" ["A*B", "C**D", "E\F", "", Nothing]
+            expression_test "text_replace([D], regex('/'), '*')" ["A*B", "C**D", "E\F", "", Nothing]
+
+        if setup.is_database.not then specify_test "other regex escape characters work" group_builder expression_test->
+            expression_test "text_replace([D], r/\\{1}/, '*')" ["A/B", "C//D", "E*F", "", Nothing]
+            expression_test 'text_replace([D], regex("\\\\{1}"), "*")' ["A/B", "C//D", "E*F", "", Nothing]
             
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         expect_error ctor expr =


### PR DESCRIPTION
### Pull Request Description

Enables use of forwardslash in regex expression literals via backslash escaping it.

e.g. (GRR Markdown stops me showing you a good example. You will have to look at the code) matches a single forwardslash

### Important Notes

Switched the recommended syntax to be the r/ / literal rather than regex("") as escaping is actually very painful inside of regex("") as it is a string literal inside a string literal...

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
