### PR TITLE
Avoid usage of isaot property in favor of ImageInfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2159,12 +2159,15 @@ lazy val `engine-common` = project
     commands += WithDebugCommand.withDebug,
     Test / envVars ++= distributionEnvironmentOverrides,
     libraryDependencies ++= Seq(
-      "org.graalvm.polyglot" % "polyglot" % graalMavenPackagesVersion % "provided"
+      "org.graalvm.sdk"      % "nativeimage" % graalMavenPackagesVersion % "provided",
+      "org.graalvm.polyglot" % "polyglot"    % graalMavenPackagesVersion % "provided"
     ),
     Compile / moduleDependencies ++= {
       Seq(
-        "org.graalvm.polyglot" % "polyglot"  % graalMavenPackagesVersion,
-        "org.slf4j"            % "slf4j-api" % slf4jVersion
+        "org.graalvm.sdk"      % "nativeimage" % graalMavenPackagesVersion,
+        "org.graalvm.sdk"      % "word"        % graalMavenPackagesVersion,
+        "org.graalvm.polyglot" % "polyglot"    % graalMavenPackagesVersion,
+        "org.slf4j"            % "slf4j-api"   % slf4jVersion
       )
     },
     Compile / internalModuleDependencies := Seq(

--- a/engine/common/src/main/java/module-info.java
+++ b/engine/common/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.enso.engine.common {
+  requires org.graalvm.nativeimage;
   requires org.graalvm.polyglot;
   requires org.enso.logging.utils;
   requires org.enso.logging.config;

--- a/engine/common/src/main/java/org/enso/common/ContextFactory.java
+++ b/engine/common/src/main/java/org/enso/common/ContextFactory.java
@@ -176,7 +176,7 @@ public final class ContextFactory {
     }
     var julLogLevel = Converter.toJavaLevel(logLevel);
     var logLevelName = julLogLevel.getName();
-    var inAOTMode = java.lang.Boolean.getBoolean("com.oracle.graalvm.isaot");
+    var inAOTMode = HostEnsoUtils.isAot();
     java.util.Map<String, String> engineOptions = null;
     if (runtimerServerKey != null) {
       if (!inAOTMode) {
@@ -249,7 +249,7 @@ public final class ContextFactory {
           .allowCreateThread(true);
     }
 
-    if (inAOTMode) {
+    if (engineOptions != null) {
       // In AOT mode one must not use a shared engine; the latter causes issues when initializing
       // message transport - it is set to `null`.
       var eng = Engine.newBuilder().allowExperimentalOptions(true).options(engineOptions);

--- a/engine/common/src/main/java/org/enso/common/HostEnsoUtils.java
+++ b/engine/common/src/main/java/org/enso/common/HostEnsoUtils.java
@@ -23,8 +23,9 @@ public final class HostEnsoUtils {
   }
 
   /**
-   * Checks the AOT mode.Delegates to {@link ImageInfo#is}
-     * @return {@code true} if running inside of native executable, {@code false} otherwise
+   * Checks state of the AOT mode. Delegates to {@link ImageInfo#inImageRuntimeCode}.
+   *
+   * @return {@code true} if running inside of native executable, {@code false} otherwise
    */
   public static boolean isAot() {
     return ImageInfo.inImageRuntimeCode();

--- a/engine/common/src/main/java/org/enso/common/HostEnsoUtils.java
+++ b/engine/common/src/main/java/org/enso/common/HostEnsoUtils.java
@@ -1,5 +1,6 @@
 package org.enso.common;
 
+import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.polyglot.PolyglotException;
 
 public final class HostEnsoUtils {
@@ -19,5 +20,13 @@ public final class HostEnsoUtils {
       default ->
         ex.getClass().getName();
     };
+  }
+
+  /**
+   * Checks the AOT mode.Delegates to {@link ImageInfo#is}
+     * @return {@code true} if running inside of native executable, {@code false} otherwise
+   */
+  public static boolean isAot() {
+    return ImageInfo.inImageRuntimeCode();
   }
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -49,6 +49,7 @@ import org.enso.lockmanager.server.LockManagerService
 import org.enso.logger.masking.Masking
 import org.enso.common.RuntimeOptions
 import org.enso.common.ContextFactory
+import org.enso.common.HostEnsoUtils
 import org.enso.logging.utils.akka.AkkaConverter
 import org.enso.polyglot.RuntimeServerInfo
 import org.enso.profiling.events.NoopEventsMonitor
@@ -316,7 +317,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     Runtime.getRuntime.availableProcessors().toString
   )
 
-  if (java.lang.Boolean.getBoolean("com.oracle.graalvm.isaot")) {
+  if (HostEnsoUtils.isAot()) {
     log.info("Running Language Server in AOT mode")
   } else {
     log.info("Running Language Server in JVM mode")

--- a/lib/java/desktop-environment/src/main/java/org/enso/desktopenvironment/MacTrashBin.java
+++ b/lib/java/desktop-environment/src/main/java/org/enso/desktopenvironment/MacTrashBin.java
@@ -2,6 +2,7 @@ package org.enso.desktopenvironment;
 
 import java.nio.file.Path;
 import java.util.List;
+import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.nativeimage.c.CContext;
 import org.graalvm.nativeimage.c.function.CFunction;
@@ -32,7 +33,7 @@ final class MacTrashBin implements TrashBin {
       try {
         return moveToTrashImpl(path);
       } catch (NullPointerException | LinkageError err) {
-        if (!Boolean.getBoolean("com.oracle.graalvm.isaot")) {
+        if (!ImageInfo.inImageRuntimeCode()) {
           var logger = LoggerFactory.getLogger(MacTrashBin.class);
           logger.warn("Moving to MacOS's Trash Bin is not supported in non-AOT mode.");
           return false;

--- a/lib/java/desktop-environment/src/main/java/org/enso/desktopenvironment/WindowsTrashBin.java
+++ b/lib/java/desktop-environment/src/main/java/org/enso/desktopenvironment/WindowsTrashBin.java
@@ -2,6 +2,7 @@ package org.enso.desktopenvironment;
 
 import java.nio.file.Path;
 import java.util.List;
+import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.c.CContext;
 import org.graalvm.nativeimage.c.constant.CConstant;
@@ -35,7 +36,7 @@ final class WindowsTrashBin implements TrashBin {
       try {
         return moveToTrashImpl(path);
       } catch (NullPointerException | LinkageError err) {
-        if (!Boolean.getBoolean("com.oracle.graalvm.isaot")) {
+        if (!ImageInfo.inImageRuntimeCode()) {
           var logger = LoggerFactory.getLogger(MacTrashBin.class);
           logger.warn("Moving to Windows' Trash Bin is not supported in non-AOT mode.");
           return false;

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -15,7 +15,7 @@ case class NativeExecCommand(executablePath: Path) extends ExecCommand {
     engine: Engine,
     jvmSettings: JVMSettings
   ): Seq[String] =
-    Seq("-Dcom.oracle.graalvm.isaot=true")
+    Seq()
 
   override def javaHome: Option[String] = None
 }

--- a/test/Generic_JDBC_Tests/src/H2_Spec.enso
+++ b/test/Generic_JDBC_Tests/src/H2_Spec.enso
@@ -20,7 +20,7 @@ type H2_JDBC_Config
     name self = "H2"
 
     with_database self ~action =
-        database_root = data_dir / "h2_tests"
+        database_root = data_dir / ("h2_tests" + (Date_Time.now.format "yyyy-MM-dd_HHmmss.f"))
         url = "jdbc:h2:" + database_root.path + "/test"
         cleanup =
             database_root . delete_if_exists recursive=True


### PR DESCRIPTION
### Pull Request Description

Fixes #12443 in a different way. Instead of relying on `...isaot` property, let's use proper `ImageInfo` API when outside of Truffle code. Keep using `TruffleOptions.AOT` when in Truffle code.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests remain working
