### PR TITLE
Limit the size of expressions

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,13 +7,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.Token;
 import org.enso.base.time.EnsoDateTimeFormatter;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
@@ -173,7 +171,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     var expr = parser.prog();
     int nodeCount = expr.children != null ? expr.children.size() : 0;
     if (nodeCount > 512) {
-        throw new IllegalArgumentException("Expression is too complex: exceeds 512 direct children.");
+      throw new IllegalArgumentException("Expression is too complex: exceeds 512 direct children.");
     }
     var result = visitor.visit(expr);
     return makeConstantColumn.apply(result);
@@ -185,15 +183,18 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     for (var token : tokens.getTokens()) {
       tokenCount++;
       if (tokenCount > tokenLimit) {
-          throw new SyntaxErrorException(
-              "Expression is too complex: " + tokens.size() + " tokens (exceeds " + tokenLimit + "). " +
-              "Consider splitting into multiple expressions.", 
-              token.getLine(), token.getCharPositionInLine()
-          );
+        throw new SyntaxErrorException(
+            "Expression is too complex: "
+                + tokens.size()
+                + " tokens (exceeds "
+                + tokenLimit
+                + "). "
+                + "Consider splitting into multiple expressions.",
+            token.getLine(),
+            token.getCharPositionInLine());
       }
     }
-}
-
+  }
 
   private final Function<String, Value> getColumn;
   private final Function<Object, Value> makeConstantColumn;

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -169,10 +169,6 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
             getColumn, makeConstantColumn, isColumn, getMethod, makeConstructor);
 
     var expr = parser.prog();
-    int nodeCount = expr.children != null ? expr.children.size() : 0;
-    if (nodeCount > 512) {
-      throw new IllegalArgumentException("Expression is too complex: exceeds 512 direct children.");
-    }
     var result = visitor.visit(expr);
     return makeConstantColumn.apply(result);
   }

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,11 +7,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
 import org.enso.base.time.EnsoDateTimeFormatter;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
@@ -158,6 +160,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     lexer.addErrorListener(ThrowOnErrorListener.INSTANCE);
 
     var tokens = new CommonTokenStream(lexer);
+    checkTokenLimit(tokens, 1024);
+
     var parser = new ExpressionParser(tokens);
     parser.removeErrorListeners();
     parser.addErrorListener(ThrowOnErrorListener.INSTANCE);
@@ -167,9 +171,29 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
             getColumn, makeConstantColumn, isColumn, getMethod, makeConstructor);
 
     var expr = parser.prog();
+    int nodeCount = expr.children != null ? expr.children.size() : 0;
+    if (nodeCount > 512) {
+        throw new IllegalArgumentException("Expression is too complex: exceeds 512 direct children.");
+    }
     var result = visitor.visit(expr);
     return makeConstantColumn.apply(result);
   }
+
+  private static void checkTokenLimit(CommonTokenStream tokens, int tokenLimit) {
+    tokens.fill(); // Ensure the token stream is fully populated
+    int tokenCount = 0;
+    for (var token : tokens.getTokens()) {
+      tokenCount++;
+      if (tokenCount > tokenLimit) {
+          throw new SyntaxErrorException(
+              "Expression is too complex: " + tokens.size() + " tokens (exceeds " + tokenLimit + "). " +
+              "Consider splitting into multiple expressions.", 
+              token.getLine(), token.getCharPositionInLine()
+          );
+      }
+    }
+}
+
 
   private final Function<String, Value> getColumn;
   private final Function<Object, Value> makeConstantColumn;

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -17,6 +17,8 @@ from Standard.Test import all
 from project.Util import all
 from project.Common_Table_Operations.Util import run_default_backend, build_sorted_table
 
+import Standard.Base.Runtime.Debug
+
 main filter=Nothing = run_default_backend (add_specs detailed=True) filter
 
 type Lazy_Ref
@@ -552,3 +554,18 @@ add_expression_specs suite_builder detailed setup =
             t4.at "Z" . to_vector . should_equal ["A", "A", "B"]
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Illegal_State t4
+    
+    suite_builder.group prefix+"Large expressions" group_builder->
+        group_builder.specify "Should be able to build and run large expressions up to token limit" <|
+            t1 = table_builder [["X", ["A"]]]
+            ## length([X])+length([X])+...+length([X])
+            large_expression = Vector.fill 204 "length([X])" . join "+" 
+            t2 = t1.set (expr large_expression) as="Z"
+            t2.at "Z" . to_vector . should_equal [204]
+            ## Each length([X])+ is 5 tokens so 5*205 = 1025
+            larger_expression = Vector.fill 205 "length([X])" . join "+" 
+            t1.set (expr larger_expression) as="Z" . should_fail_with (Expression_Error.Syntax_Error "Expression is too complex: 1025 tokens (exceeds 1024). Consider splitting into multiple expressions." 1 2459)
+            ## If we make the expression even larger we still get the same character count where we tip over the limit - 2459
+            even_larger_expression = Vector.fill 1000 "length([X])" . join "+" 
+            t1.set (expr even_larger_expression) as="Z" . should_fail_with (Expression_Error.Syntax_Error "Expression is too complex: 5000 tokens (exceeds 1024). Consider splitting into multiple expressions." 1 2459)
+

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -17,8 +17,6 @@ from Standard.Test import all
 from project.Util import all
 from project.Common_Table_Operations.Util import run_default_backend, build_sorted_table
 
-import Standard.Base.Runtime.Debug
-
 main filter=Nothing = run_default_backend (add_specs detailed=True) filter
 
 type Lazy_Ref


### PR DESCRIPTION
### Pull Request Description

Limits the size of expressions to 1024 tokens to avoid the stack overflow problems found with the recursive walking of the parsed expression.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
