### PR TITLE
Make Native Image opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [Disable heatmap and histogram viz][12475].
 - [Component Browser displays short summary of component's documentation][12459]
 - [For some types, Component Browser display special "suggestions" group][12477]
+- [Native Image mode is now on by default][12515]
 
 [11889]: https://github.com/enso-org/enso/pull/11889
 [11836]: https://github.com/enso-org/enso/pull/11836
@@ -70,6 +71,7 @@
 [12475]: https://github.com/enso-org/enso/pull/12475
 [12459]: https://github.com/enso-org/enso/pull/12459
 [12477]: https://github.com/enso-org/enso/pull/12477
+[12515]: https://github.com/enso-org/enso/pull/12515
 
 #### Enso Standard Library
 

--- a/app/ide-desktop/client/src/config.ts
+++ b/app/ide-desktop/client/src/config.ts
@@ -102,6 +102,11 @@ export const CONFIG = contentConfig.OPTIONS.merge(
         value: true,
         description: 'Start the engine process.',
       }),
+      jvm: new contentConfig.Option({
+        passToWebApplication: false,
+        value: false,
+        description: 'Start engine in JVM mode.',
+      }),
       inspect: new contentConfig.Option({
         passToWebApplication: false,
         primary: false,

--- a/app/ide-desktop/client/src/index.ts
+++ b/app/ide-desktop/client/src/index.ts
@@ -349,8 +349,7 @@ class App {
         this.args.groups.debug.options.profile.value ?
           ['--profiling-path', 'profiling.npss', ...backendProfileTime]
         : []
-      const backendJvmOpts =
-        this.args.options.jvm.value ? ['--jvm'] : []
+      const backendJvmOpts = this.args.options.jvm.value ? ['--jvm'] : []
       const backendOpts = [...backendVerboseOpts, ...backendProfileOpts, ...backendJvmOpts]
       const backendEnv = Object.assign({}, process.env, {
         SERVER_HOST: this.projectManagerHost,

--- a/app/ide-desktop/client/src/index.ts
+++ b/app/ide-desktop/client/src/index.ts
@@ -349,7 +349,9 @@ class App {
         this.args.groups.debug.options.profile.value ?
           ['--profiling-path', 'profiling.npss', ...backendProfileTime]
         : []
-      const backendOpts = [...backendVerboseOpts, ...backendProfileOpts]
+      const backendJvmOpts =
+        this.args.options.jvm.value ? ['--jvm'] : []
+      const backendOpts = [...backendVerboseOpts, ...backendProfileOpts, ...backendJvmOpts]
       const backendEnv = Object.assign({}, process.env, {
         SERVER_HOST: this.projectManagerHost,
         SERVER_PORT: `${this.projectManagerPort}`,

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -281,6 +281,7 @@ impl RunContext {
         // we don't want to call this in environments like GH-hosted runners.
 
         // === Build project-manager distribution and native image ===
+        env::ENSO_LAUNCHER.set(&engine::EngineLauncher::Native)?;
         let mut tasks = vec![];
         if self.config.build_engine_package() {
             tasks.push("buildEngineDistribution");

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -281,7 +281,6 @@ impl RunContext {
         // we don't want to call this in environments like GH-hosted runners.
 
         // === Build project-manager distribution and native image ===
-        env::ENSO_LAUNCHER.set(&engine::EngineLauncher::Native)?;
         let mut tasks = vec![];
         if self.config.build_engine_package() {
             tasks.push("buildEngineDistribution");

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -200,7 +200,7 @@ safely.
 
 ### Engine runner Configuration
 
-The Native Image generation for the Engine Runner is on my default for releases.
+The Native Image generation for the Engine Runner is on by default for releases.
 In development mode, Native Image build has to be enabled explicitly. It is
 triggered by `ENSO_LAUNCHER` environment variable. Its value can be one of the
 following:

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -200,9 +200,10 @@ safely.
 
 ### Engine runner Configuration
 
-The Native Image generation for the Engine Runner is currently in a preview
-state. It is triggered by `ENSO_LAUNCHER` environment variable. Its value can be
-one of the following:
+The Native Image generation for the Engine Runner is on my default for releases.
+In development mode, Native Image build has to be enabled explicitly. It is
+triggered by `ENSO_LAUNCHER` environment variable. Its value can be one of the
+following:
 
 - `shell`: The default value. `buildEngineDistribution` command does not build
   the native image.

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -202,6 +202,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     * @param useSystemJVM if set, forces to use the default configured JVM,
     *                     instead of the JVM associated with the engine version
     * @param jvmOpts additional options to pass to the launched JVM
+    * @param jvmMode if true, enables JVM mode
     * @param additionalArguments additional arguments to pass to the runner
     * @return exit code of the launched program
     */

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -74,6 +74,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     versionOverride: Option[SemVer],
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
+    jvmMode: Boolean,
     additionalArguments: Seq[String]
   ): Int = {
     val actualPath = path.getOrElse(Launcher.workingDirectory.resolve(name))
@@ -88,6 +89,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             path                = actualPath,
             name                = name,
             engineVersion       = version,
+            jvmMode             = jvmMode,
             normalizedName      = normalizedName,
             projectTemplate     = projectTemplate,
             authorName          = globalConfig.authorName,
@@ -209,6 +211,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     logLevel: Level,
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
+    jvmMode: Boolean,
     additionalArguments: Seq[String]
   ): Int = {
     runner
@@ -219,6 +222,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             versionOverride,
             logLevel,
             cliOptions.internalOptions.logMasking,
+            jvmMode,
             additionalArguments
           )
           .get,
@@ -252,6 +256,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     logLevel: Level,
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
+    jvmMode: Boolean,
     additionalArguments: Seq[String]
   ): Int = {
     val exitCode = runner
@@ -262,6 +267,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             versionOverride,
             logLevel,
             cliOptions.internalOptions.logMasking,
+            jvmMode,
             additionalArguments
           )
           .get,

--- a/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
@@ -79,6 +79,7 @@ object LauncherApplication {
         versionOverride,
         systemJVMOverride,
         jvmOpts,
+        jvmMode,
         additionalArgs
       ) mapN {
         (
@@ -89,6 +90,7 @@ object LauncherApplication {
           versionOverride,
           systemJVMOverride,
           jvmOpts,
+          jvmMode,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).newProject(
@@ -99,6 +101,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
+            jvmMode             = jvmMode,
             additionalArguments = additionalArgs
           )
       }
@@ -108,6 +111,12 @@ object LauncherApplication {
     Opts.prefixedParameters(
       "jvm",
       "These parameters will be passed to the launched JVM as -DKEY=VALUE."
+    )
+  private def jvmMode =
+    Opts.flag(
+      "jvm",
+      "Setting this flag runs Enso in JVM mode rather than the default native one.",
+      showInUsage = true
     )
   private def systemJVMOverride =
     Opts.flag(
@@ -157,6 +166,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
+        jvmMode,
         additionalArgs
       ) mapN {
         (
@@ -165,6 +175,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
+          jvmMode,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runRun(
@@ -172,6 +183,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
+            jvmMode             = jvmMode,
             additionalArguments = additionalArgs,
             logLevel            = engineLogLevel
           )
@@ -243,6 +255,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
+        jvmMode,
         additionalArgs
       ) mapN {
         (
@@ -258,6 +271,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
+          jvmMode,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runLanguageServer(
@@ -268,7 +282,8 @@ object LauncherApplication {
               rpcPort        = rpcPort,
               secureRpcPort  = secureRpcPort,
               dataPort       = dataPort,
-              secureDataPort = secureDataPort
+              secureDataPort = secureDataPort,
+              jvmMode        = jvmMode
             ),
             contentRoot         = path,
             versionOverride     = versionOverride,
@@ -301,6 +316,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
+        jvmMode,
         additionalArgs
       ) mapN {
         (
@@ -309,6 +325,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
+          jvmMode,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runRepl(
@@ -316,6 +333,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
+            jvmMode             = jvmMode,
             additionalArguments = additionalArgs,
             logLevel            = engineLogLevel
           )

--- a/engine/launcher/src/main/scala/org/enso/launcher/components/LauncherRunner.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/components/LauncherRunner.scala
@@ -45,6 +45,7 @@ class LauncherRunner(
     versionOverride: Option[SemVer],
     logLevel: Level,
     logMasking: Boolean,
+    jvmMode: Boolean,
     additionalArguments: Seq[String]
   ): Try[RunSettings] =
     Try {
@@ -67,6 +68,7 @@ class LauncherRunner(
       }
       RunSettings(
         version,
+        jvmMode,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = workingDirectory,
@@ -83,6 +85,7 @@ class LauncherRunner(
     versionOverride: Option[SemVer],
     logLevel: Level,
     logMasking: Boolean,
+    jvmMode: Boolean,
     additionalArguments: Seq[String]
   ): Try[RunSettings] =
     Try {
@@ -131,6 +134,7 @@ class LauncherRunner(
           }
       RunSettings(
         version,
+        jvmMode,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = workingDirectory,
@@ -212,6 +216,7 @@ class LauncherRunner(
       (
         RunSettings(
           version,
+          jvmMode = false,
           arguments,
           workingDirectory         = None,
           connectLoggerIfAvailable = false
@@ -262,6 +267,7 @@ class LauncherRunner(
         tokenOpts ++ hideProgressOpts
       RunSettings(
         version,
+        jvmMode = false,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = None,
@@ -310,6 +316,7 @@ class LauncherRunner(
         hideProgressOpts
       RunSettings(
         version,
+        jvmMode = false,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = None,

--- a/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
@@ -64,6 +64,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
 
       val runSettings = RunSettings(
         SemVer.of(0, 0, 0),
+        jvmMode = true,
         Seq("arg1", "--flag2"),
         workingDirectory         = None,
         connectLoggerIfAvailable = true
@@ -126,6 +127,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           path                = projectPath,
           name                = "ProjectName",
           engineVersion       = defaultEngineVersion,
+          jvmMode             = false,
           normalizedName      = None,
           projectTemplate     = None,
           authorName          = Some(authorName),
@@ -154,6 +156,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           path                = projectPath,
           name                = "ProjectName",
           engineVersion       = defaultEngineVersion,
+          jvmMode             = false,
           normalizedName      = Some(normalizedName),
           projectTemplate     = None,
           authorName          = None,
@@ -184,6 +187,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
             path                = projectPath,
             name                = "ProjectName2",
             engineVersion       = nightlyVersion,
+            jvmMode             = false,
             normalizedName      = None,
             projectTemplate     = None,
             authorName          = None,
@@ -216,7 +220,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq("arg", "--flag"),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -242,7 +247,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -258,7 +264,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -274,7 +281,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = Some(overridden),
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -297,7 +305,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
         rpcPort        = 1234,
         secureRpcPort  = None,
         dataPort       = 4321,
-        secureDataPort = None
+        secureDataPort = None,
+        jvmMode        = false
       )
       val runSettings = runner
         .languageServer(
@@ -349,7 +358,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -365,7 +375,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -380,7 +391,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = Some(overridden),
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -395,7 +407,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
             versionOverride     = None,
             additionalArguments = Seq(),
             logLevel            = Level.INFO,
-            logMasking          = true
+            logMasking          = true,
+            jvmMode             = false
           )
           .isFailure,
         "Running outside project without providing any paths should be an error"
@@ -422,7 +435,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 
@@ -447,7 +461,8 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           versionOverride     = None,
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
-          logMasking          = true
+          logMasking          = true,
+          jvmMode             = false
         )
         .get
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -16,6 +16,7 @@ object Cli {
   val PROFILING_TIME     = "profiling-time"
   val PROJECTS_DIRECTORY = "projects-directory"
   val PROJECT_LIST       = "project-list"
+  val JVM_MODE           = "jvm"
 
   val FILESYSTEM_EXISTS           = "filesystem-exists"
   val FILESYSTEM_LIST             = "filesystem-list"
@@ -90,6 +91,12 @@ object Cli {
       .argName("limit")
       .longOpt(PROJECT_LIST)
       .desc("List user projects.")
+      .build()
+
+    val jvmMode: cli.Option = cli.Option.builder
+      .hasArg(false)
+      .longOpt(JVM_MODE)
+      .desc("Run in JVM mode.")
       .build()
 
     val filesystemExists: cli.Option = cli.Option.builder
@@ -168,6 +175,7 @@ object Cli {
       .addOption(option.profilingTime)
       .addOption(option.projectsDirectory)
       .addOption(option.projectList)
+      .addOption(option.jvmMode)
       .addOption(option.filesystemExists)
       .addOption(option.filesystemList)
       .addOption(option.filesystemCreateDirectory)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
@@ -115,7 +115,8 @@ class MainModule[
   lazy val projectCreationService =
     new ProjectCreationService[F](
       distributionConfiguration,
-      loggingService
+      loggingService,
+      processConfig.jvmMode
     )
 
   lazy val globalConfigService =

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -208,10 +208,21 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
         )
       }
 
+    val parseJvmMode = ZIO
+      .attempt {
+        options.hasOption(Cli.JVM_MODE)
+      }
+      .catchAll { err =>
+        printLineError(s"Invalid ${Cli.JVM_MODE} argument.") *> ZIO.fail(
+          err
+        )
+      }
+
     for {
       profilingPath <- parseProfilingPath
       profilingTime <- parseProfilingTime
-    } yield ProjectManagerOptions(profilingPath, profilingTime)
+      jvmMode       <- parseJvmMode
+    } yield ProjectManagerOptions(profilingPath, profilingTime, jvmMode)
   }
 
   /** The main function of the application, which will be passed the command-line
@@ -297,7 +308,8 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
         procConf = MainProcessConfig(
           logLevel,
           opts.profilingPath,
-          opts.profilingTime
+          opts.profilingTime,
+          opts.jvmMode
         )
         exitCode <- mainProcess(procConf).fold(
           th => {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
@@ -11,5 +11,6 @@ import scala.concurrent.duration.FiniteDuration
   */
 case class ProjectManagerOptions(
   profilingPath: Option[Path],
-  profilingTime: Option[FiniteDuration]
+  profilingTime: Option[FiniteDuration],
+  jvmMode: Boolean
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration.FiniteDuration
   *
   * @param profilingPath the path to the profiling output file
   * @param profilingTime the time limiting the profiling duration
+  * @param jvmMode if true, enables JVM mode
   */
 case class ProjectManagerOptions(
   profilingPath: Option[Path],

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -16,6 +16,7 @@ object configuration {
     *  @param logLevel the logging level
     *  @param profilingPath the path to the profiling out file
     *  @param profilingTime the time limiting the profiling duration
+    * @param jvmMode if true, enables JVM mode
     */
   case class MainProcessConfig(
     logLevel: Level,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -20,7 +20,8 @@ object configuration {
   case class MainProcessConfig(
     logLevel: Level,
     profilingPath: Option[Path],
-    profilingTime: Option[FiniteDuration]
+    profilingTime: Option[FiniteDuration],
+    jvmMode: Boolean
   )
 
   /** A configuration object for properties of the Project Manager.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -89,7 +89,8 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
       rpcPort        = rpcPort,
       secureRpcPort  = secureRpcPort,
       dataPort       = dataPort,
-      secureDataPort = secureDataPort
+      secureDataPort = secureDataPort,
+      jvmMode        = descriptor.jvmMode
     )
     val configurationManager = new GlobalRunnerConfigurationManager(
       versionManager,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -87,6 +87,7 @@ class LanguageServerController(
       distributionConfiguration      = distributionConfiguration,
       engineVersion                  = engineVersion,
       jvmSettings                    = distributionConfiguration.defaultJVMSettings,
+      jvmMode                        = processConfig.jvmMode,
       discardOutput                  = distributionConfiguration.shouldDiscardChildOutput,
       profilingPath                  = processConfig.profilingPath,
       profilingTime                  = processConfig.profilingTime,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -44,6 +44,7 @@ case class LanguageServerDescriptor(
   distributionConfiguration: DistributionConfiguration,
   engineVersion: SemVer,
   jvmSettings: JVMSettings,
+  jvmMode: Boolean,
   discardOutput: Boolean,
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -23,6 +23,7 @@ import scala.concurrent.duration.FiniteDuration
   *                                  versions
   * @param engineVersion version of the langauge server's engine to use
   * @param jvmSettings settings to use for the JVM that will host the engine
+  * @param jvmMode if true, enables JVM mode
   * @param discardOutput specifies if the process output should be discarded or
   *                      printed to parent's streams
   * @param profilingPath the language server profiling file path

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -23,7 +23,8 @@ class ProjectCreationService[
   F[+_, +_]: Sync: ErrorChannel: CovariantFlatMap
 ](
   distributionConfiguration: DistributionConfiguration,
-  loggingServiceDescriptor: LoggingServiceDescriptor
+  loggingServiceDescriptor: LoggingServiceDescriptor,
+  jvmMode: Boolean
 ) extends ProjectCreationServiceApi[F] {
 
   private lazy val logger = Logger[ProjectCreationService[F]]
@@ -61,6 +62,7 @@ class ProjectCreationService[
             path,
             name,
             engineVersion,
+            jvmMode,
             None,
             projectTemplate,
             None,

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
@@ -94,7 +94,8 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
     MainProcessConfig(
       logLevel      = if (debugLogs) Level.TRACE else Level.ERROR,
       profilingPath = profilingPath,
-      profilingTime = None
+      profilingTime = None,
+      jvmMode       = false
     )
 
   val testClock =
@@ -192,7 +193,8 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
   lazy val projectCreationService =
     new ProjectCreationService[ZIO[ZAny, +*, +*]](
       distributionConfiguration,
-      loggingService
+      loggingService,
+      jvmMode = false
     )
 
   lazy val globalConfigService = new GlobalConfigService[ZIO[ZAny, +*, +*]](

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/TestDistributionConfiguration.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/TestDistributionConfiguration.scala
@@ -98,8 +98,7 @@ class TestDistributionConfiguration(
     new JVMSettings(
       javaCommandOverride = Some(javaCommand),
       jvmOptions          = Seq(),
-      extraOptions        = Seq(),
-      nativeImage         = false
+      extraOptions        = Seq()
     )
   }
 

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateHandleMissingRuntimeSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateHandleMissingRuntimeSpec.scala
@@ -18,8 +18,7 @@ class ProjectCreateHandleMissingRuntimeSpec
       override def defaultJVMSettings: JVMSettings = JVMSettings(
         javaCommandOverride = None,
         jvmOptions          = Seq(),
-        extraOptions        = Seq(),
-        nativeImage         = false
+        extraOptions        = Seq()
       )
     }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/JVMSettings.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/JVMSettings.scala
@@ -12,8 +12,7 @@ package org.enso.runtimeversionmanager.runner
 case class JVMSettings(
   javaCommandOverride: Option[JavaExecCommand],
   jvmOptions: Seq[(String, String)],
-  extraOptions: Seq[(String, String)],
-  nativeImage: Boolean
+  extraOptions: Seq[(String, String)]
 )
 
 object JVMSettings {
@@ -28,14 +27,12 @@ object JVMSettings {
   def apply(
     useSystemJVM: Boolean,
     jvmOptions: Seq[(String, String)],
-    extraOptions: Seq[(String, String)],
-    nativeImage: Boolean = false
+    extraOptions: Seq[(String, String)]
   ): JVMSettings =
     new JVMSettings(
       if (useSystemJVM) Some(JavaExecCommand.defaultSystem) else None,
       jvmOptions,
-      extraOptions,
-      nativeImage
+      extraOptions
     )
 
   // See propositions in #9475 for alternatives
@@ -56,8 +53,7 @@ object JVMSettings {
     JVMSettings(
       useSystemJVM = false,
       jvmOptions   = jvmOptions.result(),
-      extraOptions = Seq(nioOpen),
-      nativeImage  = false
+      extraOptions = Seq(nioOpen)
     )
   }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
@@ -19,5 +19,6 @@ case class LanguageServerOptions(
   rpcPort: Int,
   secureRpcPort: Option[Int],
   dataPort: Int,
-  secureDataPort: Option[Int]
+  secureDataPort: Option[Int],
+  jvmMode: Boolean
 )

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
@@ -11,6 +11,7 @@ import java.util.UUID
   * @param secureRpcPort an option secure RPC port that the server listen to
   * @param dataPort a data port that the server listen to
   * @param secureDataPort an optional secure data port that the server listen to
+  * @param jvmMode if true, enables JVM mode
   */
 case class LanguageServerOptions(
   rootId: UUID,

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -43,7 +43,7 @@ object NativeExecCommand {
       ) {
         Some(NativeExecCommand(fallbackExecPath))
       } else {
-        logger.debug(
+        logger.warn(
           "Failed to find native launcher at a pre-determined location: {}",
           fallbackExecPath
         )

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/NativeExecCommand.scala
@@ -21,9 +21,6 @@ case class NativeExecCommand(executablePath: Path) extends ExecCommand {
 }
 
 object NativeExecCommand {
-
-  private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
-
   def apply(
     version: String,
     engine: Engine,
@@ -34,11 +31,10 @@ object NativeExecCommand {
     val execName = OS.executableName("enso")
     val fullExecPath =
       dm.paths.engines.resolve(version).resolve("bin").resolve(execName)
-    val ensoLauncher = Option(System.getenv(LAUNCHER_ENV_NAME))
 
     if (fullExecPath.toFile.exists() && isBinary(fullExecPath, logger)) {
       Some(NativeExecCommand(fullExecPath))
-    } else if (ensoLauncher.map(_.equals("native")).getOrElse(false)) {
+    } else {
       val component =
         engine.componentDirPath.resolve("..").toAbsolutePath.normalize
       val fallbackExecPath = component.resolve("bin").resolve(execName)
@@ -53,8 +49,6 @@ object NativeExecCommand {
         )
         None
       }
-    } else {
-      None
     }
   }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
@@ -7,6 +7,7 @@ import java.nio.file.Path
 /** Represents settings that are used to launch the runner JAR.
   *
   * @param engineVersion Enso engine version to use
+  * @param jvmMode Should Enso be run in JVM mode
   * @param runnerArguments arguments that should be passed to the runner
   * @param workingDirectory the working directory override
   * @param connectLoggerIfAvailable specifies if the ran component should
@@ -14,6 +15,7 @@ import java.nio.file.Path
   */
 case class RunSettings(
   engineVersion: SemVer,
+  jvmMode: Boolean,
   runnerArguments: Seq[String],
   workingDirectory: Option[Path],
   connectLoggerIfAvailable: Boolean

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -224,18 +224,28 @@ class Runner(
       case None =>
         runtimeVersionManager.withEngineAndRuntime(engineVersion) {
           (engine, runtime) =>
-            NativeExecCommand.apply(
-              engineVersion.toString,
-              engine,
-              logger
-            ) match {
-              case Some(cmd) =>
-                prepareAndRunCommand(engine, cmd)
-              case None =>
-                prepareAndRunCommand(
-                  engine,
-                  JavaExecCommand.forRuntime(runtime)
-                )
+            val ensoLauncher      = Option(System.getenv(Runner.LAUNCHER_ENV_NAME))
+            val requiresJVMRunner = ensoLauncher.exists(_.equals("shell"))
+            if (requiresJVMRunner) {
+              prepareAndRunCommand(
+                engine,
+                JavaExecCommand.forRuntime(runtime)
+              )
+            } else {
+              NativeExecCommand.apply(
+                engineVersion.toString,
+                engine,
+                logger
+              ) match {
+                case Some(cmd) =>
+                  prepareAndRunCommand(engine, cmd)
+                case None =>
+                  // Fallback, JVM-mode
+                  prepareAndRunCommand(
+                    engine,
+                    JavaExecCommand.forRuntime(runtime)
+                  )
+              }
             }
         }
     }
@@ -302,4 +312,10 @@ class Runner(
         globalConfigurationManager.defaultVersion
     }
   }
+}
+
+object Runner {
+
+  private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
+
 }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -43,6 +43,7 @@ class Runner(
     path: Path,
     name: String,
     engineVersion: SemVer,
+    jvmMode: Boolean,
     normalizedName: Option[String],
     projectTemplate: Option[String],
     authorName: Option[String],
@@ -78,6 +79,7 @@ class Runner(
       }
       RunSettings(
         engineVersion,
+        jvmMode,
         arguments,
         workingDirectory         = None,
         connectLoggerIfAvailable = false
@@ -142,6 +144,7 @@ class Runner(
         Option.unless(logMasking)(Seq("--no-log-masking")).getOrElse(Seq.empty)
       RunSettings(
         version,
+        options.jvmMode,
         arguments ++ additionalArguments,
         workingDirectory         = Some(workingDirectory),
         connectLoggerIfAvailable = true
@@ -224,8 +227,9 @@ class Runner(
       case None =>
         runtimeVersionManager.withEngineAndRuntime(engineVersion) {
           (engine, runtime) =>
-            val ensoLauncher      = Option(System.getenv(Runner.LAUNCHER_ENV_NAME))
-            val requiresJVMRunner = ensoLauncher.exists(_.equals("shell"))
+            val ensoLauncher = Option(System.getenv(Runner.LAUNCHER_ENV_NAME))
+            val requiresJVMRunner =
+              ensoLauncher.exists(_.equals("shell")) || runSettings.jvmMode
             if (requiresJVMRunner) {
               prepareAndRunCommand(
                 engine,

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -276,7 +276,7 @@ object DistributionPackage {
             "JAVA_OPTS" -> "-Dorg.jline.terminal.dumb=true"
           ).run
           // Poor man's solution to stuck index generation
-          val GENERATING_INDEX_TIMEOUT = 60 * 2 // 2 minutes
+          val GENERATING_INDEX_TIMEOUT = 60 * 4 // 2 minutes
           var current                  = 0
           var timeout                  = false
           while (runningProcess.isAlive() && !timeout) {

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -15,7 +15,7 @@ object GraalVM {
     override def toString(): String = {
       val prop = System.getenv(VAR_NAME)
       // default value is `shell` for development and `native` for the release
-      return if (prop != null) {
+      if (prop != null) {
         prop
       } else {
         if (BuildInfo.isReleaseMode) {

--- a/test/Google_Api_Test/src/Main.enso
+++ b/test/Google_Api_Test/src/Main.enso
@@ -10,7 +10,7 @@ main filter=Nothing =
 
 
 add_specs suite_builder =
-    suite_builder.group "Google Spreadsheets" group_builder->
+    suite_builder.group "Google Spreadsheets" pending="outdated" group_builder->
         group_builder.specify "should allow downloading a spreadsheet" <|
             secret = enso_project.data / 'secret.json'
             api = Google_Sheets.initialize secret


### PR DESCRIPTION
### Pull Request Description

This change makes Native Image build opt-out rather than opt-in. To use JVM mode, IDE has to start with `--jvm` or `ENSO_LAUNCHER=shell`.

An alternative approach to https://github.com/enso-org/enso/pull/12501. Closes #12483.
Likely also addresses https://github.com/enso-org/enso/issues/12303.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
