### PR TITLE
Fix atom types in generated expression names

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1743,7 +1743,7 @@ type DB_Column
             Value_Type.expect_type end (== my_type) my_type.to_display_text <|
                 aligned_period = Date_Time_Helpers.align_period_with_value_type my_type period
                 aligned_period.if_not_error <|
-                    new_name = self.naming_helper.function_name "date_diff" [self, end, period.to_display_text]
+                    new_name = self.naming_helper.function_name "date_diff" [self, end, period]
                     metadata = self.connection.dialect.prepare_metadata_for_period aligned_period my_type
                     self.make_op "date_diff" [end] new_name metadata
 
@@ -1773,7 +1773,7 @@ type DB_Column
             Helpers.expect_dialect_specific_integer_type self amount <|
                 aligned_period = Date_Time_Helpers.align_period_with_value_type my_type period
                 aligned_period.if_not_error <|
-                    new_name = self.naming_helper.function_name "date_add" [self, amount, period.to_display_text]
+                    new_name = self.naming_helper.function_name "date_add" [self, amount, period]
                     metadata = self.connection.dialect.prepare_metadata_for_period aligned_period my_type
                     self.make_op "date_add" [amount] new_name metadata
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -1645,7 +1645,7 @@ type Column
             Value_Type.expect_type end (== my_type) my_type.to_display_text <|
                 aligned_period = Date_Time_Helpers.align_period_with_value_type my_type period
                 aligned_period.if_not_error <|
-                    new_name = naming_helper.function_name "date_diff" [self, end, period.to_display_text]
+                    new_name = naming_helper.function_name "date_diff" [self, end, period]
                     java_unit = aligned_period.to_java_unit
                     fn = case my_type of
                         Value_Type.Date_Time _ ->
@@ -1683,7 +1683,7 @@ type Column
             Value_Type.expect_integer amount <|
                 aligned_period = Date_Time_Helpers.align_period_with_value_type my_type period
                 aligned_period.if_not_error <|
-                    new_name = naming_helper.function_name "date_add" [self, amount, period.to_display_text]
+                    new_name = naming_helper.function_name "date_add" [self, amount, period]
                     java_unit = aligned_period.to_java_unit
                     ## Here we do not need a Time_Utils helper like in scalar
                        implementations of `date_add`, because the date coming

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -104,7 +104,8 @@ type Column_Naming_Helper
     to_expression_text self value =
         if is_column value then "[" + value.name + "]" else
             if value.is_a Regex then "r/" + (value.pattern.replace "/" "\/") + "/" else
-                value.pretty
+                if Meta.is_atom value then ".."+value.to_text else
+                    value.pretty
 
     ## PRIVATE
        Concatenates a vector of texts that are meant to make a single column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -104,7 +104,7 @@ type Column_Naming_Helper
     to_expression_text self value =
         if is_column value then "[" + value.name + "]" else
             if value.is_a Regex then "r/" + (value.pattern.replace "/" "\/") + "/" else
-                if Meta.is_atom value then ".."+value.to_text else
+                if Meta.is_atom value then value.pretty.replace (Meta.Type.from value . name)+"." ".." else
                     value.pretty
 
     ## PRIVATE

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -89,23 +89,54 @@ add_derived_columns_specs suite_builder setup =
                 t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 2023 1 12, Date.new 2020 5 12]
                 t.set (Simple_Expression.Simple_Expr (Date_Time.new 1999 12 10 14 55 11) Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 1999 12 10, Date.new 1999 12 10]
 
-            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add (Column_Ref.Name "x"))) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
-            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add 10 Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
-            t.set (Simple_Expression.Simple_Expr (Date_Time.new 2001 12 15 11 00) (Simple_Calculation.Date_Add 10 Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
+            r = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add (Column_Ref.Name "x"))) . at -1
+            r.to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
+            r.name . should_equal "date_add([A], [x], ..Day)"
+            
+            r2 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add 10 Date_Period.Year)) . at -1
+            r2.to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
+            r2.name . should_equal "date_add([A], 10, ..Year)"
 
