### PR TITLE
Avoid StringBuilder.setLength

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Pgpass.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Pgpass.enso
@@ -90,8 +90,9 @@ parse_line line =
     Vector.build existing_entries->
         current_entry = Java_String_Builder.new
         next_entry =
-            existing_entries.append current_entry.toString
-            current_entry.setLength 0
+            current_str = current_entry.toString
+            existing_entries.append current_str
+            current_entry.delete 0 current_str.length
         characters = line.characters
         go ix is_escape = case ix>=characters.length of
             True ->

--- a/test/Base_Tests/src/Data/Text_Spec.enso
+++ b/test/Base_Tests/src/Data/Text_Spec.enso
@@ -11,6 +11,8 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Test import all
 
+polyglot java import java.lang.StringBuilder as Java_String_Builder
+
 type Auto
     Value a
 
@@ -1778,6 +1780,13 @@ add_specs suite_builder =
             res2 = input3.cleanse [Named_Pattern.Leading_Numbers, Named_Pattern.Leading_Whitespace]
             res1.should_equal "String with Leading Spaces then Leading Numbers"
             res2.should_equal "11String with Leading Spaces then Leading Numbers"
+
+    suite_builder.group "StringBuilder" group_builder->
+        group_builder.specify "append and set length" <|
+            sb = Java_String_Builder.new
+            sb.append "Hello World"
+            sb.delete 5 sb.toString.length
+            sb.toString . should_equal "Hello"
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

Mitigates https://github.com/oracle/graal/issues/10831 by using `.delete` method instead. See [discussion](https://github.com/enso-org/enso/pull/12500#issuecomment-2735320540) for more details.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the Enso style guides
- [x] Unit tests continue to work
