### PR TITLE
Do not dispose LS when ModulePersistence is still using it.

### DIFF
--- a/app/ydoc-server/src/languageServerSession.ts
+++ b/app/ydoc-server/src/languageServerSession.ts
@@ -330,15 +330,19 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
     }
     const onFileModified = this.handleFileModified.bind(this)
     const onFileRemoved = this.handleFileRemoved.bind(this)
+    const onTransportClosed = () => this.setState(LsSyncState.Closed)
     this.doc.ydoc.on('update', onLocalUpdate)
     sharedDoc.on('update', onRemoteUpdate)
+    this.ls.retain()
     this.ls.on('text/fileModifiedOnDisk', onFileModified)
     this.ls.on('file/rootRemoved', onFileRemoved)
+    this.ls.on('transport/closed', onTransportClosed)
     this.cleanup = () => {
       this.doc.ydoc.off('update', onLocalUpdate)
       sharedDoc.off('update', onRemoteUpdate)
       this.ls.off('text/fileModifiedOnDisk', onFileModified)
       this.ls.off('file/rootRemoved', onFileRemoved)
+      this.ls.off('transport/closed', onTransportClosed)
     }
   }
 
@@ -818,13 +822,17 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
   }
 
   async dispose(): Promise<void> {
-    this.cleanup()
-    const alreadyClosed = this.inState(LsSyncState.Closing, LsSyncState.Closed)
-    this.setState(LsSyncState.Disposed)
-    if (alreadyClosed) return Promise.resolve()
-    const closing = await this.ls.closeTextFile(this.path)
-    if (!closing.ok) {
-      closing.error.log(`Closing text file ${this.path}`)
+    try {
+      this.cleanup()
+      const alreadyClosed = this.inState(LsSyncState.Closing, LsSyncState.Closed)
+      this.setState(LsSyncState.Disposed)
+      if (alreadyClosed) return Promise.resolve()
+      const closing = await this.ls.closeTextFile(this.path)
+      if (!closing.ok) {
+        closing.error.log(`Closing text file ${this.path}`)
+      }
+    } finally {
+      this.ls.release()
     }
   }
 }

--- a/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
+++ b/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
@@ -6,7 +6,6 @@
 
 import { WebSocketTransport } from '@open-rpc/client-js'
 import WS from 'modern-isomorphic-ws'
-import { WebSocket } from 'partysocket'
 import type { Options } from 'partysocket/ws'
 import ReconnectingWebSocket, { type WebSocketEventMap } from 'partysocket/ws'
 
@@ -26,7 +25,7 @@ export class ReconnectingWebSocketTransport extends WebSocketTransport {
   constructor(uri: string, wsOptions: Options = {}) {
     super(uri)
     this.uri = uri
-    this._reconnectingConnection = new WebSocket(uri, undefined, {
+    this._reconnectingConnection = new ReconnectingWebSocket(uri, undefined, {
       WebSocket: WS,
       ...wsOptions,
     })


### PR DESCRIPTION
### Pull Request Description

Fixes #10634

LanguageServerSession closed the LS connection while ModulePersistence was still waiting for closeFile response.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
