### PR TITLE
getSourceSection and hasSourceSection must be consistent

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -494,20 +494,16 @@ public final class ExecutionService {
    * @param o the object to get the language for
    * @return the associated language, or {@code null} if it doesn't exist
    */
-  public String getLanguage(Object o) {
+  public String getLanguage(Object o) throws UnsupportedMessageException {
     var iop = InteropLibrary.getUncached(o);
     if (iop.hasSourceLocation(o)) {
-      try {
-        var sourceSection = iop.getSourceLocation(o);
-        var source = sourceSection.getSource();
-        if (source != null) {
-          return source.getLanguage();
-        }
-      } catch (UnsupportedMessageException ignored) {
-        CompilerDirectives.shouldNotReachHere("Message support already checked.");
+      var sourceSection = iop.getSourceLocation(o);
+      var source = sourceSection.getSource();
+      if (source != null) {
+        return source.getLanguage();
       }
     }
-    return null;
+    throw UnsupportedMessageException.create();
   }
 
   /**
@@ -516,16 +512,12 @@ public final class ExecutionService {
    * @param o the object to get the source section for
    * @return the associated source section, or {@code null} if it doesn't exist
    */
-  public SourceSection getSourceLocation(Object o) {
+  public SourceSection getSourceLocation(Object o) throws UnsupportedMessageException {
     var iop = InteropLibrary.getUncached(o);
     if (iop.hasSourceLocation(o)) {
-      try {
-        return iop.getSourceLocation(o);
-      } catch (UnsupportedMessageException ignored) {
-        CompilerDirectives.shouldNotReachHere("Message support already checked.");
-      }
+      return iop.getSourceLocation(o);
     }
-    return null;
+    throw UnsupportedMessageException.create();
   }
 
   public boolean isExitException(AbstractTruffleException ex) {

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -178,7 +178,12 @@ public final class ExecutionService {
     var pending =
         submitExecution(
             () -> {
-              SourceSection src = call.getFunction().getSourceSection();
+              SourceSection src;
+              try {
+                src = call.getFunction().getSourceSection();
+              } catch (UnsupportedMessageException ex) {
+                src = null;
+              }
               if (src == null) {
                 throw new SourceNotFoundException(call.getFunction().getName());
               }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -499,16 +499,20 @@ public final class ExecutionService {
    * @param o the object to get the language for
    * @return the associated language, or {@code null} if it doesn't exist
    */
-  public String getLanguage(Object o) throws UnsupportedMessageException {
+  public String getLanguage(Object o) {
     var iop = InteropLibrary.getUncached(o);
     if (iop.hasSourceLocation(o)) {
-      var sourceSection = iop.getSourceLocation(o);
-      var source = sourceSection.getSource();
-      if (source != null) {
-        return source.getLanguage();
+      try {
+        var sourceSection = iop.getSourceLocation(o);
+        var source = sourceSection.getSource();
+        if (source != null) {
+          return source.getLanguage();
+        }
+      } catch (UnsupportedMessageException ex) {
+        // fallthru
       }
     }
-    throw UnsupportedMessageException.create();
+    return null;
   }
 
   /**
@@ -517,12 +521,16 @@ public final class ExecutionService {
    * @param o the object to get the source section for
    * @return the associated source section, or {@code null} if it doesn't exist
    */
-  public SourceSection getSourceLocation(Object o) throws UnsupportedMessageException {
+  public SourceSection getSourceLocation(Object o) {
     var iop = InteropLibrary.getUncached(o);
     if (iop.hasSourceLocation(o)) {
-      return iop.getSourceLocation(o);
+      try {
+        return iop.getSourceLocation(o);
+      } catch (UnsupportedMessageException ex) {
+        // fallthru
+      }
     }
-    throw UnsupportedMessageException.create();
+    return null;
   }
 
   public boolean isExitException(AbstractTruffleException ex) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -381,6 +381,7 @@ public final class Module extends EnsoObject {
    * @param sourceLength length at the time compilation was performed
    * @return
    */
+  @TruffleBoundary
   public final SourceSection createSection(int sourceStartIndex, int sourceLength) {
     var src = sources.source();
     if (src == null) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
@@ -158,13 +159,23 @@ public final class Function extends EnsoObject {
     return getCallTarget().getRootNode().getName();
   }
 
+  @ExportMessage
+  boolean hasSourceLocation() {
+    return getCallTarget().getRootNode().getSourceSection() != null;
+  }
+
   /**
    * @return the source section this function was defined in.
    */
   @TruffleBoundary
   @ExportMessage(name = "getSourceLocation")
-  public SourceSection getSourceSection() {
-    return getCallTarget().getRootNode().getSourceSection();
+  public SourceSection getSourceSection() throws UnsupportedMessageException {
+    var section = getCallTarget().getRootNode().getSourceSection();
+    if (section == null) {
+      throw UnsupportedMessageException.create();
+    } else {
+      return section;
+    }
   }
 
   /**
@@ -212,11 +223,6 @@ public final class Function extends EnsoObject {
   @ExportMessage
   boolean isExecutable() {
     return true;
-  }
-
-  @ExportMessage
-  boolean hasSourceLocation() {
-    return getSourceSection() != null;
   }
 
   @ExportMessage
@@ -281,7 +287,10 @@ public final class Function extends EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   Object invokeMember(String member, Object... args)
-      throws ArityException, UnknownIdentifierException, UnsupportedTypeException {
+      throws ArityException,
+          UnknownIdentifierException,
+          UnsupportedTypeException,
+          UnsupportedMessageException {
     switch (member) {
       case MethodNames.Function.EQUALS:
         Object that = Types.extractArguments(args, Object.class);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -312,11 +312,12 @@ public final class PanicException extends AbstractTruffleException {
 
   @ExportMessage(name = "getSourceLocation")
   SourceSection getSourceSection() throws UnsupportedMessageException {
-    SourceSection loc = getLocation().getEncapsulatingSourceSection();
-    if (loc == null) {
+    SourceSection section = getLocation().getEncapsulatingSourceSection();
+    if (section == null) {
       throw UnsupportedMessageException.create();
+    } else {
+      return getLocation().getEncapsulatingSourceSection();
     }
-    return getLocation().getEncapsulatingSourceSection();
   }
 
   private static Logger logger() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
@@ -229,13 +229,18 @@ public class DebugLocalScope extends EnsoObject {
 
   @ExportMessage
   boolean hasSourceLocation() {
-    return true;
+    return rootNode.getSourceSection() != null;
   }
 
   @ExportMessage
   @TruffleBoundary
-  SourceSection getSourceLocation() {
-    return rootNode.getSourceSection();
+  SourceSection getSourceLocation() throws UnsupportedMessageException {
+    var section = rootNode.getSourceSection();
+    if (section == null) {
+      throw UnsupportedMessageException.create();
+    } else {
+      return section;
+    }
   }
 
   @ExportMessage


### PR DESCRIPTION
### Pull Request Description

Fixes #12678 by modifying `getSourceSection` interop messages to throw `UnsupportedMessageException` rather than returning `null`. There is a Truffle `assert` to verify that when `!hasSourceSection`, then throws exception which was violated.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually tested
