### PR TITLE
Ensure project-manager's logs are centrally collected

### DIFF
--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
@@ -76,7 +76,10 @@ public class SocketLoggingNode implements Runnable {
         event = (ILoggingEvent) hardenedLoggingEventInputStream.readObject();
         if (projectId == null) {
           try {
-            projectId = UUID.fromString(event.getMDCPropertyMap().get("project.id"));
+            var property = event.getMDCPropertyMap().get("project.id");
+            if (property != null) {
+              projectId = UUID.fromString(property);
+            }
           } catch (IllegalArgumentException e) {
             // ignore
           }

--- a/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingSetupHelper.java
+++ b/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingSetupHelper.java
@@ -77,12 +77,12 @@ public abstract class LoggingSetupHelper {
                   if (result.isFailure()) {
                     setup(Option.apply(logLevel), Option.empty(), logMasking, loggerSetup);
                   } else {
-                    URI uri = result.get();
                     Masking.setup(logMasking);
                     if (!loggerSetup.setup(logLevel)) {
                       LoggingServiceManager.teardown();
                       loggingServiceEndpointPromise.failure(new LoggerInitializationFailed());
                     } else {
+                      URI uri = result.get();
                       loggingServiceEndpointPromise.success(Option.apply(uri));
                     }
                   }

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -40,7 +40,7 @@ logging-service {
         name = "file"
       }
   ]
-  default-appender = file
+  default-appender = socket
   default-appender = ${?ENSO_APPENDER_DEFAULT}
   log-to-file {
     enable = true
@@ -55,9 +55,9 @@ logging-service {
     port = ${?ENSO_LOGSERVER_PORT}
     log-to-file {
       enable = true
-      enable = ${?ENSO_LOG_TO_FILE}
+      enable = ${?ENSO_LOGSERVER_LOG_TO_FILE}
       log-level = debug
-      log-level = ${?ENSO_LOG_TO_FILE_LOG_LEVEL}
+      log-level = ${?ENSO_LOGSERVER_LOG_TO_FILE_LOG_LEVEL}
     }
     appenders = [ # file/console/socket/sentry
         {


### PR DESCRIPTION
### Pull Request Description

Minor fix to bring back project-manager's logs.

Previous, default, configuration meant that logs for project-manager ended up in a separate file from the rest of the logs. Language server logs are being sent to the logging server by default, so should project-manager's ones as well.

Fixed NPE in `SocketLoggingNode` when no `project.id` is present in loggers, as is the case with logs coming from project-manager.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
