### PR TITLE
Move `from_text` to `parse`.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
@@ -20,14 +20,14 @@
     - format self format:Standard.Base.Data.Text.Text= locale:Standard.Base.Data.Locale.Locale= -> Standard.Base.Data.Text.Text
     - from_float f:Standard.Base.Data.Numbers.Float mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= explicit:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - from_integer i:Standard.Base.Data.Numbers.Integer mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Data.Decimal.Decimal
-    - from_text s:Standard.Base.Data.Text.Text mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any
+    - from_text text:Standard.Base.Data.Text.Text locale:Standard.Base.Data.Locale.Locale= format:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - internal_representation self -> (Standard.Base.Data.Vector.Vector Standard.Base.Data.Numbers.Integer)
     - max self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Data.Decimal.Decimal
     - min self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Data.Decimal.Decimal
     - multiply self that:Standard.Base.Data.Decimal.Decimal math_context:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any
     - negate self -> Standard.Base.Data.Decimal.Decimal
     - new x:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer|Standard.Base.Data.Numbers.Float) mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any
-    - parse text:Standard.Base.Data.Text.Text locale:Standard.Base.Data.Locale.Locale= format:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - parse text:Standard.Base.Data.Text.Text locale:Standard.Base.Data.Locale.Locale= format:Standard.Base.Data.Text.Text= mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any
     - pow self exp:Standard.Base.Data.Numbers.Integer -> Standard.Base.Data.Decimal.Decimal
     - precision self -> Standard.Base.Data.Numbers.Integer
     - remainder self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Data.Decimal.Decimal

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/XML.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/XML.md
@@ -20,6 +20,7 @@
     - name self -> Standard.Base.Any.Any
     - new doc:Standard.Base.Data.XML.Document -> Standard.Base.Any.Any
     - outer_xml self -> Standard.Base.Any.Any
+    - parse xml_string:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
     - root_element self -> Standard.Base.Any.Any
     - text self -> Standard.Base.Any.Any
     - to_default_visualization_data self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -36,28 +36,42 @@ from project.Metadata.Choice import Option
 from project.Metadata.Widget import File_Browse, Folder_Browse, Text_Input, Vector_Editor
 from project.System.File_Format import Auto_Detect, File_Format
 
-## ALIAS load, open
+## ALIAS csv, delimited, excel, hyper, load, open, tableau
    GROUP File
    ICON data_input
    SUGGESTED 1
    Reads a file into Enso.
+
    Uses the specified file format to parse the file into an Enso type. If not
    specified will use the file's extension to determine the file format.
 
-   Arguments:
-   - path: The path to the file to read. If the path is a URI, then the data
-     will be fetched if from a supported protocol.
+   - path: The path to the file to read. If the path is a URI, the data
+     will be fetched from a supported protocol.
    - format: A `File_Format` object used to read file into memory.
-     If `Auto_Detect` is specified; the provided file determines the specific
-     type and configures it appropriately. If there is no matching type then
-     a `File_Error.Unsupported_Type` error is returned.
-     You can use `File_Format.all` to get a list of currently loaded
-     formats.
+     If `Auto_Detect` is specified, the provided file determines the specific
+     type and configures it appropriately. A `File_Error.Unsupported_Type`
+     error is returned if it cannot match the type.
    - on_problems: Specifies the behavior when a problem occurs during the
-     function.
-     By default, a warning is issued, but the operation proceeds.
+     function. By default, a warning is issued, but the operation proceeds.
      If set to `Report_Error`, the operation fails with a dataflow error.
-     If set to `Ignore`, the operation proceeds without errors or warnings.
+     The operation proceeds without errors or warnings if set to `Ignore`.
+
+   > Example
+     Read the first sheet of an XLSX from disk and convert it into a table.
+
+         from Standard.Table import all
+         import Standard.Examples
+
+         example_xlsx_to_table = Data.read Examples.xlsx
+
+
+   > Example
+     Read the sheet named `Dates` from an XLS and convert it to a table.
+
+         from Standard.Table import all
+         import Standard.Examples
+
+         example_xls_to_table = Data.read Examples.xls (..Sheet 'Dates')
 
    ! Request Caching
 
@@ -71,22 +85,6 @@ from project.System.File_Format import Auto_Detect, File_Format
 
      The cached values are retained as long as the project remains open. Closing
      a project will clear the cache.
-
-   > Example
-     Read the first sheet of an XLSX from disk and convert it into a table.
-
-         from Standard.Table import all
-         import Standard.Examples
-
-         example_xlsx_to_table = Data.read Examples.xlsx
-
-   > Example
-     Read the sheet named `Dates` from an XLS and convert it to a table.
-
-         from Standard.Table import all
-         import Standard.Examples
-
-         example_xls_to_table = Data.read Examples.xls (..Sheet 'Dates')
 @path (Text_Input display=..Always)
 @format File_Format.default_widget
 read : Text | URI | File -> File_Format -> Problem_Behavior -> Any ! File_Error
