### PR TITLE
Fix broken link to blank issue in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,5 +13,5 @@ contact_links:
     url: https://github.com/enso-org/enso/blob/develop/CHANGELOG.md
     about: See our changelog.
   - name: Blank Issue (Enso Core Dev Team Only)
-    url: https://github.com/enso-org/enso/issues/new
+    url: https://github.com/enso-org/enso/issues/new?template=blank
     about: To be used by our core dev team only.


### PR DESCRIPTION
Fixes broken "blank issue" link when trying to create a bug.