### PR TITLE
Reset form values when changing between secrets

### DIFF
--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetProperties.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetProperties.tsx
@@ -339,6 +339,7 @@ function AssetPropertiesInternal(props: AssetPropertiesInternalProps) {
             {getText('secret')}
           </Heading>
           <UpsertSecretModal
+            key={item.id}
             noDialog
             canReset
             canCancel={false}

--- a/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
+++ b/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
@@ -1,11 +1,9 @@
 /** @file Modal for confirming delete of any type of asset. */
 import { ButtonGroup, Dialog, DialogDismiss, Form, Input } from '#/components/AriaComponents'
+import { useSyncRef } from '#/hooks/syncRefHooks'
 import { useText } from '#/providers/TextProvider'
 import type { SecretId } from '#/services/Backend'
-
-// =========================
-// === UpsertSecretModal ===
-// =========================
+import { useEffect } from 'react'
 
 /** Props for a {@link UpsertSecretModal}. */
 export interface UpsertSecretModalProps {
@@ -26,20 +24,26 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
   const { canCancel = true, canReset = false } = props
   const { getText } = useText()
 
+  const form = Form.useForm({
+    schema: (z) => z.object({ title: z.string().min(1), value: z.string() }),
+    defaultValues: { title: nameRaw ?? '', value: '' },
+    onSubmit: async ({ title, value }) => {
+      await doCreate(title, value)
+      form.reset({ title, value })
+    },
+  })
+
+  const resetFormDeps = useSyncRef({ form })
+
+  useEffect(() => {
+    const deps = resetFormDeps.current
+    deps.form.reset({ title: nameRaw ?? '' })
+  }, [nameRaw, resetFormDeps])
+
   const isCreatingSecret = id == null
 
   const content = (
-    <Form
-      method="dialog"
-      schema={(z) => z.object({ title: z.string().min(1), value: z.string() })}
-      defaultValues={{ title: nameRaw ?? '', value: '' }}
-      onSubmit={async ({ title, value }, form) => {
-        await doCreate(title, value)
-        form.reset({ title, value })
-      }}
-      testId="upsert-secret-modal"
-      className="w-full"
-    >
+    <Form form={form} method="dialog" testId="upsert-secret-modal" className="w-full">
       <Input
         name="title"
         autoFocus

--- a/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
+++ b/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
@@ -1,9 +1,7 @@
 /** @file Modal for confirming delete of any type of asset. */
 import { ButtonGroup, Dialog, DialogDismiss, Form, Input } from '#/components/AriaComponents'
-import { useSyncRef } from '#/hooks/syncRefHooks'
 import { useText } from '#/providers/TextProvider'
 import type { SecretId } from '#/services/Backend'
-import { useEffect } from 'react'
 
 /** Props for a {@link UpsertSecretModal}. */
 export interface UpsertSecretModalProps {
@@ -32,13 +30,6 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
       form.reset({ title, value })
     },
   })
-
-  const resetFormDeps = useSyncRef({ form })
-
-  useEffect(() => {
-    const deps = resetFormDeps.current
-    deps.form.reset({ title: nameRaw ?? '' })
-  }, [nameRaw, resetFormDeps])
 
   const isCreatingSecret = id == null
 


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1800
  - Update "name" field in "upsert secret" form when selecting a different secret

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
