### PR TITLE
Use @TruffleBoundary instead of transferToInterpreter()

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -77,15 +77,17 @@ public final class Text extends BuiltinObject {
     return switch (fcdNormalized) {
       case 1 -> true;
       case -1 -> false;
-      case 0 -> {
-        CompilerDirectives.transferToInterpreter();
-        Normalizer2 normalizer = Normalizer2.getNFDInstance();
-        boolean isNormalized = normalizer.isNormalized(toString());
-        fcdNormalized = (byte) (isNormalized ? 1 : -1);
-        yield isNormalized;
-      }
+      case 0 -> computeAndSetFcd();
       default -> false;
     };
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private boolean computeAndSetFcd() {
+    var normalizer = Normalizer2.getNFDInstance();
+    var isNormalized = normalizer.isNormalized(toString());
+    fcdNormalized = (byte) (isNormalized ? 1 : -1);
+    return isNormalized;
   }
 
   public static Text empty() {


### PR DESCRIPTION
### Pull Request Description

Attempt to fix #12374 by using `@TruffleBoundary` instead of `CompilerDirectives.transferToInterpreter()`.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] stdlib [benchmark run](https://github.com/enso-org/enso/actions/runs/13559557223) shows an improvement