@@ -112,16 +110,16 @@ read path=(Missing_Argument.throw "path") format=Auto_Detect (on_problems : Prob
    GROUP File
    ICON data_input
    SUGGESTED 2
-   Reads a a list of files into Enso.
+   Reads a list of files into Enso.
 
    Arguments:
    - paths: A list of files to load. It can be a Vector, Column or Table of
      files, paths or URIs to fetch. If a Table is provided, it must either
      contain a single column or a column called `path` (case insensitive).
-   - format: A `File_Format` object used to read files into memory.
-     If `Auto_Detect` is specified; each file determines the specific
-     type and configures it appropriately. If there is no matching type then
-     a `File_Error.Unsupported_Type` error is returned.
+   - format: A `File_Format` object used to read file into memory.
+     If `Auto_Detect` is specified, the provided file determines the specific
+     type and configures it appropriately. A `File_Error.Unsupported_Type`
+     error is returned if it cannot match the type.
    - return: Specifies the shape of the data to return.
    - on_problems: Specifies the behavior when a problem occurs during the
      function.
@@ -131,6 +129,15 @@ read path=(Missing_Argument.throw "path") format=Auto_Detect (on_problems : Prob
      first failing file.
      If set to `Ignore`, the operation proceeds without errors or warnings,
      replacing files that fail to load with `Nothing`.
+
+   > Example
+     Read all CSV files from a directory into a single merged table.
+
+         from Standard.Table import all
+         import Standard.Examples
+
+         files = Data.list name_filter="*.csv"
+         example_csv_dir_to_table = Data.read_many files
 
    ! Request Caching
 
@@ -144,15 +151,6 @@ read path=(Missing_Argument.throw "path") format=Auto_Detect (on_problems : Prob
 
      The cached values are retained as long as the project remains open. Closing
      a project will clear the cache.
-
-   > Example
-     Read all CSV files from a directory into a single merged table.
-
-         from Standard.Table import all
-         import Standard.Examples
-
-         files = Data.list name_filter="*.csv"
-         example_csv_dir_to_table = Data.read_many files
 @paths (Vector_Editor item_editor=File_Browse item_default='""' display=..Always)
 @format File_Format.default_widget
 @return Return_As.default_widget
@@ -197,17 +195,25 @@ read_text path=(Missing_Argument.throw "path") (encoding : Encoding = Encoding.d
     File.new path . read_text encoding on_problems
 
 ## GROUP File
-   ICON data_input
+   ICON folder
    SUGGESTED 3
    Lists files contained in the provided directory.
 
-   Arguments:
    - directory: A path or `File` object to get the contents of.
    - name_filter: A glob pattern that can be used to filter the returned files.
      If it is not specified, all files are returned.
    - recursive: Specifies whether the returned list of files should include also
      files from the subdirectories. If set to `False` (the default), only the
      immediate children of the listed directory are considered.
+
+   > Example
+     List all files with `.md` extension in the example directory and any of its
+     subdirectories.
+
+         import Standard.Examples
+
+         example_list_files =
+             Data.list Examples.data_dir name_filter="**.md" recursive=True
 
    ? Name Filter Rules
 
@@ -243,14 +249,6 @@ read_text path=(Missing_Argument.throw "path") (encoding : Encoding = Encoding.d
    listed directory, to list files recursively you need to use a filter like
    `"**.txt"` or `"*/*"` (which will match only files that are exactly one
    directory down from the listed directory) or no filter at all.
-
-   > Example
-     List all files with `.md` extension in the example directory and any of its
-     subdirectories.
-
-         import Standard.Examples
-
-         example_list_files =
 @directory (Folder_Browse display=..Always)
 @name_filter File_Format.name_filter_widget
 list : Text | File -> Text -> Boolean -> Vector File
@@ -328,6 +326,7 @@ fetch (uri:(URI | Text)=(Missing_Argument.throw "uri")) (method:HTTP_Method=..Ge
 ## ALIAS http post, upload
    GROUP Web
    ICON data_upload
+   SUGGESTED 8
    Writes the provided data to the provided URI. Returns the response,
    parsing the body if the content-type is recognised. Returns an  error if the
    status code does not represent a successful response.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -45,6 +45,7 @@ from project.System.File_Format import Auto_Detect, File_Format
    Uses the specified file format to parse the file into an Enso type. If not
    specified will use the file's extension to determine the file format.
 
+   Arguments:
    - path: The path to the file to read. If the path is a URI, the data
      will be fetched from a supported protocol.
    - format: A `File_Format` object used to read file into memory.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -1274,7 +1274,7 @@ type Decimal
            c = dec 12.345
 dec : Text | Integer | Float -> Math_Context | Nothing -> Decimal ! Arithmetic_Error | Number_Parse_Error
 dec (x : Text | Integer | Float) (mc : Math_Context | Nothing = Nothing) -> Decimal ! Arithmetic_Error | Number_Parse_Error =
-    Decimal.new x mc
+    if x.is_a Float then Decimal.from_float x mc explicit=True else Decimal.new x mc
 
 ## PRIVATE
 handle_number_format_exception ~action =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -248,7 +248,7 @@ type Decimal
 
              Decimal.parse "(123,456,789.654)" format="###,###.##;(###,###.##)"
              # => -123456789.654
-    parse : Text -> Locale -> Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error
+    parse : Text -> Locale -> Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error | Illegal_Argument
     parse (text : Text) (locale:Locale=Locale.default) (format:Text="") (mc : Math_Context | Nothing = Nothing) -> Decimal ! Number_Parse_Error | Illegal_Argument =
         Illegal_Argument.handle_java_exception <| handle_java_exception <| handle_number_format_exception <|
             case (locale == Locale.default && format == "") of

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -6,6 +6,7 @@ import project.Data.Numeric.Rounding_Mode.Rounding_Mode
 import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Error.Error
+import project.Errors.Deprecated.Deprecated
 import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Nothing.Nothing
 import project.Panic.Panic
@@ -110,7 +111,7 @@ type Decimal
 
          When creating a `Decimal` from a literal floating-point value, the
          preferred method is to express the literal as a string and use
-         `Decimal.from_text`, since this will give a `Decimal` that matches the
+         `Decimal.parse`, since this will give a `Decimal` that matches the
          value precisely.
 
          To convert a `Float` or `Integer` to a `Decimal`, use its `.to_decimal`
@@ -126,7 +127,7 @@ type Decimal
            is thrown.
          - If the construction of the Decimal results in a loss of precision, a
            `Loss_Of_Numeric_Precision` warning is attached. This can happen in
-           the followoing ways:
+           the following ways:
            - A `Float` value is implicitly converted to a `Decimal` (either by
              calling `Decimal.from` or by passing the `Float` as a parameter of
              type `Decimal`)
@@ -145,7 +146,7 @@ type Decimal
         ^ Example
           Create a `Decimal` from a `Text`.
 
-              c = Decimal.from_text "12.345"
+              c = Decimal.parse "12.345"
 
         ^ Example
           Create a `Decimal` from an `Integer`.
@@ -165,16 +166,20 @@ type Decimal
     new (x : Text | Integer | Float) (mc : Math_Context | Nothing = Nothing) -> Decimal ! Arithmetic_Error | Number_Parse_Error =
         handle_java_exception <|
             case x of
-                _ : Text -> Decimal.from_text x mc
+                _ : Text -> Decimal.parse x mc=mc
                 _ : Integer -> Decimal.from_integer x mc
                 _ : Float -> Decimal.from_float x mc explicit=False
 
-    ## GROUP Conversions
+    ## ALIAS from text
+       GROUP Conversions
        ICON convert
-       Construct a `Decimal` from a `Text`.
+       Parses a string into a `Decimal`, returning a `Number_Parse_Error` if the
+       text does not represent a valid `Decimal`.
 
        Arguments:
-       - s: The `Text` to construct a `Decimal` from.
+       - text: The text to parse into a `Decimal`.
+       - locale: The locale that specifies the format to use when parsing.
+       - format: The Java-style format to use to parse the string.
        - mc: The `Math_Context` to use to specify precision and `Rounding_Mode`.
          If a `Math_Context` is used, there is a possibility of a loss of
          precision.
@@ -188,7 +193,7 @@ type Decimal
 
          When creating a `Decimal` from a literal floating-point value, the
          preferred method is to express the literal as a string and use
-         `Decimal.from_text`, since this will give a `Decimal` that matches the
+         `Decimal.parse`, since this will give a `Decimal` that matches the
          value precisely.
 
          To convert a `Float` or `Integer` to a `Decimal`, use its `.to_decimal`
@@ -202,9 +207,11 @@ type Decimal
 
          - If a `Text` argument is incorrectly formatted, a `Number_Parse_Error`
            is thrown.
+         - If `format` is incorrectly formatted (or does not match the `locale`,
+           an `Illegal_Argument` is thrown.
          - If the construction of the Decimal results in a loss of precision, a
            `Loss_Of_Numeric_Precision` warning is attached. This can happen in
-           the followoing ways:
+           the following ways:
            - A `Float` value is implicitly converted to a `Decimal` (either by
              calling `Decimal.from` or by passing the `Float` as a parameter of
              type `Decimal`)
@@ -217,24 +224,47 @@ type Decimal
            converted from a `Float` (either by calling `Decimal.from` or by
            passing the `Float` as a parameter of type `Decimal`), an
            `Illegal_Argument` error is thrown.
-         - If a floating-poing argument is `NaN` or `+/- Inf`, an
+         - If a floating-point argument is `NaN` or `+/- Inf`, an
            `Illegal_Argument` error is thrown.
 
-        ^ Example
-          Create a `Decimal` from a `Text`.
+       > Example
+         Create a `Decimal` from a `Text` using default locale.
 
-              d = Decimal.from_text "12.345"
+              d = Decimal.parse "12.345"
+       > Example
+         Parse a `Decimal` with the US locale.
 
-        ^ Example
-          Create a `Decimal` from a `Text`.
+             Decimal.parse "123,456,789.87654" locale=Locale.us
+             # => 123456789.87654
 
-              d = dec "12.345"
-    from_text : Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error
-    from_text (s : Text) (mc : Math_Context | Nothing = Nothing) -> Decimal ! Number_Parse_Error =
-        handle_java_exception <| handle_number_format_exception <|
-            case mc of
-                _ : Math_Context -> Decimal.Value <| handle_precision_loss s <| Decimal_Utils.fromString s mc.math_context
-                _ : Nothing -> Decimal.Value (Decimal_Utils.fromString s)
+       > Example
+         Parse a `Decimal` with the Italy locale.
+
+             Decimal.parse "123.456.789,87654" locale=Locale.italy
+             # => 123456789.87654
+
+       > Example
+         Parse a `Decimal` with an explicit negative number format.
+
+             Decimal.parse "(123,456,789.654)" format="###,###.##;(###,###.##)"
+             # => -123456789.654
+    parse : Text -> Locale -> Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error
+    parse (text : Text) (locale:Locale=Locale.default) (format:Text="") (mc : Math_Context | Nothing = Nothing) -> Decimal ! Number_Parse_Error | Illegal_Argument =
+        Illegal_Argument.handle_java_exception <| handle_java_exception <| handle_number_format_exception <|
+            case (locale == Locale.default && format == "") of
+                True ->
+                    case mc of
+                        _ : Math_Context -> Decimal.Value <| handle_precision_loss text <| Decimal_Utils.fromString text mc.math_context
+                        _ : Nothing -> Decimal.Value (Decimal_Utils.fromString text)
+                False ->
+                    # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
+                    decimal_format = NumberFormat.getInstance locale.java_locale
+                    decimal_format.applyLocalizedPattern format
+                    decimal_format.setParseBigDecimal True
+                    decimal = Panic.catch ParseException (Decimal.Value (decimal_format.parse text)) _->
+                        Error.throw (Number_Parse_Error.Error text)
+                    if mc == Nothing then decimal else
+                        Decimal.Value (decimal.big_decimal.round mc.math_context)
 
     ## GROUP conversions
        ICON convert
@@ -250,7 +280,7 @@ type Decimal
 
          When creating a `Decimal` from a literal floating-point value, the
          preferred method is to express the literal as a string and use
-         `Decimal.from_text`, since this will give a `Decimal` that matches the
+         `Decimal.parse`, since this will give a `Decimal` that matches the
          value precisely.
 
          To convert a `Float` or `Integer` to a `Decimal`, use its `.to_decimal`
@@ -320,7 +350,7 @@ type Decimal
 
          When creating a `Decimal` from a literal floating-point value, the
          preferred method is to express the literal as a string and use
-         `Decimal.from_text`, since this will give a `Decimal` that matches the
+         `Decimal.parse`, since this will give a `Decimal` that matches the
          value precisely.
 
          To convert a `Float` or `Integer` to a `Decimal`, use its `.to_decimal`
@@ -1106,62 +1136,23 @@ type Decimal
         formatter = DecimalFormat.new format symbols
         formatter.format self.big_decimal
 
-    ## ALIAS from text
+    ## PRIVATE
+       ALIAS from text
        GROUP conversions
        ICON convert
 
        Parses a string into a `Decimal`, returning a `Number_Parse_Error` if the
-       text does not represent a valid `Decimal`.
+       text does not represent a valid `Decimal`. This has been deprecated in
+       favour of `Decimal.parse`.
 
        Arguments:
        - text: The text to parse into a `Decimal`.
        - locale: The locale that specifies the format to use when parsing.
        - format: The Java-style format to use to parse the string.
-
-       ! Error Conditions
-
-         - If `text` is incorrectly formatted, a `Number_Parse_Error` is thrown.
-         - If `format` is incorrectly formatted (or does not match the `locale`,
-           an `Illegal_Argument` is thrown.
-
-       > Example
-         Parse a `Decimal` with no local specifier.
-
-             Decimal.parse "123456789.87654"
-             # => 123456789.87654
-
-       > Example
-         Parse a `Decimal` with the default locale.
-
-             Decimal.parse "123,456,789.87654" locale=Locale.default
-             # => 123456789.87654
-
-       > Example
-         Parse a `Decimal` with the US locale.
-
-             Decimal.parse "123,456,789.87654" locale=Locale.us
-             # => 123456789.87654
-
-       > Example
-         Parse a `Decimal` with the Italy locale.
-
-             Decimal.parse "123.456.789,87654" locale=Locale.italy
-             # => 123456789.87654
-
-       > Example
-         Parse a `Decimal` with an explicit negative number format.
-
-             Decimal.parse "(123,456,789.654)" format="###,###.##;(###,###.##)"
-             # => -123456789.654
-    parse : Text -> Locale -> Text -> Decimal ! Number_Parse_Error | Illegal_Argument
-    parse text:Text locale:Locale=Locale.default format:Text="" -> Decimal ! Number_Parse_Error | Illegal_Argument =
-        Illegal_Argument.handle_java_exception <|
-            # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
-            decimal_format = NumberFormat.getInstance locale.java_locale
-            decimal_format.applyLocalizedPattern format
-            decimal_format.setParseBigDecimal True
-            Panic.catch ParseException (Decimal.Value (decimal_format.parse text)) _->
-                Error.throw (Number_Parse_Error.Error text)
+    from_text : Text -> Locale -> Text -> Decimal ! Number_Parse_Error | Illegal_Argument
+    from_text text:Text locale:Locale=Locale.default format:Text="" -> Decimal ! Number_Parse_Error | Illegal_Argument =
+        Warning.attach (Deprecated.Warning "Standard.Base.Data.Decimal.Decimal" "from_text" "Deprecated: use `Decimal.parse` instead.") <|
+            Decimal.parse text locale format
 
     ## PRIVATE
     precision : Integer
@@ -1283,11 +1274,7 @@ type Decimal
            c = dec 12.345
 dec : Text | Integer | Float -> Math_Context | Nothing -> Decimal ! Arithmetic_Error | Number_Parse_Error
 dec (x : Text | Integer | Float) (mc : Math_Context | Nothing = Nothing) -> Decimal ! Arithmetic_Error | Number_Parse_Error =
-    handle_java_exception <|
-        case x of
-            _ : Text -> Decimal.from_text x mc
-            _ : Integer -> Decimal.from_integer x mc
-            _ : Float -> Decimal.from_float x mc explicit=True
+    Decimal.new x mc
 
 ## PRIVATE
 handle_number_format_exception ~action =
@@ -1322,7 +1309,7 @@ Comparable.from (that : Decimal) = Comparable.new that Decimal_Comparator
 Comparable.from (that : Number) = Comparable.new that Decimal_Comparator
 
 ## PRIVATE
-Decimal.from (that : Text) = Decimal.from_text that
+Decimal.from (that : Text) = Decimal.parse that
 
 ## PRIVATE
 Decimal.from (that : Integer) = Decimal.new that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -251,20 +251,14 @@ type Decimal
     parse : Text -> Locale -> Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error | Illegal_Argument
     parse (text : Text) (locale:Locale=Locale.default) (format:Text="") (mc : Math_Context | Nothing = Nothing) -> Decimal ! Number_Parse_Error | Illegal_Argument =
         Illegal_Argument.handle_java_exception <| handle_java_exception <| handle_number_format_exception <|
-            case (locale == Locale.default && format == "") of
-                True ->
-                    case mc of
-                        _ : Math_Context -> Decimal.Value <| handle_precision_loss text <| Decimal_Utils.fromString text mc.math_context
-                        _ : Nothing -> Decimal.Value (Decimal_Utils.fromString text)
-                False ->
-                    # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
-                    decimal_format = NumberFormat.getInstance locale.java_locale
-                    decimal_format.applyLocalizedPattern format
-                    decimal_format.setParseBigDecimal True
-                    decimal = Panic.catch ParseException (Decimal.Value (decimal_format.parse text)) _->
-                        Error.throw (Number_Parse_Error.Error text)
-                    if mc == Nothing then decimal else
-                        Decimal.Value (decimal.big_decimal.round mc.math_context)
+            # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
+            decimal_format = NumberFormat.getInstance locale.java_locale
+            decimal_format.applyLocalizedPattern format
+            decimal_format.setParseBigDecimal True
+            decimal = Panic.catch ParseException (Decimal.Value (decimal_format.parse text)) _->
+                Error.throw (Number_Parse_Error.Error text)
+            if mc == Nothing then decimal else
+                Decimal.Value <| handle_precision_loss text <| Decimal_Utils.applyMathContext decimal.big_decimal mc.math_context
 
     ## GROUP conversions
        ICON convert

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -1273,7 +1273,9 @@ type Decimal
            c = dec 12.345
 dec : Text | Integer | Float -> Math_Context | Nothing -> Decimal ! Arithmetic_Error | Number_Parse_Error
 dec (x : Text | Integer | Float) (mc : Math_Context | Nothing = Nothing) -> Decimal ! Arithmetic_Error | Number_Parse_Error =
-    if x.is_a Float then Decimal.from_float x mc explicit=True else Decimal.new x mc
+    case x of
+        _ : Float -> Decimal.from_float x mc
+        _ -> Decimal.new x mc
 
 ## PRIVATE
 handle_number_format_exception ~action =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -251,12 +251,17 @@ type Decimal
     parse : Text -> Locale -> Text -> Math_Context | Nothing -> Decimal ! Number_Parse_Error | Illegal_Argument
     parse (text : Text) (locale:Locale=Locale.default) (format:Text="") (mc : Math_Context | Nothing = Nothing) -> Decimal ! Number_Parse_Error | Illegal_Argument =
         Illegal_Argument.handle_java_exception <| handle_java_exception <| handle_number_format_exception <|
-            # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
-            decimal_format = NumberFormat.getInstance locale.java_locale
-            decimal_format.applyLocalizedPattern format
-            decimal_format.setParseBigDecimal True
-            decimal = Panic.catch ParseException (Decimal.Value (decimal_format.parse text)) _->
-                Error.throw (Number_Parse_Error.Error text)
+            number_format_parse txt =
+                # `getInstance` returns `DecimalFormat` or a subclass of `DecimalFormat`.
+                decimal_format = NumberFormat.getInstance locale.java_locale
+                decimal_format.applyLocalizedPattern format
+                decimal_format.setParseBigDecimal True
+                Panic.catch ParseException (Decimal.Value (decimal_format.parse txt)) _->
+                    Error.throw (Number_Parse_Error.Error text)
+            decimal = case format == "" && locale == Locale.default of
+                True -> Panic.catch ParseException (Decimal.Value (Decimal_Utils.fromString text)) _->
+                    number_format_parse text
+                False -> number_format_parse text
             if mc == Nothing then decimal else
                 Decimal.Value <| handle_precision_loss text <| Decimal_Utils.applyMathContext decimal.big_decimal mc.math_context
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -1235,8 +1235,7 @@ type Decimal
     to_text_without_scientific_notation : Text
     to_text_without_scientific_notation self -> Text = self.big_decimal.toPlainString
 
-## GROUP Math
-   ICON input_number
+## ICON input_number
    Construct a `Decimal` from a `Text`, `Integer` or `Float`.
 
    Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -1137,7 +1137,7 @@ type Decimal
         formatter.format self.big_decimal
 
     ## PRIVATE
-       ALIAS from text
+       DEPRECATED
        GROUP conversions
        ICON convert
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Interval.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Interval.enso
@@ -48,8 +48,7 @@ type Interval_Type
 
 ## A type representing an interval over real numbers.
 type Interval
-    ## GROUP DateTime
-       ICON time
+    ## ICON time
        Creates an interval.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
@@ -80,7 +80,7 @@ Decimal.from (that:JS_Object) =
     case that.get "type" == "Decimal" && ["value", "scale", "precision"].all that.contains_key of
         True ->
             math_context = Math_Context.new (that.at "precision")
-            raw_value = Decimal.parse (that.at "value") math_context
+            raw_value = Decimal.parse (that.at "value") mc=math_context
             raw_value.set_scale (that.at "scale")
         False -> Error.throw (Illegal_Argument.Error "Invalid JS_Object for Decimal.")
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
@@ -80,7 +80,7 @@ Decimal.from (that:JS_Object) =
     case that.get "type" == "Decimal" && ["value", "scale", "precision"].all that.contains_key of
         True ->
             math_context = Math_Context.new (that.at "precision")
-            raw_value = Decimal.from_text (that.at "value") math_context
+            raw_value = Decimal.parse (that.at "value") math_context
             raw_value.set_scale (that.at "scale")
         False -> Error.throw (Illegal_Argument.Error "Invalid JS_Object for Decimal.")
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -1937,7 +1937,7 @@ Text.parse_time_zone self = Time_Zone.parse self
          # => Arithmetic_Error
 Text.to_decimal : Integer | Nothing -> Decimal
 Text.to_decimal self (scale : Integer | Nothing = Nothing) -> Decimal =
-    d_unscaled = Decimal.from_text self
+    d_unscaled = Decimal.parse self
     if scale == Nothing then d_unscaled else
         d_unscaled.set_scale scale
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -63,7 +63,7 @@ new_builtin year month day = @Builtin_Method "Date.new_builtin"
 type Date
     ## ALIAS current date, now
        GROUP DateTime
-       ICON time
+       ICON calendar
 
        Obtains the current date from the system clock in the system timezone.
 
@@ -74,8 +74,8 @@ type Date
     today : Date
     today = @Builtin_Method "Date.today"
 
-    ## GROUP DateTime
-       ICON time
+    ## GROUP Constants
+       ICON calendar
        Constructs a new Date from a year, month, and day.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -106,6 +106,7 @@ type Date_Time
     ## ALIAS current time
        GROUP DateTime
        ICON time
+       SUGGESTED 10
 
        Obtains the current date-time from the system clock in the system timezone.
 
@@ -118,7 +119,7 @@ type Date_Time
     now : Date_Time
     now = @Builtin_Method "Date_Time.now"
 
-    ## GROUP DateTime
+    ## GROUP Constants
        ICON time
        Obtains an instance of `Date_Time` from a year, month, day, hour, minute,
        second, nanosecond and timezone.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
@@ -85,8 +85,7 @@ type Duration
     between start_inclusive end_exclusive timezone_aware=True =
         between_builtin start_inclusive end_exclusive timezone_aware
 
-    ## GROUP DateTime
-       ICON time
+    ## ICON time
        Create a duration from time units.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
@@ -56,17 +56,15 @@ type Period
     between start_date_inclusive end_date_exclusive =
         Period.Value (Java_Period.between start_date_inclusive end_date_exclusive)
 
-    ## GROUP DateTime
-       ICON time
-       Create a new Period from years, months and days.
+    ## ICON time
+       Create a new Period for years, months, and days.
 
-       Arguments:
        - years: Amount of years.
        - months: Amount of months.
        - days: Amount of days.
 
        > Example
-         Create a Period of 2 years and 5 days
+         Create 2 years and 5 days `Period`.
 
              import Standard.Base.Data.Time.Period
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -55,7 +55,7 @@ new_builtin hour minute second nanosecond = @Builtin_Method "Time_Of_Day.new_bui
 @Builtin_Type
 type Time_Of_Day
     ## GROUP DateTime
-       ICON time
+       ICON time2
        Obtains the current time from the system clock in the default time-zone.
 
        > Example
@@ -67,8 +67,8 @@ type Time_Of_Day
     now : Time_Of_Day
     now = @Builtin_Method "Time_Of_Day.now"
 
-    ## GROUP DateTime
-       ICON time
+    ## GROUP Constants
+       ICON time2
        Obtains an instance of `Time_Of_Day` from an hour, minute, second
        and nanosecond.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -89,11 +89,26 @@ type XML_Document
          Read an XML document from an string.
 
              xml_string = "<foo></foo>"
-             doc = XML_Document.from_text xml_string
-    from_text : Text -> XML_Document ! XML_Error
-    from_text xml_string:Text =
+             doc = XML_Document.parse xml_string
+    parse : Text -> XML_Document ! XML_Error
+    parse xml_string:Text =
         XML_Error.handle_java_exceptions <|
             XML_Document.Value (XML_Utils.parseString xml_string)
+
+    ## PRIVATE
+       DEPRECATED
+       GROUP Conversions
+       ICON convert
+       Read an XML document from a string.
+       If there is a parsing error, `XML_Error.Parse_Error` is thrown. This has
+       been deprecated in favour of `XML_Document.parse`.
+
+       Arguments:
+       - xml_string: The string to read the XML document from.
+    from_text : Text -> XML_Document ! XML_Error
+    from_text xml_string:Text =
+        Warning.attach (Deprecated.Warning "Standard.Base.Data.XML.XML_Document" "from_text" "Deprecated: use `XML_Document.parse` instead.") <|
+            XML_Document.parse xml_string
 
     ## PRIVATE
        Wrap Java's Document to XML_Document
@@ -124,7 +139,7 @@ type XML_Document
        > Example
          Get the tag of an XML document's root element.
 
-             XML_Document.from_text '<foo>hello</foo>' . name
+             XML_Document.parse '<foo>hello</foo>' . name
              # => "foo"
     name : Text ! XML_Error
     name self = self.root_element.name
@@ -142,14 +157,14 @@ type XML_Document
        > Example
          Get the first child of the document (the root element).
 
-             XML_Document.from_text '<foo><baz>hello</baz></foo>' . get 0
-             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+             XML_Document.parse '<foo><baz>hello</baz></foo>' . get 0
+             # => XML_Document.parse "<foo><baz>hello</baz></foo>" . root_element
 
        > Example
          Get the child of the document (the root element) by name.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . get "foo"
-             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+             root = XML_Document.parse '<foo bar="one">hello</foo>' . get "foo"
+             # => XML_Document.parse "<foo><baz>hello</baz></foo>" . root_element
     @key child_selector
     get : Text | Integer -> Any -> Any | Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
     get self key:(Text | Integer)="." ~if_missing=Nothing = case key of
@@ -186,14 +201,14 @@ type XML_Document
        > Example
          Get the first child of the document (the root element).
 
-             XML_Document.from_text '<foo><baz>hello</baz></foo>' . at 0
-             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+             XML_Document.parse '<foo><baz>hello</baz></foo>' . at 0
+             # => XML_Document.parse "<foo><baz>hello</baz></foo>" . root_element
 
        > Example
          Get the child of the document (the root element) by name.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . get "foo"
-             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+             root = XML_Document.parse '<foo bar="one">hello</foo>' . get "foo"
+             # => XML_Document.parse "<foo><baz>hello</baz></foo>" . root_element
     @key child_selector
     at : Text | Integer -> Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
     at self key:(Text | Integer)="." =
@@ -208,7 +223,7 @@ type XML_Document
        > Example
          Get the outer XML of the document.
 
-             XML_Document.from_text '<foo>hello</foo>' . outer_xml
+             XML_Document.parse '<foo>hello</foo>' . outer_xml
              # => '<foo>hello</foo>'
     outer_xml : Text ! XML_Error
     outer_xml self =
@@ -221,7 +236,7 @@ type XML_Document
        > Example
          Get the inner XML of the document.
 
-             XML_Document.from_text '<foo><bar>hello</bar></foo>' . inner_xml
+             XML_Document.parse '<foo><bar>hello</bar></foo>' . inner_xml
              # => '<foo><bar>hello</bar></foo>'
     inner_xml : Text ! XML_Error
     inner_xml self =
@@ -276,7 +291,7 @@ type XML_Document
        Gets the child elements of an XML document.
 
        > Example
-             XML_Document.from_text '<foo><baz>hello</baz></foo>' . children
+             XML_Document.parse '<foo><baz>hello</baz></foo>' . children
              # => [XML_Element'<foo><baz>hello</baz></foo>']
     children : Vector (XML_Element | Text) ! XML_Error
     children self = [self.root_element]
@@ -292,7 +307,7 @@ type XML_Document
        > Example
          Get the number of children of an document.
 
-             XML_Document.from_text '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . child_count
+             XML_Document.parse '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . child_count
              # => 1
     child_count : Integer
     child_count self = 1
@@ -344,7 +359,7 @@ type XML_Document
 
              root = XML_Document.from_file test_file
              root.get_xpath "/class/teacher[1]/firstname"
-             # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
+             # => [XML_Document.parse "<firstname>Alice</firstname>" . root_element]
     get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
     get_xpath self key:Text =
         XML_Error.handle_java_exceptions <|
@@ -369,8 +384,8 @@ type XML_Document
        - tag_name: The tag name to search for.
 
        > Example
-             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
-             # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
+             XML_Document.parse '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
+             # => [XML_Document.parse "<baz>hello</baz>" . root_element, XML_Document.parse "<baz>goodbye</baz>" . root_element]
     get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
     get_descendants_by_tag_name self tag_name:Text =
         root = if tag_name == self.root_element.name then [self.root_element] else []
@@ -404,7 +419,7 @@ type XML_Element
        > Example
          Get the tag of an XML element.
 
-             XML_Document.from_text '<foo>hello</foo>' . root_element . name
+             XML_Document.parse '<foo>hello</foo>' . root_element . name
              # => "foo"
     name : Text ! XML_Error
     name self =
@@ -423,13 +438,13 @@ type XML_Element
        - if_missing: The value returned if the key does not exist.
 
        > Example
-           XML_Document.from_text '<foo><baz>hello</baz></foo>' . root_element . get 0
-           # => XML_Document.from_text "<baz>hello</baz>" . root_element
+           XML_Document.parse '<foo><baz>hello</baz></foo>' . root_element . get 0
+           # => XML_Document.parse "<baz>hello</baz>" . root_element
 
        > Example
          Get a tag attribute.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element . get "@bar"
+             root = XML_Document.parse '<foo bar="one">hello</foo>' . root_element . get "@bar"
              # => "one"
     @key child_selector
     get : Text | Integer -> Any -> Any | Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
@@ -451,13 +466,13 @@ type XML_Element
        > Example
          Get a nested tag:
 
-             XML_Document.from_text '<foo><baz>hello</baz></foo>' . root_element . at 0
-             # => XML_Document.from_text "<baz>hello</baz>" . root_element
+             XML_Document.parse '<foo><baz>hello</baz></foo>' . root_element . at 0
+             # => XML_Document.parse "<baz>hello</baz>" . root_element
 
        > Example
          Get a tag attribute.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element
+             root = XML_Document.parse '<foo bar="one">hello</foo>' . root_element
              root.at "@bar"
              # => "one"
     @key child_selector
@@ -476,8 +491,8 @@ type XML_Element
        100% whitespace. Other node types, such as comments, are not included.
 
        > Example
-             XML_Document.from_text '<foo><baz>hello</baz></foo>' . root_element . children
-             # => [XML_Document.from_text "<baz>hello</baz>"]
+             XML_Document.parse '<foo><baz>hello</baz></foo>' . root_element . children
+             # => [XML_Document.parse "<baz>hello</baz>"]
     children : Vector (XML_Element | Text) ! XML_Error
     children self = self.children_cache
 
@@ -492,7 +507,7 @@ type XML_Element
        > Example
          Get the number of children of an element.
 
-             XML_Document.from_text '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . root_element . child_count
+             XML_Document.parse '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . root_element . child_count
              # => 2
     child_count : Integer ! XML_Error
     child_count self = self.children_cache.length
@@ -516,7 +531,7 @@ type XML_Element
        > Example
          Get an attribute of an element.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element
+             root = XML_Document.parse '<foo bar="one">hello</foo>' . root_element
              root.attribute "bar"
              # => "one"
     @name (e-> make_single_choice e.attribute_names)
@@ -538,7 +553,7 @@ type XML_Element
        Gets a Dictionary containing of the attributes of an XML element.
 
        > Example
-           XML_Document.from_text '<foo bar="one">hello</foo>' . root_element . attributes
+           XML_Document.parse '<foo bar="one">hello</foo>' . root_element . attributes
            # => Dictionary.from_vector [["bar", "one"]]
     attributes : Dictionary Text Text ! XML_Error
     attributes self =
@@ -557,7 +572,7 @@ type XML_Element
        > Example
          Get the text content of an element.
 
-             XML_Document.from_text '<foo>hello</foo>' . root_element . text
+             XML_Document.parse '<foo>hello</foo>' . root_element . text
              # => "hello"
     text : Text ! XML_Error
     text self =
@@ -570,7 +585,7 @@ type XML_Element
        > Example
          Get the outer XML of an element.
 
-             XML_Document.from_text '<foo>hello</foo>' . root_element . outer_xml
+             XML_Document.parse '<foo>hello</foo>' . root_element . outer_xml
              # => '<foo>hello</foo>'
     outer_xml : Text ! XML_Error
     outer_xml self =
@@ -584,7 +599,7 @@ type XML_Element
        > Example
          Get the inner XML of an element.
 
-             XML_Document.from_text '<foo><bar>hello</bar></foo>' . root_element . inner_xml
+             XML_Document.parse '<foo><bar>hello</bar></foo>' . root_element . inner_xml
              # => '<bar>hello</bar>'
     inner_xml : Text ! XML_Error
     inner_xml self =
@@ -645,7 +660,7 @@ type XML_Element
 
              root = XML_Document.from_file test_file . root_element
              root.get_xpath "/class/teacher[1]/firstname"
-             # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
+             # => [XML_Document.parse "<firstname>Alice</firstname>" . root_element]
     get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
     get_xpath self key:Text =
         XML_Error.handle_java_exceptions <|
@@ -671,8 +686,8 @@ type XML_Element
        - tag_name: The tag name to search for.
 
        > Example
-             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
-             # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
+             XML_Document.parse '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
+             # => [XML_Document.parse "<baz>hello</baz>" . root_element, XML_Document.parse "<baz>goodbye</baz>" . root_element]
     get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
     get_descendants_by_tag_name self tag_name:Text =
         XML_Error.handle_java_exceptions <|

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -8,6 +8,7 @@ import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Error.Error
 import project.Errors.Common.Index_Out_Of_Bounds
+import project.Errors.Deprecated.Deprecated
 import project.Errors.File_Error.File_Error
 import project.Errors.Illegal_State.Illegal_State
 import project.Errors.No_Such_Key.No_Such_Key
@@ -20,6 +21,7 @@ import project.System.File.File_Access.File_Access
 import project.System.File.Generic.Writable_File.Writable_File
 import project.System.File.Write_Extensions
 import project.System.Input_Stream.Input_Stream
+import project.Warning.Warning
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -269,8 +269,7 @@ type Enso_File
             create_tags_if_not_exist labels . if_not_error <|
                 update_asset_labels self labels . if_not_error self
 
-    ## GROUP EnsoCloud
-       ICON data_output
+    ## ICON data_output
        Creates a new label with the given name and color.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -51,7 +51,8 @@ type Warning
     remove_warnings value warning_type=Any =
         Warning.detach_selected_warnings value (w-> w.is_a warning_type) . first
 
-    ## GROUP Errors
+    ## PRIVATE
+       GROUP Errors
        ICON error
        Throws the first matching warning (either all or of a specified type) as a data flow error.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Database.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Database.enso
@@ -13,7 +13,7 @@ from project.Errors import SQL_Error
 polyglot java import org.enso.database.DatabaseConnectionDetailsSPI
 
 ## GROUP Standard.Base.Database
-   ICON data_input
+   ICON drive
    SUGGESTED 5
    Tries to connect to the database.
 

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
@@ -20,7 +20,8 @@ polyglot java import org.enso.google.GoogleAnalyticsReader
 ## Type providing API access to Google Analytics.
 type Google_Analytics
     ## GROUP Standard.Base.Web
-       ICON data_input
+       ICON cloud_from
+       SUGGESTED 9
        Performs Google Analytics call
        This method calls the Google Analytics Reporting v4 API.
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Excel_Extensions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Excel_Extensions.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 polyglot java import org.enso.table.excel.ExcelUtils
 
 ## GROUP Standard.Base.Conversions
-   ICON date_and_time
+   ICON calendar
    Converts an Excel date to a `Date`.
 Date.from_excel : Integer -> Date
 Date.from_excel excel_date:Integer = case excel_date of
@@ -13,7 +13,7 @@ Date.from_excel excel_date:Integer = case excel_date of
     _ -> ExcelUtils.fromExcelDateTime excel_date
 
 ## GROUP Standard.Base.Conversions
-   ICON date_and_time
+   ICON time
    Converts an Excel date time to a `Date_Time`.
 Date_Time.from_excel : Number -> Date_Time
 Date_Time.from_excel excel_date:Number =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
@@ -72,7 +72,7 @@ XML_Element.to_table : Table ! Type_Error
 XML_Element.to_table self =
     self.to Table
 
-## GROUP Standard.Base.Constants
+## PRIVATE
    ICON data_input
    Converts an object or a Vector of object into a Table, by looking up the
    requested fields from each item.

--- a/std-bits/base/src/main/java/org/enso/base/numeric/Decimal_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/numeric/Decimal_Utils.java
@@ -4,20 +4,23 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.Locale;
 
 /** Utils for the Enso Decmial type. */
 public class Decimal_Utils {
   private static final BigDecimal MIN_LONG_BIGDECIMAL = BigDecimal.valueOf(Long.MIN_VALUE);
   private static final BigDecimal MAX_LONG_BIGDECIMAL = BigDecimal.valueOf(Long.MAX_VALUE);
 
-  public static BigDecimal fromString(String s) {
-    return new BigDecimal(s);
-  }
-
-  public static ConversionResult fromString(String s, MathContext mc) {
-    BigDecimal bd = new BigDecimal(s, mc);
-    BigDecimal withoutMC = new BigDecimal(s);
-    return new ConversionResult(bd, bd.compareTo(withoutMC) != 0);
+  public static Number fromString(String s) throws ParseException {
+    try {
+      return new BigDecimal(s);
+    } catch (NumberFormatException e) {
+      var df = (DecimalFormat)DecimalFormat.getInstance(Locale.ROOT);
+      df.setParseBigDecimal(true);
+      return df.parse(s);
+    }
   }
 
   public static ConversionResult applyMathContext(BigDecimal bd, MathContext mc) {

--- a/std-bits/base/src/main/java/org/enso/base/numeric/Decimal_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/numeric/Decimal_Utils.java
@@ -20,6 +20,11 @@ public class Decimal_Utils {
     return new ConversionResult(bd, bd.compareTo(withoutMC) != 0);
   }
 
+  public static ConversionResult applyMathContext(BigDecimal bd, MathContext mc) {
+    BigDecimal rounded = bd.round(mc);
+    return new ConversionResult(rounded, bd.compareTo(rounded) != 0);
+  }
+
   public static BigDecimal fromInteger(Object o) {
     if (o instanceof Long l) {
       // According to the BigInteger Javadocs, valueOf is preferred "because it

--- a/test/Base_Tests/src/Data/Decimal_Spec.enso
+++ b/test/Base_Tests/src/Data/Decimal_Spec.enso
@@ -27,6 +27,7 @@ add_specs suite_builder =
 
         group_builder.specify "should be able to construct a Decimal from a string" <|
             Decimal.new "123.45" . should_have_rep [12345, 5, 2]
+            Decimal.parse "123.45" . should_have_rep [12345, 5, 2]
             Decimal.from_text "123.45" . should_have_rep [12345, 5, 2]
 
         group_builder.specify "should throw Number_Parse_Error on a badly-formatted string" <|
@@ -45,7 +46,7 @@ add_specs suite_builder =
 
         group_builder.specify "should be able to construct a Decimal from a long string" <|
             Decimal.new "495782984723948723947239938732974241.2345" . should_have_rep [4957829847239487239472399387329742412345, 40, 4]
-            Decimal.from_text "495782984723948723947239938732974241.2345" . should_have_rep [4957829847239487239472399387329742412345, 40, 4]
+            Decimal.parse "495782984723948723947239938732974241.2345" . should_have_rep [4957829847239487239472399387329742412345, 40, 4]
 
         group_builder.specify "should be able to construct a Decimal from a small integer" <|
             Decimal.new 1234500 . should_have_rep [1234500, 7, 0]
@@ -126,7 +127,7 @@ add_specs suite_builder =
 
         group_builder.specify "should be convertible via .from" <|
             Decimal.from "123.45" . should_equal (Decimal.new "123.45")
-            Decimal.from "123.45" . should_equal (Decimal.from_text "123.45")
+            Decimal.from "123.45" . should_equal (Decimal.parse "123.45")
             Decimal.from 123.45 . should_equal (Decimal.new 123.45)
             Decimal.from 123.45 . should_equal (Decimal.from_float 123.45)
             Decimal.from 12345 . should_equal (Decimal.new 12345)

--- a/test/Base_Tests/src/Data/Decimal_Spec.enso
+++ b/test/Base_Tests/src/Data/Decimal_Spec.enso
@@ -28,6 +28,8 @@ add_specs suite_builder =
         group_builder.specify "should be able to construct a Decimal from a string" <|
             Decimal.new "123.45" . should_have_rep [12345, 5, 2]
             Decimal.parse "123.45" . should_have_rep [12345, 5, 2]
+
+        group_builder.specify "should be able to construct a Decimal from a string using from_text (deprecated)" <|
             Decimal.from_text "123.45" . should_have_rep [12345, 5, 2]
 
         group_builder.specify "should throw Number_Parse_Error on a badly-formatted string" <|

--- a/test/Base_Tests/src/Data/Json_Spec.enso
+++ b/test/Base_Tests/src/Data/Json_Spec.enso
@@ -159,7 +159,7 @@ add_specs suite_builder =
             large_number.to_json . parse_json . should_equal large_number
 
         group_builder.specify "should serialise decimals and parse back" <|
-            decimal = Decimal.from_text "1234567890123456789012345678901234567890.1234567890123456789012345678901234567890"
+            decimal = Decimal.parse "1234567890123456789012345678901234567890.1234567890123456789012345678901234567890"
             decimal.to_json . should_equal '{"type":"Decimal","value":"1234567890123456789012345678901234567890.1234567890123456789012345678901234567890","scale":40,"precision":80}'
             decimal.to_json . parse_json . should_equal decimal
             decimal.to_json . parse_json . scale . should_equal 40

--- a/test/Base_Tests/src/Data/XML/XML_Spec.enso
+++ b/test/Base_Tests/src/Data/XML/XML_Spec.enso
@@ -41,12 +41,17 @@ add_specs suite_builder =
 
         group_builder.specify "Can read from a string" <|
             xml_string = data.test_file.read_text
+            doc = XML_Document.parse xml_string
+            doc.root_element.name . should_equal "class"
+
+        group_builder.specify "Can read from a string using XML_Document.from_text (deprecated)" <|
+            xml_string = data.test_file.read_text
             doc = XML_Document.from_text xml_string
             doc.root_element.name . should_equal "class"
 
         group_builder.specify "Can read from a short string" <|
             xml_string = "<class></class>"
-            doc = XML_Document.from_text xml_string
+            doc = XML_Document.parse xml_string
             doc.root_element.name . should_equal "class"
 
         group_builder.specify "Parse error from file" <|
@@ -55,7 +60,7 @@ add_specs suite_builder =
 
         group_builder.specify "Parse error from string" <|
             xml_string = "<<<<</"
-            XML_Document.from_text xml_string . catch . should_be_a XML_Error.Parse_Error
+            XML_Document.parse xml_string . catch . should_be_a XML_Error.Parse_Error
 
     suite_builder.group "Write XML" group_builder->
         group_builder.specify "Can roundtrip a document to and from a file" <|

--- a/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
@@ -448,7 +448,7 @@ add_specs suite_builder =
                     <c id="4"/>
                   </b>
                 </a>
-            xml = XML_Document.from_text xml_string . root_element
+            xml = XML_Document.parse xml_string . root_element
             t = xml.to Table . expand_to_rows "Children" . expand_column "Children" . expand_to_rows "Children Children" . expand_column "Children Children"
             t.at "Children Children @id" . to_vector . should_equal ["1", "2", "3", "4"]
 
@@ -461,7 +461,7 @@ add_specs suite_builder =
             t.at "Value" . to_vector . should_equal ["My Book"]
 
         group_builder.specify "Converting a node without any child nodes does not produce Value or Children columns" <|
-            xml = XML_Document.from_text '<foo id="10"></foo>'
+            xml = XML_Document.parse '<foo id="10"></foo>'
             t = xml.to Table
             t.at "Name" . to_vector . should_equal ["foo"]
             t.at "@id" . to_vector . should_equal ["10"]


### PR DESCRIPTION
### Pull Request Description

- Deprecate `Decimal.from_text` and `XML_Document.from_text`.
- Merge `Decimal.from_text` into `Decimal.parse`.
- New `XML_Document.parse` replacing `XML_Document.from_text`.
- Tidy up the static methods some more.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
