### PR TITLE
Mapbox token from current env takes precedence

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -616,16 +616,16 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "hCuKz2FMeqFDuYQoH1d3ptMTfAOR4t1WTwnn+cqGoWc=",
-        "usagesDigest": "jdSuIdTp7Rqi17ioQocHd+ejglFQ3z+AyEWLmlCK/og=",
+        "bzlTransitiveDigest": "2bm8JGpVfTeP2/OEWLfaiC0BppLkZjpmq45/K90H3Zw=",
+        "usagesDigest": "hS+FhJH7CqGt4T1cVOYgEsYbEdtnyHf5KbpPm2ZiT0c=",
         "recordedFileInputs": {
-          "@@rules_rust++rust_host_tools+rust_host_tools//bin/rustc": "b953c69e6f682bf55e39bdd55bdcbd3e1cc0cbdf9dfda24b9c6478ee2c38359b",
+          "@@rules_rust++rust_host_tools+rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//app/rust-ffi/Cargo.toml": "b17bf21f56720ffba5031fdf70296acb53ff018adcf17a8cdcec86b46103d1d8",
           "@@//build_tools/install/config/Cargo.toml": "a6d15eb23a5f90467f680b296fe2e35af904f9ff00ce9530d754c96728288008",
           "@@//lib/rust/parser/debug/fuzz/Cargo.toml": "d93cea0a1b3a5e96ea99d0f57c7a07361b6e3b46afb95dab362e7562d86655d0",
           "@@//build_tools/macros/lib/Cargo.toml": "9cd827c2abf32278530d4312e45a9ecd15c122cc180289ed1a58a632f46d1911",
           "@@//lib/rust/parser/doc-parser/Cargo.toml": "5416f179aa138f97123f02b999ab71338f489f6b912f31a17735375c1e2e704a",
-          "@@//MODULE.bazel": "db1bab27ac7b5124180f2a3b55fba526b152c13f71f07b0eea760ddcaeb19e91",
+          "@@//MODULE.bazel": "5bba807265158f71fbbf3292698460fa47614eb782f655d1fe6e5ba32c1ceb6e",
           "@@//build_tools/install/installer/Cargo.toml": "285f8e82a63acb798f9b19307e2f9a16ae7f1cc73bbec40804249cab86ea879e",
           "@@//lib/rust/parser/debug/Cargo.toml": "c7af0403667534b52690811421790515f98b22d95932cadcd9cc8a3ac79bb06d",
           "@@//lib/rust/parser/generate-java/Cargo.toml": "c74133c954f6c6ef3b8af72a466a313ca583f7130e7c4c5779c8c352d8d96a65",
@@ -650,7 +650,7 @@
           "@@//lib/rust/prelude/Cargo.toml": "d247be5470788ea62ada9fcc9aeb65be876c77fc7a0689a660c43b266bd6c504",
           "@@+_repo_rules+wasm_bindgen_cli_crate//Cargo.toml": "40b1c540eed2e2031f1622391be27ec7f28ddea710447f078c5f2fd245ef2750",
           "@@//lib/rust/metamodel/Cargo.toml": "20f5bb60a5c394ee059eecf25bcf5d3dd15151600e50cbc069c1e4fdb77d7ab9",
-          "@@rules_rust++rust_host_tools+rust_host_tools//bin/cargo": "be459aeefa634aa6693a9a4741cfa4d63dd8a50af2d1a8ff221b7565e7eb4e4c"
+          "@@rules_rust++rust_host_tools+rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },
         "recordedDirentsInputs": {},
         "envVariables": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -616,16 +616,16 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "2bm8JGpVfTeP2/OEWLfaiC0BppLkZjpmq45/K90H3Zw=",
-        "usagesDigest": "hS+FhJH7CqGt4T1cVOYgEsYbEdtnyHf5KbpPm2ZiT0c=",
+        "bzlTransitiveDigest": "hCuKz2FMeqFDuYQoH1d3ptMTfAOR4t1WTwnn+cqGoWc=",
+        "usagesDigest": "jdSuIdTp7Rqi17ioQocHd+ejglFQ3z+AyEWLmlCK/og=",
         "recordedFileInputs": {
-          "@@rules_rust++rust_host_tools+rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
+          "@@rules_rust++rust_host_tools+rust_host_tools//bin/rustc": "b953c69e6f682bf55e39bdd55bdcbd3e1cc0cbdf9dfda24b9c6478ee2c38359b",
           "@@//app/rust-ffi/Cargo.toml": "b17bf21f56720ffba5031fdf70296acb53ff018adcf17a8cdcec86b46103d1d8",
           "@@//build_tools/install/config/Cargo.toml": "a6d15eb23a5f90467f680b296fe2e35af904f9ff00ce9530d754c96728288008",
           "@@//lib/rust/parser/debug/fuzz/Cargo.toml": "d93cea0a1b3a5e96ea99d0f57c7a07361b6e3b46afb95dab362e7562d86655d0",
           "@@//build_tools/macros/lib/Cargo.toml": "9cd827c2abf32278530d4312e45a9ecd15c122cc180289ed1a58a632f46d1911",
           "@@//lib/rust/parser/doc-parser/Cargo.toml": "5416f179aa138f97123f02b999ab71338f489f6b912f31a17735375c1e2e704a",
-          "@@//MODULE.bazel": "5bba807265158f71fbbf3292698460fa47614eb782f655d1fe6e5ba32c1ceb6e",
+          "@@//MODULE.bazel": "db1bab27ac7b5124180f2a3b55fba526b152c13f71f07b0eea760ddcaeb19e91",
           "@@//build_tools/install/installer/Cargo.toml": "285f8e82a63acb798f9b19307e2f9a16ae7f1cc73bbec40804249cab86ea879e",
           "@@//lib/rust/parser/debug/Cargo.toml": "c7af0403667534b52690811421790515f98b22d95932cadcd9cc8a3ac79bb06d",
           "@@//lib/rust/parser/generate-java/Cargo.toml": "c74133c954f6c6ef3b8af72a466a313ca583f7130e7c4c5779c8c352d8d96a65",
@@ -650,7 +650,7 @@
           "@@//lib/rust/prelude/Cargo.toml": "d247be5470788ea62ada9fcc9aeb65be876c77fc7a0689a660c43b266bd6c504",
           "@@+_repo_rules+wasm_bindgen_cli_crate//Cargo.toml": "40b1c540eed2e2031f1622391be27ec7f28ddea710447f078c5f2fd245ef2750",
           "@@//lib/rust/metamodel/Cargo.toml": "20f5bb60a5c394ee059eecf25bcf5d3dd15151600e50cbc069c1e4fdb77d7ab9",
-          "@@rules_rust++rust_host_tools+rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
+          "@@rules_rust++rust_host_tools+rust_host_tools//bin/cargo": "be459aeefa634aa6693a9a4741cfa4d63dd8a50af2d1a8ff221b7565e7eb4e4c"
         },
         "recordedDirentsInputs": {},
         "envVariables": {

--- a/app/gui/src/config.ts
+++ b/app/gui/src/config.ts
@@ -26,7 +26,7 @@ const $config = {
   YDOC_SERVER_URL: import.meta.env.ENSO_IDE_YDOC_SERVER_URL,
   CLOUD_BUILD: import.meta.env.ENSO_IDE_CLOUD_BUILD,
   AG_GRID_LICENSE_KEY: import.meta.env.ENSO_IDE_AG_GRID_LICENSE_KEY,
-  MAPBOX_API_TOKEN: import.meta.env.ENSO_IDE_MAPBOX_API_TOKEN || window.mapBoxApiToken?.(),
+  MAPBOX_API_TOKEN: window.mapBoxApiToken?.() || import.meta.env.ENSO_IDE_MAPBOX_API_TOKEN,
 } as const
 
 // Undefined env variables are typed as `any`, but we want them to be `string | undefined`.


### PR DESCRIPTION
### Pull Request Description

Before, if the _build_ env contained ENSO_IDE_MAPBOX_API_TOKEN, it was inserted and current env was ignored.

Because we have _wrong_ env set on CI, this effectively blocked mapbox entirely.

After consulting with @jdunkerley we decided that current env should override build env.
