### PR TITLE
Rely on ThreadManager when interrupting Enso execution

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
@@ -23,11 +23,7 @@ class InterruptContextCmd(
   ): Future[Unit] =
     if (doesContextExist) {
       Future {
-        ctx.jobControlPlane.abortJobs(
-          request.contextId,
-          "interrupt context",
-          false
-        )
+        ctx.executionService.getContext.getThreadManager.interruptThreads()
         reply(Api.InterruptContextResponse(request.contextId))
       }
     } else {


### PR DESCRIPTION
### Pull Request Description

There is `ThreadManager` responsible for managing _Truffle guest_ threads inside of a single `EnsoContext`. Rather than relying on direct `Thread.interrupt`, let's delegate to `ThreadManager.interruptThreads()` and let it do its best to interrupt existing _Truffle guest_ threads.

The current behavior of `ThreadManager.interruptThreads()` relies on [TruffleSafepoint action](https://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/TruffleSafepoint.html). If that's not enough, the `interruptThreads` can be enhanced/changed, but it should be in full charge of _processing the interruption_.

This work is based on [notes in 12602](https://github.com/enso-org/enso/pull/12602#issuecomment-2753353944) and work on #12613 - should there really be a dedicated _thread pool_ of _Truffle guest threads_ as #12613 suggests, we need `ThreadManager` to have full control over it. This is an enabler for #12500 because https://github.com/oracle/graal/issues/10923 is said to be Enso fault and needs to be addressed before we can update to Truffle 24.2.0 and newer.
 
<!--
Closes #11576
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
    - This functionality is tested by `RuntimeAsyncCommandTest`. 
    - The test continues to work even with `ThreadManager.interruptThreads()`
    - If there is more intricate test to be written, it can be written
