### PR TITLE
Display no dropdown for boolean values

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -428,10 +428,7 @@ const CustomDropdownItemsKey: unique symbol = Symbol.for('WidgetInput:CustomDrop
 function isHandledByCheckboxWidget(parameter: SuggestionEntryArgument | undefined): boolean {
   return (
     parameter?.tagValues != null &&
-    arrayEquals(Array.from(parameter.tagValues).sort(), [
-      'Standard.Base.Data.Boolean.Boolean.False',
-      'Standard.Base.Data.Boolean.Boolean.True',
-    ])
+    arrayEquals(Array.from(parameter.tagValues).sort(), ['False', 'True'])
   )
 }
 


### PR DESCRIPTION
### Pull Request Description

Fixes #12568

Engine now returns simply `True`/`False` in tag values, while we were expecting fully qualified type. It probably shouldn’t break anything, unless I’m missing something. cc @farmaazon @kazcw  

<img width="585" alt="image" src="https://github.com/user-attachments/assets/cf0d7012-6b0c-467e-85f5-83135b57ad88" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