-            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Diff (Column_Ref.Name "B") Date_Period.Day)) "Z" . at "Z" . to_vector . should_equal [3, 31]
-            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2023, 2020]
-            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 45]
+            r3 = t.set (Simple_Expression.Simple_Expr (Date_Time.new 2001 12 15 11 00) (Simple_Calculation.Date_Add 10 Time_Period.Minute)) . at -1
+            r3.to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
+            r3.name . should_equal "date_add([Date_Time.new 2001 12 15 11], 10, ..Minute)"
+
+            r4 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Diff (Column_Ref.Name "B") Date_Period.Day)) . at -1
+            r4.to_vector . should_equal [3, 31]
+            r4.name . should_equal "date_diff([A], [B], ..Day)"
+
+            r5 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Date_Period.Year)) . at -1
+            r5.to_vector . should_equal [2023, 2020]
+            r5.name . should_equal "date_part([A], ..Year)"
+            
+            r6 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Time_Period.Minute)) . at -1
+            r6.to_vector . should_equal [45, 45]
+            r6.name . should_equal "date_part([A], ..Minute)"
 
             t2 = table_builder [["C", [Date.new 2002 12 10, Date.new 2005 01 01]], ["D", [Time_Of_Day.new 12 45, Time_Of_Day.new 01 01]]]
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Add 5 Date_Period.Month)) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Add 15 Time_Period.Hour)) "Z" . at "Z" . to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
+            r7 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Add 5 Date_Period.Month)) . at -1
+            r7.to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
+            r7.name . should_equal "date_add([C], 5, ..Month)"
 
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Diff (Date.new 2003 01 01) Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [0, -2]
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Diff (Time_Of_Day.new 13) Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [15, 59+(60*11)]
+            r8 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Add 15 Time_Period.Hour)) . at -1
+            r8.to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
+            r8.name . should_equal "date_add([D], 15, ..Hour)"
 
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2002, 2005]
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 1]
+            r9 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Diff (Date.new 2003 01 01) Date_Period.Year)) . at -1
+            r9.to_vector . should_equal [0, -2]
+            r9.name . should_equal "date_diff([C], Date.new 2003 1 1, ..Year)"
+
+            r10 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Diff (Time_Of_Day.new 13) Time_Period.Minute)) . at -1
+            r10.to_vector . should_equal [15, 59+(60*11)]
+            r10.name . should_equal "date_diff([D], Time_Of_Day.new 13, ..Minute)"
+
+            r11 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Part Date_Period.Year)) . at -1
+            r11.to_vector . should_equal [2002, 2005]
+            r11.name . should_equal "date_part([C], ..Year)"
+
+            r12 = t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Part Time_Period.Minute)) . at -1
+            r12.to_vector . should_equal [45, 1]
+            r12.name . should_equal "date_part([D], ..Minute)"
 
             # error handling
             t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument

--- a/test/Table_Tests/src/Common_Table_Operations/Offset_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Offset_Spec.enso
@@ -41,7 +41,7 @@ add_offset_specs suite_builder setup =
         group_builder.specify "Works with default values" <|
             r = c.offset
             r.to_vector . should_equal [Nothing, 1, 2]
-            r.name . should_equal "offset([A], -1, Fill_With.Nothing)"
+            r.name . should_equal "offset([A], -1, ..Nothing)"
         group_builder.specify "Negative n shifts the values down" <|
             r = c.offset -1
             r.to_vector . should_equal [Nothing, 1, 2]
@@ -168,71 +168,71 @@ add_offset_specs suite_builder setup =
         t1 = build_sorted_table [colA]
         group_builder.specify "Works with default values" <|
             t1.offset ["A"] . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], -1, Fill_With.Nothing)", [Nothing, 1, 2]]]
+                Table.new [colA, ["offset([A], -1, ..Nothing)", [Nothing, 1, 2]]]
         group_builder.specify "Works with negative n values" <|
             t1.offset ["A"] -2 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], -2, Fill_With.Nothing)", [Nothing, Nothing, 1]]]
+                Table.new [colA, ["offset([A], -2, ..Nothing)", [Nothing, Nothing, 1]]]
         group_builder.specify "Works with positive n values (n=1)" <|
             t1.offset ["A"] 1 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], 1, Fill_With.Nothing)", [2, 3, Nothing]]]
