### PR TITLE
Ensure docker is properly notified of NI

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -207,7 +207,8 @@ class JsonConnectionController(
             logger.trace("Resources have been initialized")
             self ! InitializationComponentInitialized.getInstance()
           } else {
-            logger.warn(s"Failed to initialize resources: {}", ex.getMessage, ex)
+            logger
+              .warn(s"Failed to initialize resources: {}", ex.getMessage, ex)
           }
         )
         .pipeTo(self)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -207,7 +207,7 @@ class JsonConnectionController(
             logger.trace("Resources have been initialized")
             self ! InitializationComponentInitialized.getInstance()
           } else {
-            logger.warn("Failed to initialize resources", ex)
+            logger.warn(s"Failed to initialize resources: {}", ex.getMessage, ex)
           }
         )
         .pipeTo(self)

--- a/tools/ci/docker/engine/docker-entrypoint.sh
+++ b/tools/ci/docker/engine/docker-entrypoint.sh
@@ -17,5 +17,9 @@ PROFILING_OPTIONS=""
 if [ "$PROFILING_FILENAME" != "" ] && [ "$PROFILING_TIME" != "" ]; then
   PROFILING_OPTIONS="--profiling-path /opt/enso/profiling/$PROFILING_FILENAME --profiling-time=$PROFILING_TIME"
 fi
+NATIVE_PROP="--jvm"
+if [ "$ENSO_LAUNCHER" != "" ] && [ "$ENSO_LAUNCHER" == "native" ]; then
+  NATIVE_PROP="-Dcom.oracle.graalvm.isaot=true"
+fi
 
-/opt/enso/bin/enso $PROFILING_OPTIONS --log-level "$LOG_LEVEL" --rpc-port $RPC_PORT --data-port $DATA_PORT --root-id "$LS_ROOT_ID" --interface "$INTERFACE" "$@"
+/opt/enso/bin/enso $PROFILING_OPTIONS $NATIVE_PROP --log-level "$LOG_LEVEL" --rpc-port $RPC_PORT --data-port $DATA_PORT --root-id "$LS_ROOT_ID" --interface "$INTERFACE" "$@"


### PR DESCRIPTION
### Pull Request Description

Looks like `com.oracle.graalvm.isaot` is not set properly when running in native image. Also, we must provide `--jvm` when we execute in JVM mode (the default mode for now).

This allows LS to start without any issues when invoked via docker.

### Important Notes

I'd like to take a closer look at how we build the executable provided to docker and maybe avoid this band-aid but for now this unblocks staging. Tested locally by sending appropriate message to server's websocket.

Previously:
![Screenshot from 2025-03-07 17-26-39](https://github.com/user-attachments/assets/d0a4237c-3e97-462a-8b1d-d7ce43ad1899)

Now:
![Screenshot from 2025-03-07 17-26-17](https://github.com/user-attachments/assets/06f15822-01a9-443c-b934-2a185e028b8d)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
