### PR TITLE
Fix passing variants into BasicInput

### DIFF
--- a/app/gui/src/dashboard/components/AriaComponents/Inputs/ComboBox/ComboBox.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Inputs/ComboBox/ComboBox.tsx
@@ -15,11 +15,11 @@ import { forwardRef } from '#/utilities/react'
 import type { VariantProps } from '#/utilities/tailwindVariants'
 import { tv } from '#/utilities/tailwindVariants'
 import {
+  BasicInput,
   Button,
   Form,
   Popover,
   Text,
-  UncontrolledInput,
   type FieldComponentProps,
   type FieldPath,
   type FieldProps,
@@ -164,7 +164,7 @@ export const ComboBox = forwardRef(function ComboBox<
           >
             <div ref={popoverTriggerRef} className={styles.inputContainer()}>
               <Button variant="icon" icon={ArrowIcon} className="rotate-90" />
-              <UncontrolledInput
+              <BasicInput
                 name={name}
                 placeholder={placeholder}
                 addonStart={addonStart}

--- a/app/gui/src/dashboard/components/AriaComponents/Inputs/Input/Input.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Inputs/Input/Input.tsx
@@ -139,8 +139,8 @@ export const Input = forwardRef(function Input<
       name={name}
       data-testid={testId}
     >
-      <UncontrolledInput
-        {...aria.mergeProps<UncontrolledInputProps>()(
+      <BasicInput
+        {...aria.mergeProps<BasicInputProps>()(
           {
             className: (classNameStates) =>
               classes.textArea({ className: computedClassName(classNameStates) }),
@@ -148,6 +148,10 @@ export const Input = forwardRef(function Input<
             name,
             isInvalid: invalid,
             isDisabled: disabled,
+            variant,
+            size,
+            rounded,
+            variants,
           },
           omit(inputProps, 'isInvalid', 'isRequired', 'isDisabled'),
           omit(fieldProps, 'isInvalid', 'isRequired', 'isDisabled', 'invalid'),
@@ -160,8 +164,8 @@ export const Input = forwardRef(function Input<
   )
 })
 
-/** Props for an {@link UncontrolledInput}. */
-export interface UncontrolledInputProps
+/** Props for an {@link BasicInput}. */
+export interface BasicInputProps
   extends Omit<aria.InputProps, 'children' | 'size'>,
     Omit<VariantProps<typeof INPUT_STYLES>, 'disabled' | 'invalid'>,
     TestIdProps {
@@ -178,8 +182,8 @@ export interface UncontrolledInputProps
 }
 
 /** An input without a {@link Form.Field}. */
-export const UncontrolledInput = forwardRef(function UncontrolledInput(
-  props: UncontrolledInputProps,
+export const BasicInput = forwardRef(function BasicInput(
+  props: BasicInputProps,
   ref?: Ref<HTMLInputElement>,
 ) {
   const {


### PR DESCRIPTION
### Pull Request Description

This PR fixes broken EditableSpan: 

![CleanShot 2025-03-03 at 12 38 23@2x](https://github.com/user-attachments/assets/c1c3c848-9392-4150-a81c-eaf05a09f9da)

the bug was introduced in https://github.com/enso-org/enso/pull/12282

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
