### PR TITLE
Make Decimal constructors private

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
@@ -1,8 +1,6 @@
 ## Enso Signatures 1.0
 ## module Standard.Base.Data.Decimal
 - type Decimal
-    - From_Float big_decimal:Standard.Base.Data.Decimal.BigDecimal original_value:Standard.Base.Data.Numbers.Float
-    - Value big_decimal:Standard.Base.Data.Decimal.BigDecimal
     - % self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Data.Decimal.Decimal
     - * self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Any.Any
     - + self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -87,10 +87,10 @@ polyglot java import org.enso.base.numeric.Decimal_Utils
    an explicit precision using a `Math_Context`.
 type Decimal
     ## PRIVATE
-    Value (big_decimal : BigDecimal)
+    private Value (big_decimal : BigDecimal)
 
     ## PRIVATE
-    From_Float (big_decimal : BigDecimal) (original_value : Float)
+    private From_Float (big_decimal : BigDecimal) (original_value : Float)
 
     ## ICON input_number
        Construct a `Decimal` from a `Text`, `Integer` or `Float`.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Statement_Setter.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Statement_Setter.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_State.Illegal_State
+from Standard.Base.Data.Decimal import get_big_decimal
 
 from Standard.Table import Value_Type
 
@@ -40,7 +41,7 @@ fill_hole_default stmt i type_hint value = case value of
             big_decimal = NumericConverter.bigIntegerAsBigDecimal value
             stmt.setBigDecimal i big_decimal
         False -> stmt.setLong i value
-    _ : Decimal   -> stmt.setBigDecimal i value.big_decimal
+    _ : Decimal   -> stmt.setBigDecimal i (get_big_decimal value)
     _ : Float     -> stmt.setDouble i value
     _ : Text      -> stmt.setString i value
     _ : Date_Time ->


### PR DESCRIPTION
Fixes #10799

### Pull Request Description

Declare `Decimal` constructors as `private`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
