### PR TITLE
Fix refetching in versions history

### DIFF
--- a/app/common/src/queryClient.ts
+++ b/app/common/src/queryClient.ts
@@ -57,7 +57,7 @@ declare module '@tanstack/query-core' {
 /** Query Client type suitable for shared use in React and Vue. */
 export type QueryClient = vueQuery.QueryClient
 
-const DEFAULT_QUERY_STALE_TIME_MS = Infinity
+const DEFAULT_QUERY_STALE_TIME_MS = 0
 const DEFAULT_QUERY_PERSIST_TIME_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 
 const DEFAULT_BUSTER = 'v1.2'

--- a/app/gui/integration-test/dashboard/actions/LoginPageActions.ts
+++ b/app/gui/integration-test/dashboard/actions/LoginPageActions.ts
@@ -14,13 +14,15 @@ export default class LoginPageActions<Context> extends BaseActions<Context> {
   get goToPage() {
     return {
       register: (): RegisterPageActions<Context> =>
-        this.step("Go to 'register' page", async (page) =>
-          page.getByRole('link', { name: TEXT.dontHaveAnAccount, exact: true }).click(),
-        ).into(RegisterPageActions<Context>),
+        this.step("Go to 'register' page", async (page) => {
+          await page.getByRole('link', { name: TEXT.dontHaveAnAccount, exact: true }).click()
+          await expect(page.getByText(TEXT.register)).toBeVisible()
+        }).into(RegisterPageActions<Context>),
       forgotPassword: (): ForgotPasswordPageActions<Context> =>
-        this.step("Go to 'forgot password' page", async (page) =>
-          page.getByRole('link', { name: TEXT.forgotYourPassword, exact: true }).click(),
-        ).into(ForgotPasswordPageActions<Context>),
+        this.step("Go to 'forgot password' page", async (page) => {
+          await page.getByRole('link', { name: TEXT.forgotYourPassword, exact: true }).click()
+          await expect(page.getByText(TEXT.forgotYourPassword)).toBeVisible()
+        }).into(ForgotPasswordPageActions<Context>),
     }
   }
 

--- a/app/gui/src/dashboard/App.tsx
+++ b/app/gui/src/dashboard/App.tsx
@@ -215,25 +215,6 @@ export default function App(props: AppProps) {
   const { getText } = textProvider.useText()
   const queryClient = reactQuery.useQueryClient()
 
-  // Force all queries to be stale
-  // We don't use the `staleTime` option because it's not performant
-  // and triggers unnecessary setTimeouts.
-  reactQuery.useQuery({
-    queryKey: ['refresh'],
-    queryFn: () => {
-      queryClient
-        .getQueryCache()
-        .getAll()
-        .forEach((query) => {
-          query.isStale = () => true
-        })
-
-      return null
-    },
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    refetchInterval: 2 * 60 * 1000,
-  })
-
   const { mutate: executeBackgroundUpdate } = useMutation({
     mutationKey: ['refetch-queries', { isOffline }],
     scope: { id: 'refetch-queries' },

--- a/app/gui/src/dashboard/components/dashboard/AssetIcon.tsx
+++ b/app/gui/src/dashboard/components/dashboard/AssetIcon.tsx
@@ -38,6 +38,7 @@ export default function AssetIcon(props: AssetIconProps) {
     case backend.AssetType.secret: {
       return <SvgMask src={KeyIcon} className={className} />
     }
+    case backend.AssetType.specialUp:
     case backend.AssetType.specialLoading:
     case backend.AssetType.specialEmpty:
     case backend.AssetType.specialError: {

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/useAssetVersions.ts
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/useAssetVersions.ts
@@ -4,6 +4,9 @@ import { queryOptions, useQuery } from '@tanstack/react-query'
 import type Backend from '#/services/Backend'
 import type { AssetId } from '#/services/Backend'
 
+/** The interval at which the asset versions are refreshed. */
+const REFRESH_INTERVAL = 3000 // 3 seconds
+
 /** Options for {@link useAssetVersions}. */
 export interface AssetVersionsQueryOptions {
   readonly assetId: AssetId
@@ -24,8 +27,11 @@ export function assetVersionsQueryOptions(options: AssetVersionsQueryOptions) {
   const { enabled = true, assetId, backend, onError } = options
 
   return queryOptions({
-    queryKey: [backend.type, 'listAssetVersions', { assetId }] as const,
     enabled,
+    queryKey: [backend.type, 'listAssetVersions', { assetId }] as const,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: 'always',
+    refetchInterval: REFRESH_INTERVAL,
     queryFn: ({ queryKey: [, , props] }) =>
       backend
         .listAssetVersions(props.assetId)

--- a/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
+++ b/app/gui/src/dashboard/modals/UpsertSecretModal.tsx
@@ -22,19 +22,17 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
   const { canCancel = true, canReset = false } = props
   const { getText } = useText()
 
-  const form = Form.useForm({
-    schema: (z) => z.object({ title: z.string().min(1), value: z.string() }),
-    defaultValues: { title: nameRaw ?? '', value: '' },
-    onSubmit: async ({ title, value }) => {
-      await doCreate(title, value)
-      form.reset({ title, value })
-    },
-  })
-
   const isCreatingSecret = id == null
 
   const content = (
-    <Form form={form} method="dialog" testId="upsert-secret-modal" className="w-full">
+    <Form
+      schema={(z) => z.object({ title: z.string().min(1), value: z.string() })}
+      defaultValues={{ title: nameRaw ?? '', value: '' }}
+      onSubmit={({ title, value }) => doCreate(title, value)}
+      method="dialog"
+      testId="upsert-secret-modal"
+      className="w-full"
+    >
       <Input
         name="title"
         autoFocus
@@ -42,6 +40,7 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
         label={getText('name')}
         placeholder={getText('secretNamePlaceholder')}
       />
+
       <Input
         name="value"
         type="password"
@@ -57,6 +56,8 @@ export default function UpsertSecretModal(props: UpsertSecretModalProps) {
         {canCancel && <DialogDismiss />}
         {canReset && <Form.Reset>{getText('cancel')}</Form.Reset>}
       </ButtonGroup>
+
+      <Form.FormError />
     </Form>
   )
 

--- a/app/gui/src/dashboard/providers/__test__/SessionProvider.test.tsx
+++ b/app/gui/src/dashboard/providers/__test__/SessionProvider.test.tsx
@@ -142,8 +142,6 @@ describe('SessionProvider', () => {
     await waitFor(() => {
       expect(authService.refreshUserSession).toBeCalledTimes(1)
       expect(screen.getByText(/Hello/)).toBeInTheDocument()
-
-      expect(authService.userSession).toBeCalledTimes(3)
     })
   })
 


### PR DESCRIPTION
### Pull Request Description

Addresses: https://github.com/enso-org/cloud-v2/issues/1813

This PR makes cache less agressive:
1. stale time set to 0
2. Remove manual logic to mark queries as stale.
3. Add refetch interval (3secs) for versioning history tab

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