+                Table.new [colA, ["offset([A], 1, ..Nothing)", [2, 3, Nothing]]]
         group_builder.specify "Works with positive n values (n=2)" <|
             t1.offset ["A"] 2 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], 2, Fill_With.Nothing)", [3, Nothing, Nothing]]]
+                Table.new [colA, ["offset([A], 2, ..Nothing)", [3, Nothing, Nothing]]]
         group_builder.specify "Zero n is a no-op" <|
             t1.offset ["A"] 0 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], 0, Fill_With.Nothing)" , [1, 2, 3]]]
+                Table.new [colA, ["offset([A], 0, ..Nothing)" , [1, 2, 3]]]
         group_builder.specify "Large negative n values work" <|
             t1.offset ["A"] -1024 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], -1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, ["offset([A], -1024, ..Nothing)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Large positive n values work" <|
             t1.offset ["A"] 1024 . should_equal ignore_order=setup.is_database
-                Table.new [colA, ["offset([A], 1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, ["offset([A], 1024, ..Nothing)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Works with zero rows" <|
             build_sorted_table [["A",[], Value_Type.Integer],["B",[], Value_Type.Integer]] . sort ["B"] . offset ["A"] -1 . should_equal ignore_order=setup.is_database
-                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, Fill_With.Nothing)", [], Value_Type.Integer]]
+                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, ..Nothing)", [], Value_Type.Integer]]
     suite_builder.group prefix+"Table.Offset with default fill strategy (Text Values)" group_builder->
         colText = ["Text Values", ["A", "B", "C"]]
         t1 = build_sorted_table [colText]
         group_builder.specify "Works with default values" <|
             t1.offset ["Text Values"] . should_equal ignore_order=setup.is_database
-                Table.new [colText, ["offset([Text Values], -1, Fill_With.Nothing)", [Nothing, "A", "B"]]]
+                Table.new [colText, ["offset([Text Values], -1, ..Nothing)", [Nothing, "A", "B"]]]
         group_builder.specify "Works with negative n values" <|
             t1.offset ["Text Values"] -2 . should_equal ignore_order=setup.is_database
-                Table.new [colText, ["offset([Text Values], -2, Fill_With.Nothing)", [Nothing, Nothing, "A"]]]
+                Table.new [colText, ["offset([Text Values], -2, ..Nothing)", [Nothing, Nothing, "A"]]]
         group_builder.specify "Works with positive n values (n=1)" <|
             t1.offset ["Text Values"] 1 . should_equal ignore_order=setup.is_database
-                Table.new [colText, ["offset([Text Values], 1, Fill_With.Nothing)", ["B", "C", Nothing]]]
+                Table.new [colText, ["offset([Text Values], 1, ..Nothing)", ["B", "C", Nothing]]]
         group_builder.specify "Works with positive n values (n=2)" <|
             t1.offset ["Text Values"] 2 . should_equal ignore_order=setup.is_database
-                Table.new [colText, ["offset([Text Values], 2, Fill_With.Nothing)", ["C", Nothing, Nothing]]]
+                Table.new [colText, ["offset([Text Values], 2, ..Nothing)", ["C", Nothing, Nothing]]]
     suite_builder.group prefix+"Table.Offset with closest value fill strategy" group_builder->
         colA = ["A", [1, 2, 3]]
         colB = ["B", [Nothing, Nothing, Nothing], Value_Type.Integer]
         t1 = build_sorted_table [colA, colB]
         group_builder.specify "Negative n shifts the values down" <|
             t1.offset ["A"] -1 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -1, Fill_With.Closest_Value)", [1, 1, 2]]]
+                Table.new [colA, colB, ["offset([A], -1, ..Closest_Value)", [1, 1, 2]]]
         group_builder.specify "Positive n shifts the values up" <|
             t1.offset ["A"] 1 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 1, Fill_With.Closest_Value)", [2, 3, 3]]]
+                Table.new [colA, colB, ["offset([A], 1, ..Closest_Value)", [2, 3, 3]]]
         group_builder.specify "Zero n is a no-op" <|
             t1.offset ["A"] 0 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 0, Fill_With.Closest_Value)", [1, 2, 3]]]
