### PR TITLE
Confirm overwritting files in file browser widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - [Output port ‘plus’ button is hidden if there are existing outgoing
   connections][12576]
 - [Navigate up button for file browser and collapsed components][12603]
+- [File Browser Widget warns when trying to override an existing file][12644]
 
 [11889]: https://github.com/enso-org/enso/pull/11889
 [11836]: https://github.com/enso-org/enso/pull/11836
@@ -88,6 +89,7 @@
 [12502]: https://github.com/enso-org/enso/pull/12502
 [12576]: https://github.com/enso-org/enso/pull/12576
 [12603]: https://github.com/enso-org/enso/pull/12603
+[12644]: https://github.com/enso-org/enso/pull/12644
 
 #### Enso Standard Library
 

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -27,6 +27,7 @@ import Backend, {
   assetIsDatalink,
   assetIsDirectory,
   assetIsFile,
+  AssetType,
 } from 'enso-common/src/services/Backend'
 import { computed, onMounted, reactive, ref, toRef, toValue, watch } from 'vue'
 
@@ -70,6 +71,7 @@ const {
   initializeStack,
   enterSubdirectories,
   isDirectoryStackInitializing,
+  assetExists,
 } = useFileBrowserStack(
   backend,
   toRef(props, 'choosenPath'),
@@ -114,10 +116,6 @@ const isEmpty = computed(
   () => directories.value?.length === 0 && files.value?.length === 0 && editedAsset.value == null,
 )
 
-function fileExists(title: string) {
-  return files.value?.some((file) => file.title === title)
-}
-
 // === Prefetching ===
 
 watch(directories, (directories) => {
@@ -157,7 +155,8 @@ const askForOverwrite = ref(false)
 
 async function tryAcceptCurrentFile() {
   await enterSubdirectories()
-  if (fileExists(filenameInputContents.value) && props.writeMode) {
+  const assetInfo = await assetExists(filenameInputContents.value)
+  if (assetInfo.exists && assetInfo.type === AssetType.file && props.writeMode) {
     askForOverwrite.value = true
   } else {
     acceptCurrentFile()

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -152,12 +152,19 @@ function chooseFile(file: FileAsset | DatalinkAsset) {
 }
 
 const askForOverwrite = ref(false)
+const warningText = ref<string | null>(null)
 
 async function tryAcceptCurrentFile() {
-  await enterSubdirectories()
+  const enteringResult = await enterSubdirectories()
+  if (!enteringResult.ok) {
+    warningText.value = `${enteringResult.error.payload.toString()}`
+    return
+  }
   const assetInfo = await assetExists(filenameInputContents.value)
   if (assetInfo.exists && assetInfo.type === AssetType.file && props.writeMode) {
     askForOverwrite.value = true
+  } else if (assetInfo.exists && assetInfo.type === AssetType.directory) {
+    warningText.value = `'${filenameInputContents.value}' is a directory, not a file`
   } else {
     acceptCurrentFile()
   }
@@ -176,6 +183,10 @@ function overwriteConfirmed() {
 
 function overwriteCancelled() {
   askForOverwrite.value = false
+}
+
+function warningDismissed() {
+  warningText.value = null
 }
 
 const isBusy = computed(() => isDirectoryStackInitializing.value || isPending.value)
@@ -294,6 +305,10 @@ onMounted(() => {
         <SvgButton class="confirmationButton" label="No" @click.stop="overwriteCancelled" />
         <SvgButton class="confirmationButton" label="Yes" @click.stop="overwriteConfirmed" />
       </div>
+    </div>
+    <div v-if="warningText" class="confirmationModal">
+      <div class="confirmationText">{{ 'Warning: ' + warningText }}</div>
+      <SvgButton class="confirmationButton" label="Dismiss" @click.stop="warningDismissed" />
     </div>
     <div class="topBar">
       <div class="directoryStack">

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -272,10 +272,10 @@ onMounted(() => {
 
 <template>
   <div class="FileBrowserWidget">
-    <div class="confirmationModal">
-      <span class="confirmationText">{{
-        `File '${currentFilePath ?? ''}' already exists. Overwrite?`
-      }}</span>
+    <div v-if="askForOverwrite" class="confirmationModal">
+      <div class="confirmationText">
+        {{ `File '${filenameInputContents ?? ''}' already exists. Overwrite?` }}
+      </div>
       <div class="confirmationButtons">
         <SvgButton class="confirmationButton" label="No" @click.stop="overwriteCancelled" />
         <SvgButton class="confirmationButton" label="Yes" @click.stop="overwriteConfirmed" />
@@ -386,6 +386,7 @@ onMounted(() => {
   left: 0;
   width: 100%;
   height: 100%;
+  padding: 32px;
   background-color: rgba(0, 0, 0, 0.8);
   border-radius: 0 0 var(--radius-default) var(--radius-default);
   display: flex;
@@ -397,11 +398,15 @@ onMounted(() => {
 
 .confirmationText {
   color: white;
+  text-align: center;
+  font-size: 1.2em;
+  display: flex;
+  overflow: hidden;
 }
 
 .confirmationButtons {
   display: flex;
-  width: 30%;
+  width: 40%;
   flex-direction: row;
   justify-content: space-between;
 }

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -524,15 +524,7 @@ onMounted(() => {
   user-select: all;
 }
 
-.fileNameAcceptButton {
-  --color-menu-entry-hover-bg: color-mix(in oklab, var(--color-frame-selected-bg), black 10%);
-  border-radius: var(--border-radius-inner);
-  height: calc(var(--border-radius-inner) * 2);
-  margin: 0px;
-  padding: 4px 12px;
-  background-color: var(--color-frame-selected-bg);
-}
-
+.fileNameAcceptButton,
 .confirmationButton {
   --color-menu-entry-hover-bg: color-mix(in oklab, var(--color-frame-selected-bg), black 10%);
   border-radius: var(--border-radius-inner);

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -68,6 +68,7 @@ const {
   currentFilePath,
   highlightedName,
   initializeStack,
+  enterSubdirectories,
   isDirectoryStackInitializing,
 } = useFileBrowserStack(
   backend,
@@ -154,7 +155,8 @@ function chooseFile(file: FileAsset | DatalinkAsset) {
 
 const askForOverwrite = ref(false)
 
-function tryAcceptCurrentFile() {
+async function tryAcceptCurrentFile() {
+  await enterSubdirectories()
   if (fileExists(filenameInputContents.value) && props.writeMode) {
     askForOverwrite.value = true
   } else {

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -129,8 +129,6 @@ watch(directories, (directories) => {
 
 // === Interactivity ===
 
-const askForOverwrite = ref(false)
-
 function enterDir(dir: DirectoryAsset) {
   directoryStack.value.push(dir)
 }
@@ -154,6 +152,8 @@ function chooseFile(file: FileAsset | DatalinkAsset) {
   }
 }
 
+const askForOverwrite = ref(false)
+
 function tryAcceptCurrentFile() {
   if (fileExists(filenameInputContents.value) && props.writeMode) {
     askForOverwrite.value = true
@@ -166,6 +166,15 @@ function acceptCurrentFile() {
   if (currentFilePath.value) {
     emit('pathAccepted', currentFilePath.value)
   }
+}
+
+function overwriteConfirmed() {
+  askForOverwrite.value = false
+  acceptCurrentFile()
+}
+
+function overwriteCancelled() {
+  askForOverwrite.value = false
 }
 
 const isBusy = computed(() => isDirectoryStackInitializing.value || isPending.value)
@@ -261,15 +270,6 @@ const renameAction: Action = {
   description: 'Rename directory',
   disabled: computed(() => focusedDirectory.value == null || editedAsset.value != null),
   action: () => focusedDirectory.value && renameDirectory(focusedDirectory.value),
-}
-
-function overwriteConfirmed() {
-  askForOverwrite.value = false
-  acceptCurrentFile()
-}
-
-function overwriteCancelled() {
-  askForOverwrite.value = false
 }
 
 // === Initialization ===

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -251,6 +251,14 @@ const renameAction: Action = {
   action: () => focusedDirectory.value && renameDirectory(focusedDirectory.value),
 }
 
+function overwriteConfirmed() {
+  console.log('overwriteConfirmed')
+}
+
+function overwriteCancelled() {
+  console.log('overwriteCancelled')
+}
+
 // === Initialization ===
 
 onMounted(() => {
@@ -264,6 +272,15 @@ onMounted(() => {
 
 <template>
   <div class="FileBrowserWidget">
+    <div class="confirmationModal">
+      <span class="confirmationText">{{
+        `File '${currentFilePath ?? ''}' already exists. Overwrite?`
+      }}</span>
+      <div class="confirmationButtons">
+        <SvgButton class="confirmationButton" label="No" @click.stop="overwriteCancelled" />
+        <SvgButton class="confirmationButton" label="Yes" @click.stop="overwriteConfirmed" />
+      </div>
+    </div>
     <div class="topBar">
       <div class="directoryStack">
         <SvgButton name="navigate_up" title="Up" :disabled="!canPop" @click.stop="popDirectory" />
@@ -363,6 +380,32 @@ onMounted(() => {
   flex-direction: column;
 }
 
+.confirmationModal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 0 0 var(--radius-default) var(--radius-default);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirmationText {
+  color: white;
+}
+
+.confirmationButtons {
+  display: flex;
+  width: 30%;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 .topBar {
   color: white;
   background-color: var(--background-color);
@@ -448,6 +491,15 @@ onMounted(() => {
 }
 
 .fileNameAcceptButton {
+  --color-menu-entry-hover-bg: color-mix(in oklab, var(--color-frame-selected-bg), black 10%);
+  border-radius: var(--border-radius-inner);
+  height: calc(var(--border-radius-inner) * 2);
+  margin: 0px;
+  padding: 4px 12px;
+  background-color: var(--color-frame-selected-bg);
+}
+
+.confirmationButton {
   --color-menu-entry-hover-bg: color-mix(in oklab, var(--color-frame-selected-bg), black 10%);
   border-radius: var(--border-radius-inner);
   height: calc(var(--border-radius-inner) * 2);

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -113,6 +113,10 @@ const isEmpty = computed(
   () => directories.value?.length === 0 && files.value?.length === 0 && editedAsset.value == null,
 )
 
+function fileExists(title: string) {
+  return files.value?.some((file) => file.title === title)
+}
+
 // === Prefetching ===
 
 watch(directories, (directories) => {
@@ -124,6 +128,8 @@ watch(directories, (directories) => {
 })
 
 // === Interactivity ===
+
+const askForOverwrite = ref(false)
 
 function enterDir(dir: DirectoryAsset) {
   directoryStack.value.push(dir)
@@ -148,11 +154,17 @@ function chooseFile(file: FileAsset | DatalinkAsset) {
   }
 }
 
+function tryAcceptCurrentFile() {
+  if (fileExists(filenameInputContents.value) && props.writeMode) {
+    askForOverwrite.value = true
+  } else {
+    acceptCurrentFile()
+  }
+}
+
 function acceptCurrentFile() {
   if (currentFilePath.value) {
     emit('pathAccepted', currentFilePath.value)
-  } else {
-    return false
   }
 }
 
@@ -252,11 +264,12 @@ const renameAction: Action = {
 }
 
 function overwriteConfirmed() {
-  console.log('overwriteConfirmed')
+  askForOverwrite.value = false
+  acceptCurrentFile()
 }
 
 function overwriteCancelled() {
-  console.log('overwriteCancelled')
+  askForOverwrite.value = false
 }
 
 // === Initialization ===
@@ -352,13 +365,13 @@ onMounted(() => {
         @keydown.delete.stop
         @keydown.arrow-left.stop
         @keydown.arrow-right.stop
-        @keydown.enter.stop="acceptCurrentFile()"
+        @keydown.enter.stop="tryAcceptCurrentFile"
       />
       <SvgButton
         class="fileNameAcceptButton"
         label="Ok"
         :disabled="!filenameInputContents"
-        @click.stop="acceptCurrentFile"
+        @click.stop="tryAcceptCurrentFile"
       />
     </div>
   </div>

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/paths.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/paths.test.ts
@@ -55,7 +55,7 @@ const MOCK_FS: Record<string, { type: AnyAsset['type']; name: string; contents: 
   '4': {
     type: AssetType.directory,
     name: 'New Folder 1',
-    contents: ['6'],
+    contents: ['6', '7'],
   },
   '5': {
     type: AssetType.file,
@@ -65,6 +65,16 @@ const MOCK_FS: Record<string, { type: AnyAsset['type']; name: string; contents: 
   '6': {
     type: AssetType.file,
     name: 'input.csv',
+    contents: [],
+  },
+  '7': {
+    type: AssetType.directory,
+    name: 'Nested',
+    contents: ['8'],
+  },
+  '8': {
+    type: AssetType.file,
+    name: 'test.txt',
     contents: [],
   },
 }
@@ -148,7 +158,7 @@ test.each`
 )
 
 test.each`
-  initialPath                                       | expectedInputContets
+  initialPath                                       | expectedInputContents
   ${''}                                             | ${''}
   ${''}                                             | ${''}
   ${'enso://Users/user/input.csv'}                  | ${'input.csv'}
@@ -157,7 +167,7 @@ test.each`
   ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${''}
 `(
   'Initial input content in write mode $initialPath',
-  async ({ initialPath, expectedInputContets }) => {
+  async ({ initialPath, expectedInputContents }) => {
     const { initializeStack, filenameInputContents, highlightedName } = fixture(
       'enso://',
       '0',
@@ -165,8 +175,8 @@ test.each`
       true,
     )
     await initializeStack(MOCK_USER, MOCK_ORGANIZATION_INFO)
-    expect(filenameInputContents.value).toBe(expectedInputContets)
-    expect(highlightedName.value).toBe(expectedInputContets)
+    expect(filenameInputContents.value).toBe(expectedInputContents)
+    expect(highlightedName.value).toBe(expectedInputContents)
   },
 )
 
@@ -191,5 +201,36 @@ test.each`
         expected ? 'input.csv' : undefined,
       )
     }
+  },
+)
+
+test.each`
+  initialInputContents                  | expectedStack                | expectedInputContents
+  ${''}                                 | ${['0', '1', '3']}           | ${''}
+  ${'New Folder 1'}                     | ${['0', '1', '3']}           | ${'New Folder 1'}
+  ${'New Folder 1/input.csv'}           | ${['0', '1', '3', '4']}      | ${'input.csv'}
+  ${'New Folder 1/Nested/test.txt'}     | ${['0', '1', '3', '4', '7']} | ${'test.txt'}
+  ${'New Folder 1/Nested/non-existent'} | ${['0', '1', '3', '4', '7']} | ${'non-existent'}
+  ${'New Folder 1/invalid/test.txt'}    | ${['0', '1', '3', '4']}      | ${'invalid/test.txt'}
+`(
+  'Enter subdirectories (input: $initialInputContents)',
+  async ({ initialInputContents, expectedStack, expectedInputContents }) => {
+    const { initializeStack, filenameInputContents, enterSubdirectories, directoryStack } = fixture(
+      'enso://',
+      '0',
+      '',
+      true,
+    )
+    await initializeStack(MOCK_USER, MOCK_ORGANIZATION_INFO)
+    filenameInputContents.value = initialInputContents
+    await enterSubdirectories()
+    const expectedStackStructure = expectedStack.map((id: string, index: number) =>
+      expect.objectContaining({
+        id: id as DirectoryId,
+        title: index === 0 ? 'Cloud' : MOCK_FS[id]?.name,
+      }),
+    )
+    expect(directoryStack.value).toEqual(expectedStackStructure)
+    expect(filenameInputContents.value).toBe(expectedInputContents)
   },
 )

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/paths.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/paths.test.ts
@@ -234,3 +234,20 @@ test.each`
     expect(filenameInputContents.value).toBe(expectedInputContents)
   },
 )
+
+test.each`
+  initialPath                         | inputContents     | expectedResult
+  ${''}                               | ${''}             | ${{ exists: false }}
+  ${''}                               | ${'input.csv'}    | ${{ exists: true, type: AssetType.file }}
+  ${'enso://Users/user/New Folder 1'} | ${'input.csv'}    | ${{ exists: true, type: AssetType.file }}
+  ${'enso://Users/user/New Folder 1'} | ${'non-existent'} | ${{ exists: false }}
+  ${'enso://Users/user/New Folder 1'} | ${'Nested'}       | ${{ exists: true, type: AssetType.directory }}
+`(
+  'File exists (path: $initialPath, input: $inputContents)',
+  async ({ initialPath, inputContents, expectedResult }) => {
+    const { initializeStack, assetExists } = fixture('enso://', '0', initialPath, true)
+    await initializeStack(MOCK_USER, MOCK_ORGANIZATION_INFO)
+    const exists = await assetExists(inputContents)
+    expect(exists).toEqual(expectedResult)
+  },
+)

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
@@ -134,7 +134,7 @@ export function useFileBrowserStack(
   }
 
   /** Split `filenameInputContents` into subdirectories by `/` and enter them, up to last existing directory. */
-  async function enterSubdirectories() {
+  async function enterSubdirectories(): Promise<Result<void, CannotEnterDir>> {
     let nextSlash = filenameInputContents.value.indexOf('/')
     while (nextSlash !== -1) {
       const directoryName = filenameInputContents.value.slice(0, nextSlash)
@@ -143,9 +143,10 @@ export function useFileBrowserStack(
         filenameInputContents.value = filenameInputContents.value.slice(nextSlash + 1)
         nextSlash = filenameInputContents.value.indexOf('/')
       } else {
-        break
+        return result
       }
     }
+    return Ok()
   }
 
   function dirsToEnterOnInit(user: User) {

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
@@ -122,6 +122,21 @@ export function useFileBrowserStack(
     return Ok()
   }
 
+  /** Split `filenameInputContents` into subdirectories by `/` and enter them, up to last existing directory. */
+  async function enterSubdirectories() {
+    let nextSlash = filenameInputContents.value.indexOf('/')
+    while (nextSlash !== -1) {
+      const directoryName = filenameInputContents.value.slice(0, nextSlash)
+      const result = await enterDirByName(directoryName, directoryStack.value)
+      if (result.ok) {
+        filenameInputContents.value = filenameInputContents.value.slice(nextSlash + 1)
+        nextSlash = filenameInputContents.value.indexOf('/')
+      } else {
+        break
+      }
+    }
+  }
+
   function dirsToEnterOnInit(user: User) {
     const initialSegments = unwrapOr(choosenPathSegments.value, ['Users', user.name])
     const rootSegs = unwrapOrWithLog(rootSegments.value ?? Err('cannot load root directory'), [])
@@ -176,6 +191,7 @@ export function useFileBrowserStack(
     currentFilePath,
     highlightedName,
     initializeStack,
+    enterSubdirectories,
     isDirectoryStackInitializing,
   }
 }

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
@@ -108,6 +108,17 @@ export function useFileBrowserStack(
       `${currentPath.value}${filenameInputContents.value}`,
   )
 
+  type AssetExists = { exists: true; type: AssetType } | { exists: false }
+
+  async function assetExists(name: string): Promise<AssetExists> {
+    const currentDir = directoryStack.value[directoryStack.value.length - 1]
+    if (currentDir == null) return { exists: false }
+    const content = await listDirectory(currentDir)
+    const asset = content.find((asset) => asset.title === name)
+    if (!asset) return { exists: false }
+    return { exists: true, type: asset.type }
+  }
+
   async function enterDirByName(
     name: string,
     stack: Directory[],
@@ -190,6 +201,7 @@ export function useFileBrowserStack(
     currentPath,
     currentFilePath,
     highlightedName,
+    assetExists,
     initializeStack,
     enterSubdirectories,
     isDirectoryStackInitializing,


### PR DESCRIPTION
### Pull Request Description

Closes #12114

- Confirmation modal when targeting existing file
- Entering subdirectories by typing path with slashes in the input box
- Warning modal when targeting wrong asset type/non-existing directories

See video for overview of the features:

https://github.com/user-attachments/assets/8d574cd3-4f8f-423b-a0c2-fdb55be26ccc

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
