### PR TITLE
Add rolling policy to cli logs' appender

### DIFF
--- a/engine/runner/src/main/resources/application.conf
+++ b/engine/runner/src/main/resources/application.conf
@@ -10,7 +10,13 @@ logging-service {
   appenders = [
       {
         name = "file",
-        pattern = "[%level{lowercase=true}] [%d{yyyy-MM-dd'T'HH:mm:ssXXX}] [%logger] %msg%n"
+        pattern = "[%level{lowercase=true}] [%d{yyyy-MM-dd'T'HH:mm:ssXXX}] [%logger] %msg%n",
+        append = false,
+        rolling-policy {
+          max-file-size = "20MB"
+          max-history = 50
+          max-total-size = "1GB"
+        }
       },
       {
         name = "console"

--- a/lib/scala/logging-config/src/main/java/org/enso/logging/config/FileAppender.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logging/config/FileAppender.java
@@ -116,6 +116,8 @@ public final class FileAppender extends Appender {
         + pattern
         + ", immediate-flush - "
         + immediateFlush
+        + ", append -"
+        + append
         + ", rolling-policy - "
         + (rollingPolicy == null ? "no" : rollingPolicy.toString());
   }


### PR DESCRIPTION
### Pull Request Description

Previously cli logs would be written to files on a per-day basis. There was no rolling policy used, meaning that logs could increase arbitrarily. And they did, under heavy dev usage.

Also, addressed #11657 by creating a fresh log file on every execution.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
