### PR TITLE
Set ENSO_CLOUD_PROJECT_DIRECTORY_PATH when running project

### DIFF
--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
@@ -11,12 +11,14 @@ import java.nio.file.Path
   * @param runnerArguments arguments that should be passed to the runner
   * @param workingDirectory the working directory override
   * @param connectLoggerIfAvailable specifies if the ran component should
-  *                                 connect to launcher's logging service
+  * connect to launcher's logging service
+  * @param extraEnv extra environment variables
   */
 case class RunSettings(
   engineVersion: SemVer,
   jvmMode: Boolean,
   runnerArguments: Seq[String],
   workingDirectory: Option[Path],
-  connectLoggerIfAvailable: Boolean
+  connectLoggerIfAvailable: Boolean,
+  extraEnv: Seq[(String, String)] = Seq()
 )

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -10,8 +10,10 @@ import org.slf4j.event.Level
 import java.net.URI
 import org.enso.runtimeversionmanager.components.{Engine, RuntimeVersionManager}
 import org.enso.runtimeversionmanager.config.GlobalRunnerConfigurationManager
+import org.enso.runtimeversionmanager.runner.Runner.ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME
 
 import java.nio.file.Path
+
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future, TimeoutException}
 import scala.util.Try
@@ -117,8 +119,6 @@ class Runner(
     additionalArguments: Seq[String]
   ): Try[RunSettings] =
     Try {
-      val workingDirectory =
-        Path.of(projectPath).toAbsolutePath.normalize.getParent
       val arguments = Seq(
         "--server",
         "--root-id",
@@ -142,12 +142,17 @@ class Runner(
           .map(port => Seq("--secure-data-port", port.toString))
           .getOrElse(Seq.empty) ++
         Option.unless(logMasking)(Seq("--no-log-masking")).getOrElse(Seq.empty)
+
+      val projectDirectory = Path.of(projectPath).toAbsolutePath.normalize
       RunSettings(
         version,
         options.jvmMode,
         arguments ++ additionalArguments,
-        workingDirectory         = Some(workingDirectory),
-        connectLoggerIfAvailable = true
+        workingDirectory         = Some(projectDirectory.getParent),
+        connectLoggerIfAvailable = true,
+        extraEnv = Seq(
+          ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME -> projectDirectory.toString
+        )
       )
     }
 
@@ -202,12 +207,14 @@ class Runner(
           logger.info(
             "Using explicit " + JVM_PATH_ENV_VAR + " JVM: " + p
           )
-          p.toString()
+          p.toString
         }
         .orElse(cmd.javaHome)
 
       val extraEnvironmentOverrides =
-        javaHome.map("JAVA_HOME" -> _).toSeq ++ distributionSettings.toSeq
+        javaHome
+          .map("JAVA_HOME" -> _)
+          .toSeq ++ distributionSettings.toSeq ++ runSettings.extraEnv
 
       action(
         RawCommand(
@@ -322,4 +329,7 @@ object Runner {
 
   private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
 
+  /** The variable is used in stdlib to resolve relative paths. */
+  private val ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME =
+    "ENSO_CLOUD_PROJECT_DIRECTORY_PATH"
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #12536 

Changelog:
- update: set `ENSO_CLOUD_PROJECT_DIRECTORY_PATH` when starting the project

### Important Notes

> [TRACE] [2025-03-18T17:55:32.286] [org.enso.projectmanager.infrastructure.languageserver.ExecutorWithUnlimitedPool] Starting Language Server Process [JAVA_HOME="/home/dbushev/.local/share/enso/runtime/graalvm-ce-java21.0.2-24.0.0" ENSO_DATA_DIRECTORY="/home/dbushev/.local/share/enso" ENSO_AUXILIARY_LIBRARY_CACHES="/home/dbushev/.local/share/enso/dist/0.0.0-dev/lib" ENSO_RUNTIME_DIRECTORY="/run/user/1000/enso" ENSO_EDITION_PATH="/home/dbushev/enso/editions" ENSO_CONFIG_DIRECTORY="/home/dbushev/.config/enso" ENSO_HOME="/home/dbushev/enso" ENSO_LOG_DIRECTORY="/home/dbushev/.local/share/enso/log" ENSO_LIBRARY_PATH="/home/dbushev/enso/libraries" ENSO_CLOUD_PROJECT_DIRECTORY_PATH="/home/dbushev/Documents/enso-projects/NewProject1" "/home/dbushev/.local/share/enso/runtime/graalvm-ce-java21.0.2-24.0.0/bin/java" "-Dgraal.PrintGraph=Network" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--module-path" "/home/dbushev/.local/share/enso/dist/0.0.0-dev/component" "-m" "org.enso.runner/org.enso.runner.Main" "--logger-connect" "//localhost:6000" "--server" "--root-id" "c3fd5f2a-5d4b-4b0d-9623-ad79ae3d6430" "--project-id" "8c4a20a8-77df-4c1c-89e0-4bf7711fcf65" "--path" "/home/dbushev/Documents/enso-projects/NewProject1" "--interface" "127.0.0.1" "--rpc-port" "52750" "--data-port" "54262" "--log-level" "TRACE" "--no-log-masking"]


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