+                Table.new [colA, colB, ["offset([A], 0, ..Closest_Value)", [1, 2, 3]]]
         group_builder.specify "Large negative n values work" <|
             t1.offset ["A"] -1024 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -1024, Fill_With.Closest_Value)", [1, 1, 1]]]
+                Table.new [colA, colB, ["offset([A], -1024, ..Closest_Value)", [1, 1, 1]]]
         group_builder.specify "Large positive n values work" <|
             t1.offset ["A"] 1024 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 1024, Fill_With.Closest_Value)", [3, 3, 3]]]
+                Table.new [colA, colB, ["offset([A], 1024, ..Closest_Value)", [3, 3, 3]]]
         group_builder.specify "Works with zero rows" <|
             build_sorted_table [["A",[], Value_Type.Integer],["B",[], Value_Type.Integer]] . sort ["B"] . offset ["A"] -1 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, Fill_With.Closest_Value)", [], Value_Type.Integer]]
+                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, ..Closest_Value)", [], Value_Type.Integer]]
         group_builder.specify "Works with negative n and column of nothings" <|
             t1.offset ["B"] -1 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([B], -1, Fill_With.Closest_Value)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, colB, ["offset([B], -1, ..Closest_Value)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Works with positive n and column of nothings" <|
             t1.offset ["B"] 1 ..Closest_Value . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([B], 1, Fill_With.Closest_Value)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, colB, ["offset([B], 1, ..Closest_Value)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
     if setup.is_database then suite_builder.group prefix+"Table.Offset with wrap around fill strategy" group_builder->
         colA = ["A", [1, 2, 3]]
         colB = ["B", [Nothing, Nothing, Nothing], Value_Type.Integer]
@@ -246,215 +246,215 @@ add_offset_specs suite_builder setup =
         t1 = build_sorted_table [colA, colB]
         group_builder.specify "Negative n shifts the values down" <|
             t1.offset ["A"] -1 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -1, Fill_With.Wrap_Around)", [3, 1, 2]]]
+                Table.new [colA, colB, ["offset([A], -1, ..Wrap_Around)", [3, 1, 2]]]
         group_builder.specify "Positive n shifts the values up" <|
             t1.offset ["A"] 1 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 1, Fill_With.Wrap_Around)", [2, 3, 1]]]
+                Table.new [colA, colB, ["offset([A], 1, ..Wrap_Around)", [2, 3, 1]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t1.offset ["A"] -2 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -2, Fill_With.Wrap_Around)", [2, 3, 1]]]
+                Table.new [colA, colB, ["offset([A], -2, ..Wrap_Around)", [2, 3, 1]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t1.offset ["A"] 2 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 2, Fill_With.Wrap_Around)", [3, 1, 2]]]
+                Table.new [colA, colB, ["offset([A], 2, ..Wrap_Around)", [3, 1, 2]]]
         group_builder.specify "Zero n is a no-op" <|
             t1.offset ["A"] 0 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 0, Fill_With.Wrap_Around)", [1, 2, 3]]]
+                Table.new [colA, colB, ["offset([A], 0, ..Wrap_Around)", [1, 2, 3]]]
         group_builder.specify "Larger than num rows negative n values work" <|
             t1.offset ["A"] -4 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -4, Fill_With.Wrap_Around)", [3, 1, 2]]]
+                Table.new [colA, colB, ["offset([A], -4, ..Wrap_Around)", [3, 1, 2]]]
         group_builder.specify "Larger than num rows positive n values work" <|
             t1.offset ["A"] 4 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 4, Fill_With.Wrap_Around)", [2, 3, 1]]]
+                Table.new [colA, colB, ["offset([A], 4, ..Wrap_Around)", [2, 3, 1]]]
         group_builder.specify "Large negative n values work" <|
             t1.offset ["A"] -1024 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], -1024, Fill_With.Wrap_Around)", [3, 1, 2]]]
+                Table.new [colA, colB, ["offset([A], -1024, ..Wrap_Around)", [3, 1, 2]]]
         group_builder.specify "Large positive n values work" <|
             t1.offset ["A"] 1024 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([A], 1024, Fill_With.Wrap_Around)", [2, 3, 1]]]
