### PR TITLE
Reduce logging noise for heartbeats

### DIFF
--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
@@ -94,7 +94,7 @@ public class SocketLoggingNode implements Runnable {
         }
       }
     } catch (java.io.EOFException e) {
-      if (state.isBefore(State.CLOSING)) {
+      if (state.isBefore(State.CLOSING) && projectId != null) {
         logger.debug("Caught java.io.EOFException closing connection.", e);
       }
     } catch (java.net.SocketException e) {

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketServer.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketServer.java
@@ -52,11 +52,9 @@ public class SocketServer extends Thread {
       logger.debug("Listening on port " + port);
       serverSocket = getServerSocketFactory().createServerSocket(port);
       while (!closed) {
-        logger.debug("Waiting to accept a new client.");
         signalAlmostReadiness();
         Socket socket = serverSocket.accept();
         logger.debug("Connected to client at " + socket.getInetAddress());
-        logger.debug("Starting new socket node.");
         SocketLoggingNode newSocketNode = new SocketLoggingNode(this, socket, lc);
         synchronized (socketNodeList) {
           socketNodeList.add(newSocketNode);


### PR DESCRIPTION
### Pull Request Description

Logs are rather full of useless entries
```
[DEBUG] [org.enso.logging.service.logback.SocketServer] Connected to client at /127.0.0.1
[DEBUG] [org.enso.logging.service.logback.SocketServer] Starting new socket node.
[DEBUG] [org.enso.logging.service.logback.SocketServer] Waiting to accept a new client.
[DEBUG] [org.enso.logging.service.logback.SocketLoggingNode] Caught java.io.EOFException closing connection.
java.io.EOFException: null
	at java.base@21.0.2/java.io.ObjectInputStream$BlockDataInputStream.peekByte(ObjectInputStream.java:3232)
	at java.base@21.0.2/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1713)
	at java.base@21.0.2/java.io.ObjectInputStream.readObject(ObjectInputStream.java:540)
	at java.base@21.0.2/java.io.ObjectInputStream.readObject(ObjectInputStream.java:498)
	at org.enso.logging.service.logback.SocketLoggingNode.run(SocketLoggingNode.java:76)
	at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:833)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:211)
[DEBUG] [org.enso.logging.service.logback.SocketServer] Removing org.enso.logging.service.logback.SocketLoggingNode/127.0.0.1:60972
```
Those appear to come from project-manager's heartbeat sessions. This change removes the noise.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
