### PR TITLE
Fix booting of native language server

### DIFF
--- a/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reflect-config.json
+++ b/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reflect-config.json
@@ -254,6 +254,15 @@
   "queryAllPublicMethods":true
 },
 {
+  "name":"com.sun.management.OperatingSystemMXBean",
+  "methods": [
+    {
+      "name": "getTotalPhysicalMemorySize",
+      "parameterTypes": []
+    }
+  ]
+},
+{
   "name":"com.sun.management.VMOption",
   "queryAllPublicMethods":true
 },


### PR DESCRIPTION
Follow-up of #12620

### Pull Request Description

#12620 broken booting of NI LS:
```
Exception in thread "main" javax.management.RuntimeErrorException: org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively invoke method public default long com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize() without it being registered for runtime reflection. Add public default long com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
        at java.management@21.0.2/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrow(DefaultMBeanServerInterceptor.java:821)
[INFO] [2025-03-25T12:55:55.688] [org.enso.languageserver.boot.LanguageServerComponent] Starting Language Server...
        at java.management@21.0.2/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrowMaybeMBeanException(DefaultMBeanServerInterceptor.java:832)
        at java.management@21.0.2/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttribute(DefaultMBeanServerInterceptor.java:640)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.JmxMBeanServer.getAttribute(JmxMBeanServer.java:679)
        at org.enso.languageserver.boot.MainModule.initialTelemetry(MainModule.scala:545)
        at org.enso.languageserver.boot.MainModule.<init>(MainModule.scala:85)
        at org.enso.languageserver.boot.LanguageServerComponent.start(LanguageServerComponent.scala:47)
        at org.enso.languageserver.boot.LanguageServerApp$.run(LanguageServerApp.scala:37)
        at org.enso.languageserver.boot.LanguageServerApp.run(LanguageServerApp.scala)
        at org.enso.languageserver.boot.LanguageServerRunner.runLanguageServer(LanguageServerRunner.java:25)
        at org.enso.runner.common.LanguageServerApi.launchLanguageServer(LanguageServerApi.java:28)
        at org.enso.runner.Main.launch(Main.java:1495)
        at org.enso.runner.Main.launch(Main.java:1444)
        at org.enso.runner.Main.main(Main.java:1063)
Caused by: org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively invoke method public default long com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize() without it being registered for runtime reflection. Add public default long com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.forQueriedOnlyExecutable(MissingReflectionRegistrationUtils.java:72)
        at java.base@21.0.2/java.lang.reflect.Method.acquireMethodAccessor(Method.java:77)
        at java.base@21.0.2/java.lang.reflect.Method.invoke(Method.java:577)
        at java.base@21.0.2/sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:217)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.ConvertingMethod.invokeWithOpenReturn(ConvertingMethod.java:193)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.ConvertingMethod.invokeWithOpenReturn(ConvertingMethod.java:175)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.MXBeanIntrospector.invokeM2(MXBeanIntrospector.java:115)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.MXBeanIntrospector.invokeM2(MXBeanIntrospector.java:52)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.invokeM(MBeanIntrospector.java:236)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.PerInterface.getAttribute(PerInterface.java:83)
        at java.management@21.0.2/com.sun.jmx.mbeanserver.MBeanSupport.getAttribute(MBeanSupport.java:206)
        at java.management@21.0.2/javax.management.StandardMBean.getAttribute(StandardMBean.java:372)
        at java.management@21.0.2/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttribute(DefaultMBeanServerInterceptor.java:636)
        ... 11 more
```

This PR fixes that - adds the necessary method to reflect config.

This time, I have manually tested:
```
$ env ENSO_LAUNCHER=native ./run --skip-version-check ide build --mode staging
$ ./dist/ide/enso-linux-x86_64-0.0.0-dev.AppImage
```

Collected telemetry seems OK:
![Pasted image](https://github.com/user-attachments/assets/908d90ac-6bbb-4ff8-bf4a-8bc25ec87c90)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
