### PR TITLE
Only use the server model for tables with more than 1000 rows 

### DIFF
--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -26,7 +26,7 @@ test('Load Table Visualisation', async ({ page }) => {
   await page.waitForTimeout(1000)
   const tableVisualization = locate.tableVisualization(page)
   await expect(tableVisualization).toExist()
-  await expect(tableVisualization).toContainText('10 rows.')
+  await expect(tableVisualization).toContainText('Total Row Count: 10')
   await expect(tableVisualization).toContainText('0,0')
   await expect(tableVisualization).toContainText('1,0')
   await expect(tableVisualization).toContainText('2,0')

--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -361,6 +361,7 @@ const { AgGridVue } = await import('./AgGridTableView/AgGridVue')
       :suppressMoveWhenColumnDragging="suppressMoveWhenColumnDragging"
       :processDataFromClipboard="processDataFromClipboard"
       :allowContextMenuWithControlKey="true"
+      :cacheBlockSize="1000"
       @gridReady="onGridReady"
       @firstDataRendered="updateColumnWidths"
       @rowDataUpdated="(updateColumnWidths($event), emit('rowDataUpdated', $event))"

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -167,7 +167,7 @@ const statusBar = computed(() =>
   allRowCount.value ?
     {
       statusPanels:
-        isSSRM.value ?
+        config.nodeType === TABLE_NODE_TYPE ?
           [
             {
               statusPanel: TableVizStatusBar,
@@ -732,7 +732,7 @@ watchEffect(() => {
       : dataHeader
     if (!data_.is_using_server_sort_and_filter) {
       rowData.value =
-        data_.data ? createRowsForTable(data_.data, 0, data_.is_using_server_sort_and_filter) : []
+        data_.data ? createRowsForTable(data_.data, 1, data_.is_using_server_sort_and_filter) : []
     }
     const headers = data_.header
     if (headers) {
@@ -769,7 +769,7 @@ watchEffect(() => {
   }
   // Update paging
   const newRowCount = data_.all_rows_count == null ? 1 : data_.all_rows_count
-  showRowCount.value = !(data_.all_rows_count == null)
+  showRowCount.value = !(data_.all_rows_count == null) && config.nodeType != TABLE_NODE_TYPE
   rowCount.value = newRowCount
   const newPageLimit = Math.ceil(newRowCount / rowLimit.value)
   pageLimit.value = newPageLimit

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -291,7 +291,7 @@ apply_filter_to_table table i filter_col filter_action filter_val =
 
 get_rows_for_table : Any -> Integer -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing-> JS_Object
 get_rows_for_table table start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_action=Nothing filter_val=Nothing =
-    max_rows=100
+    max_rows=1000
     col_name = table.make_temp_column_name
     table_with_index = table.add_row_number col_name
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -202,7 +202,8 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table =
     has_index_col        = ["has_index_col", True]
     links                = ["get_child_node_action", "get_row"]
     child_label          = ["child_label", "row"]
-    data                 = if is_db_table then columns.map get_vector else Nothing
+    is_using_server_model = if is_db_table then False else all_rows_count > 1000
+    data                 = if is_using_server_model.not then columns.map get_vector else Nothing
     requires_number_formatting = ["requires_number_format", columns.map .requires_numeric_formatter_check]
     data_quality_metrics = if is_db_table then [] else
         number_nothing = JS_Object.from_pairs [["name", "Count nothings"], ["percentage_value", columns.map .count_nothing]]
@@ -211,7 +212,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table =
         number_non_triv = JS_Object.from_pairs [["name", "Count non trivial whitespace" + sampled_label], ["percentage_value", columns.map .count_non_trivial_whitespace]]
         JS_Object.from_pairs
         [number_nothing, number_untrimmed, number_non_triv]
-    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, ["data_quality_metrics", data_quality_metrics] ,["type", "Table"], child_label, ["is_using_server_sort_and_filter", is_db_table.not], requires_number_formatting]
+    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, ["data_quality_metrics", data_quality_metrics] ,["type", "Table"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -92,13 +92,13 @@ add_specs suite_builder =
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=Nothing all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=True number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False]
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=Nothing all_rows=3 value_type=[value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=True number_of_nothing=[0] number_of_untrimmed_whitespace=[Nothing] number_non_trivial_ws=[Nothing] requires_number_format=[False]
+            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0] number_of_untrimmed_whitespace=[Nothing] number_non_trivial_ws=[Nothing] requires_number_format=[False]
             vis . should_equal json
 
         group_builder.specify "should handle Vectors" <|
@@ -141,21 +141,21 @@ add_specs suite_builder =
         group_builder.specify "should indicate number of Nothing/Nulls" <|
             vis = Visualization.prepare_visualization data.t3_with_nulls 3
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=Nothing all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=True number_of_nothing=[1, 2, 2] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[[1, Nothing, 3], [4, Nothing, Nothing], [7, Nothing, Nothing]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[1, 2, 2] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False]
             vis . should_equal json
 
         group_builder.specify "should indicate number of leading/trailing whitespace" <|
             vis = Visualization.prepare_visualization data.t4_with_space 3
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=Nothing all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=True number_of_nothing=[0, 0, 0] number_of_untrimmed_whitespace=[2, 0, Nothing] number_non_trivial_ws=[0, 0, Nothing] requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[['hello', '   leading space', 'trailing space    '], ['a', 'b', 'c'], [7, 8, 9]] all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0, 0, 0] number_of_untrimmed_whitespace=[2, 0, Nothing] number_non_trivial_ws=[0, 0, Nothing] requires_number_format=[False, False, False]
             vis . should_equal json
 
         group_builder.specify "should indicate number of non trivial whitespace" <|
             vis = Visualization.prepare_visualization data.t5_with_non_trivial_ws 3
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=Nothing all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=True number_of_nothing=[0, 0, 0] number_of_untrimmed_whitespace=[0,0,Nothing] number_non_trivial_ws=[1, 0, Nothing] requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[['hello', 'extra \r space', 'world'], ['a', 'b', 'c'], [7, 8, 9]] all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0, 0, 0] number_of_untrimmed_whitespace=[0,0,Nothing] number_non_trivial_ws=[1, 0, Nothing] requires_number_format=[False, False, False]
             vis . should_equal json
 
         group_builder.specify "should indicate number of leading/trailing whitespace with sample if more than 10000 rows" <|
@@ -185,7 +185,7 @@ add_specs suite_builder =
             num_table = Table.new [["A", [1, 2, 3]], ["B", [12345678, 5,6]], ["C", [-12345678, -5,6]]]
             vis = Visualization.prepare_visualization num_table 1000
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=Nothing all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True is_ssrm=True get_child_node="get_row" number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, True, True]
+            json = make_json header=["A", "B", "C"] data=[[1, 2, 3], [12345678, 5,6], [-12345678, -5,6]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True is_ssrm=False get_child_node="get_row" number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, True, True]
             vis . should_equal json
 
 main filter=Nothing =


### PR DESCRIPTION
If a table has <1000 rows it will use the previous table visualisation method 
the page size for table visualizations using the server method has been increased to 1000

<img width="701" alt="image" src="https://github.com/user-attachments/assets/aa2b0bd9-a2b3-4ef2-a9db-825ade78a438" />


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
