### PR TITLE
Ignore tests that rely on external service

### DIFF
--- a/test/Table_Tests/src/IO/Fetch_Spec.enso
+++ b/test/Table_Tests/src/IO/Fetch_Spec.enso
@@ -423,7 +423,7 @@ add_specs suite_builder =
 
         cloud_setup = Cloud_Tests_Setup.prepare
 
-        group_builder.specify "Should work with secrets in the URI" pending=pending_has_url <| Test.with_retries <|
+        group_builder.specify "Should work with secrets in the URI" pending="https://github.com/enso-org/enso/issues/12575" <| Test.with_retries <|
             cloud_setup.with_prepared_environment <|
                 secret1 = Enso_Secret.create "http-cache-secret-1-"+Random.uuid "My Value"
                 secret2 = Enso_Secret.create "http-cache-secret-2-"+Random.uuid "Some Value"
@@ -444,7 +444,7 @@ add_specs suite_builder =
                     HTTP.fetch uri2 . decode_as_text . should_succeed
                     get_num_response_cache_entries . should_equal 2
 
-        group_builder.specify "Should work with secrets in the headers" pending=pending_has_url <| Test.with_retries <|
+        group_builder.specify "Should work with secrets in the headers" pending="https://github.com/enso-org/enso/issues/12575" <| Test.with_retries <|
             cloud_setup.with_prepared_environment <|
                 secret1 = Enso_Secret.create "http-cache-secret-1-"+Random.uuid "My Value"
                 secret2 = Enso_Secret.create "http-cache-secret-2-"+Random.uuid "Some Value"


### PR DESCRIPTION
### Pull Request Description

Ignore tests that sends requests to `https://httpbin.org/bytes/`. In few recent days, this service seems to be down a lot and causing a lot of transient failures in our CI. The follow-up created in https://github.com/enso-org/enso/issues/12575

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
