### PR TITLE
Fix md file pattern match in API change stdlib label jobs

### DIFF
--- a/.github/workflows/std-libs-labels.yml
+++ b/.github/workflows/std-libs-labels.yml
@@ -28,7 +28,7 @@ jobs:
         name: AWS-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/AWS/**/docs/api/**.md
+          files: distribution/lib/Standard/AWS/**/docs/api/**/**.md
       - name: List all changed files in AWS
         run: "\n        if [[ \"${{ steps.AWS-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -53,7 +53,7 @@ jobs:
         name: Base-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Base/**/docs/api/**.md
+          files: distribution/lib/Standard/Base/**/docs/api/**/**.md
       - name: List all changed files in Base
         run: "\n        if [[ \"${{ steps.Base-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -78,7 +78,7 @@ jobs:
         name: Database-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Database/**/docs/api/**.md
+          files: distribution/lib/Standard/Database/**/docs/api/**/**.md
       - name: List all changed files in Database
         run: "\n        if [[ \"${{ steps.Database-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -103,7 +103,7 @@ jobs:
         name: Google_Api-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Google_Api/**/docs/api/**.md
+          files: distribution/lib/Standard/Google_Api/**/docs/api/**/**.md
       - name: List all changed files in Google_Api
         run: "\n        if [[ \"${{ steps.Google_Api-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -128,7 +128,7 @@ jobs:
         name: Image-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Image/**/docs/api/**.md
+          files: distribution/lib/Standard/Image/**/docs/api/**/**.md
       - name: List all changed files in Image
         run: "\n        if [[ \"${{ steps.Image-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -153,7 +153,7 @@ jobs:
         name: Microsoft-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Microsoft/**/docs/api/**.md
+          files: distribution/lib/Standard/Microsoft/**/docs/api/**/**.md
       - name: List all changed files in Microsoft
         run: "\n        if [[ \"${{ steps.Microsoft-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -178,7 +178,7 @@ jobs:
         name: Snowflake-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Snowflake/**/docs/api/**.md
+          files: distribution/lib/Standard/Snowflake/**/docs/api/**/**.md
       - name: List all changed files in Snowflake
         run: "\n        if [[ \"${{ steps.Snowflake-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -203,7 +203,7 @@ jobs:
         name: Table-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Table/**/docs/api/**.md
+          files: distribution/lib/Standard/Table/**/docs/api/**/**.md
       - name: List all changed files in Table
         run: "\n        if [[ \"${{ steps.Table-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -228,7 +228,7 @@ jobs:
         name: Tableau-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Tableau/**/docs/api/**.md
+          files: distribution/lib/Standard/Tableau/**/docs/api/**/**.md
       - name: List all changed files in Tableau
         run: "\n        if [[ \"${{ steps.Tableau-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -253,7 +253,7 @@ jobs:
         name: Test-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Test/**/docs/api/**.md
+          files: distribution/lib/Standard/Test/**/docs/api/**/**.md
       - name: List all changed files in Test
         run: "\n        if [[ \"${{ steps.Test-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:
@@ -278,7 +278,7 @@ jobs:
         name: Visualization-changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files: distribution/lib/Standard/Visualization/**/docs/api/**.md
+          files: distribution/lib/Standard/Visualization/**/docs/api/**/**.md
       - name: List all changed files in Visualization
         run: "\n        if [[ \"${{ steps.Visualization-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
         env:

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -375,7 +375,7 @@ impl StandardLibraryLabelCheck {
 
     fn changed_files_step(&self) -> Step {
         let changed_files_pattern =
-            format!("distribution/lib/Standard/{}/**/docs/api/**.md", self.lib_name);
+            format!("distribution/lib/Standard/{}/**/docs/api/**/**.md", self.lib_name);
         let changed_files_action = "tj-actions/changed-files@v45".to_string();
         Step {
             id: Some(self.changed_files_step_name()),

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/Process.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/Process.md
@@ -2,4 +2,3 @@
 ## module Standard.Base.System.Process
 - new_builder command:Standard.Base.Any.Any arguments:Standard.Base.Any.Any= stdin:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - run command:Standard.Base.Data.Text.Text arguments:Standard.Base.Any.Any= stdin:Standard.Base.Data.Text.Text= redirect_out_err:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
-- foo -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/Process.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/Process.md
@@ -2,3 +2,4 @@
 ## module Standard.Base.System.Process
 - new_builder command:Standard.Base.Any.Any arguments:Standard.Base.Any.Any= stdin:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - run command:Standard.Base.Data.Text.Text arguments:Standard.Base.Any.Any= stdin:Standard.Base.Data.Text.Text= redirect_out_err:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
+- foo -> Standard.Base.Any.Any


### PR DESCRIPTION
A small fix after #12326

### Pull Request Description

[Base-change-labels job](https://github.com/enso-org/enso/actions/runs/13846542636/job/38746058226?pr=12490) on https://github.com/enso-org/enso/pull/12490 didn't recognize that `distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/Process.md` changed.  @hubertp had to manually assign `-libs-API-change-Base` in https://github.com/enso-org/enso/pull/12490#event-16777489164.

This PR updates the pattern used in `actions/changed-files` to recognize changed md files in subdirectories.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
