### PR TITLE
Ability to generate cloud credentials in the CLI build tool

### DIFF
--- a/build_tools/build/src/cloud_tests/mod.rs
+++ b/build_tools/build/src/cloud_tests/mod.rs
@@ -33,6 +33,11 @@ pub async fn prepare_credentials_file(auth_config: AuthConfig) -> Result<NamedTe
     Ok(credentials_temp_file)
 }
 
+pub async fn build_credentials_file(auth_config: AuthConfig, path: &Path) -> Result<()> {
+    let credentials = build_credentials(auth_config).await?;
+    save_credentials(&credentials, path)
+}
+
 #[derive(Debug)]
 pub struct AuthConfig {
     web_client_id: String,

--- a/build_tools/cli/src/arg/backend.rs
+++ b/build_tools/cli/src/arg/backend.rs
@@ -59,6 +59,9 @@ pub enum Command {
     CiCheck {},
     /// Perform the stdlib API checks
     StdlibApiCheck {},
+
+    /// Generate Cloud credentials
+    GenerateCloudCredentials {},
 }
 
 #[derive(Args, Clone, Debug, PartialEq)]

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -29,6 +29,7 @@ use crate::arg::WatchJob;
 use anyhow::Context;
 use arg::BuildDescription;
 use clap::Parser;
+use enso_build::cloud_tests;
 use enso_build::config::Config;
 use enso_build::context::BuildContext;
 use enso_build::engine::context::EnginePackageProvider;
@@ -449,6 +450,12 @@ impl Processor {
                 .void_ok()
                 .boxed()
             }
+            arg::backend::Command::GenerateCloudCredentials {} => async move {
+                let auth_config = cloud_tests::build_auth_config_from_environment()?;
+                let path = Path::new("enso.credentials");
+                cloud_tests::build_credentials_file(auth_config, path).await
+            }
+            .boxed(),
         }
     }
 


### PR DESCRIPTION
### Pull Request Description

I needed to generate credentials for the staging environment.
The standard workflow to do this was to rebuild the IDE with a different `.env` file. However this took so long, as it was finishing (and the build failed for me), I was already finishing this script.

This should be useful for testing cloud integration from the CLI during development. It relies on the same logic as is used for generating credentials in our CI tests.

### Important Notes

Usage:
- You need to set up the same set of environment variables as for the CI workflow:
   - `ENSO_CLOUD_COGNITO_REGION`, `ENSO_CLOUD_COGNITO_USER_POOL_ID`, `ENSO_CLOUD_COGNITO_USER_POOL_WEB_CLIENT_ID` - which can be taken from the `.env` file corresponding to a given environment, although there they have slightly different prefixes (as the config is for IDE not CI).
   - `ENSO_CLOUD_TEST_ACCOUNT_USERNAME` and `ENSO_CLOUD_TEST_ACCOUNT_PASSWORD`
- Then running `./run backend generate-cloud-credentials` should create a `enso.credentials` file in your CWD. To make our libs use it, you can set `ENSO_CLOUD_CREDENTIALS_FILE` env var to point at it.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
