### PR TITLE
Fix sorting and Nothing filters 

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -321,6 +321,7 @@ function createServer() {
         valueList,
       )
       const response = await config.executeExpression(expressionFunction)
+      console.log({response})
       return {
         success: true,
         data: response.value.rows,

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -321,7 +321,6 @@ function createServer() {
         valueList,
       )
       const response = await config.executeExpression(expressionFunction)
-      console.log({response})
       return {
         success: true,
         data: response.value.rows,

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/TableVizDataSourceUtils.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/TableVizDataSourceUtils.ts
@@ -13,7 +13,7 @@ import { getCellValueType } from './tableVizUtils'
 type ValueTypes = 'Date' | 'Time' | 'Date_Time' | 'Integer' | 'Char'
 type ValueTypeArgumentChild = { valueType: ValueTypes; value: string }
 type ValueTypeArgumentParent =
-  | { valueType: ValueTypes; value: string }
+  | { valueType: ValueTypes; value: string | string[] }
   | { valueType: 'Mixed'; value: ValueTypeArgumentChild[] }
 type PossibleArguments = string | ValueTypeArgumentParent
 export type Argument = string | Array<PossibleArguments>
@@ -30,7 +30,18 @@ const parseSingleArgument = (
   switch (value.valueType) {
     case 'Date': {
       const datePattern = Pattern.parseExpression('(Date.new __ __ __)')
-      const dateParts = value.value
+      if (typeof value.value === 'object' && value.value.length === 2) {
+        const items = value.value.map((val: string) => {
+          const dateParts = val
+            .match(/\d+/g)!
+            .slice(0, 3)
+            .map((part: string) => Ast.tryNumberToEnso(Number(part), tempModule)!)
+          return datePattern.instantiateCopied(dateParts)
+        })
+
+        return Ast.Vector.new(tempModule, items)
+      }
+      const dateParts = (value.value as string)
         .match(/\d+/g)!
         .slice(0, 3)
         .map((part: string) => Ast.tryNumberToEnso(Number(part), tempModule)!)
@@ -38,16 +49,34 @@ const parseSingleArgument = (
     }
     case 'Time': {
       const pattern = Pattern.parseExpression('Time_Of_Day.parse (__)')!
-      return pattern.instantiateCopied([Ast.TextLiteral.new(value.value, tempModule)])
+      if (typeof value.value === 'object' && value.value.length === 2) {
+        const items = value.value.map((val: string) =>
+          pattern.instantiateCopied([Ast.TextLiteral.new(val, tempModule)]),
+        )
+        return Ast.Vector.new(tempModule, items)
+      }
+      return pattern.instantiateCopied([Ast.TextLiteral.new(value.value as string, tempModule)])
     }
     case 'Date_Time': {
       const pattern = Pattern.parseExpression('Date_Time.parse (__)')!
-      return pattern.instantiateCopied([Ast.TextLiteral.new(value.value, tempModule)])
+      if (typeof value.value === 'object' && value.value.length === 2) {
+        const items = value.value.map((val: string) =>
+          pattern.instantiateCopied([Ast.TextLiteral.new(val, tempModule)]),
+        )
+        return Ast.Vector.new(tempModule, items)
+      }
+      return pattern.instantiateCopied([Ast.TextLiteral.new(value.value as string, tempModule)])
     }
-    case 'Integer':
-      return Ast.parseExpression(value.value, tempModule)!
-    case 'Char':
-      return Ast.TextLiteral.new(value.value)
+    case 'Integer': {
+      if (typeof value.value === 'object' && value.value.length === 2) {
+        const items = value.value.map((val: string) => Ast.parseExpression(val, tempModule)!)
+        return Ast.Vector.new(tempModule, items)
+      }
+      return Ast.parseExpression(value.value as string, tempModule)!
+    }
+    case 'Char': {
+      return Ast.TextLiteral.new(value.value as string)
+    }
     case 'Mixed': {
       const items = value.value.map((val: { valueType: ValueTypes; value: string }) =>
         parseSingleArgument(val, tempModule),
@@ -132,7 +161,14 @@ export const convertFilterModel = (
           typeof value.value === 'object' &&
           'fromValue' in value.value
         ) {
-          return { valueType: value.valType as ValueTypes, value: `${value.value.fromValue}` }
+          return {
+            valueType: value.valType as ValueTypes,
+            value: [`${value.value.fromValue}`, `${value.value.toValue}`],
+          }
+        }
+
+        if(value.action === '..Is_Nothing' || value.action === '..Not_Nothing') {
+          return { valueType: 'Char' as ValueTypes, value: 'Nothing' }
         }
 
         return { valueType: value.valType as ValueTypes, value: `${value.value}` }

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -241,7 +241,7 @@ get_distinct_values_for_column table column_index =
 apply_sort_to_table : Table -> Vector -> Vector -> Table
 apply_sort_to_table table sort_col_index_list sort_direction_list =
     parse_direction d = if d == -1 then Sort_Direction.Descending else Sort_Direction.Ascending
-    get_pattern i = (Sort_Column.Index (sort_col_index_list.get i) (parse_direction (sort_direction_list.get i)))
+    get_pattern i = (Sort_Column.Index ((sort_col_index_list.get i) + 1) (parse_direction (sort_direction_list.get i)))
     sort_pattern = ((0.up_to sort_col_index_list.length).map idx-> get_pattern idx)
     table.sort sort_pattern
 
@@ -299,7 +299,7 @@ get_rows_for_table table start_number sort_col_index_list=Nothing sort_direction
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns
     filtered_table = if filter_col.is_nothing then table_with_index_ordered else apply_filter_to_table table_with_index_ordered 0 filter_col filter_action filter_val
     sorted_table = if sort_col_index_list.is_nothing then filtered_table else apply_sort_to_table filtered_table sort_col_index_list sort_direction_list
-    all_rows_count = filtered_table.row_count
+    all_rows_count = sorted_table.row_count
     bucket_size = if all_rows_count > start_number + max_rows then max_rows else (all_rows_count - (start_number))
     get_vector c         = Warning.set (Vector.new bucket_size i-> make_json_for_value (c.get (i + start_number))) []
     columns              = sorted_table.columns

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -258,7 +258,7 @@ apply_sort_to_table table sort_col_index_list sort_direction_list =
 apply_single_filter_to_table : Table -> Text -> Any -> Any -> Table
 apply_single_filter_to_table table filter_col filter_action filter_val =
     column = filter_col+1
-    result = case filter_action of
+    result = case filter_action:Filter_Condition of
         Filter_Condition.Not_Nothing -> table.filter column ..Not_Nothing
         Filter_Condition.Is_Nothing -> table.filter column ..Is_Nothing
         Filter_Condition.Is_In _ _ -> if filter_val.length > 0 then table.filter column (Filter_Condition.Is_In filter_val) else table.filter column (Filter_Condition.Is_In [""])

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -255,14 +255,17 @@ apply_sort_to_table table sort_col_index_list sort_direction_list =
    - filter_action: filter action
    - filter_val: values to filter
 
-apply_single_filter_to_table : Table -> Text -> Filter_Condition -> Any -> Table
+apply_single_filter_to_table : Table -> Text -> Any -> Any -> Table
 apply_single_filter_to_table table filter_col filter_action filter_val =
-    case filter_action of
-      Filter_Condition.Is_In _ _ -> if filter_val.length > 0 then table.filter (filter_col+1) (Filter_Condition.Is_In filter_val) else table.filter filter_col (Filter_Condition.Is_In [""])
-      _ -> table.filter (filter_col+1) (filter_action (filter_val)) 
+    column = filter_col+1
+    result = case filter_action of
+        Filter_Condition.Not_Nothing -> table.filter column ..Not_Nothing
+        Filter_Condition.Is_Nothing -> table.filter column ..Is_Nothing
+        Filter_Condition.Is_In _ _ -> if filter_val.length > 0 then table.filter column (Filter_Condition.Is_In filter_val) else table.filter column (Filter_Condition.Is_In [""])
+        _ -> table.filter column (filter_action (filter_val))
+    result
 
 ## PRIVATE
-
    applies the filter model to the table.
 
    Arguments:


### PR DESCRIPTION
As the row count column is added all column indexes are shifted by one. Shifting the column sort fixes the sorting. Casting the filter condition allows the case to check the correct filter condition. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