+                Table.new [colA, colB, ["offset([A], 1024, ..Wrap_Around)", [2, 3, 1]]]
         group_builder.specify "Works with zero rows" <|
             build_sorted_table [["A",[], Value_Type.Integer],["B",[], Value_Type.Integer]] . sort ["B"] . offset ["A"] -1 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, Fill_With.Wrap_Around)", [], Value_Type.Integer]]
+                Table.new [["A", [], Value_Type.Integer], ["B", [], Value_Type.Integer], ["offset([A], -1, ..Wrap_Around)", [], Value_Type.Integer]]
         group_builder.specify "Works with negative n and column of nothings" <|
             t1.offset ["B"] -1 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([B], -1, Fill_With.Wrap_Around)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, colB, ["offset([B], -1, ..Wrap_Around)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Works with positive n and column of nothings" <|
             t1.offset ["B"] 1 ..Wrap_Around . should_equal ignore_order=setup.is_database
-                Table.new [colA, colB, ["offset([B], 1, Fill_With.Wrap_Around)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [colA, colB, ["offset([B], 1, ..Wrap_Around)", [Nothing, Nothing, Nothing], Value_Type.Integer]]
     suite_builder.group prefix+"Table.Offset works with grouping - default fill strategy" group_builder->
         groupColumn = ["Group", ["A", "A", "A", "B", "B", "B", "B", "C", "C"]]
         dataCol = ["Col", [1, 2, 3, 1, 2, 3, 4, 1, 2]]
         t2 = build_sorted_table [groupColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1, Fill_With.Nothing)", [Nothing, 1, 2, Nothing, 1, 2, 3, Nothing, 1]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1, ..Nothing)", [Nothing, 1, 2, Nothing, 1, 2, 3, Nothing, 1]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1, Fill_With.Nothing)", [2, 3, Nothing, 2, 3, 4, Nothing, 2, Nothing]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1, ..Nothing)", [2, 3, Nothing, 2, 3, 4, Nothing, 2, Nothing]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -2, Fill_With.Nothing)", [Nothing, Nothing, 1, Nothing, Nothing, 1, 2, Nothing, Nothing]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -2, ..Nothing)", [Nothing, Nothing, 1, Nothing, Nothing, 1, 2, Nothing, Nothing]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 2, Fill_With.Nothing)", [3, Nothing, Nothing, 3, 4, Nothing, Nothing, Nothing, Nothing]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 2, ..Nothing)", [3, Nothing, Nothing, 3, 4, Nothing, Nothing, Nothing, Nothing]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 0, Fill_With.Nothing)", [1, 2, 3, 1, 2, 3, 4, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 0, ..Nothing)", [1, 2, 3, 1, 2, 3, 4, 1, 2]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1024 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1024 ..Nothing group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
     suite_builder.group prefix+"Table.Offset works with grouping - closest fill strategy" group_builder->
         groupColumn = ["Group", ["A", "A", "A", "B", "B", "B", "B", "C", "C"]]
         dataCol = ["Col", [1, 2, 3, 10, 20, 30, 40, 100, 200]]
         t2 = build_sorted_table [groupColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1, Fill_With.Closest_Value)", [1, 1, 2, 10, 10, 20, 30, 100, 100]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1, ..Closest_Value)", [1, 1, 2, 10, 10, 20, 30, 100, 100]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1, Fill_With.Closest_Value)", [2, 3, 3, 20, 30, 40, 40, 200, 200]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1, ..Closest_Value)", [2, 3, 3, 20, 30, 40, 40, 200, 200]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -2, Fill_With.Closest_Value)", [1, 1, 1, 10, 10, 10, 20, 100, 100]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -2, ..Closest_Value)", [1, 1, 1, 10, 10, 10, 20, 100, 100]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 2, Fill_With.Closest_Value)", [3, 3, 3, 30, 40, 40, 40, 200, 200]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 2, ..Closest_Value)", [3, 3, 3, 30, 40, 40, 40, 200, 200]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 0, Fill_With.Closest_Value)", [1, 2, 3, 10, 20, 30, 40, 100, 200]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 0, ..Closest_Value)", [1, 2, 3, 10, 20, 30, 40, 100, 200]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1024 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1024, Fill_With.Closest_Value)", [1, 1, 1, 10, 10, 10, 10, 100, 100]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1024, ..Closest_Value)", [1, 1, 1, 10, 10, 10, 10, 100, 100]]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1024 ..Closest_Value group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1024, Fill_With.Closest_Value)", [3, 3, 3, 40, 40, 40, 40, 200, 200]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1024, ..Closest_Value)", [3, 3, 3, 40, 40, 40, 40, 200, 200]]]
     if setup.is_database.not then suite_builder.group prefix+"Table.Offset works with grouping - wrap around fill strategy" group_builder->
         groupColumn = ["Group", ["A", "A", "A", "B", "B", "B", "B", "C", "C"]]
         dataCol = ["Col", [1, 2, 3, 1, 2, 3, 4, 1, 2]]
         t2 = build_sorted_table [groupColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1, Fill_With.Wrap_Around)", [3, 1, 2, 4, 1, 2, 3, 2, 1]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1, ..Wrap_Around)", [3, 1, 2, 4, 1, 2, 3, 2, 1]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1, Fill_With.Wrap_Around)", [2, 3, 1, 2, 3, 4, 1, 2, 1]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1, ..Wrap_Around)", [2, 3, 1, 2, 3, 4, 1, 2, 1]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -2, Fill_With.Wrap_Around)", [2, 3, 1, 3, 4, 1, 2, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -2, ..Wrap_Around)", [2, 3, 1, 3, 4, 1, 2, 1, 2]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 2, Fill_With.Wrap_Around)", [3, 1, 2, 3, 4, 1, 2, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 2, ..Wrap_Around)", [3, 1, 2, 3, 4, 1, 2, 1, 2]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 0, Fill_With.Wrap_Around)", [1, 2, 3, 1, 2, 3, 4, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 0, ..Wrap_Around)", [1, 2, 3, 1, 2, 3, 4, 1, 2]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1022 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], -1022, Fill_With.Wrap_Around)", [2, 3, 1, 3, 4, 1, 2, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], -1022, ..Wrap_Around)", [2, 3, 1, 3, 4, 1, 2, 1, 2]]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1022 ..Wrap_Around group_by=["Group"] . should_equal ignore_order=setup.is_database
