### PR TITLE
Add more telemetry info during LS start

### DIFF
--- a/engine/language-server/src/main/java/module-info.java
+++ b/engine/language-server/src/main/java/module-info.java
@@ -2,6 +2,7 @@ import org.enso.runner.common.LanguageServerApi;
 
 module org.enso.language.server {
   requires java.logging;
+  requires java.management;
   requires scala.library;
 
   requires commons.cli;

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -61,6 +61,7 @@ import org.slf4j.event.Level
 import org.slf4j.{LoggerFactory, MDC}
 
 import java.io.{File, PrintStream}
+import java.lang.management.ManagementFactory
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Clock
@@ -74,22 +75,14 @@ import scala.concurrent.duration.DurationInt
 class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
 
   private val log = LoggerFactory.getLogger(this.getClass)
-  private val telemetryLog =
-    LoggerFactory.getLogger("org.enso.telemetry.languageserver.boot.MainModule")
   log.debug(
     "Initializing main module of the Language Server from [{}, {}, {}]",
     BuildVersion.currentEdition,
     serverConfig,
     logLevel
   )
-  telemetryLog.trace(
-    "Initializing main module of the Language Server: edition={}, graal_version={}, enso_version={}, is_release={}, AOT={}",
-    BuildVersion.currentEdition(),
-    BuildVersion.graalVersion(),
-    BuildVersion.ensoVersion(),
-    BuildVersion.isRelease,
-    HostEnsoUtils.isAot
-  )
+
+  initialTelemetry()
 
   private val contextSupervisor = new ComponentSupervisor()
   private val utcClock          = Clock.systemUTC()
@@ -537,5 +530,35 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
       .withFallback(empty)
       .getConfig("akka")
       .getConfig("https")
+  }
+
+  private def initialTelemetry(): Unit = {
+    val telemetryLog =
+      LoggerFactory.getLogger(
+        "org.enso.telemetry.languageserver.boot.MainModule"
+      )
+    val osBean     = ManagementFactory.getOperatingSystemMXBean
+    val mServer    = ManagementFactory.getPlatformMBeanServer
+    val memoryBean = ManagementFactory.getMemoryMXBean
+    val maxHeapMB  = (memoryBean.getHeapMemoryUsage.getMax / 1024) / 1024
+    val totalMem = mServer
+      .getAttribute(osBean.getObjectName, "TotalPhysicalMemorySize")
+      .asInstanceOf[Long]
+    val totalMemMB = totalMem / 1024 / 1024
+    ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+    telemetryLog.trace(
+      "Initializing main module of the Language Server: edition={}, graal_version={}, enso_version={}, is_release={}, AOT={}, os_name={}, os_arch={}, os_version={}, available_cpus={}, total_memory_MB={}, available_memory_MB={}",
+      BuildVersion.currentEdition(),
+      BuildVersion.graalVersion(),
+      BuildVersion.ensoVersion(),
+      BuildVersion.isRelease,
+      HostEnsoUtils.isAot,
+      osBean.getName,
+      osBean.getArch,
+      osBean.getVersion,
+      osBean.getAvailableProcessors,
+      totalMemMB,
+      maxHeapMB
+    )
   }
 }


### PR DESCRIPTION
### Pull Request Description

Added some telemetry about OS, CPU, and RAM during language server initialization:

![pasted](https://github.com/user-attachments/assets/c7965e6a-e0d9-49c2-96fd-b50df9152d13)

Inspiration from:
- https://github.com/apache/netbeans/blob/master/platform/uihandler/src/org/netbeans/modules/uihandler/CPUInfo.java
- https://github.com/apache/netbeans/blob/master/platform/core.ui/src/org/netbeans/core/ui/warmup/DiagnosticTask.java#L75
- https://github.com/apache/netbeans/blob/master/platform/uihandler/src/org/netbeans/modules/uihandler/ScreenSize.java

Tested on `java -jar project-manager.jar` as well as `project-manager` NI.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
