### PR TITLE
Re-enable H2 tests for non-Windows

### DIFF
--- a/test/Generic_JDBC_Tests/src/H2_Spec.enso
+++ b/test/Generic_JDBC_Tests/src/H2_Spec.enso
@@ -41,12 +41,16 @@ type H2_JDBC_Config
 add_specs suite_builder =
     config = H2_JDBC_Config.Value
 
-    # Uncomment after https://github.com/enso-org/enso/issues/12489
-    # Generic_JDBC_Connection_Spec.add_specs_for_backend config suite_builder
+    # Remove https://github.com/enso-org/enso/issues/12489
+    is_windows = Platform.os == Platform.OS.Windows
+    windows_pending = if is_windows then "disabled on windows" else Nothing
+
+    if is_windows.not then
+        Generic_JDBC_Connection_Spec.add_specs_for_backend config suite_builder
 
     ## These tests are here instead of in Generic_JDBC_Connection_Spec because
        they are backend-dependent.
-    suite_builder.group "(H2) Generic JDBC Connection" pending="https://github.com/enso-org/enso/issues/12489" group_builder->
+    suite_builder.group "(H2) Generic JDBC Connection" pending=windows_pending group_builder->
         with_connection = config.with_connection
 
         # Cleans things up afterwards, but also before for easier debugging.


### PR DESCRIPTION
### Pull Request Description

H2 tests are currently failing on Windows due to filesystem problems.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