-                Table.new [groupColumn, dataCol, ["offset([Col], 1022, Fill_With.Wrap_Around)", [3, 1, 2, 3, 4, 1, 2, 1, 2]]]
+                Table.new [groupColumn, dataCol, ["offset([Col], 1022, ..Wrap_Around)", [3, 1, 2, 3, 4, 1, 2, 1, 2]]]
     suite_builder.group prefix+"Table.Offset works with ordering - default fill strategy" group_builder->
         orderColumn = ["Order", [1, 4, 2, 5, 3]]
         dataCol = ["Col", ["A", "D", "B", "E", "C"]]
         t2 = build_sorted_table [orderColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1, Fill_With.Nothing)", [Nothing, "C", "A", "D", "B"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1, ..Nothing)", [Nothing, "C", "A", "D", "B"]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1, Fill_With.Nothing)", ["B", "E", "C", Nothing, "D"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1, ..Nothing)", ["B", "E", "C", Nothing, "D"]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -2, Fill_With.Nothing)", [Nothing, "B", Nothing, "C", "A"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -2, ..Nothing)", [Nothing, "B", Nothing, "C", "A"]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 2, Fill_With.Nothing)", ["C", Nothing, "D", Nothing, "E"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 2, ..Nothing)", ["C", Nothing, "D", Nothing, "E"]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 0, Fill_With.Nothing)", ["A", "D", "B", "E", "C"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 0, ..Nothing)", ["A", "D", "B", "E", "C"]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1024 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Char]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Char]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1024 ..Nothing order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Char]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing, Nothing], Value_Type.Char]]
     suite_builder.group prefix+"Table.Offset works with ordering - closest fill strategy" group_builder->
         orderColumn = ["Order", [1, 4, 2, 5, 3]]
         dataCol = ["Col", ["A", "D", "B", "E", "C"]]
         t2 = build_sorted_table [orderColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1, Fill_With.Closest_Value)", ["A", "C", "A", "D", "B"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1, ..Closest_Value)", ["A", "C", "A", "D", "B"]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1, Fill_With.Closest_Value)", ["B", "E", "C", "E", "D"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1, ..Closest_Value)", ["B", "E", "C", "E", "D"]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -2, Fill_With.Closest_Value)", ["A", "B", "A", "C", "A"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -2, ..Closest_Value)", ["A", "B", "A", "C", "A"]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 2, Fill_With.Closest_Value)", ["C", "E", "D", "E", "E"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 2, ..Closest_Value)", ["C", "E", "D", "E", "E"]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 0, Fill_With.Closest_Value)", ["A", "D", "B", "E", "C"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 0, ..Closest_Value)", ["A", "D", "B", "E", "C"]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1024 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1024, Fill_With.Closest_Value)", ["A", "A", "A", "A", "A"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1024, ..Closest_Value)", ["A", "A", "A", "A", "A"]]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1024 ..Closest_Value order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1024, Fill_With.Closest_Value)", ["E", "E", "E", "E", "E"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1024, ..Closest_Value)", ["E", "E", "E", "E", "E"]]]
     if setup.is_database.not then suite_builder.group prefix+"Table.Offset works with ordering - wrap around fill strategy" group_builder->
         orderColumn = ["Order", [1, 4, 2, 5, 3]]
         dataCol = ["Col", ["A", "D", "B", "E", "C"]]
         t2 = build_sorted_table [orderColumn, dataCol]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col"] -1 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1, Fill_With.Wrap_Around)", ["E", "C", "A", "D", "B"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1, ..Wrap_Around)", ["E", "C", "A", "D", "B"]]]
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col"] 1 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1, Fill_With.Wrap_Around)", ["B", "E", "C", "A", "D"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1, ..Wrap_Around)", ["B", "E", "C", "A", "D"]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col"] -2 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -2, Fill_With.Wrap_Around)", ["D", "B", "E", "C", "A"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -2, ..Wrap_Around)", ["D", "B", "E", "C", "A"]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col"] 2 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 2, Fill_With.Wrap_Around)", ["C", "A", "D", "B", "E"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 2, ..Wrap_Around)", ["C", "A", "D", "B", "E"]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col"] 0 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 0, Fill_With.Wrap_Around)", ["A", "D", "B", "E", "C"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 0, ..Wrap_Around)", ["A", "D", "B", "E", "C"]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col"] -1024 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], -1024, Fill_With.Wrap_Around)", ["B", "E", "C", "A", "D"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], -1024, ..Wrap_Around)", ["B", "E", "C", "A", "D"]]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col"] 1024 ..Wrap_Around order_by=["Order"] . should_equal ignore_order=setup.is_database
-                Table.new [orderColumn, dataCol, ["offset([Col], 1024, Fill_With.Wrap_Around)", ["E", "C", "A", "D", "B"]]]
+                Table.new [orderColumn, dataCol, ["offset([Col], 1024, ..Wrap_Around)", ["E", "C", "A", "D", "B"]]]
     suite_builder.group prefix+"Table.Offset works with multiple columns" group_builder->
         col1 = ["Col1", ["A", "B", "C", "D"]]
         col2 = ["Col2", [1, 2, 3, 4]]
         t2 = build_sorted_table [col1, col2]
         group_builder.specify "Negative n shifts the values down" <|
             t2.offset ["Col1", "Col2"] -1 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], -1, Fill_With.Nothing)", [Nothing, "A", "B", "C"]], ["offset([Col2], -1, Fill_With.Nothing)", [Nothing, 1, 2, 3]]]           
