### PR TITLE
Fix sorting in Table viz

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -338,7 +338,6 @@ function createServerSideDatasource(): IServerSideDatasource {
     getRows: async (params) => {
       const server = createServer()
       const response: Response = await server.getData(params.request)
-      const startIndex = params.request.startRow ? params.request.startRow : 0
       const rows = createRowsForTable(response.data, 0, true)
       setTimeout(() => {
         if (response.success) {
@@ -431,7 +430,7 @@ function getFilterType(valueType: string) {
 
 function getFilterOptions(valueType: string) {
   if (valueType === 'Date') {
-    return ['equals', 'notEqual', 'greaterThan', 'lessThan', 'blank', 'notBlank']
+    return ['equals', 'notEqual', 'greaterThan', 'lessThan']
   } else if (isNumericType(valueType)) {
     return [
       'equals',
@@ -440,11 +439,9 @@ function getFilterOptions(valueType: string) {
       'greaterThanOrEqual',
       'lessThan',
       'lessThanOrEqual',
-      'blank',
-      'notBlank',
     ]
   } else if (valueType === 'Char') {
-    return ['equals', 'notEqual', 'blank', 'notBlank', 'contains', 'startsWith', 'endsWith']
+    return ['equals', 'notEqual', 'contains', 'startsWith', 'endsWith']
   } else {
     return null
   }

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -242,7 +242,7 @@ get_distinct_values_for_column table column_index =
 apply_sort_to_table : Table -> Vector -> Vector -> Table
 apply_sort_to_table table sort_col_index_list sort_direction_list =
     parse_direction d = if d == -1 then Sort_Direction.Descending else Sort_Direction.Ascending
-    get_pattern i = (Sort_Column.Index (sort_col_index_list.get i) (parse_direction (sort_direction_list.get i)))
+    get_pattern i = (Sort_Column.Index ((sort_col_index_list.get i)+1) (parse_direction (sort_direction_list.get i)))
     sort_pattern = ((0.up_to sort_col_index_list.length).map idx-> get_pattern idx)
     table.sort sort_pattern
 


### PR DESCRIPTION
As the row column is added to the table before filtering/sorting the column index needs to be shifted by one to reflect it and sort the correct column.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
