### PR TITLE
Ensure project dir exist when using --docs cmdline

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -811,8 +811,15 @@ public class Main {
     if (projectPath == null || projectPath.isEmpty()) {
       throw exitFail("Specify path to a project with --in-project option");
     }
+    if (!fileExists(projectPath)) {
+      throw exitFail("Project specified in --in-project option does not exist: " + projectPath);
+    }
     generateDocsFrom(docsFormat, projectPath, logLevel, logMasking, enableIrCaches);
     throw exitSuccess();
+  }
+
+  private static boolean fileExists(String path) {
+    return new File(path).exists();
   }
 
   /**

--- a/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
+++ b/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
@@ -91,6 +91,21 @@ public class EngineMainTest {
     }
   }
 
+  @Test
+  public void genDocsFails_WhenProjectDoesNotExist() throws IOException {
+    try {
+      var m = new MainMock();
+      // Using --docs api on purpose - as `--run` is able to detect project dir itself.
+      var line =
+          m.preprocessArguments("--in-project", "NON_EXISTING_DIR/foo/bar/xxx/zz", "--docs", "api");
+      m.mainEntry(line, Level.INFO, false);
+    } catch (ExitCode ex) {
+      assertEquals("Execution fails", 1, ex.exitCode);
+      assertEquals("One line printed", 1, linesOut.size());
+      assertThat(linesOut.get(0), containsString("does not exist"));
+    }
+  }
+
   private final class MainMock extends Main {
     boolean helpPrinted;
 


### PR DESCRIPTION
### Pull Request Description

Previously, `enso --in-project NON_EXISTING_DIR --docs api` used to succeed without any output. Now, the engine runner fails with non-zero exit code.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [X] Unit tests have been written where possible.
