### PR TITLE
Honor ENSO_LAUNCHER in runProjectManagerDistribution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5485,16 +5485,25 @@ runEngineDistribution := {
   )
 }
 
+lazy val buildProjectManagerDistributionCond =
+  taskKey[Unit](
+    "Builds the project manager distribution either via NativeImage, or just assembly Jar"
+  )
+buildProjectManagerDistributionCond := Def.taskIf {
+  if (shouldBuildNativeImage.value) {
+    buildProjectManagerDistribution.value
+  } else {
+    (`project-manager` / assembly).value
+  }
+}.value
+
 lazy val runProjectManagerDistribution =
   inputKey[Unit](
     "Run or --debug the project manager distribution with arguments"
   )
 runProjectManagerDistribution := {
   buildEngineDistributionNoIndex.value
-  if (GraalVM.EnsoLauncher.native) {
-    // how do I do the following only when `ENSO_LAUNCHER=native`?
-    // buildProjectManagerDistributionCond.value
-  }
+  buildProjectManagerDistributionCond.value
   val projectManagerJar = (`project-manager` / assembly).value.getAbsoluteFile()
   val args: Seq[String] = spaceDelimited("<arg>").parsed
   DistributionPackage.runProjectManagerPackage(

--- a/build.sbt
+++ b/build.sbt
@@ -5490,12 +5490,17 @@ lazy val runProjectManagerDistribution =
     "Run or --debug the project manager distribution with arguments"
   )
 runProjectManagerDistribution := {
-  buildEngineDistribution.value
-  buildProjectManagerDistribution.value
+  buildEngineDistributionNoIndex.value
+  if (GraalVM.EnsoLauncher.native) {
+    // how do I do the following only when `ENSO_LAUNCHER=native`?
+    // buildProjectManagerDistributionCond.value
+  }
+  val projectManagerJar = (`project-manager` / assembly).value.getAbsoluteFile()
   val args: Seq[String] = spaceDelimited("<arg>").parsed
   DistributionPackage.runProjectManagerPackage(
     engineDistributionRoot.value,
     projectManagerDistributionRoot.value,
+    projectManagerJar,
     args,
     streams.value.log
   )

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -661,9 +661,11 @@ enso$ corepack pnpm i
 enso$ corepack pnpm dev:gui
 ```
 
-To build the `project-manager` one needs to launch `sbt` - one way to do it is
-to execute `./run backend sbt`. When in the _sbt prompt_ one can request
-compilation of the `project-manager`:
+To assemble and run the `project-manager` one needs to launch `sbt` - one way to
+do it is to execute `./run backend sbt`. When in the _sbt prompt_ one can
+request execution of the `project-manager`:
+
+<!--
 
 ```bash
 sbt:enso> buildProjectManagerDistribution
@@ -694,15 +696,18 @@ orchestration. One can pass following environment variables to
 
 One doesn't need to deal with these options directly, there is an _sbt command_
 to orchestrate them all:
+-->
 
 ```bash
 sbt:enso> runProjectManagerDistribution
 ```
 
+<!--
 The above command invokes `buildProjectManagerDistribution`,
 `buildEngineDistribution` and then defines `ENSO_ENGINE_PATH` to connect them
 together and also specifies the `ENSO_JVM_PATH` to the JVM `sbt` process runs
 on.
+-->
 
 There also is a simple way to [debug](debugger/README.md). When adding `--debug`
 option to the _sbt command_:
@@ -711,25 +716,15 @@ option to the _sbt command_:
 sbt:enso> runProjectManagerDistribution --debug
 ```
 
-the system also sets
-`ENSO_JVM_OPTS=-agentlib:jdwp=transport=dt_socket,address=5005`. Just
-[configure your Java IDE](debugger/README.md) to listen on port 5005 before
+the system sets `ENSO_JVM_OPTS=-agentlib:jdwp=transport=dt_socket,address=5005`.
+Just [configure your Java IDE](debugger/README.md) to listen on port 5005 before
 invoking the command and you'll be able to debug the engine launched by the
 project manager.
 
-To summarize, these are the steps required to run IDE with the development
-version of the language server:
-
-```bash
-enso$ ./run gui watch --skip-wasm-opt
-```
-
-together with that also (after launching `./run backend sbt`) following _sbt
-command_:
-
-```bash
-sbt:enso> runProjectManagerDistribution
-```
+By default the `runProjectManagerDistribution` command is useful for
+development, but it differs from the binary used during production. To work with
+a system closer to production one specify `ENSO_LAUNCHER=native` environment
+variable before starting `sbt` and use the same commands as described above.
 
 #### Language Server Mode
 

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -444,16 +444,30 @@ object DistributionPackage {
   def runProjectManagerPackage(
     engineRoot: File,
     distributionRoot: File,
+    projectManagerJar: File,
     args: Seq[String],
     log: Logger
   ): Boolean = {
     import scala.collection.JavaConverters._
 
+    val pb   = new java.lang.ProcessBuilder()
+    val all  = new java.util.ArrayList[String]()
     val enso = distributionRoot / "bin" / "project-manager"
-    log.info(s"Executing $enso ${args.mkString(" ")}")
-    val pb  = new java.lang.ProcessBuilder()
-    val all = new java.util.ArrayList[String]()
-    all.add(enso.getAbsolutePath())
+    if (enso.canExecute()) {
+      log.info(s"Executing $enso ${args.mkString(" ")}")
+      all.add(enso.getAbsolutePath())
+    } else {
+      val java =
+        new File(System.getProperty("java.home")) / "bin" / executableName(
+          "java"
+        )
+      log.info(
+        s"Cannot find $enso, trying to execute $java -jar $projectManagerJar with ${args.mkString(" ")}"
+      )
+      all.add(java.getPath())
+      all.add("-jar")
+      all.add(projectManagerJar.getPath())
+    }
     all.addAll(args.asJava)
     pb.command(all)
     pb.environment().put("ENSO_ENGINE_PATH", engineRoot.toString())


### PR DESCRIPTION
### Pull Request Description

To speed developer experience up let's use JAR version of project manager when calling
```
sbt:enso> runProjectManagerDistribution
```
unless `ENSO_LAUNCHER=native` is specified or unless `buildProjectManagerDistribution` has explicitly been called.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Manually tested
