### PR TITLE
Append x-ide-version to all requests to the backend

### DIFF
--- a/app/gui/src/ReactRoot.tsx
+++ b/app/gui/src/ReactRoot.tsx
@@ -28,14 +28,28 @@ function resolveEnvUrl(url: string | undefined) {
   return url?.replace('__HOSTNAME__', window.location.hostname)
 }
 
+function generateSessionID() {
+  const sessionID = sessionStorage.getItem('sessionID')
+  if (sessionID) {
+    return sessionID
+  }
+
+  const newSessionID = crypto.randomUUID()
+  sessionStorage.setItem('sessionID', newSessionID)
+  return newSessionID
+}
+
 /**
  * A component gathering all views written currently in React with necessary contexts.
  */
 export default function ReactRoot(props: ReactRootProps) {
   const { config, queryClient, onAuthenticated } = props
 
+  const sessionID = generateSessionID()
+
   const httpClient = new HttpClient({
-    'x-ide-version': $config.VERSION ?? '',
+    'x-enso-ide-version': $config.VERSION ?? '',
+    'x-enso-session-id': sessionID,
   })
 
   const supportsDeepLinks = !IS_DEV_MODE && !isOnLinux() && isOnElectron()

--- a/app/gui/src/ReactRoot.tsx
+++ b/app/gui/src/ReactRoot.tsx
@@ -34,7 +34,9 @@ function resolveEnvUrl(url: string | undefined) {
 export default function ReactRoot(props: ReactRootProps) {
   const { config, queryClient, onAuthenticated } = props
 
-  const httpClient = new HttpClient()
+  const httpClient = new HttpClient({
+    'x-ide-version': $config.VERSION ?? '',
+  })
 
   const supportsDeepLinks = !IS_DEV_MODE && !isOnLinux() && isOnElectron()
 


### PR DESCRIPTION
### Pull Request Description

This PR adds a header, that attaches the IDE version to every request on the Dashboard for better logging on the backend.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
