### PR TITLE
Fix spurious import warning

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.java
@@ -236,6 +236,9 @@ public final class AmbiguousImportsAnalysis implements MiniPassFactory {
       } else {
         var encounteredFullName = encounteredSymbols.getPathForSymbol(symbolName);
         var originalImport = encounteredSymbols.getOriginalImportForSymbol(symbolName);
+        if (originalImport == currentImport) {
+          return;
+        }
         if (symbolPath.equals(encounteredFullName)) {
           // symbolName is already imported with the same symbolPath --> attach warning.
           var warn = createWarningForDuplicatedImport(originalImport, currentImport, symbolName);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.java
@@ -235,18 +235,16 @@ public final class AmbiguousImportsAnalysis implements MiniPassFactory {
         encounteredSymbols.addSymbol(currentImport, symbolName, symbolPath, resolvedName);
       } else {
         var encounteredFullName = encounteredSymbols.getPathForSymbol(symbolName);
+        var encounteredResolution =
+            encounteredSymbols.getResolvedNameForSymbol(symbolName);
         var originalImport = encounteredSymbols.getOriginalImportForSymbol(symbolName);
-        if (originalImport == currentImport) {
-          return;
-        }
-        if (symbolPath.equals(encounteredFullName)) {
+        if (symbolPath.equals(encounteredFullName) && !areResolvedNamesAllowedToClash(resolvedName, encounteredResolution)) {
           // symbolName is already imported with the same symbolPath --> attach warning.
           var warn = createWarningForDuplicatedImport(originalImport, currentImport, symbolName);
           currentImport.getDiagnostics().add(warn);
         } else {
           // There is an encountered symbol with different physical path than symbolPath.
-          var resolution = encounteredSymbols.getResolvedNameForSymbol(symbolName);
-          if (resolution instanceof BindingsMap.ResolvedMethod resMethod &&
+          if (encounteredResolution instanceof BindingsMap.ResolvedMethod resMethod &&
               resMethod.methodName().equals(symbolName)) {
             // This is a valid ambiguous case - in previously encountered import, the symbol was resolved
             // to either an extension, static, or conversion method.
@@ -292,6 +290,30 @@ public final class AmbiguousImportsAnalysis implements MiniPassFactory {
           ),
           new MetadataStorage()
       );
+    }
+
+    /**
+     * {@link org.enso.compiler.data.BindingsMap.ResolvedModuleMethod} and
+     * {@link org.enso.compiler.data.BindingsMap.ResolvedExtensionMethod} are allowed to
+     * clash - they are allowed to have the same fully qualified name, and no
+     * "duplicate import" warning should be generated for them.
+     */
+    private static boolean areResolvedNamesAllowedToClash(ResolvedName name1, ResolvedName name2) {
+      if (name1 instanceof BindingsMap.ResolvedExtensionMethod &&
+            name2 instanceof BindingsMap.ResolvedExtensionMethod) {
+        throw new AssertionError("Two extension methods with the same name should not be allowed.");
+      }
+      if (name1 instanceof BindingsMap.ResolvedModuleMethod &&
+          name2 instanceof BindingsMap.ResolvedModuleMethod) {
+        throw new AssertionError("Two module methods with the same name should not be allowed.");
+      }
+      if (name1 instanceof BindingsMap.ResolvedExtensionMethod && name2 instanceof BindingsMap.ResolvedModuleMethod) {
+        return true;
+      }
+      if (name1 instanceof BindingsMap.ResolvedModuleMethod && name2 instanceof BindingsMap.ResolvedExtensionMethod) {
+        return true;
+      }
+      return false;
     }
 
     private List<ImportTarget> getImportTargets(Import imp) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -156,10 +156,10 @@ public class ExecStrictCompilerTest {
   public void noDuplicateImportWarning() {
     var code =
         """
-        from Standard.Table.Column import apply_unary_operation, naming_helper
+        from Standard.Table.Column import naming_helper
 
         main =
-            [apply_unary_operation, naming_helper]
+            naming_helper
         """;
     var res = ContextUtils.evalModule(ctx, code);
     assertThat(res, is(notNullValue()));

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -2,6 +2,8 @@ package org.enso.compiler.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -147,5 +149,24 @@ public class ExecStrictCompilerTest {
     var res = ContextUtils.evalModule(ctx, code);
     assertTrue("Compiles and returns result", res.isNumber());
     assertEquals("Returns correct result", 11, res.asInt());
+  }
+
+  // https://github.com/enso-org/enso/issues/12376
+  @Test
+  public void noDuplicateImportWarning() {
+    var code =
+        """
+        from Standard.Table.Column import apply_unary_operation, naming_helper
+
+        main =
+            [apply_unary_operation, naming_helper]
+        """;
+    var res = ContextUtils.evalModule(ctx, code);
+    assertThat(res, is(notNullValue()));
+    var errors = MESSAGES.toString(StandardCharsets.UTF_8);
+    assertThat(
+        "There should be no errors or warnings. But there was: " + errors,
+        errors.isEmpty(),
+        is(true));
   }
 }


### PR DESCRIPTION
Fixes #12376

### Pull Request Description

Avoid processing the same import statement in [AmbiguousImportsAnalysis](https://github.com/enso-org/enso/blob/63910f3f2f49604c59f44a94c57a4b042a21c9ac/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.java) in some cases.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
