### PR TITLE
Enable https on native-image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3806,7 +3806,7 @@ lazy val `engine-runner` = project
       val NI_MODULES =
         "org.graalvm.nativeimage,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.base,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
       val JDK_MODULES =
-        "jdk.localedata,jdk.httpserver,java.naming,java.net.http,java.desktop"
+        "jdk.localedata,jdk.httpserver,java.naming,java.net.http,java.desktop,jdk.crypto.ec"
       val DEBUG_MODULES  = "jdk.jdwp.agent"
       val PYTHON_MODULES = "jdk.security.auth,java.naming"
 
@@ -3878,7 +3878,6 @@ lazy val `engine-runner` = project
             ),
             additionalOptions = Seq(
               "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog",
-              "-H:IncludeResources=.*Main.enso$",
               "-H:+AddAllCharsets",
               "-H:+IncludeAllLocales",
               // Workaround a problem with build-/runtime-initialization conflict

--- a/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/native-image.properties
+++ b/engine/runner/src/main/resources/META-INF/native-image/org/enso/runner/native-image.properties
@@ -1,1 +1,1 @@
-Args=--features=org.enso.runner.EnsoLibraryFeature,org.sqlite.nativeimage.SqliteJdbcFeature
+Args=--features=org.enso.runner.EnsoLibraryFeature

--- a/lib/scala/pkg/src/main/resources/META-INF/native-image/org/enso/pkg/resource-config.json
+++ b/lib/scala/pkg/src/main/resources/META-INF/native-image/org/enso/pkg/resource-config.json
@@ -1,0 +1,7 @@
+{
+    "resources":{
+        "includes":[{
+            "pattern":"\\Qdefault/src/Main.enso\\E"
+        }]},
+    "bundles":[]
+}

--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -204,7 +204,7 @@ object NativeImage {
         Seq("-cp", cpStr) ++
         staticParameters ++
         configs ++
-        Seq("--no-fallback", "--no-server") ++
+        Seq("--no-fallback") ++
         Seq("-march=compatibility") ++
         initializeAtBuildtimeOptions ++
         initializeAtRuntimeOptions ++

--- a/std-bits/database/src/main/resources/META-INF/native-image/org/enso/database/native-image.properties
+++ b/std-bits/database/src/main/resources/META-INF/native-image/org/enso/database/native-image.properties
@@ -1,0 +1,1 @@
+Args=--features=org.sqlite.nativeimage.SqliteJdbcFeature


### PR DESCRIPTION
### Pull Request Description

Added `jdk.crypto.ec` to the list of modules used to create a small jdk. Used an opportunity to remove some warnings produced during NI build.

`https` no longer complains:
![Screenshot from 2025-03-10 15-02-55](https://github.com/user-attachments/assets/4ac123f1-d0b4-438e-b94a-66cfee34c2e3)

Closes #12444.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
