### PR TITLE
Eliminate a number of memory leaks in tests

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -52,6 +52,7 @@ public class DocsGenerateTest {
   public static void closeCtx() {
     ctx.close();
     ctx = null;
+    leak.shutdown();
     leak = null;
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
@@ -22,6 +22,7 @@ import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.io.IOAccess;
 import org.hamcrest.core.AllOf;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -55,6 +56,12 @@ public class ExecCompilerTest {
   @AfterClass
   public static void closeEnsoContext() throws Exception {
     ctx.close();
+    ctx = null;
+    out.close();
+  }
+
+  @After
+  public void cleanup() {
     out.reset();
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/ManagedResourceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/ManagedResourceTest.java
@@ -53,7 +53,12 @@ public class ManagedResourceTest {
   @AfterClass
   public static void closeCtx() throws Exception {
     ctx.close();
+    ensoCtx.shutdown();
     ctx = null;
+    ensoCtx = null;
+    newResource = null;
+    createResource = null;
+    getResource = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/RefTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/RefTest.java
@@ -35,6 +35,9 @@ public class RefTest {
   public static void closeCtx() throws Exception {
     ctx.close();
     ctx = null;
+    refType = null;
+    ensoCtx.shutdown();
+    ensoCtx = null;
   }
 
   private static Value getRef(Value ref) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ProgressTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ProgressTest.java
@@ -30,6 +30,8 @@ public class ProgressTest {
   public static void closeCtx() throws Exception {
     ctx.close();
     ctx = null;
+    ensoCtx.shutdown();
+    ensoCtx = null;
   }
 
   public ProgressTest() {}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AnyOrStaticTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AnyOrStaticTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames;
 import org.enso.test.utils.ContextUtils;
@@ -24,8 +25,10 @@ public class AnyOrStaticTest {
   }
 
   @After
-  public void disposeCtx() {
+  public void disposeCtx() throws IOException {
     ctx.close();
+    ctx = null;
+    out.close();
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AnyToTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AnyToTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.Type;
@@ -27,9 +28,10 @@ public class AnyToTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    out.close();
   }
 
   @Before

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AutoscopedConstructorTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AutoscopedConstructorTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.enso.common.MethodNames;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
@@ -34,9 +35,10 @@ public class AutoscopedConstructorTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    out.close();
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryOpFloatTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryOpFloatTest.java
@@ -90,6 +90,7 @@ public class BinaryOpFloatTest {
   public static void closeContext() {
     ctx.close();
     ctx = null;
+    wrapReal = null;
   }
 
   private final String operation;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryOpIntegerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryOpIntegerTest.java
@@ -109,6 +109,7 @@ public class BinaryOpIntegerTest {
   public static void closeContext() {
     ctx.close();
     ctx = null;
+    wrapInt = null;
   }
 
   private final String operation;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/CaseOfTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/CaseOfTest.java
@@ -25,6 +25,7 @@ public class CaseOfTest {
   public static void closeCtx() {
     ctx.close();
     ctx = null;
+    leak.shutdown();
     leak = null;
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ConversionMethodTests.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ConversionMethodTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
@@ -17,7 +18,6 @@ import org.junit.Test;
 
 public class ConversionMethodTests {
   private static Context ctx;
-
   private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
   @BeforeClass
@@ -26,9 +26,10 @@ public class ConversionMethodTests {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    out.close();
   }
 
   @After

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
@@ -92,6 +92,7 @@ public class DebuggingEnsoTest {
     engine.close();
     engine = null;
     debugger = null;
+    out.close();
   }
 
   @Before

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EnsoMultiValueInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EnsoMultiValueInteropTest.java
@@ -29,20 +29,21 @@ public class EnsoMultiValueInteropTest {
 
   @Parameterized.Parameters
   public static Object[][] allEnsoMultiValuePairs() throws Exception {
-    var g = ValuesGenerator.create(ctx());
     var typeOf =
         ContextUtils.evalModule(
             ctx(),
             """
-    from Standard.Base import all
+            from Standard.Base import all
 
-    typ obj = Meta.type_of obj
-    main = typ
-    """);
+            typ obj = Meta.type_of obj
+            main = typ
+            """);
     var data = new ArrayList<Object[]>();
-    for (var v1 : g.allValues()) {
-      for (var v2 : g.allValues()) {
-        registerValue(g, typeOf, v1, v2, data);
+    try (ValuesGenerator g = ValuesGenerator.create(ctx())) {
+      for (var v1 : g.allValues()) {
+        for (var v2 : g.allValues()) {
+          registerValue(g, typeOf, v1, v2, data);
+        }
       }
     }
     return data.toArray(new Object[0][]);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EqualsMultiValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EqualsMultiValueTest.java
@@ -44,6 +44,9 @@ public class EqualsMultiValueTest {
   public static void disposeContext() {
     context.close();
     context = null;
+    equalsNode = null;
+    testRootNode = null;
+    hostValueToEnsoNode = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EqualsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EqualsTest.java
@@ -63,37 +63,39 @@ public class EqualsTest {
     context.close();
     context = null;
     unwrappedValues = null;
+    equalsNode = null;
+    testRootNode = null;
+    hostValueToEnsoNode = null;
   }
 
   @DataPoints public static Object[] unwrappedValues;
 
   private static Object[] fetchAllUnwrappedValues() {
-    var valGenerator =
-        ValuesGenerator.create(
-            context, ValuesGenerator.Language.ENSO, ValuesGenerator.Language.JAVA);
     List<Value> values = new ArrayList<>();
-    values.addAll(valGenerator.numbers());
-    values.addAll(valGenerator.booleans());
-    values.addAll(valGenerator.textual());
-    values.addAll(valGenerator.arrayLike());
-    values.addAll(valGenerator.vectors());
-    values.addAll(valGenerator.maps());
-    values.addAll(valGenerator.multiLevelAtoms());
-    values.addAll(valGenerator.timesAndDates());
-    values.addAll(valGenerator.timeZones());
-    values.addAll(valGenerator.durations());
-    values.addAll(valGenerator.periods());
-    values.addAll(valGenerator.warnings());
-    try {
-      return values.stream()
-          .map(value -> unwrapValue(context, value))
-          .map(unwrappedValue -> hostValueToEnsoNode.execute(unwrappedValue))
-          .collect(Collectors.toList())
-          .toArray(new Object[] {});
-    } catch (Exception e) {
-      throw new AssertionError(e);
-    } finally {
-      valGenerator.dispose();
+    try (ValuesGenerator valGenerator =
+        ValuesGenerator.create(
+            context, ValuesGenerator.Language.ENSO, ValuesGenerator.Language.JAVA)) {
+      values.addAll(valGenerator.numbers());
+      values.addAll(valGenerator.booleans());
+      values.addAll(valGenerator.textual());
+      values.addAll(valGenerator.arrayLike());
+      values.addAll(valGenerator.vectors());
+      values.addAll(valGenerator.maps());
+      values.addAll(valGenerator.multiLevelAtoms());
+      values.addAll(valGenerator.timesAndDates());
+      values.addAll(valGenerator.timeZones());
+      values.addAll(valGenerator.durations());
+      values.addAll(valGenerator.periods());
+      values.addAll(valGenerator.warnings());
+      try {
+        return values.stream()
+            .map(value -> unwrapValue(context, value))
+            .map(unwrappedValue -> hostValueToEnsoNode.execute(unwrappedValue))
+            .collect(Collectors.toList())
+            .toArray(new Object[] {});
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/LazyAtomFieldTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/LazyAtomFieldTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -33,8 +34,10 @@ public class LazyAtomFieldTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
+    ctx = null;
+    out.close();
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MethodResolutionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MethodResolutionTest.java
@@ -38,6 +38,7 @@ public final class MethodResolutionTest {
   public static void disposeCtx() {
     ctx.close();
     ctx = null;
+    methodResolverNode = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
@@ -26,7 +26,6 @@ public final class MockLogHandler extends Handler {
 
   @Override
   public void close() throws SecurityException {
-    super.close();
     logs.clear();
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
@@ -25,7 +25,10 @@ public final class MockLogHandler extends Handler {
   public void flush() {}
 
   @Override
-  public void close() throws SecurityException {}
+  public void close() throws SecurityException {
+    super.close();
+    logs.clear();
+  }
 
   public void reset() {
     logs.clear();

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NativeLibraryFinderTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NativeLibraryFinderTest.java
@@ -23,6 +23,7 @@ import org.enso.interpreter.runtime.util.TruffleFileSystem;
 import org.enso.pkg.NativeLibraryFinder;
 import org.enso.pkg.Package;
 import org.enso.test.utils.ContextUtils;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -34,6 +35,12 @@ public class NativeLibraryFinderTest {
   @Rule public final TestRule printContextRule = new PrintSystemInfoRule();
   private Package<TruffleFile> stdImgPkg;
   private Package<TruffleFile> stdTableauPkg;
+
+  @After
+  public void cleanup() {
+    stdImgPkg = null;
+    stdTableauPkg = null;
+  }
 
   @Test
   public void standardImageShouldHaveNativeLib() {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
@@ -39,6 +39,7 @@ public class NonStrictModeTests {
   public static void disposeCtx() {
     nonStrictCtx.close();
     nonStrictCtx = null;
+    logHandler.close();
   }
 
   @Before

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/PolyglotFindExceptionMessageTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/PolyglotFindExceptionMessageTest.java
@@ -23,6 +23,7 @@ public class PolyglotFindExceptionMessageTest {
   @AfterClass
   public static void disposeCtx() {
     ctx.close();
+    ctx = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/PrintTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/PrintTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +13,7 @@ import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,12 +24,18 @@ public class PrintTest {
   @Before
   public void prepareCtx() {
     ctx = ContextUtils.createDefaultContext(out);
-    out.reset();
   }
 
   @After
-  public void disposeCtx() {
+  public void disposeCtx() throws IOException {
     ctx.close();
+    ctx = null;
+    out.reset();
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    out.close();
   }
 
   private void checkPrint(String code, String expected) throws Exception {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
@@ -56,7 +56,7 @@ public class RootNamesTest {
     this.insightHandle.close();
     this.ctx.close();
     this.ctx = null;
-    this.out.reset();
+    this.out.close();
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
@@ -41,11 +41,13 @@ public class SharedEngineTest {
   @AfterClass
   public static void disposeEngine() {
     sharedEngine.close();
+    sharedEngine = null;
   }
 
   @After
   public void disposeCtx() {
     this.ctx.close();
+    this.ctx = null;
   }
 
   private final Source typeCase =

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignaturePolyglotTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignaturePolyglotTest.java
@@ -31,6 +31,7 @@ public class SignaturePolyglotTest {
   @AfterClass
   public static void disposeCtx() {
     ctx.close();
+    ctx = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TypeInferenceConsistencyTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.enso.common.MethodNames;
@@ -46,9 +47,10 @@ public class TypeInferenceConsistencyTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    output.close();
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
@@ -40,7 +40,7 @@ import org.graalvm.polyglot.Value;
  * call appropriate methods to obtain such values. It's up to the tests to use these values
  * meaningfully.
  */
-public final class ValuesGenerator {
+public final class ValuesGenerator implements AutoCloseable {
   private final Context ctx;
   private final Set<Language> languages;
   private final Map<String, ValueInfo> values = new HashMap<>();
@@ -1009,7 +1009,7 @@ public final class ValuesGenerator {
     return v;
   }
 
-  public void dispose() {
+  public void close() {
     values.clear();
     multiValues.clear();
     computed.clear();

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/VectorSortTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/VectorSortTest.java
@@ -40,14 +40,15 @@ public class VectorSortTest {
     equalsFunc = ContextUtils.getMethodFromModule(context, code, "equals");
 
     values = new ArrayList<>();
-    var valuesGenerator = ValuesGenerator.create(context, Language.ENSO, Language.JAVA);
-    values.addAll(valuesGenerator.numbers());
-    values.addAll(valuesGenerator.vectors());
-    values.addAll(valuesGenerator.arrayLike());
-    values.addAll(valuesGenerator.booleans());
-    values.addAll(valuesGenerator.durations());
-    values.addAll(valuesGenerator.maps());
-    valuesGenerator.dispose();
+    try (ValuesGenerator valuesGenerator =
+        ValuesGenerator.create(context, Language.ENSO, Language.JAVA)) {
+      values.addAll(valuesGenerator.numbers());
+      values.addAll(valuesGenerator.vectors());
+      values.addAll(valuesGenerator.arrayLike());
+      values.addAll(valuesGenerator.booleans());
+      values.addAll(valuesGenerator.durations());
+      values.addAll(valuesGenerator.maps());
+    }
   }
 
   @AfterClass
@@ -55,6 +56,8 @@ public class VectorSortTest {
     values.clear();
     context.close();
     context = null;
+    sortFunc = null;
+    equalsFunc = null;
   }
 
   @DataPoints public static List<Value> values;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -61,11 +61,12 @@ public class WarningsTest {
 
   @AfterClass
   public static void disposeContext() {
-    generator.dispose();
+    generator.close();
     ctx.close();
     ctx = null;
     ensoContext.shutdown();
     ensoContext = null;
+    wrap = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames;
@@ -27,7 +28,7 @@ public class AssertionsTest {
 
   private static Context ctx;
 
-  private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private static ByteArrayOutputStream out = new ByteArrayOutputStream();
 
   @BeforeClass
   public static void setupCtx() {
@@ -40,9 +41,11 @@ public class AssertionsTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close(true);
     ctx = null;
+    out.close();
+    out = null;
   }
 
   @After

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/SuccessfulAssertionExpressionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/SuccessfulAssertionExpressionTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test.asserts;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import org.enso.common.LanguageInfo;
 import org.enso.test.utils.ContextUtils;
@@ -21,7 +22,7 @@ public class SuccessfulAssertionExpressionTest {
 
   private static Context ctx;
 
-  private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private static ByteArrayOutputStream out = new ByteArrayOutputStream();
 
   @BeforeClass
   public static void setupCtx() {
@@ -34,9 +35,11 @@ public class SuccessfulAssertionExpressionTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close(true);
     ctx = null;
+    out.close();
+    out = null;
   }
 
   @After

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/BuiltinTypesExposeMethodsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/BuiltinTypesExposeMethodsTest.java
@@ -43,20 +43,21 @@ public class BuiltinTypesExposeMethodsTest {
 
   @Parameters(name = "{index}: {0}")
   public static Iterable<Value> generateBuiltinObjects() {
-    var valuesGenerator = ValuesGenerator.create(ctx(), Language.ENSO);
     var builtinTypes = new ArrayList<Value>();
-    ContextUtils.executeInContext(
-        ctx(),
-        () -> {
-          valuesGenerator.allTypes().stream()
-              .filter(
-                  val -> {
-                    var asType = getType(val);
-                    return !shouldSkipType(asType);
-                  })
-              .forEach(builtinTypes::add);
-          return null;
-        });
+    try (ValuesGenerator valuesGenerator = ValuesGenerator.create(ctx(), Language.ENSO)) {
+      ContextUtils.executeInContext(
+          ctx(),
+          () -> {
+            valuesGenerator.allTypes().stream()
+                .filter(
+                    val -> {
+                      var asType = getType(val);
+                      return !shouldSkipType(asType);
+                    })
+                .forEach(builtinTypes::add);
+            return null;
+          });
+    }
     return builtinTypes;
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/BuiltinsJavaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/BuiltinsJavaInteropTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
 import org.junit.After;
@@ -25,9 +26,10 @@ public class BuiltinsJavaInteropTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    out.close();
   }
 
   @After

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/hash/HashCodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/hash/HashCodeTest.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 @RunWith(Theories.class)
 public class HashCodeTest {
   private static Context context;
-  private static final InteropLibrary interop = InteropLibrary.getUncached();
 
   private static HashCodeNode hashCodeNode;
   private static EqualsNode equalsNode;
@@ -57,6 +56,10 @@ public class HashCodeTest {
     context.close();
     context = null;
     unwrappedValues = null;
+    hashCodeNode = null;
+    equalsNode = null;
+    hostValueToEnsoNode = null;
+    testRootNode = null;
   }
 
   /**
@@ -66,36 +69,38 @@ public class HashCodeTest {
   @DataPoints public static Object[] unwrappedValues;
 
   private static Object[] fetchAllUnwrappedValues() {
-    var valGenerator =
-        ValuesGenerator.create(
-            context, ValuesGenerator.Language.ENSO, ValuesGenerator.Language.JAVA);
     List<Value> values = new ArrayList<>();
-    values.addAll(valGenerator.numbers());
-    values.addAll(valGenerator.booleans());
-    values.addAll(valGenerator.textual());
-    values.addAll(valGenerator.numbersMultiText());
-    values.addAll(valGenerator.arrayLike());
-    values.addAll(valGenerator.vectors());
-    values.addAll(valGenerator.maps());
-    values.addAll(valGenerator.multiLevelAtoms());
-    values.addAll(valGenerator.timesAndDates());
-    values.addAll(valGenerator.timeZones());
-    values.addAll(valGenerator.durations());
-    values.addAll(valGenerator.periods());
-    values.addAll(valGenerator.warnings());
-    try {
-      return values.stream()
-          .map(value -> ContextUtils.unwrapValue(context, value))
-          .map(unwrappedValue -> hostValueToEnsoNode.execute(unwrappedValue))
-          .collect(Collectors.toList())
-          .toArray(new Object[] {});
-    } catch (Exception e) {
-      throw new AssertionError(e);
+    try (ValuesGenerator valGenerator =
+        ValuesGenerator.create(
+            context, ValuesGenerator.Language.ENSO, ValuesGenerator.Language.JAVA)) {
+      values.addAll(valGenerator.numbers());
+      values.addAll(valGenerator.booleans());
+      values.addAll(valGenerator.textual());
+      values.addAll(valGenerator.numbersMultiText());
+      values.addAll(valGenerator.arrayLike());
+      values.addAll(valGenerator.vectors());
+      values.addAll(valGenerator.maps());
+      values.addAll(valGenerator.multiLevelAtoms());
+      values.addAll(valGenerator.timesAndDates());
+      values.addAll(valGenerator.timeZones());
+      values.addAll(valGenerator.durations());
+      values.addAll(valGenerator.periods());
+      values.addAll(valGenerator.warnings());
+      try {
+        return values.stream()
+            .map(value -> ContextUtils.unwrapValue(context, value))
+            .map(unwrappedValue -> hostValueToEnsoNode.execute(unwrappedValue))
+            .collect(Collectors.toList())
+            .toArray(new Object[] {});
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
     }
   }
 
   @Theory
   public void hashCodeContractTheory(Object firstValue, Object secondValue) {
+    InteropLibrary interop = InteropLibrary.getUncached();
     ContextUtils.executeInContext(
         context,
         () -> {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
@@ -44,9 +44,9 @@ public class AvoidIdInstrumentationTagTest {
 
   @After
   public void disposeContext() {
-    nodes = null;
     context.close();
     context = null;
+    nodes = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/DebugServerInspectTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/DebugServerInspectTest.java
@@ -35,7 +35,9 @@ public class DebugServerInspectTest {
   public static void closeContext() throws Exception {
     ctx.close();
     ctx = null;
+    out.close();
     out = null;
+    err.close();
     err = null;
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
@@ -62,7 +62,7 @@ public class InsightForEnsoTest {
     this.insightHandle.close();
     this.out.reset();
     this.ctx.close();
-    ctx = null;
+    this.ctx = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
@@ -53,6 +53,7 @@ public class RuntimeProgressTest {
   public void teardownContext() {
     context.close();
     context = null;
+    mainFile = null;
   }
 
   @Test
@@ -241,32 +242,47 @@ public class RuntimeProgressTest {
 
   private static final class TestContext extends InstrumentTestContext {
 
+    private Context _context;
+
     TestContext(String packageName) {
       super(packageName);
     }
 
     @Override
     public Context context() {
-      return Context.newBuilder(LanguageInfo.ID)
-          .allowExperimentalOptions(true)
-          .allowAllAccess(true)
-          .option(RuntimeOptions.PROJECT_ROOT, pkg().root().getAbsolutePath())
-          .option(RuntimeOptions.LOG_LEVEL, java.util.logging.Level.WARNING.getName())
-          .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
-          .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
-          .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "true")
-          .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
-          .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
-          .option(RuntimeOptions.STRICT_ERRORS, "false")
-          .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
-          .option(RuntimeServerInfo.ENABLE_OPTION, "true")
-          .option(RuntimeOptions.INTERACTIVE_MODE, "true")
-          .option(
-              RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-              Paths.get("../../distribution/component").toFile().getAbsolutePath())
-          .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-          .serverTransport(runtimeServerEmulator().makeServerTransport())
-          .build();
+      if (_context == null) {
+        _context =
+            Context.newBuilder(LanguageInfo.ID)
+                .allowExperimentalOptions(true)
+                .allowAllAccess(true)
+                .option(RuntimeOptions.PROJECT_ROOT, pkg().root().getAbsolutePath())
+                .option(RuntimeOptions.LOG_LEVEL, java.util.logging.Level.WARNING.getName())
+                .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
+                .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
+                .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "true")
+                .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+                .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
+                .option(RuntimeOptions.STRICT_ERRORS, "false")
+                .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
+                .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+                .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+                .option(
+                    RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+                    Paths.get("../../distribution/component").toFile().getAbsolutePath())
+                .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+                .serverTransport(runtimeServerEmulator().makeServerTransport())
+                .build();
+      }
+      return _context;
+    }
+
+    @Override
+    public void close() {
+      super.close();
+      if (_context != null) {
+        _context.close();
+        _context = null;
+      }
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.enso.test.utils.ContextUtils;
@@ -28,9 +29,10 @@ public class JavaInteropTest {
   }
 
   @AfterClass
-  public static void disposeCtx() {
+  public static void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
+    out.close();
   }
 
   @After

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JsInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JsInteropTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test.interop;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
@@ -12,7 +13,7 @@ import org.junit.Test;
 
 public class JsInteropTest {
 
-  private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private static ByteArrayOutputStream out = new ByteArrayOutputStream();
   private Context ctx;
 
   @Before
@@ -21,10 +22,11 @@ public class JsInteropTest {
   }
 
   @After
-  public void disposeCtx() {
+  public void disposeCtx() throws IOException {
     ctx.close();
     ctx = null;
-    out.reset();
+    out.close();
+    out = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MetaObjectTest.java
@@ -16,6 +16,7 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.enso.common.MethodNames;
@@ -53,7 +54,7 @@ public class MetaObjectTest {
   @AfterClass
   public static void disposeCtx() {
     if (generator != null) {
-      generator.dispose();
+      generator.close();
       generator = null;
     }
     ctx.close();
@@ -238,8 +239,10 @@ public class MetaObjectTest {
 
   @Test
   public void nothingIsNotMeta() {
-    var g = ValuesGenerator.create(ctx, ValuesGenerator.Language.ENSO);
-    var nothing = g.typeNothing();
+    Value nothing;
+    try (ValuesGenerator g = ValuesGenerator.create(ctx, ValuesGenerator.Language.ENSO)) {
+      nothing = g.typeNothing();
+    }
     assertThat("Nothing is not meta", nothing.isMetaObject(), is(false));
   }
 
@@ -287,11 +290,13 @@ main = Nothing
    */
   @Test
   public void allEnsoNonPrimitiveValuesHaveLanguage() throws Exception {
-    var gen = ValuesGenerator.create(ctx, Language.ENSO);
     Predicate<Value> isPrimitiveOrException =
         (val) -> val.fitsInInt() || val.fitsInDouble() || val.isBoolean() || val.isException();
-    var nonPrimitiveValues =
-        gen.allValues().stream().filter(isPrimitiveOrException.negate()).toList();
+    List<Value> nonPrimitiveValues;
+    try (ValuesGenerator gen = ValuesGenerator.create(ctx, Language.ENSO)) {
+      nonPrimitiveValues =
+          gen.allValues().stream().filter(isPrimitiveOrException.negate()).toList();
+    }
     var interop = InteropLibrary.getUncached();
     ContextUtils.executeInContext(
         ctx,

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
@@ -84,13 +84,15 @@ public final class MethodInvocationOnTypeConsistencyTest {
       ctx.close();
       ctx = null;
     }
+    module = null;
+    anyType = null;
+    myType = null;
+    myTypeAtom = null;
   }
 
   @Parameters(name = "{index}: expression = {0}")
   public static List<TestArgs> testArgs() {
-    if (ctx == null) {
-      initCtx();
-    }
+    initCtx();
     return List.of(
         new TestArgs(
             new EnsoInvokeArgs("Any.to_display_text My_Type"),

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypesExposeConstructorsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypesExposeConstructorsTest.java
@@ -55,20 +55,21 @@ public class TypesExposeConstructorsTest {
     ContextUtils.executeInContext(
         ctx(),
         () -> {
-          var valuesGenerator = ValuesGenerator.create(ctx(), Language.ENSO);
-          valuesGenerator.allTypes().stream()
-              .map(
-                  tp -> {
-                    var unwrappedTp = ContextUtils.unwrapValue(ctx(), tp);
-                    if (unwrappedTp instanceof Type type) {
-                      return new TypeWithWrapper(type, tp);
-                    } else {
-                      return null;
-                    }
-                  })
-              .filter(Objects::nonNull)
-              .filter(tp -> !tp.type.getConstructors().isEmpty())
-              .forEach(collectedTypes::add);
+          try (ValuesGenerator valuesGenerator = ValuesGenerator.create(ctx(), Language.ENSO)) {
+            valuesGenerator.allTypes().stream()
+                .map(
+                    tp -> {
+                      var unwrappedTp = ContextUtils.unwrapValue(ctx(), tp);
+                      if (unwrappedTp instanceof Type type) {
+                        return new TypeWithWrapper(type, tp);
+                      } else {
+                        return null;
+                      }
+                    })
+                .filter(Objects::nonNull)
+                .filter(tp -> !tp.type.getConstructors().isEmpty())
+                .forEach(collectedTypes::add);
+          }
           return null;
         });
     return collectedTypes;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsATest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaIsATest.java
@@ -52,7 +52,7 @@ public class MetaIsATest {
   @AfterClass
   public static void disposeCtx() {
     if (generator != null) {
-      generator.dispose();
+      generator.close();
       generator = null;
     }
     isACheck = null;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaTypeMethodsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/meta/MetaTypeMethodsTest.java
@@ -51,6 +51,7 @@ public class MetaTypeMethodsTest {
 
   @AfterClass
   public static void disposeCtx() {
+    valuesGenerator.close();
     ctx.close();
     ctx = null;
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/semantic/DataflowErrorPropagationTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/semantic/DataflowErrorPropagationTest.java
@@ -48,6 +48,8 @@ public class DataflowErrorPropagationTest {
   public static void disposeCtx() {
     ctx.close();
     ctx = null;
+    suppressError = null;
+    suppressErrorWithAssign = null;
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
@@ -88,8 +88,12 @@ class ImportExportTest
 
   after {
     ctx.leave()
-    out.reset()
+    ctx.close()
+    langCtx.shutdown()
+    ctx = null
+    out.close()
     ProjectUtils.deleteRecursively(tmpDir)
+    pkg = null
   }
 
   implicit private class CreateModule(moduleCode: String) {

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
@@ -27,14 +27,14 @@ abstract class InstrumentTestContext(packageName: String) {
   val pkg: Package[File] =
     PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
 
-  protected val context: Context
+  protected def context(): Context
 
   protected var executionContext: PolyglotContext = null
 
   def init(): Unit = {
-    assert(context != null)
-    executionContext = new PolyglotContext(context)
-    context.initialize(LanguageInfo.ID)
+    assert(context() != null)
+    executionContext = new PolyglotContext(context())
+    context().initialize(LanguageInfo.ID)
   }
 
   protected val runtimeServerEmulator: RuntimeServerEmulator =
@@ -154,8 +154,8 @@ abstract class InstrumentTestContext(packageName: String) {
     Api.Response(Api.ExecutionComplete(contextId))
 
   def close(): Unit = {
-    if (context != null) {
-      context.close()
+    if (context() != null) {
+      context().close()
     }
     Await.ready(runtimeServerEmulator.terminate(), 5.seconds)
     lockManager.reset()

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -38,7 +38,7 @@ class RuntimeServerTest
 
     val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
     val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
-    private var _context: Context = null;
+    private var _context: Context     = null;
     protected def context(): Context = {
       if (_context == null) {
         _context = Context
@@ -50,7 +50,10 @@ class RuntimeServerTest
             RuntimeOptions.LOG_LEVEL,
             java.util.logging.Level.WARNING.getName
           )
-          .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
+          .option(
+            RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION,
+            "true"
+          )
           .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
           .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "false")
           .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -38,40 +38,45 @@ class RuntimeServerTest
 
     val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
     val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
-    protected val context =
-      Context
-        .newBuilder(LanguageInfo.ID)
-        .allowExperimentalOptions(true)
-        .allowAllAccess(true)
-        .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(
-          RuntimeOptions.LOG_LEVEL,
-          java.util.logging.Level.WARNING.getName
-        )
-        .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
-        .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
-        .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "false")
-        .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
-        .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
-        .option(RuntimeOptions.STRICT_ERRORS, "false")
-        .option(
-          RuntimeOptions.DISABLE_IR_CACHES,
-          InstrumentTestContext.DISABLE_IR_CACHE
-        )
-        .option(RuntimeServerInfo.ENABLE_OPTION, "true")
-        .option(RuntimeOptions.INTERACTIVE_MODE, "true")
-        .option(
-          RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths
-            .get("../../test/micro-distribution/component")
-            .toFile
-            .getAbsolutePath
-        )
-        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-        .logHandler(new TeeOutputStream(logOut, System.err))
-        .out(new TeeOutputStream(out, System.err))
-        .serverTransport(runtimeServerEmulator.makeServerTransport)
-        .build()
+    private var _context: Context = null;
+    protected def context(): Context = {
+      if (_context == null) {
+        _context = Context
+          .newBuilder(LanguageInfo.ID)
+          .allowExperimentalOptions(true)
+          .allowAllAccess(true)
+          .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
+          .option(
+            RuntimeOptions.LOG_LEVEL,
+            java.util.logging.Level.WARNING.getName
+          )
+          .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
+          .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
+          .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "false")
+          .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+          .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
+          .option(RuntimeOptions.STRICT_ERRORS, "false")
+          .option(
+            RuntimeOptions.DISABLE_IR_CACHES,
+            InstrumentTestContext.DISABLE_IR_CACHE
+          )
+          .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+          .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+          .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths
+              .get("../../test/micro-distribution/component")
+              .toFile
+              .getAbsolutePath
+          )
+          .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+          .logHandler(new TeeOutputStream(logOut, System.err))
+          .out(new TeeOutputStream(out, System.err))
+          .serverTransport(runtimeServerEmulator.makeServerTransport)
+          .build()
+      }
+      _context
+    }
 
     lazy val languageContext = executionContext.context
       .getBindings(LanguageInfo.ID)
@@ -79,7 +84,7 @@ class RuntimeServerTest
       .asHostObject[EnsoContext]
 
     private def ensureInstrumentsAvailable() = {
-      val instruments = context.getEngine.getInstruments
+      val instruments = context().getEngine.getInstruments
       if (instruments.get(IdExecutionService.INSTRUMENT_ID) == null) {
         throw new IllegalStateException(
           "RuntimeServerTest cannot be initialized: IdExecutionService instrument must be available on module-path"
@@ -106,6 +111,14 @@ class RuntimeServerTest
       val result = out.toString
       out.reset()
       result.linesIterator.toList
+    }
+
+    override def close(): Unit = {
+      super.close();
+      if (_context != null) {
+        _context.close()
+        _context = null;
+      }
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -27,40 +27,55 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
       extends InstrumentTestContext(packageName) {
 
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val context =
-      Context
-        .newBuilder()
-        .allowExperimentalOptions(true)
-        .allowAllAccess(true)
-        .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-        .option(
-          RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION,
-          sequentialExecution.toString
-        )
-        .option(
-          RuntimeOptions.INTERPRETER_RANDOM_DELAYED_COMMAND_EXECUTION,
-          (!sequentialExecution).toString
-        )
-        .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
-        .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "false")
-        .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
-        .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
-        .option(RuntimeServerInfo.ENABLE_OPTION, "true")
-        .option(RuntimeOptions.INTERACTIVE_MODE, "true")
-        .option(
-          RuntimeOptions.DISABLE_IR_CACHES,
-          InstrumentTestContext.DISABLE_IR_CACHE
-        )
-        .option("engine.WarnInterpreterOnly", "false")
-        .option(
-          RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
-        )
-        .logHandler(System.err)
-        .out(out)
-        .serverTransport(runtimeServerEmulator.makeServerTransport)
-        .build()
+
+    var _context: Context = null
+
+    override def context(): Context = {
+      if (_context == null) {
+        _context = Context
+          .newBuilder()
+          .allowExperimentalOptions(true)
+          .allowAllAccess(true)
+          .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
+          .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
+          .option(
+            RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION,
+            sequentialExecution.toString
+          )
+          .option(
+            RuntimeOptions.INTERPRETER_RANDOM_DELAYED_COMMAND_EXECUTION,
+            (!sequentialExecution).toString
+          )
+          .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
+          .option(RuntimeOptions.ENABLE_PROGRESS_REPORT, "false")
+          .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+          .option(RuntimeOptions.ENABLE_EXECUTION_TIMER, "false")
+          .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+          .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+          .option(
+            RuntimeOptions.DISABLE_IR_CACHES,
+            InstrumentTestContext.DISABLE_IR_CACHE
+          )
+          .option("engine.WarnInterpreterOnly", "false")
+          .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile.getAbsolutePath
+          )
+          .logHandler(System.err)
+          .out(out)
+          .serverTransport(runtimeServerEmulator.makeServerTransport)
+          .build()
+      }
+      _context
+    }
+
+    override def close(): Unit = {
+      super.close()
+      if (_context != null) {
+        _context.close()
+        _context = null
+      }
+    }
 
     def writeFile(file: File, contents: String): File =
       Files.write(file.toPath, contents.getBytes).toFile

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ApiTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ApiTest.scala
@@ -13,8 +13,8 @@ import java.nio.file.Paths
 class ApiTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   import org.enso.common.LanguageInfo._
 
-  var out: ByteArrayOutputStream = _
-  var ctx: Context = _
+  var out: ByteArrayOutputStream        = _
+  var ctx: Context                      = _
   var executionContext: PolyglotContext = _
 
   override protected def beforeAll(): Unit = {

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ApiTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ApiTest.scala
@@ -3,17 +3,23 @@ package org.enso.polyglot.test
 import org.enso.common.RuntimeOptions
 import org.enso.polyglot.PolyglotContext
 import org.graalvm.polyglot.Context
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.ByteArrayOutputStream
 import java.nio.file.Paths
 
-class ApiTest extends AnyFlatSpec with Matchers {
+class ApiTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   import org.enso.common.LanguageInfo._
-  val out = new ByteArrayOutputStream()
-  val executionContext = new PolyglotContext(
-    Context
+
+  var out: ByteArrayOutputStream = _
+  var ctx: Context = _
+  var executionContext: PolyglotContext = _
+
+  override protected def beforeAll(): Unit = {
+    out = new ByteArrayOutputStream()
+    ctx = Context
       .newBuilder(ID)
       .allowExperimentalOptions(true)
       .allowAllAccess(true)
@@ -25,7 +31,17 @@ class ApiTest extends AnyFlatSpec with Matchers {
       .err(out)
       .logHandler(out)
       .build()
-  )
+    executionContext = new PolyglotContext(ctx)
+  }
+
+  override protected def afterAll(): Unit = {
+    if (ctx != null) {
+      ctx.close()
+      ctx = null
+      out.close()
+      out = null;
+    }
+  }
 
   "Parsing a file and calling a toplevel function defined in it" should "be possible" in {
     val code =

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ModuleManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ModuleManagementTest.scala
@@ -38,19 +38,19 @@ class ModuleManagementTest
       )
     var out = new ByteArrayOutputStream()
     var context = Context
-        .newBuilder(org.enso.common.LanguageInfo.ID)
-        .allowExperimentalOptions(true)
-        .allowAllAccess(true)
-        .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(
-          RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
-        )
-        .option(RuntimeOptions.STRICT_ERRORS, "true")
-        .out(out)
-        .err(out)
-        .logHandler(out)
-        .build()
+      .newBuilder(org.enso.common.LanguageInfo.ID)
+      .allowExperimentalOptions(true)
+      .allowAllAccess(true)
+      .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
+      .option(
+        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+        Paths.get("../../distribution/component").toFile.getAbsolutePath
+      )
+      .option(RuntimeOptions.STRICT_ERRORS, "true")
+      .out(out)
+      .err(out)
+      .logHandler(out)
+      .build()
     val executionContext = new PolyglotContext(context)
 
     def mkFile(name: String): File = new File(getTestDirectory.toFile, name)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ModuleManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/polyglot/test/ModuleManagementTest.scala
@@ -22,6 +22,13 @@ class ModuleManagementTest
     ctx = new TestContext("test")
   }
 
+  override def afterEach(): Unit = {
+    super.afterEach()
+    if (ctx != null) {
+      ctx.close()
+    }
+  }
+
   class TestContext(packageName: String) {
     val pkg: Package[File] =
       PackageManager.Default.create(
@@ -29,9 +36,8 @@ class ModuleManagementTest
         packageName,
         "Enso_Test"
       )
-    val out = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
-      Context
+    var out = new ByteArrayOutputStream()
+    var context = Context
         .newBuilder(org.enso.common.LanguageInfo.ID)
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
@@ -45,7 +51,7 @@ class ModuleManagementTest
         .err(out)
         .logHandler(out)
         .build()
-    )
+    val executionContext = new PolyglotContext(context)
 
     def mkFile(name: String): File = new File(getTestDirectory.toFile, name)
 
@@ -55,6 +61,13 @@ class ModuleManagementTest
 
     def writeMain(contents: String): Unit = {
       Files.write(pkg.mainFile.toPath, contents.getBytes): Unit
+    }
+
+    def close(): Unit = {
+      out.close()
+      out = null
+      context.close()
+      context = null
     }
   }
 

--- a/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/NodeCountingTestInstrument.java
+++ b/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/NodeCountingTestInstrument.java
@@ -41,6 +41,13 @@ public class NodeCountingTestInstrument extends TruffleInstrument {
     this.env = env;
   }
 
+  @Override
+  protected void onDispose(Env env) {
+    all.clear();
+    counter.clear();
+    calls.clear();
+  }
+
   public void enable() {
     this.env
         .getInstrumenter()


### PR DESCRIPTION
### Pull Request Description

Memory usage has spin out of control recently when running our test-suite. Unnecessarily.
This change eliminates a number of leaks that haven't been properly cleaned up on test teardown.
Also closed a number of stale threads.

### Important Notes

Before:
![Screenshot from 2025-02-28 14-40-14](https://github.com/user-attachments/assets/25b084f9-a13d-4199-a7ab-5628d3ee421d)

After:
![Screenshot from 2025-03-04 17-43-23](https://github.com/user-attachments/assets/c5b3ee34-cea0-4774-953d-42cf54bbd94c)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.