+                Table.new [col1, col2, ["offset([Col1], -1, ..Nothing)", [Nothing, "A", "B", "C"]], ["offset([Col2], -1, ..Nothing)", [Nothing, 1, 2, 3]]]           
         group_builder.specify "Positive n shifts the values up" <|
             t2.offset ["Col1", "Col2"] 1 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], 1, Fill_With.Nothing)", ["B", "C", "D", Nothing]], ["offset([Col2], 1, Fill_With.Nothing)", [2, 3, 4, Nothing]]]
+                Table.new [col1, col2, ["offset([Col1], 1, ..Nothing)", ["B", "C", "D", Nothing]], ["offset([Col2], 1, ..Nothing)", [2, 3, 4, Nothing]]]
         group_builder.specify "Negative n shifts the values down (n=2)" <|
             t2.offset ["Col1", "Col2"] -2 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], -2, Fill_With.Nothing)", [Nothing, Nothing, "A", "B"]], ["offset([Col2], -2, Fill_With.Nothing)", [Nothing, Nothing, 1, 2]]]
+                Table.new [col1, col2, ["offset([Col1], -2, ..Nothing)", [Nothing, Nothing, "A", "B"]], ["offset([Col2], -2, ..Nothing)", [Nothing, Nothing, 1, 2]]]
         group_builder.specify "Positive n shifts the values up (n=2)" <|
             t2.offset ["Col1", "Col2"] 2 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], 2, Fill_With.Nothing)", ["C", "D", Nothing, Nothing]], ["offset([Col2], 2, Fill_With.Nothing)", [3, 4, Nothing, Nothing]]]
