### PR TITLE
Add locks in ExcelConnectionPool

### DIFF
--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketServer.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketServer.java
@@ -126,7 +126,7 @@ public class SocketServer extends Thread {
     if (projectId != null) {
       synchronized (socketNodeList) {
         for (SocketLoggingNode sn : socketNodeList) {
-          if (sn.projectId.equals(projectId)) sn.closing();
+          if (sn.projectId != null && sn.projectId.equals(projectId)) sn.closing();
         }
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -228,12 +228,16 @@ public class ExcelConnectionPool {
 
   /** Public for testing. */
   public int getConnectionRecordCount() {
-    return records.size();
+    synchronized (this) {
+      return records.size();
+    }
   }
 
   /** Public for testing. */
   public void simulateReloadTestOnly() {
-    reloadDetector.simulateReloadTestOnly();
+    synchronized (this) {
+      reloadDetector.simulateReloadTestOnly();
+    }
   }
 
   static class ConnectionRecord {


### PR DESCRIPTION
### Pull Request Description

Lack of locking was likely the reason for random test failures we continue to experience in CI, such as
```
 INFO ide_ci::program::command: bash ℹ️ [FAILED] Read XLSX / XLS Files: [16/17, 2985ms]
 INFO ide_ci::program::command: bash ℹ️
Error: 1 did not equal 2 (at Table_Tests/src/IO/Excel_Spec.enso:1162:13-82).
 INFO ide_ci::program::command: bash ℹ️     - [FAILED] should clear cache on simulated reload [180ms]
 INFO ide_ci::program::command: bash ℹ️         Reason: 1 did not equal 2 (at Table_Tests/src/IO/Excel_Spec.enso:1162:13-82).
 INFO ide_ci::program::command: bash ℹ️
```
and a fix for a minor NPE.

### Important Notes

https://github.com/enso-org/enso/actions/runs/13580535838/job/37965645804#step:10:2204

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
