### PR TITLE
Use slf4j in instrument non-guest code

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
@@ -1,12 +1,11 @@
 package org.enso.interpreter.instrument.command;
 
-import com.oracle.truffle.api.TruffleLogger;
 import java.util.UUID;
-import java.util.logging.Level;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.interpreter.instrument.job.DeserializeLibrarySuggestionsJob;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.polyglot.runtime.Runtime$Api$InvalidateModulesIndexResponse;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -29,9 +28,9 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
   public Future<BoxedUnit> executeAsynchronously(RuntimeContext ctx, ExecutionContext ec) {
     return Future.apply(
         () -> {
-          TruffleLogger logger = ctx.executionService().getLogger();
+          var logger = LoggerFactory.getLogger(InvalidateModulesIndexCommand.class);
           try {
-            logger.log(Level.FINE, "Invalidating modules, cancelling background jobs");
+            logger.debug("Invalidating modules, cancelling background jobs");
             ctx.jobControlPlane().stopBackgroundJobs();
             ctx.jobControlPlane()
                 .abortBackgroundJobs(

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.instrument.command;
 
 import java.util.UUID;
-import java.util.logging.Level;
 import org.enso.interpreter.instrument.CacheInvalidation;
 import org.enso.interpreter.instrument.InstrumentFrame;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
@@ -41,7 +40,6 @@ public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
   @SuppressWarnings("unchecked")
   private void setExecutionEnvironment(
       Runtime$Api$ExecutionEnvironment executionEnvironment, UUID contextId, RuntimeContext ctx) {
-    var logger = ctx.executionService().getLogger();
     ctx.locking()
         .withContextLock(
             ctx.locking().getOrCreateContextLock(contextId),
@@ -81,11 +79,11 @@ public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
                           return null;
                         });
               } else {
-                logger.log(
-                    Level.FINE,
-                    "Requested environment '{}' is the same as the current one. Request has no"
-                        + " effect",
-                    oldEnvironmentName);
+                org.slf4j.LoggerFactory.getLogger(SetExecutionEnvironmentCommand.class)
+                    .debug(
+                        "Requested environment '{}' is the same as the current one. Request has no"
+                            + " effect",
+                        oldEnvironmentName);
                 reply(new Runtime$Api$SetExecutionEnvironmentResponse(contextId), ctx);
               }
               return null;

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -8,6 +8,7 @@ import org.enso.interpreter.instrument.job.ExecuteJob;
 import org.enso.interpreter.runtime.state.ExecutionEnvironment;
 import org.enso.polyglot.runtime.Runtime$Api$ExecutionEnvironment;
 import org.enso.polyglot.runtime.Runtime$Api$SetExecutionEnvironmentResponse;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.collection.mutable.Stack;
 import scala.concurrent.ExecutionContext;
@@ -79,7 +80,7 @@ public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
                           return null;
                         });
               } else {
-                org.slf4j.LoggerFactory.getLogger(SetExecutionEnvironmentCommand.class)
+                LoggerFactory.getLogger(SetExecutionEnvironmentCommand.class)
                     .debug(
                         "Requested environment '{}' is the same as the current one. Request has no"
                             + " effect",

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.instrument.job;
 import org.enso.common.CompilationStage;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.pkg.QualifiedName;
+import org.slf4j.LoggerFactory;
 
 /** The job that serializes module. */
 public final class SerializeModuleJob extends BackgroundJob<Void> {
@@ -31,7 +32,7 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
                   .ifPresent(
                       module -> {
                         if (module.getCompilationStage().isBefore(CompilationStage.AFTER_CODEGEN)) {
-                          org.slf4j.LoggerFactory.getLogger(SerializeModuleJob.class)
+                          LoggerFactory.getLogger(SerializeModuleJob.class)
                               .warn(
                                   "Attempt to serialize the module [{}] at stage [{}].",
                                   new Object[] {module.getName(), module.getCompilationStage()});

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.instrument.job;
 
-import java.util.logging.Level;
 import org.enso.common.CompilationStage;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.pkg.QualifiedName;
@@ -32,10 +31,8 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
                   .ifPresent(
                       module -> {
                         if (module.getCompilationStage().isBefore(CompilationStage.AFTER_CODEGEN)) {
-                          ctx.executionService()
-                              .getLogger()
-                              .log(
-                                  Level.WARNING,
+                          org.slf4j.LoggerFactory.getLogger(SerializeModuleJob.class)
+                              .warn(
                                   "Attempt to serialize the module [{}] at stage [{}].",
                                   new Object[] {module.getName(), module.getCompilationStage()});
                           return;

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -60,6 +60,7 @@ import org.enso.polyglot.debugger.ExecutedVisualization;
 import org.enso.polyglot.debugger.IdExecutionService;
 import org.enso.text.editing.JavaEditorAdapter;
 import org.enso.text.editing.model;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -438,12 +439,14 @@ public final class ExecutionService {
    *
    * @param module the module to edit.
    * @param edits the edits to apply.
+   * @param simpleUpdate identification of a "simple edit" or {@code null}
+   * @param logger logger to use for logging
    */
   public void modifyModuleSources(
       Module module,
       scala.collection.immutable.Seq<model.TextEdit> edits,
       SimpleUpdate simpleUpdate,
-      org.slf4j.Logger logger) {
+      Logger logger) {
     try {
       module.getSource();
     } catch (IOException e) {

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.service;
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.EventBinding;
@@ -23,8 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames;
 import org.enso.compiler.suggestions.SimpleUpdate;
 import org.enso.interpreter.instrument.Endpoint;
@@ -63,6 +60,7 @@ import org.enso.polyglot.debugger.ExecutedVisualization;
 import org.enso.polyglot.debugger.IdExecutionService;
 import org.enso.text.editing.JavaEditorAdapter;
 import org.enso.text.editing.model;
+import org.slf4j.LoggerFactory;
 
 /**
  * A service allowing externally-triggered code execution, registered by an instance of the
@@ -74,8 +72,6 @@ public final class ExecutionService {
   private final EnsoContext context;
   private final Optional<IdExecutionService> idExecutionInstrument;
   private final NotificationHandler.Forwarder notificationForwarder;
-  private final TruffleLogger logger =
-      TruffleLogger.getLogger(LanguageInfo.ID, ExecutionService.class);
   private final ConnectedLockManager connectedLockManager;
   private final ExecuteRootNode execute = new ExecuteRootNode();
   private final CallRootNode call = new CallRootNode();
@@ -113,13 +109,6 @@ public final class ExecutionService {
     return context;
   }
 
-  /**
-   * @return the execution service logger.
-   */
-  public TruffleLogger getLogger() {
-    return logger;
-  }
-
   public FunctionCallInstrumentationNode.FunctionCall prepareFunctionCall(
       Module module, String typeName, String methodName)
       throws TypeNotFoundException, MethodNotFoundException {
@@ -144,9 +133,10 @@ public final class ExecutionService {
     if (connectedLockManager != null) {
       connectedLockManager.connect(endpoint);
     } else {
-      logger.warning(
-          "ConnectedLockManager was not initialized, even though a Language Server connection has"
-              + " been established. This may result in synchronization errors.");
+      LoggerFactory.getLogger(ExecutionService.class)
+          .warn(
+              "ConnectedLockManager was not initialized, even though a Language Server connection"
+                  + " has been established. This may result in synchronization errors.");
     }
   }
 
@@ -453,7 +443,7 @@ public final class ExecutionService {
       Module module,
       scala.collection.immutable.Seq<model.TextEdit> edits,
       SimpleUpdate simpleUpdate,
-      TruffleLogger logger) {
+      org.slf4j.Logger logger) {
     try {
       module.getSource();
     } catch (IOException e) {
@@ -468,9 +458,8 @@ public final class ExecutionService {
                     module.getName(), edits, failure, module.getLiteralSource());
               },
               rope -> {
-                logger.log(
-                    Level.FINE,
-                    "Applied edits. Source has {0} lines, last line has {1} characters.",
+                logger.trace(
+                    "Applied edits. Source has {} lines, last line has {} characters.",
                     new Object[] {
                       rope.lines().length(),
                       rope.lines().drop(rope.lines().length() - 1).characters().length()
@@ -568,7 +557,7 @@ public final class ExecutionService {
   }
 
   @SuppressWarnings("unchecked")
-  static <E extends Exception> E raise(Class<E> type, Exception ex) throws E {
+  static <E extends Throwable> E raise(Class<E> type, Throwable ex) throws E {
     throw (E) ex;
   }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
@@ -1,12 +1,10 @@
 package org.enso.interpreter.instrument.command
 
-import com.oracle.truffle.api.TruffleLogger
 import org.enso.interpreter.instrument.execution.Completion.{Done, Interrupted}
 import org.enso.interpreter.instrument.execution.{Completion, RuntimeContext}
 import org.enso.interpreter.runtime.control.ThreadInterruptedException
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
-import java.util.logging.Level
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -20,17 +18,16 @@ abstract class AsynchronousCommand(maybeRequestId: Option[RequestId])
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Result[Completion] = {
-    val logger = ctx.executionService.getLogger
     for {
       _ <- Future {
-        logger.log(Level.FINE, s"Executing command asynchronously: $this...")
+        logger.debug(s"Executing command asynchronously: $this...")
       }
-      result <- mapFailures(logger, executeAsynchronously(ctx, ec))
-      _      <- Future { logger.log(Level.FINE, s"Command $this finished.") }
+      result <- mapFailures(executeAsynchronously(ctx, ec))
+      _      <- Future { logger.debug(s"Command $this finished.") }
     } yield result
   }
 
-  private def mapFailures(logger: TruffleLogger, result: Future[Unit])(implicit
+  private def mapFailures(result: Future[Unit])(implicit
     ex: ExecutionContext
   ): Future[Completion] = {
     result.transformWith[Completion] {
@@ -41,16 +38,14 @@ abstract class AsynchronousCommand(maybeRequestId: Option[RequestId])
         Future.successful[Completion](Interrupted)
 
       case Failure(NonFatal(ex)) =>
-        logger.log(
-          Level.SEVERE,
+        logger.error(
           s"An error occurred during execution of $this command",
           ex
         )
         Future.failed[Completion](ex)
 
       case Failure(ex) =>
-        logger.log(
-          Level.SEVERE,
+        logger.error(
           s"An error occurred during execution of $this command",
           ex
         )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
@@ -4,7 +4,6 @@ import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.interpreter.instrument.job.{ExecuteJob, UpsertVisualizationJob}
 import org.enso.polyglot.runtime.Runtime.Api
 
-import java.util.logging.Level
 import scala.concurrent.{ExecutionContext, Future}
 
 /** A command that attaches a visualization to an expression.
@@ -24,9 +23,8 @@ class AttachVisualizationCmd(
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
-    ctx.executionService.getLogger.log(
-      Level.FINE,
-      "Attach visualization cmd for request id [{0}] and visualization id [{1}]",
+    logger.debug(
+      "Attach visualization cmd for request id [{}] and visualization id [{}]",
       Array[Object](maybeRequestId.toString, request.visualizationId)
     )
     ctx.endpoint.sendToClient(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/Command.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/Command.scala
@@ -1,10 +1,14 @@
-package org.enso.interpreter.instrument.command
+package org.enso.interpreter.instrument
+package command
 
 import org.enso.interpreter.instrument.execution.{Completion, RuntimeContext}
 import org.enso.polyglot.runtime.Runtime.{Api, ApiNotification, ApiResponse}
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
 import scala.concurrent.ExecutionContext
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Base command trait that encapsulates a function request. Uses
   * [[RuntimeContext]] to perform a request.
@@ -35,4 +39,7 @@ abstract class Command(maybeRequestId: Option[RequestId]) {
   )(implicit ctx: RuntimeContext): Unit = {
     ctx.endpoint.sendToClient(Api.Response(None, payload))
   }
+
+  final private[instrument] def logger: Logger =
+    LoggerFactory.getLogger(classOf[Command])
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -6,7 +6,6 @@ import org.enso.interpreter.instrument.job.{EnsureCompiledJob, ExecuteJob}
 import org.enso.logger.masking.MaskedPath
 import org.enso.polyglot.runtime.Runtime.Api
 
-import java.util.logging.Level
 import scala.concurrent.ExecutionContext
 
 /** A command that performs edition of a file.
@@ -24,7 +23,6 @@ class EditFileCmd(request: Api.EditFileNotification)
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Unit = {
-    val logger = ctx.executionService.getLogger
     ctx.locking.withFileLock(
       request.path,
       this.getClass,
@@ -32,9 +30,8 @@ class EditFileCmd(request: Api.EditFileNotification)
         ctx.locking.withPendingEditsLock(
           this.getClass,
           () => {
-            logger.log(
-              Level.FINEST,
-              "Adding pending file [{0}] edits [{1}] and IdMap of length {2}",
+            logger.trace(
+              "Adding pending file [{}] edits [{}] and IdMap of length {}",
               Array[Any](
                 MaskedPath(request.path.toPath),
                 request.edits.map(e => (e.range, e.text.length)),

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualizationCmd.scala
@@ -10,7 +10,6 @@ import org.enso.interpreter.instrument.job.{
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.runtime.Runtime.Api.ExpressionId
 
-import java.util.logging.Level
 import scala.concurrent.{ExecutionContext, Future}
 
 /** A command that modifies a visualization.
@@ -30,8 +29,7 @@ class ModifyVisualizationCmd(
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
-    ctx.executionService.getLogger.log(
-      Level.FINE,
+    logger.debug(
       "Modify visualization cmd for request id [{}] and visualization id [{}]",
       Array[Object](maybeRequestId, request.visualizationId)
     )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -11,7 +11,6 @@ import org.enso.interpreter.instrument.{
 }
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.interpreter.instrument.job.{EnsureCompiledJob, ExecuteJob}
-import org.enso.interpreter.runtime.EnsoContext
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
@@ -43,8 +42,7 @@ class RecomputeContextCmd(
     ec: ExecutionContext
   ): Future[Boolean] = {
     Future {
-      EnsoContext
-        .get(null)
+      ctx.executionService.getContext
         .getResourceManager()
         .scheduleFinalizationOfSystemReferences();
       ctx.jobControlPlane.abortJobs(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
@@ -1,6 +1,5 @@
 package org.enso.interpreter.instrument.command
 
-import java.util.logging.Level
 import org.enso.interpreter.runtime.Module
 import org.enso.interpreter.instrument.{CacheInvalidation, InstrumentFrame}
 import org.enso.interpreter.instrument.execution.RuntimeContext
@@ -33,13 +32,11 @@ class RenameProjectCmd(
     } yield ()
 
   private def doRename(implicit ctx: RuntimeContext): Unit = {
-    val logger = ctx.executionService.getLogger
     ctx.locking.withWriteCompilationLock(
       this.getClass,
       () =>
         try {
-          logger.log(
-            Level.FINE,
+          logger.debug(
             s"Renaming project [old:${request.namespace}.${request.oldName},new:${request.namespace}.${request.newName}]..."
           )
           val packageRepository =
@@ -94,21 +91,18 @@ class RenameProjectCmd(
               newConfig.name
             )
           )
-          logger.log(
-            Level.INFO,
+          logger.info(
             s"Project renamed to ${request.namespace}.${request.newName}"
           )
         } catch {
           case ex: RenameProjectCmd.MainProjectPackageNotFound =>
-            logger.log(
-              Level.SEVERE,
+            logger.error(
               "Main project package is not found.",
               ex
             )
             reply(Api.ProjectRenameFailed(request.oldName, request.newName))
           case ex: RenameProjectCmd.FailedToReloadConfig =>
-            logger.log(
-              Level.SEVERE,
+            logger.error(
               "Failed to reload package config.",
               ex
             )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -5,7 +5,6 @@ import org.enso.interpreter.instrument.execution.Completion.{Done, Interrupted}
 import org.enso.interpreter.runtime.control.ThreadInterruptedException
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
-import java.util.logging.Level
 import scala.concurrent.ExecutionContext
 
 /** `SynchronousCommand`, despite its name,. will still execute asynchronously along with other commands except that
@@ -24,8 +23,7 @@ abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Result[Completion] = {
-    val logger = ctx.executionService.getLogger
-    logger.log(Level.FINE, s"Executing command synchronously: $this...")
+    logger.debug(s"Executing command synchronously: $this...")
     try {
       executeSynchronously
       Done
@@ -34,19 +32,11 @@ abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
         Interrupted
       case ex: Throwable => {
         val msg = s"An error occurred during execution of $this command"
-        try {
-          logger.log(Level.SEVERE, msg, ex)
-        } catch {
-          case ise: IllegalStateException =>
-            // Thread using TruffleLogger has to have a current context or the TruffleLogger has to be bound to an engine
-            ex.printStackTrace()
-            ise.initCause(ex)
-            throw ise
-        }
+        logger.error(msg, ex)
         Done
       }
     } finally {
-      logger.log(Level.FINE, s"Command $this finished.")
+      logger.trace(s"Command $this finished.")
     }
   }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
@@ -28,23 +28,24 @@ class CommandExecutionEngine(interpreterContext: InterpreterContext)
     interpreterContext.executionService.getContext
       .isInterpreterSequentialCommandExection()
 
-  private val locking = new ReentrantLocking(
-    interpreterContext.executionService.getLogger
-  )
+  private val locking = new ReentrantLocking()
 
   private val executionState = new ExecutionState()
 
   private val jobExecutionEngine =
     new JobExecutionEngine(interpreterContext, executionState, locking)
 
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(classOf[CommandExecutionEngine])
+
   private val commandExecutor =
     if (isSequential) {
-      interpreterContext.executionService.getLogger.fine(
+      logger.debug(
         "Executing commands sequentially"
       )
       jobExecutionEngine.jobExecutor
     } else {
-      interpreterContext.executionService.getLogger.fine(
+      logger.debug(
         "Executing commands in a separate command pool"
       )
       interpreterContext.executionService.getContext

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
@@ -1,5 +1,6 @@
 package org.enso.interpreter.instrument.execution
 
+import org.slf4j.LoggerFactory
 import org.enso.interpreter.instrument.InterpreterContext
 import org.enso.interpreter.instrument.command.{
   AsynchronousCommand,
@@ -36,7 +37,7 @@ class CommandExecutionEngine(interpreterContext: InterpreterContext)
     new JobExecutionEngine(interpreterContext, executionState, locking)
 
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(classOf[CommandExecutionEngine])
+    LoggerFactory.getLogger(classOf[CommandExecutionEngine])
 
   private val commandExecutor =
     if (isSequential) {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -1,16 +1,17 @@
 package org.enso.interpreter.instrument.execution
 
-import com.oracle.truffle.api.TruffleLogger
 import org.enso.common.Asserts.assertInJvm
 import org.enso.interpreter.instrument.InterpreterContext
 import org.enso.interpreter.instrument.job.{BackgroundJob, Job, UniqueJob}
 import org.enso.text.Sha3_224VersionCalculator
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 import java.util
 import java.util.{Collections, UUID}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{CancellationException, ExecutorService, TimeUnit}
-import java.util.logging.Level
 import scala.concurrent.{Future, Promise, TimeoutException}
 import scala.util.control.NonFatal
 
@@ -78,8 +79,8 @@ final class JobExecutionEngine(
       versionCalculator = Sha3_224VersionCalculator
     )
 
-  private lazy val logger: TruffleLogger =
-    runtimeContext.executionService.getLogger
+  private lazy val logger: Logger =
+    LoggerFactory.getLogger(classOf[JobExecutionEngine])
 
   // Independent Runnable that has a list of jobs that should finish within a pre-determined window
   // and, if not, are interrupted.
@@ -96,8 +97,7 @@ final class JobExecutionEngine(
             assertInJvm(timeSinceRequestedToCancel > 0)
             val timeToCancel =
               forceInterruptTimeout - timeSinceRequestedToCancel
-            logger.log(
-              Level.FINEST,
+            logger.trace(
               "About to wait {}ms  to cancel job {}",
               Array[Any](
                 timeToCancel,
@@ -105,9 +105,9 @@ final class JobExecutionEngine(
               )
             )
             runningJob.future.get(timeToCancel, TimeUnit.MILLISECONDS)
-            logger.log(
-              Level.FINEST,
-              "Job {} finished within the allocated soft-cancel time"
+            logger.trace(
+              "Job {} finished within the allocated soft-cancel time",
+              runningJob.id
             )
           } catch {
             case _: TimeoutException =>
@@ -129,17 +129,15 @@ final class JobExecutionEngine(
                     .append(")\n")
                 }
               }
-              logger.log(Level.WARNING, sb.toString())
+              logger.warn(sb.toString())
               runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
             case _: CancellationException =>
-              logger.log(
-                Level.FINE,
+              logger.debug(
                 "Job `{}` was cancelled by an external task",
                 runningJob.id
               )
             case e: Throwable =>
-              logger.log(
-                Level.WARNING,
+              logger.warn(
                 "Encountered exception while waiting on status of pending jobs",
                 e
               )
@@ -201,8 +199,7 @@ final class JobExecutionEngine(
         allJobs.foreach { runningJob =>
           runningJob.job match {
             case jobRef: UniqueJob[_] if jobRef.equalsTo(job) =>
-              logger
-                .log(Level.FINEST, s"Cancelling duplicate job [$jobRef].")
+              logger.trace("Cancelling duplicate job [{}].", jobRef)
               updatePendingCancellations(
                 maybeForceCancelRunningJob(
                   runningJob,
@@ -221,9 +218,8 @@ final class JobExecutionEngine(
   ): Unit = {
     val at = System.currentTimeMillis()
     if (jobsToCancel.nonEmpty) {
-      logger.log(
-        Level.FINEST,
-        "Submitting {0} job(s) for future cancellation",
+      logger.trace(
+        "Submitting {} job(s) for future cancellation",
         jobsToCancel.map(j => (j.job.getClass, j.id))
       )
     }
@@ -240,37 +236,34 @@ final class JobExecutionEngine(
   ): Future[A] = {
     val jobId   = UUID.randomUUID()
     val promise = Promise[A]()
-    logger.log(
-      Level.FINE,
-      s"Submitting job: {0} with {1} id...",
+    logger.debug(
+      s"Submitting job: {} with {} id...",
       Array[AnyRef](job, jobId)
     )
     val future = executorService.submit(() => {
-      logger.log(Level.FINE, s"Executing job: {0}...", job)
+      logger.debug("Executing job: {}...", job)
       val before = System.currentTimeMillis()
       try {
         val result = job.run(runtimeContext)
         val took   = System.currentTimeMillis() - before
-        logger.log(
-          Level.FINE,
-          s"Job {0} finished in {1} ms.",
+        logger.debug(
+          "Job {} finished in {} ms.",
           Array[Any](job, took)
         )
         promise.success(result)
       } catch {
         case NonFatal(ex) =>
-          logger.log(Level.SEVERE, s"Error executing $job", ex)
+          logger.error(s"Error executing $job", ex)
           promise.failure(ex)
         case _: InterruptedException =>
-          logger.log(Level.WARNING, s"$job got interrupted")
+          logger.warn("{} got interrupted", job)
         case err: Throwable =>
-          logger.log(Level.SEVERE, s"Error executing $job", err)
+          logger.error(s"Error executing $job", err)
           throw err
       } finally {
         val remaining = runningJobsRef.updateAndGet(_.filterNot(_.id == jobId))
-        logger.log(
-          Level.FINEST,
-          "Number of remaining pending jobs: {0}",
+        logger.trace(
+          "Number of remaining pending jobs: {}",
           remaining.size
         )
       }
@@ -279,7 +272,7 @@ final class JobExecutionEngine(
     val runningJob = RunningJob(jobId, job, future)
 
     val queue = runningJobsRef.updateAndGet(_ :+ runningJob)
-    logger.log(Level.FINE, "Number of pending jobs: {0}", queue.size)
+    logger.debug("Number of pending jobs: {}", queue.size)
 
     promise.future
   }
@@ -299,9 +292,8 @@ final class JobExecutionEngine(
         runningJob.job.isCancellable &&
         !ignoredJobs.contains(runningJob.job.getClass)
       }
-    logger.log(
-      Level.FINE,
-      "Aborting {0} jobs because {1}: {2}",
+    logger.debug(
+      "Aborting {} jobs because {}: {}",
       Array[Any](cancellableJobs.length, reason, cancellableJobs.map(_.id))
     )
 
@@ -328,9 +320,8 @@ final class JobExecutionEngine(
           runningJob.job.isCancellable && (toAbort.isEmpty || toAbort
             .contains(runningJob.getClass))
         ) {
-          logger.log(
-            Level.FINE,
-            "Aborting job {0} because {1}",
+          logger.debug(
+            "Aborting job {} because {}",
             Array[Any](runningJob.id, reason)
           )
           Some(runningJob)
@@ -353,9 +344,8 @@ final class JobExecutionEngine(
     val pending = contextJobs
       .flatMap { runningJob =>
         if (runningJob.job.isCancellable && accept.apply(runningJob.job)) {
-          logger.log(
-            Level.FINE,
-            "Aborting job {0} because {1}",
+          logger.debug(
+            "Aborting job {} because {}",
             Array[Any](runningJob.id, reason)
           )
           Some(runningJob)
@@ -378,9 +368,8 @@ final class JobExecutionEngine(
         runningJob.job.isCancellable &&
         toAbort.contains(runningJob.job.getClass)
       }
-    logger.log(
-      Level.FINE,
-      "Aborting {0} background jobs because {1}: {2}",
+    logger.debug(
+      "Aborting {} background jobs because {}: {}",
       Array[Any](cancellableJobs.length, reason, cancellableJobs.map(_.id))
     )
     val pending = cancellableJobs.flatMap(
@@ -423,9 +412,8 @@ final class JobExecutionEngine(
       delayedBackgroundJobsQueue,
       BackgroundJob.BACKGROUND_JOBS_QUEUE_ORDER
     )
-    runtimeContext.executionService.getLogger.log(
-      Level.FINE,
-      "Submitting {0} background jobs [{1}]",
+    logger.debug(
+      "Submitting {} background jobs [{}]",
       Array[AnyRef](
         delayedBackgroundJobsQueue.size(): Integer,
         delayedBackgroundJobsQueue

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
@@ -1,17 +1,19 @@
 package org.enso.interpreter.instrument.execution
 
-import com.oracle.truffle.api.TruffleLogger
-
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.Callable
 import java.util.concurrent.locks.{Lock, ReentrantLock, ReentrantReadWriteLock}
-import java.util.logging.Level
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Provides locking capabilities for the runtime server. Ir uses reentrant
   * locks.
   */
-class ReentrantLocking(logger: TruffleLogger) extends Locking {
+class ReentrantLocking extends Locking {
+  private lazy val logger: Logger =
+    LoggerFactory.getLogger(classOf[ReentrantLocking])
 
   /** Lowest level lock obtainable at any time. */
   private val pendingEditsLock = new ReentrantLock()
@@ -93,18 +95,16 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
       callable.call()
     } catch {
       case _: InterruptedException =>
-        logger.log(
-          Level.FINE,
-          "Failed [{0}] to acquire lock: interrupted",
+        logger.debug(
+          "Failed [{}] to acquire lock: interrupted",
           Array[Any](where.getSimpleName)
         )
         null.asInstanceOf[T]
     } finally {
       if (lockTimestamp != 0) {
         releaseWriteCompilationLock()
-        logger.log(
-          Level.FINEST,
-          s"Kept write compilation lock [{0}] for {1}ms",
+        logger.trace(
+          "Kept write compilation lock [{}] for {}ms",
           Array[Any](
             where.getSimpleName,
             System.currentTimeMillis - lockTimestamp
@@ -140,18 +140,16 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
       callable.call()
     } catch {
       case _: InterruptedException =>
-        logger.log(
-          Level.FINE,
-          "Failed [{0}] to acquire lock: interrupted",
+        logger.debug(
+          "Failed [{}] to acquire lock: interrupted",
           Array[Any](where.getSimpleName)
         )
         null.asInstanceOf[T]
     } finally {
       if (lockTimestamp != 0) {
         releaseReadCompilationLock()
-        logger.log(
-          Level.FINEST,
-          s"Kept read compilation lock [{0}] for {1}ms",
+        logger.trace(
+          "Kept read compilation lock [{}] for {}ms",
           Array[Any](
             where.getSimpleName,
             System.currentTimeMillis - lockTimestamp
@@ -179,18 +177,16 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
       callable.call()
     } catch {
       case _: InterruptedException =>
-        logger.log(
-          Level.FINE,
-          "Failed [{0}] to acquire lock: interrupted",
+        logger.debug(
+          "Failed [{}] to acquire lock: interrupted",
           Array[Any](where.getSimpleName)
         )
         null.asInstanceOf[T]
     } finally {
       if (lockTimestamp != 0) {
         releasePendingEditsLock()
-        logger.log(
-          Level.FINEST,
-          s"Kept pending edits lock [{0}] for {1}ms",
+        logger.trace(
+          s"Kept pending edits lock [{}] for {}ms",
           Array[Any](
             where.getSimpleName,
             System.currentTimeMillis - lockTimestamp
@@ -217,18 +213,16 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
       callable.call()
     } catch {
       case _: InterruptedException =>
-        logger.log(
-          Level.FINE,
-          "Failed [{0}] to acquire lock: interrupted",
+        logger.debug(
+          "Failed [{}] to acquire lock: interrupted",
           Array[Any](where.getSimpleName)
         )
         null.asInstanceOf[T]
     } finally {
       if (contextLockTimestamp != 0) {
         contextLock.lock.unlock()
-        logger.log(
-          Level.FINEST,
-          s"Kept context lock [{0}] for {1}ms",
+        logger.trace(
+          "Kept context lock [{}] for {}ms",
           Array[Any](
             where.getSimpleName,
             System.currentTimeMillis - contextLockTimestamp
@@ -279,18 +273,16 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
       callable.call()
     } catch {
       case _: InterruptedException =>
-        logger.log(
-          Level.FINE,
-          "Failed [{0}] to acquire lock: interrupted",
+        logger.debug(
+          "Failed [{}] to acquire lock: interrupted",
           Array[Any](where.getSimpleName)
         )
         null.asInstanceOf[T]
     } finally {
       if (lockTimestamp != 0) {
         releaseFileLock(file)
-        logger.log(
-          Level.FINEST,
-          s"Kept file lock [{0}] for {1}ms",
+        logger.debug(
+          s"Kept file lock [{}] for {1}ms",
           Array[Any](
             where.getSimpleName,
             System.currentTimeMillis - lockTimestamp
@@ -308,9 +300,8 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
     val now = System.currentTimeMillis()
     lock.lockInterruptibly()
     val now2 = System.currentTimeMillis()
-    logger.log(
-      Level.FINEST,
-      "Waited [{0}] {1}ms for the {2}",
+    logger.trace(
+      "Waited [{}] {}ms for the {}",
       Array[Any](where.getSimpleName, now2 - now, msg)
     )
     now2

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
@@ -12,12 +12,13 @@ import org.enso.interpreter.runtime.Module
 import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.{ModuleExports, Suggestion}
+import org.slf4j.LoggerFactory
 
 final class AnalyzeModuleInScopeJob(
   modules: Iterable[(Module, IndexState, Boolean)]
 ) extends BackgroundJob[Unit](AnalyzeModuleInScopeJob.Priority) {
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(classOf[AnalyzeModuleInScopeJob])
+    getLogger(classOf[AnalyzeModuleInScopeJob])
 
   private val exportsBuilder = new ExportsBuilder
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
@@ -18,7 +18,7 @@ final class AnalyzeModuleInScopeJob(
   modules: Iterable[(Module, IndexState, Boolean)]
 ) extends BackgroundJob[Unit](AnalyzeModuleInScopeJob.Priority) {
   private def logger: org.slf4j.Logger =
-    getLogger(classOf[AnalyzeModuleInScopeJob])
+    LoggerFactory.getLogger(classOf[AnalyzeModuleInScopeJob])
 
   private val exportsBuilder = new ExportsBuilder
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
@@ -13,11 +13,11 @@ import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.{ModuleExports, Suggestion}
 
-import java.util.logging.Level
-
 final class AnalyzeModuleInScopeJob(
   modules: Iterable[(Module, IndexState, Boolean)]
 ) extends BackgroundJob[Unit](AnalyzeModuleInScopeJob.Priority) {
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(classOf[AnalyzeModuleInScopeJob])
 
   private val exportsBuilder = new ExportsBuilder
 
@@ -46,8 +46,7 @@ final class AnalyzeModuleInScopeJob(
     ctx: RuntimeContext
   ): Unit = {
     if (!state.isIndexed && hasSource) {
-      ctx.executionService.getLogger
-        .log(Level.FINEST, s"Analyzing module in scope {0}", module.getName)
+      logger.trace(s"Analyzing module in scope {}", module.getName)
       val moduleName = module.getName
       val compiler   = ctx.executionService.getContext.getCompiler
       val types      = Module.findTypeHierarchy(compiler.context)
@@ -71,12 +70,10 @@ final class AnalyzeModuleInScopeJob(
       if (ctx.state.suggestions.markAsIndexed(module, state)) {
         sendModuleUpdate(notification)
       } else {
-        ctx.executionService.getLogger
-          .log(
-            Level.FINEST,
-            s"Calculated index for module in scope {0} is not up-to-date. Discarding",
-            module.getName
-          )
+        logger.trace(
+          s"Calculated index for module in scope {} is not up-to-date. Discarding",
+          module.getName
+        )
       }
     }
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
@@ -15,6 +15,7 @@ import org.enso.polyglot.ModuleExports
 import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.buffer.Rope
+import org.slf4j.LoggerFactory
 
 final class AnalyzeModuleJob(
   module: Module,
@@ -34,7 +35,7 @@ final class AnalyzeModuleJob(
 
 object AnalyzeModuleJob {
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(getClass)
+    LoggerFactory.getLogger(getClass)
 
   def apply(
     module: Module,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
@@ -16,8 +16,6 @@ import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.buffer.Rope
 
-import java.util.logging.Level
-
 final class AnalyzeModuleJob(
   module: Module,
   state: IndexState,
@@ -35,6 +33,8 @@ final class AnalyzeModuleJob(
 }
 
 object AnalyzeModuleJob {
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(getClass)
 
   def apply(
     module: Module,
@@ -68,8 +68,7 @@ object AnalyzeModuleJob {
     val moduleName = module.getName
     val compiler   = ctx.executionService.getContext.getCompiler
     if (state.isIndexed) {
-      ctx.executionService.getLogger
-        .log(Level.FINEST, "Analyzing indexed module {0}", moduleName)
+      logger.trace("Analyzing indexed module {}", moduleName)
       val types = Module.findTypeHierarchy(compiler.context)
       val prevSuggestions =
         SuggestionBuilder(changeset.source, types, compiler)
@@ -91,16 +90,13 @@ object AnalyzeModuleJob {
       if (ctx.state.suggestions.updateState(module, state, newIr)) {
         sendModuleUpdate(notification)
       } else {
-        ctx.executionService.getLogger
-          .log(
-            Level.FINEST,
-            s"Newly calculated index for module {0} is not up-to-date. Discarding",
-            module.getName
-          )
+        logger.trace(
+          s"Newly calculated index for module {} is not up-to-date. Discarding",
+          module.getName
+        )
       }
     } else {
-      ctx.executionService.getLogger
-        .log(Level.FINEST, s"Analyzing not-indexed module {0}", module.getName)
+      logger.trace(s"Analyzing not-indexed module {}", module.getName)
       val types = Module.findTypeHierarchy(compiler.context)
       val newSuggestions =
         SuggestionBuilder(module.asCompilerModule(), types, compiler)
@@ -117,12 +113,10 @@ object AnalyzeModuleJob {
       if (ctx.state.suggestions.markAsIndexed(module, state)) {
         sendModuleUpdate(notification)
       } else {
-        ctx.executionService.getLogger
-          .log(
-            Level.FINEST,
-            s"Calculated index for module {0} is not up-to-date. Discarding",
-            module.getName
-          )
+        logger.trace(
+          s"Calculated index for module {} is not up-to-date. Discarding",
+          module.getName
+        )
       }
     }
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
@@ -6,6 +6,7 @@ import org.enso.polyglot.runtime.Runtime.Api
 
 import scala.jdk.CollectionConverters._
 import org.enso.polyglot.Suggestion
+import org.slf4j.LoggerFactory
 
 /** A job responsible for deserializing suggestions of loaded library.
   *
@@ -16,7 +17,7 @@ final class DeserializeLibrarySuggestionsJob(
 ) extends BackgroundJob[Unit](DeserializeLibrarySuggestionsJob.Priority, true)
     with UniqueJob[Unit] {
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(classOf[DeserializeLibrarySuggestionsJob])
+    LoggerFactory.getLogger(classOf[DeserializeLibrarySuggestionsJob])
 
   /** @inheritdoc */
   override def equalsTo(that: UniqueJob[_]): Boolean =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
@@ -4,8 +4,6 @@ import org.enso.editions.LibraryName
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
-import java.util.logging.Level
-
 import scala.jdk.CollectionConverters._
 import org.enso.polyglot.Suggestion
 
@@ -17,6 +15,8 @@ final class DeserializeLibrarySuggestionsJob(
   val libraryName: LibraryName
 ) extends BackgroundJob[Unit](DeserializeLibrarySuggestionsJob.Priority, true)
     with UniqueJob[Unit] {
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(classOf[DeserializeLibrarySuggestionsJob])
 
   /** @inheritdoc */
   override def equalsTo(that: UniqueJob[_]): Boolean =
@@ -28,11 +28,7 @@ final class DeserializeLibrarySuggestionsJob(
 
   /** @inheritdoc */
   override def runImpl(implicit ctx: RuntimeContext): Unit = {
-    ctx.executionService.getLogger.log(
-      Level.FINE,
-      "Deserializing suggestions for library [{}].",
-      libraryName
-    )
+    logger.debug("Deserializing suggestions for library [{}].", libraryName)
     val cc = ctx.executionService.getContext.getCompiler.context
     cc
       .deserializeSuggestions(libraryName)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -1,6 +1,8 @@
 package org.enso.interpreter.instrument.job
 
-import com.oracle.truffle.api.TruffleLogger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 import org.enso.common.{CachePreferences, CompilationStage}
 import org.enso.compiler.{data, CompilerResult}
 import org.enso.compiler.context._
@@ -38,7 +40,6 @@ import java.io.File
 import java.util
 import java.util.UUID
 import java.util.function.Consumer
-import java.util.logging.Level
 import scala.jdk.OptionConverters._
 
 /** A job that ensures that specified files are compiled.
@@ -65,7 +66,7 @@ class EnsureCompiledJob(
         val compilationResult =
           ensureCompiledFiles(files)(
             ctx,
-            ctx.executionService.getLogger
+            logger
           )
         setCacheWeights()
         compilationResult
@@ -81,7 +82,7 @@ class EnsureCompiledJob(
     */
   private def ensureCompiledFiles(
     files: Iterable[File]
-  )(implicit ctx: RuntimeContext, logger: TruffleLogger): CompilationStatus = {
+  )(implicit ctx: RuntimeContext, logger: Logger): CompilationStatus = {
     val modules = files.flatMap { file =>
       ctx.executionService.getContext.getModuleForFile(file).toScala
     }
@@ -103,12 +104,11 @@ class EnsureCompiledJob(
     module: Module
   )(implicit
     ctx: RuntimeContext,
-    logger: TruffleLogger
+    logger: Logger
   ): Option[CompilationStatus] = {
     compile(module) match {
       case Left(ex) =>
-        logger.log(
-          Level.WARNING,
+        logger.warn(
           s"Error while ensureCompiledModule ${module.getName}",
           ex
         )
@@ -138,8 +138,7 @@ class EnsureCompiledJob(
         }
         .fold(
           err => {
-            logger.log(
-              Level.WARNING,
+            logger.warn(
               s"Error while ensureCompiledModule ${module.getName}",
               err
             )
@@ -168,8 +167,7 @@ class EnsureCompiledJob(
       ) { case ((modules, statuses), module) =>
         compile(module) match {
           case Left(err) =>
-            ctx.executionService.getLogger
-              .log(Level.SEVERE, s"Compilation error in ${module.getName}", err)
+            logger.error(s"Compilation error in ${module.getName}", err)
             sendFailureUpdate(
               Api.ExecutionResult.Failure(
                 err.getMessage,
@@ -294,8 +292,7 @@ class EnsureCompiledJob(
         !compilationStage.isAtLeast(CompilationStage.AFTER_CODEGEN)
         || idMapOpt.isDefined
       ) {
-        ctx.executionService.getLogger
-          .log(Level.FINEST, s"Compiling ${module.getName}.")
+        logger.trace(s"Compiling ${module.getName}.")
         val compiler = ctx.executionService.getContext.getCompiler
 
         idMapOpt.foreach { idMap =>
@@ -330,7 +327,7 @@ class EnsureCompiledJob(
     file: File
   )(implicit
     ctx: RuntimeContext,
-    logger: TruffleLogger
+    logger: Logger
   ): Option[Changeset[Rope]] = {
     ctx.locking.withFileLock(
       file,
@@ -341,16 +338,14 @@ class EnsureCompiledJob(
           () => {
             val pendingEdits = ctx.state.pendingEdits.dequeue(file)
             val idMap        = ctx.state.pendingEdits.removeIdMap(file)
-            ctx.executionService.getLogger
-              .log(
-                Level.FINEST,
-                s"Applying pending file [{0}] edits [{1}] idMap [{2}]",
-                Array[Any](
-                  MaskedPath(file.toPath),
-                  pendingEdits.length,
-                  idMap.map(_.values.length)
-                )
+            logger.trace(
+              "Applying pending file [{}] edits [{}] idMap [{}]",
+              Array[Any](
+                MaskedPath(file.toPath),
+                pendingEdits.length,
+                idMap.map(_.values.length)
               )
+            )
             val edits = pendingEdits.map(_.edit)
             val shouldExecute =
               pendingEdits.isEmpty || pendingEdits.exists(_.execute)
@@ -486,8 +481,7 @@ class EnsureCompiledJob(
       UpsertVisualizationJob.upsertVisualization(visualization)
     }
     if (invalidatedVisualizations.nonEmpty) {
-      ctx.executionService.getLogger.log(
-        Level.FINEST,
+      logger.trace(
         "Invalidated visualizations [{}]",
         invalidatedVisualizations.map(_.id)
       )
@@ -632,6 +626,8 @@ class EnsureCompiledJob(
 }
 
 object EnsureCompiledJob {
+  private lazy val logger: Logger =
+    LoggerFactory.getLogger(classOf[EnsureCompiledJob])
 
   /** The outcome of a compilation. */
   sealed trait CompilationStatus
@@ -689,8 +685,8 @@ object EnsureCompiledJob {
             .flatMap { module =>
               val path = java.util.Optional.ofNullable(module.getPath)
               if (path.isEmpty) {
-                ctx.executionService.getLogger
-                  .severe(s"${module.getName} module path is empty")
+                logger
+                  .error(s"${module.getName} module path is empty")
               }
               path
             }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -1,12 +1,13 @@
 package org.enso.interpreter.instrument.job
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 import java.util.UUID
 import org.enso.interpreter.instrument.InstrumentFrame
 import org.enso.interpreter.instrument.execution.{Executable, RuntimeContext}
 import org.enso.interpreter.runtime.state.ExecutionEnvironment
 import org.enso.polyglot.runtime.Runtime.Api
-
-import java.util.logging.Level
 
 /** A job responsible for executing a call stack for the provided context.
   *
@@ -44,15 +45,14 @@ class ExecuteJob(
     _hasStarted = true
     _threadName = Thread.currentThread().getName
     try {
-      ctx.executionService.getLogger.log(
-        Level.FINE,
+      ExecuteJob.logger.debug(
         "Starting ExecuteJob[{}]",
         _jobId
       )
       execute
     } catch {
       case t: Throwable =>
-        ctx.executionService.getLogger.log(Level.SEVERE, "Failed to execute", t)
+        ExecuteJob.logger.error("Failed to execute", t)
         val errorMsg = if (t.getMessage == null) {
           if (t.getCause == null) {
             t.getClass.getSimpleName
@@ -75,9 +75,8 @@ class ExecuteJob(
           )
         )
     } finally {
-      ctx.executionService.getLogger.log(
-        Level.FINEST,
-        "Finished ExecuteJob[{0}]",
+      ExecuteJob.logger.trace(
+        "Finished ExecuteJob[{}]",
         _jobId
       )
     }
@@ -147,6 +146,8 @@ class ExecuteJob(
 }
 
 object ExecuteJob {
+  final private lazy val logger: Logger =
+    LoggerFactory.getLogger(classOf[ExecuteJob])
 
   /** Create execute job from the executable.
     *

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -1,5 +1,7 @@
 package org.enso.interpreter.instrument.job
 
+import org.slf4j.LoggerFactory
+
 import com.oracle.truffle.api.exception.AbstractTruffleException
 import org.enso.interpreter.instrument.{
   InstrumentFrame,
@@ -49,7 +51,6 @@ import org.enso.polyglot.runtime.Runtime.Api.{ContextId, ExecutionResult}
 import java.io.File
 import java.util.UUID
 import java.util.function.Consumer
-import java.util.logging.Level
 
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
@@ -58,6 +59,7 @@ import scala.util.Try
   * run Enso programs in a Truffle context.
   */
 object ProgramExecutionSupport {
+  private lazy val logger = LoggerFactory.getLogger(this.getClass)
 
   /** Runs the program.
     *
@@ -71,18 +73,18 @@ object ProgramExecutionSupport {
     executionFrame: ExecutionFrame,
     callStack: List[LocalCallFrame]
   )(implicit ctx: RuntimeContext): Unit = {
-    val logger           = ctx.executionService.getLogger
+
     val methodCallsCache = new MethodCallsCache
     var enterables       = Map[UUID, FunctionCall]()
 
     val onCachedMethodCallCallback: Consumer[ExpressionValue] = { value =>
-      logger.log(Level.FINEST, s"ON_CACHED_CALL ${value.getExpressionId}")
+      logger.trace(s"ON_CACHED_CALL ${value.getExpressionId}")
       sendExpressionUpdate(contextId, executionFrame.syncState, value)
     }
 
     val onCachedValueCallback: Consumer[ExpressionValue] = { value =>
       if (callStack.isEmpty) {
-        logger.log(Level.FINEST, s"ON_CACHED_VALUE ${value.getExpressionId}")
+        logger.trace(s"ON_CACHED_VALUE ${value.getExpressionId}")
         sendExpressionUpdate(contextId, executionFrame.syncState, value)
         sendVisualizationUpdates(
           contextId,
@@ -95,7 +97,7 @@ object ProgramExecutionSupport {
 
     val onComputedValueCallback: Consumer[ExpressionValue] = { value =>
       if (callStack.isEmpty) {
-        logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
+        logger.trace(s"ON_COMPUTED ${value.getExpressionId}")
 
         value.getValue match {
           case sentinel: PanicSentinel =>
@@ -258,8 +260,7 @@ object ProgramExecutionSupport {
     contextId: Api.ContextId,
     stack: List[InstrumentFrame]
   )(implicit ctx: RuntimeContext): Option[Api.ExecutionResult] = {
-    val logger = ctx.executionService.getLogger
-    logger.log(Level.FINEST, s"Run program $contextId")
+    logger.trace(s"Run program $contextId")
     @scala.annotation.tailrec
     def unwind(
       stack: List[InstrumentFrame],
@@ -297,7 +298,7 @@ object ProgramExecutionSupport {
         ).toEither.left
           .map(onExecutionError(stackItem.item, _))
     } yield ()
-    logger.log(Level.FINEST, s"Execution finished: $executionResult")
+    logger.trace(s"Execution finished: $executionResult")
     executionResult.fold(identity, _ => None)
   }
 
@@ -320,11 +321,11 @@ object ProgramExecutionSupport {
     def onFailure(): Option[Api.ExecutionResult] = error match {
       case _: ThreadInterruptedException =>
         val message = s"Execution of function $itemName interrupted."
-        ctx.executionService.getLogger.log(Level.FINE, message)
+        logger.trace(message)
         None
       case _ =>
         val message = s"Execution of function $itemName failed ($reason)."
-        ctx.executionService.getLogger.log(Level.WARNING, message, error)
+        logger.trace(message, error)
         Some(ExecutionResult.Failure(message, None))
     }
     executionUpdate.orElse(onFailure())
@@ -508,8 +509,7 @@ object ProgramExecutionSupport {
               )
             )
           } else {
-            ctx.executionService.getLogger
-              .log(Level.FINE, "computation of expression has been interrupted")
+            logger.trace("computation of expression has been interrupted")
             None
           }
         case warnings: WithWarnings
@@ -539,9 +539,8 @@ object ProgramExecutionSupport {
                   ).toEither
                     .fold(
                       error => {
-                        ctx.executionService.getLogger.log(
-                          Level.SEVERE,
-                          "Failed to execute warning preview of expression [{0}].",
+                        logger.trace(
+                          "Failed to execute warning preview of expression [{}].",
                           Array[Object](expressionId, error)
                         )
                         None
@@ -664,10 +663,8 @@ object ProgramExecutionSupport {
     expressionValue: AnyRef
   )(implicit ctx: RuntimeContext): Either[Throwable, AnyRef] =
     Try {
-      val logger = ctx.executionService.getLogger
-      logger.log(
-        Level.FINEST,
-        "Executing visualization [{0}] on expression [{1}] of [{2}]...",
+      logger.trace(
+        "Executing visualization [{}] on expression [{}] of [{}]...",
         Array[Object](
           visualization.id,
           expressionId,
@@ -689,9 +686,8 @@ object ProgramExecutionSupport {
 
       if (runtimeCache != null) {
         def processUUID(id: UUID): Unit = {
-          logger.log(
-            Level.FINE,
-            "Associating visualization [{0}] with additional ID [{1}]",
+          logger.trace(
+            "Associating visualization [{}] with additional ID [{}]",
             Array[Object](
               visualization.id,
               id
@@ -732,9 +728,8 @@ object ProgramExecutionSupport {
         if (!TypesGen.isPanicSentinel(expressionValue)) {
           val typeOfNode =
             TypeOfNode.getUncached.findTypeOrError(expressionValue)
-          ctx.executionService.getLogger.log(
-            Level.WARNING,
-            "Execution of visualization [{0}] on value [{1}] of [{2}] failed. {3} | {4} | {5}",
+          logger.warn(
+            "Execution of visualization [{}] on value [{}] of [{}] failed. {} | {} | {}",
             Array[Object](
               visualizationId,
               expressionId,
@@ -758,9 +753,8 @@ object ProgramExecutionSupport {
         Completion.Done
 
       case Right(data) =>
-        ctx.executionService.getLogger.log(
-          Level.FINEST,
-          s"Visualization executed [{0}].",
+        logger.trace(
+          "Visualization executed [{}].",
           expressionId
         )
         ctx.endpoint.sendToClient(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/RefactoringRenameJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/RefactoringRenameJob.scala
@@ -1,5 +1,6 @@
 package org.enso.interpreter.instrument.job
 
+import org.slf4j.LoggerFactory
 import org.enso.compiler.core.{ExternalID, IR}
 import org.enso.compiler.core.ir.Name
 import org.enso.compiler.refactoring.IRUtils
@@ -81,7 +82,7 @@ final class RefactoringRenameJob(
   }
 
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(classOf[RefactoringRenameJob])
+    LoggerFactory.getLogger(classOf[RefactoringRenameJob])
 
   private def applyRefactoringEdits()(implicit ctx: RuntimeContext): File = {
     val module = ctx.executionService.getContext

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/RefactoringRenameJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/RefactoringRenameJob.scala
@@ -13,7 +13,6 @@ import org.enso.text.editing.EditorOps
 
 import java.io.File
 import java.util.UUID
-import java.util.logging.Level
 
 /** A job responsible for refactoring renaming operation.
   *
@@ -35,14 +34,12 @@ final class RefactoringRenameJob(
 
   /** @inheritdoc */
   override def runImpl(implicit ctx: RuntimeContext): Seq[File] = {
-    val logger = ctx.executionService.getLogger
     ctx.locking.withReadCompilationLock(
       this.getClass,
       () =>
         try {
-          logger.log(
-            Level.FINE,
-            s"Renaming symbol [{0}]...",
+          logger.debug(
+            s"Renaming symbol [{}]...",
             expressionId
           )
           val refactoredFile = applyRefactoringEdits()
@@ -82,6 +79,9 @@ final class RefactoringRenameJob(
         }
     )
   }
+
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(classOf[RefactoringRenameJob])
 
   private def applyRefactoringEdits()(implicit ctx: RuntimeContext): File = {
     val module = ctx.executionService.getContext

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/StartBackgroundProcessingJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/StartBackgroundProcessingJob.scala
@@ -3,8 +3,6 @@ package org.enso.interpreter.instrument.job
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
-import java.util.logging.Level
-
 /** A job responsible for starting background jobs processing. */
 final class StartBackgroundProcessingJob()
     extends Job[Unit](
@@ -19,13 +17,14 @@ final class StartBackgroundProcessingJob()
 }
 
 object StartBackgroundProcessingJob {
+  private def logger: org.slf4j.Logger =
+    org.slf4j.LoggerFactory.getLogger(getClass)
 
   /** Start background jobs execution. */
   def startBackgroundJobs()(implicit ctx: RuntimeContext): Unit = {
     val jobsStarted = ctx.jobControlPlane.startBackgroundJobs()
     if (jobsStarted) {
-      ctx.executionService.getLogger
-        .log(Level.FINE, "Background jobs started")
+      logger.debug("Background jobs started")
       ctx.endpoint.sendToClient(
         Api.Response(Api.BackgroundJobsStartedNotification())
       )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/StartBackgroundProcessingJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/StartBackgroundProcessingJob.scala
@@ -1,5 +1,7 @@
 package org.enso.interpreter.instrument.job
 
+import org.slf4j.LoggerFactory
+
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
@@ -18,7 +20,7 @@ final class StartBackgroundProcessingJob()
 
 object StartBackgroundProcessingJob {
   private def logger: org.slf4j.Logger =
-    org.slf4j.LoggerFactory.getLogger(getClass)
+    LoggerFactory.getLogger(getClass)
 
   /** Start background jobs execution. */
   def startBackgroundJobs()(implicit ctx: RuntimeContext): Unit = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -1,5 +1,7 @@
 package org.enso.interpreter.instrument.job
 
+import org.slf4j.LoggerFactory
+
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Name
@@ -27,7 +29,6 @@ import org.enso.pkg.QualifiedName
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
-import java.util.logging.Level
 
 import scala.annotation.unused
 import scala.util.Try
@@ -135,9 +136,8 @@ class UpsertVisualizationJob(
     message: String,
     executionResult: Option[Api.ExecutionResult.Diagnostic]
   )(implicit ctx: RuntimeContext): Unit = {
-    ctx.executionService.getLogger.log(
-      Level.SEVERE,
-      "Visualization for expression {0} failed: {1} (evaluation result: {2})",
+    UpsertVisualizationJob.logger.error(
+      "Visualization for expression {} failed: {} (evaluation result: {})",
       Array[Object](expressionId, message, executionResult)
     )
     ctx.endpoint.sendToClient(
@@ -158,6 +158,8 @@ class UpsertVisualizationJob(
 }
 
 object UpsertVisualizationJob {
+  private lazy val logger =
+    LoggerFactory.getLogger(classOf[UpsertVisualizationJob])
 
   /** Invalidate caches for a particular expression id. */
   sealed private case class InvalidateCaches(
@@ -306,9 +308,8 @@ object UpsertVisualizationJob {
         )
 
       case error: ThreadInterruptedException =>
-        ctx.executionService.getLogger.log(
-          Level.SEVERE,
-          "Evaluation of visualization argument [{0}] in module [{1}] was interrupted [{2}] times.",
+        UpsertVisualizationJob.logger.error(
+          "Evaluation of visualization argument [{}] in module [{}] was interrupted [{}] times.",
           Array[Object](
             argumentExpression,
             module.getName.toString,
@@ -324,9 +325,8 @@ object UpsertVisualizationJob {
         )
 
       case error =>
-        ctx.executionService.getLogger.log(
-          Level.SEVERE,
-          "Evaluation of visualization argument [{0}] failed in module [{1}] with [{2}]: {3}",
+        UpsertVisualizationJob.logger.error(
+          "Evaluation of visualization argument [{}] failed in module [{}] with [{}]: {}",
           Array[Object](
             argumentExpression,
             module.getName.toString,
@@ -387,9 +387,8 @@ object UpsertVisualizationJob {
         )
 
       case error: ThreadInterruptedException =>
-        ctx.executionService.getLogger.log(
-          Level.SEVERE,
-          "Evaluation of visualization [{0}] in module [{1}] was interrupted [{2}] times.",
+        UpsertVisualizationJob.logger.error(
+          "Evaluation of visualization [{}] in module [{}] was interrupted [{}] times.",
           Array[Object](
             expression,
             expressionModule,
@@ -405,9 +404,8 @@ object UpsertVisualizationJob {
         )
 
       case error =>
-        ctx.executionService.getLogger.log(
-          Level.SEVERE,
-          "Evaluation of visualization [{0}] failed in module [{1}] with [{2}]: {3}",
+        UpsertVisualizationJob.logger.error(
+          "Evaluation of visualization [{}] failed in module [{}] with [{}]: {}",
           Array[Object](
             expression,
             expressionModule,

--- a/engine/runtime-instrument-common/src/test/scala/org/enso/interpreter/instrument/command/SlowAttachVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/test/scala/org/enso/interpreter/instrument/command/SlowAttachVisualizationCmd.scala
@@ -5,16 +5,12 @@ import org.enso.interpreter.instrument.job.{
   UpsertVisualizationJob
 }
 import org.enso.polyglot.runtime.Runtime.Api
-import org.slf4j.LoggerFactory
 
 class SlowAttachVisualizationCmd(
   maybeRequestId: Option[Api.RequestId],
   request: Api.AttachVisualization,
   delay: Boolean
 ) extends AttachVisualizationCmd(maybeRequestId, request) {
-
-  private val logger =
-    LoggerFactory.getLogger(classOf[SlowAttachVisualizationCmd])
 
   override def upsertVisualization(
     maybeRequestId: Option[Api.RequestId],

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
@@ -6,6 +6,7 @@ import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.literal.LiteralNode;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
+import org.enso.test.utils.ContextUtils;
 import org.junit.Test;
 
 public class SequenceLiteralNodeTest {
@@ -13,6 +14,12 @@ public class SequenceLiteralNodeTest {
 
   @Test
   public void propagatePanicSentinel() {
+    try (var ctx = ContextUtils.createDefaultContext()) {
+      ContextUtils.executeInContext(ctx, this::propagatePanicSentinelImpl);
+    }
+  }
+
+  private Void propagatePanicSentinelImpl() {
     var sentinel = new PanicSentinel(new PanicException(0L, null), null);
 
     var one = LiteralNode.build(1);
@@ -29,5 +36,6 @@ public class SequenceLiteralNodeTest {
         fail("The right exception should have been propagated!");
       }
     }
+    return null;
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
@@ -47,9 +47,10 @@ public class PanicExceptionTest {
     ContextUtils.executeInContext(
         context,
         () -> {
+          var leak = ContextUtils.leakContext(context);
           var text = Text.create("Some text for the exception");
           var thrown = new java.lang.AssertionError(text.toString());
-          var ex = new PanicException(text, thrown, null);
+          var ex = new PanicException(leak, text, thrown, null);
           assertEquals(text.toString(), ex.getMessage());
           var msg = InteropLibrary.getUncached().getExceptionMessage(ex);
           assertEquals(text, msg);

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -182,7 +182,7 @@ class RuntimeAsyncCommandsTest
         |loop n s=0 =
         |    if (s > n) then s else
         |        Thread.sleep 100
-        |        loop n s+1
+        |        @Tail_Call loop n s+1
         |
         |main =
         |    IO.println "started"

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -300,8 +300,9 @@ public abstract class InvokeMethodNode extends BaseNode {
   private PanicException methodNotFound(UnresolvedSymbol symbol, Object self)
       throws PanicException {
     var cause = onBoundary ? UnknownIdentifierException.create(symbol.getName()) : null;
-    var payload = EnsoContext.get(this).getBuiltins().error().makeNoSuchMethod(self, symbol);
-    throw new PanicException(payload, cause, this);
+    var ctx = EnsoContext.get(this);
+    var payload = ctx.getBuiltins().error().makeNoSuchMethod(self, symbol);
+    throw new PanicException(ctx, payload, cause, this);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
@@ -224,7 +224,7 @@ public abstract class HostMethodCallNode extends Node {
     } catch (UnsupportedMessageException | UnknownIdentifierException e) {
       CompilerDirectives.transferToInterpreter();
       var err = ctx.getBuiltins().error().makeNotInvokable(self);
-      throw new PanicException(err, e, this);
+      throw new PanicException(ctx, err, e, this);
     } catch (ArityException e) {
       var err =
           ctx.getBuiltins()
@@ -275,7 +275,7 @@ public abstract class HostMethodCallNode extends Node {
       CompilerDirectives.transferToInterpreter();
       var ctx = EnsoContext.get(this);
       var err = ctx.getBuiltins().error().makeNotInvokable(self);
-      throw new PanicException(err, e, this);
+      throw new PanicException(ctx, err, e, this);
     } catch (ArityException e) {
       throw new PanicException(
           EnsoContext.get(this)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -245,7 +245,7 @@ public final class EnsoContext {
   }
 
   /**
-   * Enters this context and then executes provide {@code action}.
+   * Enters this context and then executes provided {@code action}.
    *
    * @param <T> type the action computes
    * @param who the node who's asking to perform the action

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -245,6 +245,28 @@ public final class EnsoContext {
   }
 
   /**
+   * Enters this context and then executes provide {@code action}.
+   *
+   * @param <T> type the action computes
+   * @param who the node who's asking to perform the action
+   * @param action the action to execute
+   * @return returns the value of the {@code action}
+   */
+  public final <T> T withinCtx(Node who, Supplier<T> action) {
+    var tc = environment.getContext();
+    if (tc.isActive()) {
+      return action.get();
+    } else {
+      var prev = tc.enter(who);
+      try {
+        return action.get();
+      } finally {
+        tc.leave(who, prev);
+      }
+    }
+  }
+
+  /**
    * @param node the location of context access. Pass {@code null} if not in a node.
    * @return the proper context instance for the current {@link
    *     com.oracle.truffle.api.TruffleContext}.
@@ -895,8 +917,14 @@ public final class EnsoContext {
 
   /** Set the runtime execution environment of this context. */
   public void setExecutionEnvironment(ExecutionEnvironment executionEnvironment) {
-    this.globalExecutionEnvironment = executionEnvironment;
-    language.setExecutionEnvironment(executionEnvironment);
+    var tc = environment.getContext();
+    var prev = tc.enter(null);
+    try {
+      this.globalExecutionEnvironment = executionEnvironment;
+      language.setExecutionEnvironment(executionEnvironment);
+    } finally {
+      tc.leave(null, prev);
+    }
   }
 
   /**
@@ -966,10 +994,15 @@ public final class EnsoContext {
     return environment.isCreateThreadAllowed();
   }
 
+  private int threadCounter;
+
   public Thread createThread(boolean systemThread, Runnable run) {
-    return systemThread
-        ? environment.createSystemThread(run)
-        : environment.newTruffleThreadBuilder(run).build();
+    if (systemThread) {
+      var t = new Thread(run, "Enso thread #" + ++threadCounter);
+      return t;
+    } else {
+      return environment.newTruffleThreadBuilder(run).build();
+    }
   }
 
   public Future<Void> submitThreadLocal(Thread[] threads, ThreadLocalAction action) {
@@ -1023,7 +1056,7 @@ public final class EnsoContext {
       msg = msg + sep + message;
     }
     var err = getBuiltins().error().makeAssertionError(msg);
-    throw new PanicException(err, e, node);
+    throw new PanicException(this, err, e, node);
   }
 
   private <T> T getOption(OptionKey<T> key) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ManagedResource.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ManagedResource.java
@@ -85,14 +85,14 @@ public final class ManagedResource extends BuiltinObject {
               + " object is garbage collected.")
   @Builtin.Specialize
   public static ManagedResource register_builtin(
-      EnsoContext context, Object obj, Function function, boolean systemCanFinalize) {
+      EnsoContext ctx, Object obj, Function function, boolean systemCanFinalize) {
     if (obj instanceof TruffleObject resource) {
-      return context.getResourceManager().register(resource, function, systemCanFinalize);
+      return ctx.getResourceManager().register(resource, function, systemCanFinalize);
     } else {
-      var error = context.getBuiltins().error();
+      var error = ctx.getBuiltins().error();
       var msg = "Cannot manage non-resource object";
       var payload = error.makeUnsupportedArgumentsError(new Object[] {obj}, msg);
-      throw new PanicException(payload, null);
+      throw new PanicException(ctx, payload, null, null);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -40,6 +40,7 @@ public final class DataflowError extends AbstractTruffleException {
   /** Signals (local) values that haven't yet been initialized */
   public static final DataflowError UNINITIALIZED = new DataflowError(null, (Node) null);
 
+  private final EnsoContext ctx;
   private final Object payload;
   private final boolean ownTrace;
 
@@ -98,18 +99,21 @@ public final class DataflowError extends AbstractTruffleException {
     super(null, null, 1, location);
     this.payload = payload;
     this.ownTrace = location != null && location.getRootNode() != null;
+    this.ctx = EnsoContext.get(location);
   }
 
   private DataflowError(Object payload, AbstractTruffleException prototype) {
     super(prototype);
     this.payload = payload;
     this.ownTrace = false;
+    this.ctx = prototype instanceof PanicException panic ? panic.ctx() : null;
   }
 
   private DataflowError(Object payload, int stackTraceElementLimit, Node location) {
     super(null, null, stackTraceElementLimit, location);
     this.ownTrace = false;
     this.payload = payload;
+    this.ctx = EnsoContext.get(location);
   }
 
   /**
@@ -119,6 +123,15 @@ public final class DataflowError extends AbstractTruffleException {
    */
   public final Object getPayload() {
     return payload != null ? payload : Text.create("Uninitialized value");
+  }
+
+  /**
+   * Obtains associated context, if any.
+   *
+   * @return associated context or {@code null}
+   */
+  final EnsoContext ctx() {
+    return ctx;
   }
 
   /**
@@ -166,11 +179,12 @@ public final class DataflowError extends AbstractTruffleException {
   @ExportMessage
   Object getExceptionMessage(
       @Cached IndirectInvokeMethodNode payloads,
-      @Cached(value = "toDisplayText(this.getPayload(), payloads)", allowUncached = true)
+      @Cached(value = "toDisplayText(this.ctx(), payloads)", allowUncached = true)
           UnresolvedSymbol toDisplayText,
       @CachedLibrary(limit = "3") InteropLibrary strings,
       @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
-    return handleExceptionMessage(payload, payloads, toDisplayText, strings, typeToDisplayTextNode);
+    return handleExceptionMessage(
+        payload, ctx(), payloads, toDisplayText, strings, typeToDisplayTextNode);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -17,6 +17,7 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import org.enso.interpreter.node.BaseNode.TailStatus;
 import org.enso.interpreter.node.callable.IndirectInvokeMethodNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "payload")
 @ExportLibrary(TypesLibrary.class)
 public final class PanicException extends AbstractTruffleException {
+  private EnsoContext ctx;
   final Object payload;
   private String cacheMessage;
   private EnsoObject stackTrace;
@@ -52,20 +54,22 @@ public final class PanicException extends AbstractTruffleException {
    * @param location the node throwing this exception, for use in guest stack traces
    */
   public PanicException(Object payload, Node location) {
-    this(payload, null, location);
+    this(EnsoContext.get(location), payload, null, location);
   }
 
   /**
    * Creates user visible panic with additional cause.
    *
+   * @param ctx context the exception is associated with
    * @param payload arbitrary, user-provided payload carried by this exception
    * @param cause additional exception to carry information about the panic
    * @param location the node throwing this exception, for use in guest stack traces
    */
-  public PanicException(Object payload, Throwable cause, Node location) {
+  public PanicException(EnsoContext ctx, Object payload, Throwable cause, Node location) {
     super(null, cause, UNLIMITED_STACK_TRACE, location);
     assert InteropLibrary.isValidValue(payload) : "Only interop values are supported: " + payload;
     this.payload = payload;
+    this.ctx = ctx;
   }
 
   /**
@@ -83,6 +87,15 @@ public final class PanicException extends AbstractTruffleException {
       return computeMessage();
     }
     return cacheMessage;
+  }
+
+  /**
+   * Obtains associated context, if any.
+   *
+   * @return associated context or {@code null}
+   */
+  final EnsoContext ctx() {
+    return ctx;
   }
 
   @CompilerDirectives.TruffleBoundary
@@ -133,18 +146,8 @@ public final class PanicException extends AbstractTruffleException {
   }
 
   @NeverDefault
-  static UnresolvedSymbol toDisplayText(Object payload, IndirectInvokeMethodNode payloads)
+  static UnresolvedSymbol toDisplayText(EnsoContext ctx, IndirectInvokeMethodNode payloads)
       throws UnsupportedMessageException {
-    EnsoContext ctx;
-    try {
-      ctx = EnsoContext.get(payloads);
-      if (ctx == null) {
-        throw UnsupportedMessageException.create();
-      }
-    } catch (Error | Exception e) {
-      logger().atError().log("Cannot compute message for " + payload, e);
-      throw UnsupportedMessageException.create(e instanceof AbstractTruffleException ? e : null);
-    }
     var scope = ctx.getBuiltins().panic().getDefinitionScope();
     return UnresolvedSymbol.build("to_display_text", scope);
   }
@@ -152,20 +155,40 @@ public final class PanicException extends AbstractTruffleException {
   @ExportMessage
   Object getExceptionMessage(
       @Cached IndirectInvokeMethodNode payloads,
-      @Cached(value = "toDisplayText(this.getPayload(), payloads)", allowUncached = true)
+      @Cached(value = "toDisplayText(this.ctx(), payloads)", allowUncached = true)
           UnresolvedSymbol toDisplayText,
       @CachedLibrary(limit = "3") InteropLibrary strings,
       @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
-    return handleExceptionMessage(payload, payloads, toDisplayText, strings, typeToDisplayTextNode);
+    return handleExceptionMessage(
+        payload, ctx(), payloads, toDisplayText, strings, typeToDisplayTextNode);
   }
 
+  @CompilerDirectives.TruffleBoundary
   static Object handleExceptionMessage(
       Object payload,
+      EnsoContext ctx,
       IndirectInvokeMethodNode payloads,
       UnresolvedSymbol toDisplayText,
       InteropLibrary strings,
       TypeToDisplayTextNode typeToDisplayTextNode) {
-    var ctx = EnsoContext.get(payloads);
+    Supplier<Object> action =
+        () ->
+            findExceptionMessage(
+                payload, ctx, payloads, toDisplayText, strings, typeToDisplayTextNode);
+    if (ctx != null) {
+      return ctx.withinCtx(payloads, action);
+    } else {
+      return action.get();
+    }
+  }
+
+  private static Object findExceptionMessage(
+      Object payload,
+      EnsoContext ctx,
+      IndirectInvokeMethodNode payloads,
+      UnresolvedSymbol toDisplayText,
+      InteropLibrary strings,
+      TypeToDisplayTextNode typeToDisplayTextNode) {
     var text =
         payloads.execute(
             null,
@@ -226,7 +249,11 @@ public final class PanicException extends AbstractTruffleException {
   @CompilerDirectives.TruffleBoundary
   final Object getExceptionStackTrace(@Bind("$node") Node queryNode) {
     if (stackTrace == null) {
-      stackTrace = computeStackTrace(queryNode);
+      if (ctx != null) {
+        stackTrace = ctx.withinCtx(queryNode, () -> computeStackTrace(queryNode));
+      } else {
+        stackTrace = computeStackTrace(queryNode);
+      }
     }
     return stackTrace;
   }

--- a/lib/scala/logging-service-logback/src/test/java/org/enso/logging/service/logback/test/provider/TestLogProvider.java
+++ b/lib/scala/logging-service-logback/src/test/java/org/enso/logging/service/logback/test/provider/TestLogProvider.java
@@ -22,7 +22,10 @@ public class TestLogProvider implements SLF4JServiceProvider {
     assert factory instanceof LoggerContext;
     if (!initialized) {
       try {
-        new LogbackSetup((LoggerContext) factory).setup();
+        var setup = new LogbackSetup((LoggerContext) factory);
+        setup.setup();
+        // useful when exceptions are being swallowed in tests
+        // setup.setupConsoleAppender(Level.WARN);
         initialized = true;
       } catch (MissingConfigurationField e) {
         throw new RuntimeException(e);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/CachedPropertyCheck.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/CachedPropertyCheck.java
@@ -3,10 +3,11 @@ package org.enso.table.data.column.operation;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CachedPropertyCheck<T> {
 
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(CachedPropertyCheck.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CachedPropertyCheck.class);
 
   private final CompletableFuture<T> cachedFuture;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -12,12 +12,9 @@ import org.enso.table.data.column.operation.map.text.StringIsInOp;
 import org.enso.table.data.column.operation.map.text.StringStringOp;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
-import org.slf4j.Logger;
 
 /** A column storing strings. */
 public final class StringStorage extends SpecializedStorage<String> {
-
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(StringStorage.class);
 
   record DataQualityMetrics(Long untrimmedCount, Long whitespaceCount) {}
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/BigDecimalStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/BigDecimalStorage.java
@@ -21,12 +21,9 @@ import org.enso.table.data.column.operation.map.numeric.comparisons.LessComparis
 import org.enso.table.data.column.operation.map.numeric.comparisons.LessOrEqualComparison;
 import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.type.BigDecimalType;
-import org.slf4j.Logger;
 
 public final class BigDecimalStorage extends SpecializedStorage<BigDecimal>
     implements NumericFormattingStorage {
-
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(BigDecimalStorage.class);
 
   private CachedPropertyCheck<Boolean> isNumericFormatRequired;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/BigIntegerStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/BigIntegerStorage.java
@@ -24,12 +24,9 @@ import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
-import org.slf4j.Logger;
 
 public class BigIntegerStorage extends SpecializedStorage<BigInteger>
     implements NumericFormattingStorage {
-
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(BigIntegerStorage.class);
 
   private CachedPropertyCheck<Boolean> isNumericFormatRequired;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -41,13 +41,10 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
-import org.slf4j.Logger;
 
 /** A column containing floating point numbers. */
 public final class DoubleStorage extends Storage<Double>
     implements ColumnDoubleStorage, ColumnStorageWithNothingMap, NumericFormattingStorage {
-
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(DoubleStorage.class);
 
   final double[] data;
   final BitSet isNothing;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -21,13 +21,10 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
-import org.slf4j.Logger;
 
 /** A column storing 64-bit integers. */
 public final class LongStorage extends AbstractLongStorage
     implements ColumnStorageWithNothingMap, NumericFormattingStorage {
-
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(LongStorage.class);
 
   // TODO [RW] at some point we will want to add separate storage classes for byte, short and int,
   // for more compact storage and more efficient handling of smaller integers; for now we will be

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -24,11 +24,12 @@ import org.enso.base.cache.ReloadDetector;
 import org.enso.table.excel.xssfreader.XSSFReaderWorkbook;
 import org.enso.table.util.FunctionWithException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
   public static final ExcelConnectionPool INSTANCE = new ExcelConnectionPool();
 
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ExcelConnectionPool.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExcelConnectionPool.class);
 
   private ExcelConnectionPool() {
     ReloadDetector.register(this);


### PR DESCRIPTION
### Pull Request Description

- based on experiments made in #12613 that are by themselves motivated by #12500
- `TruffleLogger` shall **only be used** in the interpreter running _guest code_
- most of the code in `runtime-instrument-xyz` projects is **not** running a _guest code_
- most of the code in these instruments schedules runs of _guest code_
- thus using `TruffleLogger` isn't appropriate and it yields exception when it cannot find `EnsoContext` around
- let's make the code ready for _context_ **not being around**
- let's use SLF4J instead of `TruffleLogger`


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests updated to continue to pass 