### PR TITLE
Fix single stdlib bench run on CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3227,9 +3227,13 @@ lazy val `runtime-benchmarks` =
           case List(name) => name
           case _          => throw new IllegalArgumentException("Expected one argument.")
         }
-        Def.task {
-          (Compile / run).toTask(" " + name).value
-        }
+        Def
+          .task {
+            (Compile / run).toTask(" " + name).value
+          }
+          .dependsOn(
+            buildEngineDistribution
+          )
       }.evaluated
     )
     .dependsOn(`benchmarks-common`)
@@ -4317,9 +4321,13 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
         case List(name) => name
         case _          => throw new IllegalArgumentException("Expected one argument.")
       }
-      Def.task {
-        (Compile / run).toTask(" " + name).value
-      }
+      Def
+        .task {
+          (Compile / run).toTask(" " + name).value
+        }
+        .dependsOn(
+          buildEngineDistribution
+        )
     }.evaluated
   )
   .dependsOn(`bench-processor`)


### PR DESCRIPTION
### Pull Request Description

Fixes #12378 by declaring dependency on `buildEngineDistribution` task from `benchOnly` commands.

### Important Notes

I was not able to figure out exactly why `std-benchmarks/benchOnly foo` command fails on a clean repo, but simply adding the dependency on `buildEngineDistribution` task does the trick. Note that we already have such dependency for `bench` commands.

DevX should not be affected. I still recommend devs to run benchmarks via `run` command rather than `benchOnly` command. See docs in https://github.com/enso-org/enso/blob/develop/docs/infrastructure/benchmarks.md#running-the-benchmarks

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Schedule single stdlib bench run on CI
