### PR TITLE
Fix NI crash by updating reflection config

### DIFF
--- a/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
+++ b/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
@@ -1258,6 +1258,17 @@
         ]
     },
     {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.impl.CTDxfImpl",
+        "methods":[
+            {
+                "name": "<init>",
+                "parameterTypes": [
+                    "org.apache.xmlbeans.SchemaType"
+                ]
+            }
+        ]
+    },
+    {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.impl.CTDxfsImpl",
         "methods": [
             {


### PR DESCRIPTION
### Pull Request Description

Re-run profiling agent and one entry was weirdly missing. Testing revealed that by adding a missing entry we were able run the problematic program.
Closes #12656 