### PR TITLE
Fix crash in documentation editor.

### DIFF
--- a/app/gui/integration-test/project-view/rightPanel.spec.ts
+++ b/app/gui/integration-test/project-view/rightPanel.spec.ts
@@ -126,7 +126,7 @@ test('Link in documentation is rendered and interactive', async ({ page, context
   await expect(() => newPagePromise).toPass({ timeout: 5000 })
 })
 
-test('Insert link button inserts link and focuses editor', async ({ page, context }) => {
+test('Insert link button inserts link and focuses editor', async ({ page }) => {
   await actions.goToGraph(page)
   await page.keyboard.press(`${CONTROL_KEY}+D`)
   await expect(locate.rightDock(page)).toBeVisible()

--- a/app/gui/integration-test/project-view/rightPanel.spec.ts
+++ b/app/gui/integration-test/project-view/rightPanel.spec.ts
@@ -2,7 +2,7 @@ import { test } from 'playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
 import { mockCollapsedFunctionInfo, mockMethodCallInfo } from './expressionUpdates'
-import { CONTROL_KEY } from './keyboard'
+import { CONTROL_KEY, DELETE_KEY } from './keyboard'
 import * as locate from './locate'
 
 test('Main method documentation', async ({ page }) => {
@@ -124,4 +124,26 @@ test('Link in documentation is rendered and interactive', async ({ page, context
   const newPagePromise = new Promise<true>((resolve) => context.once('page', () => resolve(true)))
   await docs.locator('a').click({ modifiers: ['ControlOrMeta'] })
   await expect(() => newPagePromise).toPass({ timeout: 5000 })
+})
+
+test('Insert link button inserts link and focuses editor', async ({ page, context }) => {
+  await actions.goToGraph(page)
+  await page.keyboard.press(`${CONTROL_KEY}+D`)
+  await expect(locate.rightDock(page)).toBeVisible()
+  const docs = locate.editorRoot(locate.rightDock(page)).first()
+  await expect(docs.locator('.cm-line')).toExist()
+
+  // Delete all text and defocus the editor
+  await docs.locator('.cm-line').first().click()
+  await page.keyboard.press(`${CONTROL_KEY}+A`)
+  await page.keyboard.press(DELETE_KEY)
+  await expect(docs.locator('.cm-line')).toBeEmpty()
+  await docs.blur()
+
+  // Push the button
+  await locate.rightDock(page).getByRole('button', { name: 'Insert link' }).click()
+
+  // The link exists and is being edited
+  await expect(docs.locator('a')).toExist()
+  await expect(docs.locator('.LinkEditPopup')).toExist()
 })

--- a/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
@@ -86,15 +86,15 @@ defineExpose({
         />
         <SvgButton
           name="connector_add"
-          :disabled="!editing || !insertLink"
+          :disabled="insertLink == null"
           title="Insert link"
-          @click.stop="insertLink!"
+          @click.stop="insertLink?.()"
         />
         <SvgButton
           name="code"
-          :disabled="!editing || !insertCodeBlock"
+          :disabled="insertCodeBlock == null"
           title="Insert code block"
-          @click.stop="insertCodeBlock!"
+          @click.stop="insertCodeBlock?.()"
         />
       </template>
       <slot name="toolbarRight" />

--- a/app/gui/src/project-view/components/MarkdownEditor/codemirror/formatting/index.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/codemirror/formatting/index.ts
@@ -14,7 +14,13 @@ import {
 } from '@/components/MarkdownEditor/codemirror/formatting/inline'
 import { type SupportedBlockType as BlockType } from '@/components/MarkdownEditor/markdown/types'
 import { assert } from '@/util/assert'
-import { type Extension, Facet, Prec } from '@codemirror/state'
+import {
+  type EditorState,
+  type Extension,
+  Facet,
+  Prec,
+  type TransactionSpec,
+} from '@codemirror/state'
 import { type EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view'
 import * as objects from 'enso-common/src/utilities/data/object'
 import { computed, proxyRefs, readonly, type Ref, ref } from 'vue'
@@ -33,8 +39,12 @@ const reactiveFormattingFacet = Facet.define<ReactiveFormatting, ReactiveFormatt
 /** Supports watching and modifying the formatting of the selected text. */
 export function useMarkdownFormatting(view: EditorView) {
   const reactiveFormatting = view.state.facet(reactiveFormattingFacet)
+  function doEdit(edit: (state: EditorState) => TransactionSpec) {
+    view.dispatch(edit(view.state))
+    view.focus()
+  }
   function inlineFormat(type: InlineFormattingNode) {
-    const setter = (value: boolean) => view.dispatch(setInlineFormatting(view.state, type, value))
+    const setter = (value: boolean) => doEdit((state) => setInlineFormatting(state, type, value))
     return proxyRefs({
       value: computed(() => !!reactiveFormatting.inline[type].value),
       set: computed(() => (reactiveFormatting.inline[type] === undefined ? undefined : setter)),
@@ -44,13 +54,9 @@ export function useMarkdownFormatting(view: EditorView) {
     italic: inlineFormat('Emphasis'),
     bold: inlineFormat('StrongEmphasis'),
     strikethrough: inlineFormat('Strikethrough'),
-    insertLink: computed(
-      () => canInsertLink(view.state) && (() => view.dispatch(insertLink(view.state))),
-    ),
+    insertLink: computed(() => (canInsertLink(view.state) ? () => doEdit(insertLink) : undefined)),
     insertCodeBlock: computed(() =>
-      reactiveFormatting.unformattable.value ?
-        undefined
-      : () => view.dispatch(insertCodeBlock(view.state)),
+      reactiveFormatting.unformattable.value ? undefined : () => doEdit(insertCodeBlock),
     ),
     blockType: proxyRefs({
       value: readonly(reactiveFormatting.blockType),
@@ -58,10 +64,8 @@ export function useMarkdownFormatting(view: EditorView) {
         const currentType = getBlockType(view.state)
         if (type === currentType) return
         assert(type !== 'FencedCode')
-        view.dispatch(
-          currentType === 'FencedCode' ?
-            removeCodeBlock(view.state)
-          : setBlockType(view.state, type),
+        doEdit((state) =>
+          currentType === 'FencedCode' ? removeCodeBlock(state) : setBlockType(state, type),
         )
       },
     }),


### PR DESCRIPTION
Fix crash in documentation editor. Apparently, if an event handler is attached with a modifier, the handler value must never be nullish, or Vue will throw an exception.

Also a behaviour change: Using any formatting button focuses the editor.

Fixes #12465.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
