### PR TITLE
Fix Native Image search path on Windows

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -319,7 +319,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   if (java.lang.Boolean.getBoolean("com.oracle.graalvm.isaot")) {
     log.info("Running Language Server in AOT mode")
   } else {
-    log.info("Running Language Server in non-AOT mode")
+    log.info("Running Language Server in JVM mode")
   }
 
   private val builder = ContextFactory

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -317,9 +317,9 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   )
 
   if (java.lang.Boolean.getBoolean("com.oracle.graalvm.isaot")) {
-    log.trace("Running Language Server in AOT mode")
+    log.info("Running Language Server in AOT mode")
   } else {
-    log.trace("Running Language Server in non-AOT mode")
+    log.info("Running Language Server in non-AOT mode")
   }
 
   private val builder = ContextFactory

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -38,6 +38,9 @@ logging-service {
       },
       {
         name = "file"
+      },
+      {
+        name = "console"
       }
   ]
   default-appender = file

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -41,7 +41,7 @@ object NativeExecCommand {
     } else if (ensoLauncher.map(_.equals("native")).getOrElse(false)) {
       val component =
         engine.componentDirPath.resolve("..").toAbsolutePath.normalize
-      val fallbackExecPath = component.resolve("bin").resolve("enso")
+      val fallbackExecPath = component.resolve("bin").resolve(execName)
       if (
         fallbackExecPath.toFile.exists() && isBinary(fallbackExecPath, logger)
       ) {


### PR DESCRIPTION
### Pull Request Description

Fallback mechanism had a hardcoded `enso` executable name instead of using an OS-specific one. Hence, lack of NI support on Windows.

### Important Notes

Follow up on https://github.com/enso-org/enso/pull/12287.
