### PR TITLE
Prevent code editor from sizing to content

### DIFF
--- a/app/gui/integration-test/project-view/rightPanel.spec.ts
+++ b/app/gui/integration-test/project-view/rightPanel.spec.ts
@@ -73,6 +73,33 @@ test('Doc panel focus (regression #10471)', async ({ page }) => {
   await expect(locate.rightDock(page)).toContainText('The main TEST method')
 })
 
+test('Code editor with wide content does not take space from doc editor (#12476)', async ({
+  page,
+}) => {
+  await actions.goToGraph(page)
+
+  await page.keyboard.press(`${CONTROL_KEY}+D`)
+  await expect(locate.rightDock(page)).toBeVisible()
+  await locate
+    .rightDock(page)
+    .elementHandle()
+    .then((el) => el!.waitForElementState('stable'))
+  const docPosWithoutCodeEditor = (await locate.rightDock(page).boundingBox())!.x
+
+  await page.keyboard.press(`${CONTROL_KEY}+\``)
+  const codeEditor = page.locator('.CodeEditor')
+  await expect(codeEditor).toBeVisible()
+  await locate
+    .rightDock(page)
+    .elementHandle()
+    .then((el) => el!.waitForElementState('stable'))
+  const docPosWithCodeEditor = (await locate.rightDock(page).boundingBox())!.x
+
+  // Note that we compare `x` instead of `width`: This will catch either a change in width, or the
+  // viewport becoming larger than the page (causing a change in *apparent* width).
+  expect(docPosWithoutCodeEditor).toBe(docPosWithCodeEditor)
+})
+
 test('Component help', async ({ page }) => {
   await actions.goToGraph(page, false)
   await locate.rightDock(page).getByRole('button', { name: 'Help' }).click()

--- a/app/gui/integration-test/project-view/rightPanel.spec.ts
+++ b/app/gui/integration-test/project-view/rightPanel.spec.ts
@@ -97,7 +97,7 @@ test('Code editor with wide content does not take space from doc editor (#12476)
 
   // Note that we compare `x` instead of `width`: This will catch either a change in width, or the
   // viewport becoming larger than the page (causing a change in *apparent* width).
-  expect(docPosWithoutCodeEditor).toBe(docPosWithCodeEditor)
+  expect(docPosWithCodeEditor).toBe(docPosWithoutCodeEditor)
 })
 
 test('Component help', async ({ page }) => {

--- a/app/gui/src/project-view/ProjectView.vue
+++ b/app/gui/src/project-view/ProjectView.vue
@@ -72,6 +72,7 @@ onDeactivated(() => (visible.value = false))
 
 <style scoped>
 .ProjectView {
+  width: 100%;
   flex: 1;
   color: var(--color-text);
   font-family: var(--font-sans);

--- a/app/gui/src/project-view/components/GraphEditor.vue
+++ b/app/gui/src/project-view/components/GraphEditor.vue
@@ -700,7 +700,7 @@ const groupColors = computed(() => {
   }
   & .vertical {
     flex: auto;
-    min-width: 0;
+    overflow-x: hidden;
   }
 }
 

--- a/app/gui/src/project-view/mock/engine.ts
+++ b/app/gui/src/project-view/mock/engine.ts
@@ -90,6 +90,8 @@ main =
     aggregated = data.aggregate
     autoscoped = data.aggregate [..Group_By]
     selected = data.select_columns
+
+# To test for regressions in #12476, this line is really long and we test that the code editor doesn't resize to fit it. This line is really really long. This line is really REALLY long.
 `
 
 const fileTree = {


### PR DESCRIPTION
### Pull Request Description

Prevent code editor from sizing to content and stealing width from doc editor; add a test that catches the bug.

Fixes #12476.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