+                Table.new [col1, col2, ["offset([Col1], 2, ..Nothing)", ["C", "D", Nothing, Nothing]], ["offset([Col2], 2, ..Nothing)", [3, 4, Nothing, Nothing]]]
         group_builder.specify "Zero n is a no-op" <|
             t2.offset ["Col1", "Col2"] 0 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], 0, Fill_With.Nothing)", ["A", "B", "C", "D"]], ["offset([Col2], 0, Fill_With.Nothing)", [1, 2, 3, 4]]]
+                Table.new [col1, col2, ["offset([Col1], 0, ..Nothing)", ["A", "B", "C", "D"]], ["offset([Col2], 0, ..Nothing)", [1, 2, 3, 4]]]
         group_builder.specify "Large negative n values work" <|
             t2.offset ["Col1", "Col2"] -1024 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], -1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Char], ["offset([Col2], -1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [col1, col2, ["offset([Col1], -1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Char], ["offset([Col2], -1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
         group_builder.specify "Large positive n values work" <|
             t2.offset ["Col1", "Col2"] 1024 ..Nothing . should_equal ignore_order=setup.is_database
-                Table.new [col1, col2, ["offset([Col1], 1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Char], ["offset([Col2], 1024, Fill_With.Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
+                Table.new [col1, col2, ["offset([Col1], 1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Char], ["offset([Col2], 1024, ..Nothing)", [Nothing, Nothing, Nothing, Nothing], Value_Type.Integer]]
     suite_builder.group prefix+"Table.Offset works with multiple columns - updating in place" group_builder->
         col1 = ["Col1", ["A", "B", "C", "D"]]
         col2 = ["Col2", [1, 2, 3, 4]]
@@ -501,14 +501,14 @@ add_offset_specs suite_builder setup =
         group_builder.specify "Grouping by float warns" <|
             r = t3.offset ["Col2"] group_by=["Group"]
             Problems.expect_warning Floating_Point_Equality r
-            r . at "offset([Col2], -1, Fill_With.Nothing)" .  to_vector . should_equal [Nothing, 1, 2, 3]
+            r . at "offset([Col2], -1, ..Nothing)" .  to_vector . should_equal [Nothing, 1, 2, 3]
         group_builder.specify "Grouping by float errors if on_problems set" <|
             r = t3.offset ["Col2"] group_by=["Group"] on_problems=..Report_Error
             r.should_fail_with Floating_Point_Equality
         group_builder.specify "Grouping by float errors can be silenced using on_problems" <|
             r = t3.offset ["Col2"] group_by=["Group"] on_problems=..Ignore
             Warning.get_all r wrap_errors=True . should_equal []
-            r . at "offset([Col2], -1, Fill_With.Nothing)" .  to_vector . should_equal [Nothing, 1, 2, 3]
+            r . at "offset([Col2], -1, ..Nothing)" .  to_vector . should_equal [Nothing, 1, 2, 3]
         
 
 


### PR DESCRIPTION
### Pull Request Description

Generated expressions as column names now correctly do ..Name for atom types.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
