### PR TITLE
Unbreak NI integration for Snowflake on Linux

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3810,7 +3810,7 @@ lazy val `engine-runner` = project
       val NI_MODULES =
         "org.graalvm.nativeimage,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.base,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
       val JDK_MODULES =
-        "jdk.charsets,jdk.localedata,jdk.httpserver,java.naming,java.net.http,java.desktop,jdk.crypto.ec"
+        "java.desktop,java.naming,java.net.http,jdk.charsets,jdk.crypto.ec,jdk.localedata,jdk.httpserver,java.rmi"
       val DEBUG_MODULES  = "jdk.jdwp.agent"
       val PYTHON_MODULES = "jdk.security.auth,java.naming"
 


### PR DESCRIPTION
### Pull Request Description

Snowflake started crashing recently with a rather useless message:
```
Execution finished with an error: net.snowflake.client.jdbc.telemetry.TelemetryClient.createTelemetry(net.snowflake.client.core.SFSession)
        at <java> net.snowflake.client.core.SFSession.getTelemetryClient(SFSession.java:1064)
        at <java> net.snowflake.client.jdbc.SnowflakeDatabaseMetaData.<init>(SnowflakeDatabaseMetaData.java:148)
        at <java> net.snowflake.client.jdbc.SnowflakeConnectionV1.getMetaData(SnowflakeConnectionV1.java:277)
        at <enso> JDBC_Connection.with_metadata.JDBC_Connection.with_metadata(JDBC_Connection.enso:81:20-41)
        at <enso> Managed_Resource.with_builtin(Internal)
        at <enso> Panic.catch(Internal)
        at <enso> Panic.type.with_finalizer(Panic.enso:155:18-52)
        at <enso> JDBC_Connection.synchronized(JDBC_Connection.enso:45:9-86)
        at <enso> JDBC_Connection.with_connection(JDBC_Connection.enso:61-62)
        at <enso> JDBC_Connection.with_metadata<arg-1>(JDBC_Connection.enso:80-82)
```

Turned out small JDK was missing the appropriate module, `java.rmi`.
Now, one is able to run `enso --run tests/Snowflake_Tests` (with appropriate credentials).

### Important Notes

This problem apparently only affected Linux devs. I haven't investigated why.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
