### PR TITLE
Fix table viz stuck in loading state 

### DIFF
--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -123,6 +123,7 @@ const props = defineProps<{
   datasource?: IServerSideDatasource
   rowCount?: number
   isServerSideModel?: boolean
+  reloadGrid?: boolean
 }>()
 const emit = defineEmits<{
   cellEditingStarted: [event: CellEditingStartedEvent]
@@ -144,13 +145,22 @@ function onGridReady(event: GridReadyEvent<TData>) {
   gridApi.value = event.api
 }
 
+watch(
+  () => props.reloadGrid,
+  () => {
+    if (rowModelType.value != 'clientSide') gridApi.value?.refreshServerSide({ purge: true })
+  },
+)
+
 const rowModelType = computed(() => (props.isServerSideModel ? 'serverSide' : 'clientSide'))
 
 watch(
   () => props.textFormatOption,
   () => {
+    if (rowModelType.value === 'clientSide') {
+      gridApi.value?.resetRowHeights()
+    }
     gridApi.value?.redrawRows()
-    gridApi.value?.resetRowHeights()
   },
 )
 

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -133,6 +133,7 @@ const pageLimit = ref(0)
 const rowCount = ref(0)
 const showRowCount = ref(true)
 const isTruncated = ref(false)
+const reloadGrid = ref(false)
 const isCreateNodeEnabled = ref(false)
 const filterModel = ref<GridFilterModel[]>([])
 const sortModel = ref<SortModel[]>([])
@@ -338,7 +339,6 @@ function createServerSideDatasource(): IServerSideDatasource {
     getRows: async (params) => {
       const server = createServer()
       const response: Response = await server.getData(params.request)
-      const startIndex = params.request.startRow ? params.request.startRow : 0
       const rows = createRowsForTable(response.data, 0, true)
       setTimeout(() => {
         if (response.success) {
@@ -780,6 +780,8 @@ watchEffect(() => {
   // If data is truncated, we cannot rely on sorting/filtering so will disable.
   defaultColDef.value.filter = !isTruncated.value
   defaultColDef.value.sortable = !isTruncated.value
+
+  reloadGrid.value = !reloadGrid.value
 })
 
 const colTypeMap = computed(() => {
@@ -946,6 +948,7 @@ config.setToolbar(
         :rowCount="allRowCount"
         :isServerSideModel="isSSRM"
         :statusBar="statusBar"
+        :reloadGrid="reloadGrid"
         @sortOrFilterUpdated="(e) => checkSortAndFilter(e)"
       />
     </Suspense>


### PR DESCRIPTION
When more than one table viz was open the table was sometimes stuck in a loading state.

Fix: when the column definitions have been set the grid is refreshed making sure the 'getRows' function is correctly called and row data is loaded into the table and the viz is not in a loading state 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
