### PR TITLE
Speed Vector.at and Vector.length up by avoiding wrapping of warnings

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/AtVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/AtVectorNode.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.node.expression.builtin.immutable;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsWarning;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeAtNode;
@@ -18,7 +19,7 @@ public class AtVectorNode extends Node {
   private @Child ArrayLikeAtNode at = ArrayLikeAtNode.create();
   private @Child ArrayLikeLengthNode length;
 
-  Object execute(Object arrayLike, long index) {
+  Object execute(@AcceptsWarning Object arrayLike, long index) {
     try {
       long actualIndex = index < 0 ? index + len(arrayLike) : index;
       return at.executeAt(arrayLike, actualIndex);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/LengthVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/LengthVectorNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.immutable;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsWarning;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeLengthNode;
 
@@ -11,7 +12,7 @@ import org.enso.interpreter.runtime.data.vector.ArrayLikeLengthNode;
 public class LengthVectorNode extends Node {
   @Child ArrayLikeLengthNode length = ArrayLikeLengthNode.create();
 
-  long execute(Object arrayLike) {
+  long execute(@AcceptsWarning Object arrayLike) {
     return length.executeLength(arrayLike);
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fixes #12258 by avoiding _warnings manipulation_ when doing `vec.fold 0 (x->y->x+y)`.

### Important Notes

- Enso's default handling of warnings removes them before builtin call, adds them back to the result value
- [Vector.fold](https://github.com/enso-org/enso/blob/0b061a413dda049b872ea979edef5b398e0e8a95/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Array_Like_Helpers.enso#L240) is **not a builtin** - it could be, but it is not - making it a builtin would be another fix of the problem
- but it calls a lot of bultin functions - `length` and `at`
- all of them _add/remove warnings_ when the vector has warnings
- that is slowing the benchmark down 
- previously the benchmark was fast as #12258 describes
- as there was `value instanceof WithWarnings` check and not `WarningsLibrary.hasWarnings` check
- and `Vector`s were considered to not have warnings to re-attach (which was wrong)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
- [x] [WarningBenchmarks run](https://github.com/enso-org/enso/actions/runs/13590950248) shows speedup