### PR TITLE
`invokeMember` should behave the same as `readMember.execute`

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
@@ -11,6 +11,9 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
@@ -481,6 +484,8 @@ public class AtomInteropTest {
         type Generator
             Value n ~next
 
+            get_next self = self.next
+
         natural =
             gen n = Generator.Value n (gen n+1)
             gen 2
@@ -495,6 +500,44 @@ public class AtomInteropTest {
           var interop = InteropLibrary.getUncached();
           var next = interop.invokeMember(atomUnwrapped, "next");
           assertThat("Returns next atom", interop.hasMembers(next), is(true));
+          return null;
+        });
+  }
+
+  @Test
+  public void invokeVsReadAndExecute() {
+    var atom =
+        ContextUtils.evalModule(
+            ctx,
+            """
+        from Standard.Base.Any import all
+
+        type Generator
+            Value n ~next
+
+            ahead self n = if n <= 1 then self.next else
+                @Tail_Call self.next.ahead n-1
+
+        main =
+            gen n = Generator.Value n (gen n+1)
+            gen 2
+        """);
+    executeInContext(
+        ctx,
+        () -> {
+          var atomUnwrapped = unwrapValue(ctx, atom);
+          var interop = InteropLibrary.getUncached();
+
+          assertTrue(
+              "ahead method is invocable", interop.isMemberInvocable(atomUnwrapped, "ahead"));
+          var invokeAhead = interop.invokeMember(atomUnwrapped, "ahead", 5);
+          assertEquals("2+5", 7L, interop.readMember(invokeAhead, "n"));
+
+          var aheadFn = interop.readMember(atomUnwrapped, "ahead");
+          assertTrue("Function can be executed", interop.isExecutable(aheadFn));
+          var readNext = interop.execute(aheadFn, 5);
+
+          assertSame("invokeMember yields the same as readMember+execute", invokeAhead, readNext);
           return null;
         });
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
@@ -484,8 +484,6 @@ public class AtomInteropTest {
         type Generator
             Value n ~next
 
-            get_next self = self.next
-
         natural =
             gen n = Generator.Value n (gen n+1)
             gen 2

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CurryNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CurryNode.java
@@ -19,7 +19,7 @@ import org.enso.interpreter.runtime.state.State;
 
 /** Handles runtime function currying and oversaturated (eta-expanded) calls. */
 @NodeInfo(description = "Handles runtime currying and eta-expansion")
-public class CurryNode extends BaseNode {
+final class CurryNode extends BaseNode {
   private final FunctionSchema postApplicationSchema;
   private final boolean appliesFully;
   private @Child InvokeCallableNode oversaturatedCallableNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -297,7 +297,7 @@ public abstract class Atom extends EnsoObject {
   final Object readMember(
       String member,
       @CachedLibrary(limit = "3") StructsLibrary structs,
-      @Cached InteropApplicationNode applySelf)
+      @Cached InteropApplicationNode preApplySelf)
       throws UnknownIdentifierException, UnsupportedMessageException {
     if (!isMemberReadable(member)) {
       throw UnknownIdentifierException.create(member);
@@ -309,9 +309,10 @@ public abstract class Atom extends EnsoObject {
     }
     var method = findMethod(member);
     if (method != null) {
-      var ctx = EnsoContext.get(applySelf);
+      var ctx = EnsoContext.get(preApplySelf);
       var state = ctx.currentState();
-      return applySelf.execute(method, state, new Object[] {this});
+      var methodWithSelfApplied = preApplySelf.execute(method, state, new Object[] {this});
+      return methodWithSelfApplied;
     }
     throw UnknownIdentifierException.create(member);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.enso.interpreter.node.callable.InteropApplicationNode;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -292,7 +294,10 @@ public abstract class Atom extends EnsoObject {
    */
   @ExportMessage
   @ExplodeLoop
-  final Object readMember(String member, @CachedLibrary(limit = "3") StructsLibrary structs)
+  final Object readMember(
+      String member,
+      @CachedLibrary(limit = "3") StructsLibrary structs,
+      @Cached InteropApplicationNode applySelf)
       throws UnknownIdentifierException, UnsupportedMessageException {
     if (!isMemberReadable(member)) {
       throw UnknownIdentifierException.create(member);
@@ -304,7 +309,9 @@ public abstract class Atom extends EnsoObject {
     }
     var method = findMethod(member);
     if (method != null) {
-      return method;
+      var ctx = EnsoContext.get(applySelf);
+      var state = ctx.currentState();
+      return applySelf.execute(method, state, new Object[] {this});
     }
     throw UnknownIdentifierException.create(member);
   }


### PR DESCRIPTION
### Pull Request Description

Turns out new version of GraalPy uses `readMember . execute` instead `invokeMember`. The silent assumption is that these two approaches yield the same result. That wasn't the case in `Atom` so far. This PR fixes that by _binding_ `self` to a function returned from `readMember` interop message.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
