### PR TITLE
Set enso cloud directory

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1411,6 +1411,8 @@ export interface OpenProjectRequestBody {
   readonly cognitoCredentials: CognitoCredentials | null
   /** Only used by the Local backend. */
   readonly parentId: DirectoryId
+  /** Extra open options. */
+  readonly cloudProjectDirectoryPath: string | null
 }
 
 /** HTTP request body for the "create project execution" endpoint. */

--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1411,7 +1411,7 @@ export interface OpenProjectRequestBody {
   readonly cognitoCredentials: CognitoCredentials | null
   /** Only used by the Local backend. */
   readonly parentId: DirectoryId
-  /** Extra open options. */
+  /** Required when running in hybrid mode. */
   readonly cloudProjectDirectoryPath: string | null
 }
 

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -221,11 +221,13 @@ export function useOpenProjectMutation() {
       id,
       type,
       parentId,
+      hybrid,
       inBackground = false,
     }: LaunchedProject & { inBackground?: boolean }) => {
       const backend = type === backendModule.BackendType.remote ? remoteBackend : localBackend
 
       invariant(backend != null, 'Backend is null')
+      const cloudProjectDirectoryPath = hybrid ? hybrid.cloudProjectDirectoryPath : null
 
       return backend.openProject(
         id,
@@ -238,6 +240,7 @@ export function useOpenProjectMutation() {
             expireAt: session.expireAt,
             refreshUrl: session.refreshUrl,
           },
+          cloudProjectDirectoryPath,
           parentId,
         },
         title,
@@ -417,9 +420,12 @@ export function useOpenHybridProject() {
   const closeProject = useCloseProject()
 
   return eventCallbacks.useEventCallback(
-    async (asset: Pick<backendModule.ProjectAsset, 'id' | 'parentId' | 'title'>) => {
+    async (asset: Pick<backendModule.ProjectAsset, 'id' | 'parentId' | 'title' | 'ensoPath'>) => {
       try {
         invariant(localBackend != null, 'Local Backend is null')
+        const ensoPath = asset.ensoPath
+        invariant(ensoPath, 'Enso Path is undefined')
+        const cloudProjectDirectoryPath = ensoPath.slice(0, ensoPath.lastIndexOf('/'))
         await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)
         const localProject = await remoteBackend.downloadProject(asset.id)
 
@@ -443,7 +449,11 @@ export function useOpenHybridProject() {
           title: project.title,
           parentId: project.parentId,
           type: backendModule.BackendType.local,
-          hybrid: { cloudProjectId: asset.id, parentId: localProject.parentId },
+          hybrid: {
+            cloudProjectId: asset.id,
+            parentId: localProject.parentId,
+            cloudProjectDirectoryPath,
+          },
         })
       } catch (error) {
         toastAndLog('openProjectError', error, asset.title)

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -420,7 +420,7 @@ export function useOpenHybridProject() {
   const closeProject = useCloseProject()
 
   return eventCallbacks.useEventCallback(
-    async (asset: Pick<backendModule.ProjectAsset, 'id' | 'parentId' | 'title' | 'ensoPath'>) => {
+    async (asset: Pick<backendModule.ProjectAsset, 'ensoPath' | 'id' | 'parentId' | 'title'>) => {
       try {
         invariant(localBackend != null, 'Local Backend is null')
         await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -423,11 +423,10 @@ export function useOpenHybridProject() {
     async (asset: Pick<backendModule.ProjectAsset, 'id' | 'parentId' | 'title' | 'ensoPath'>) => {
       try {
         invariant(localBackend != null, 'Local Backend is null')
-        const ensoPath = asset.ensoPath
-        invariant(ensoPath, 'Enso Path is undefined')
-        const cloudProjectDirectoryPath = ensoPath.slice(0, ensoPath.lastIndexOf('/'))
         await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)
         const localProject = await remoteBackend.downloadProject(asset.id)
+        invariant(asset.ensoPath, 'Enso path is not defined')
+        const cloudProjectDirectoryPath = asset.ensoPath.slice(0, asset.ensoPath.lastIndexOf('/'))
 
         let project
         for (const parentId of [localProject.targetId, localProject.parentId]) {

--- a/app/gui/src/dashboard/providers/ProjectsProvider.tsx
+++ b/app/gui/src/dashboard/providers/ProjectsProvider.tsx
@@ -41,6 +41,7 @@ const PROJECT_SCHEMA = z
       z.object({
         cloudProjectId: PROJECT_ID_SCHEMA,
         parentId: DIRECTORY_ID_SCHEMA,
+        cloudProjectDirectoryPath: z.string(),
       }),
     ),
   })

--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -419,9 +419,11 @@ export default class LocalBackend extends Backend {
       await this.projectManager.openProject({
         projectId: id,
         missingComponentAction: projectManager.MissingComponentAction.install,
-        ...(body?.cloudProjectDirectoryPath != null ? {
-          cloudProjectDirectoryPath: body.cloudProjectDirectoryPath,
-        } : {}),
+        ...(body?.cloudProjectDirectoryPath != null ?
+          {
+            cloudProjectDirectoryPath: body.cloudProjectDirectoryPath,
+          }
+        : {}),
         ...(body?.parentId != null ?
           { projectsDirectory: extractTypeAndId(body.parentId).id }
         : {}),

--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -419,6 +419,9 @@ export default class LocalBackend extends Backend {
       await this.projectManager.openProject({
         projectId: id,
         missingComponentAction: projectManager.MissingComponentAction.install,
+        ...(body?.cloudProjectDirectoryPath != null ? {
+          cloudProjectDirectoryPath: body.cloudProjectDirectoryPath,
+        } : {}),
         ...(body?.parentId != null ?
           { projectsDirectory: extractTypeAndId(body.parentId).id }
         : {}),

--- a/app/gui/src/dashboard/services/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager.ts
@@ -208,6 +208,7 @@ type ProjectState = OpenedProjectState | OpenInProgressProjectState
 export interface OpenProjectParams {
   readonly projectId: UUID
   readonly missingComponentAction: MissingComponentAction
+  readonly cloudProjectDirectoryPath?: string
   readonly projectsDirectory?: string
 }
 

--- a/docs/language-server/protocol-project-manager.md
+++ b/docs/language-server/protocol-project-manager.md
@@ -422,6 +422,11 @@ the action.
   missingComponentAction?: MissingComponentAction;
 
   /**
+   * Extra open options.
+   */
+  cloudProjectDirectoryPath?: string;
+
+  /**
    * Custom directory with the user projects.
    */
   projectsDirectory?: string;

--- a/docs/language-server/protocol-project-manager.md
+++ b/docs/language-server/protocol-project-manager.md
@@ -422,7 +422,9 @@ the action.
   missingComponentAction?: MissingComponentAction;
 
   /**
-   * Extra open options.
+   * Specifies the cloud project directory.
+   *
+   * Required when running in hybrid mode.
    */
   cloudProjectDirectoryPath?: string;
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -309,7 +309,8 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
           logLevel,
           opts.profilingPath,
           opts.profilingTime,
-          opts.jvmMode
+          opts.jvmMode,
+          Seq()
         )
         exitCode <- mainProcess(procConf).fold(
           th => {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -17,6 +17,7 @@ object configuration {
     * @param profilingPath the path to the profiling out file
     * @param profilingTime the time limiting the profiling duration
     * @param jvmMode if true, enables JVM mode
+    * @param extraEnv extra environment variables
     */
   case class MainProcessConfig(
     logLevel: Level,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -11,18 +11,19 @@ import scala.concurrent.duration.FiniteDuration
 object configuration {
 
   /** The options supplied (e.g. with the command line options when starting the
-    *  main project manager process.
+    * main project manager process.
     *
-    *  @param logLevel the logging level
-    *  @param profilingPath the path to the profiling out file
-    *  @param profilingTime the time limiting the profiling duration
+    * @param logLevel the logging level
+    * @param profilingPath the path to the profiling out file
+    * @param profilingTime the time limiting the profiling duration
     * @param jvmMode if true, enables JVM mode
     */
   case class MainProcessConfig(
     logLevel: Level,
     profilingPath: Option[Path],
     profilingTime: Option[FiniteDuration],
-    jvmMode: Boolean
+    jvmMode: Boolean,
+    extraEnv: Seq[(String, String)]
   )
 
   /** A configuration object for properties of the Project Manager.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -124,7 +124,8 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
         version             = descriptor.engineVersion,
         logLevel            = inheritedLogLevel,
         logMasking          = Masking.isMaskingEnabled,
-        additionalArguments = additionalArguments
+        additionalArguments = additionalArguments,
+        extraEnv            = descriptor.extraEnv
       )
       .get
     runner.withCommand(runSettings, descriptor.jvmSettings) { command =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -92,7 +92,8 @@ class LanguageServerController(
       profilingPath                  = processConfig.profilingPath,
       profilingTime                  = processConfig.profilingTime,
       deferredLoggingServiceEndpoint = loggingServiceDescriptor.getEndpoint,
-      skipGraalVMUpdater             = bootloaderConfig.skipGraalVMUpdater
+      skipGraalVMUpdater             = bootloaderConfig.skipGraalVMUpdater,
+      extraEnv                       = processConfig.extraEnv
     )
 
   override def supervisorStrategy: SupervisorStrategy =
@@ -182,7 +183,7 @@ class LanguageServerController(
     lastClientPort: Option[Int] = None
   ): Receive =
     LoggingReceive.withLabel("supervising") {
-      case StartServer(clientId, _, requestedEngineVersion, _, _) =>
+      case StartServer(clientId, _, requestedEngineVersion, _, _, _) =>
         if (requestedEngineVersion != engineVersion) {
           sender() ! ServerBootFailed(
             new IllegalStateException(
@@ -335,7 +336,7 @@ class LanguageServerController(
   }
 
   private def bootFailed(failure: ServerStartupFailure): Receive = {
-    case StartServer(_, _, _, _, _) =>
+    case _: StartServer =>
       sender() ! failure
       stop()
   }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -33,8 +33,8 @@ import scala.concurrent.duration.FiniteDuration
   *                                       if the child component should connect
   *                                       to the logging service, it should
   *                                       contain the URI to connect to
-  * @param skipGraalVMUpdater indicates if the check and installation of GraalVM
-  *                              should be skipped
+  * @param skipGraalVMUpdater indicates if the check and installation of GraalVM should be skipped
+  * @param extraEnv extra environment variables
   */
 case class LanguageServerDescriptor(
   name: String,
@@ -50,5 +50,6 @@ case class LanguageServerDescriptor(
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],
   deferredLoggingServiceEndpoint: Future[Option[URI]],
-  skipGraalVMUpdater: Boolean
+  skipGraalVMUpdater: Boolean,
+  extraEnv: Seq[(String, String)]
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
@@ -29,13 +29,15 @@ trait LanguageServerGateway[F[+_, +_]] {
     * @param clientId a requester id
     * @param project a project to start
     * @param version engine version to use for the launched language server
+    * @param extraEnv extra environment variables
     * @return either a failure or sockets that a language server listens on
     */
   def start(
     progressTracker: ActorRef,
     clientId: UUID,
     project: Project,
-    version: SemVer
+    version: SemVer,
+    extraEnv: Seq[(String, String)]
   ): F[ServerStartupFailure, LanguageServerSockets]
 
   /** Stops a language server.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
@@ -42,7 +42,8 @@ class LanguageServerGatewayImpl[
     progressTracker: ActorRef,
     clientId: UUID,
     project: Project,
-    version: SemVer
+    version: SemVer,
+    extraEnv: Seq[(String, String)]
   ): F[ServerStartupFailure, LanguageServerSockets] = {
     implicit val timeout: Timeout = Timeout(2 * timeoutConfig.bootTimeout)
 
@@ -55,7 +56,8 @@ class LanguageServerGatewayImpl[
           project,
           version,
           progressTracker,
-          engineUpdate = false
+          engineUpdate = false,
+          extraEnv
         )).mapTo[ServerStartupResult]
       }
       .mapError(_ => ServerBootTimedOut)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
@@ -24,7 +24,8 @@ object LanguageServerProtocol {
     project: Project,
     engineVersion: SemVer,
     progressTracker: ActorRef,
-    engineUpdate: Boolean
+    engineUpdate: Boolean,
+    extraEnv: Seq[(String, String)]
   )
 
   /** Base trait for server startup results.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
@@ -16,8 +16,8 @@ object LanguageServerProtocol {
     * @param clientId the requester id
     * @param project the project to start
     * @param engineVersion version of the engine to use
-    * @param progressTracker an actor that should be sent notifications about
-    *                        locks
+    * @param progressTracker an actor that should be sent notifications about locks
+    * @param extraEnv extra environment variables
     */
   case class StartServer(
     clientId: UUID,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
@@ -53,11 +53,14 @@ class LanguageServerRegistry(
           project,
           engineVersion,
           progressTracker,
-          engineUpdate
+          engineUpdate,
+          extraEnv
         ) =>
       if (serverControllers.contains(project.id)) {
         serverControllers(project.id).forward(msg)
       } else {
+        val mainProcessConfig =
+          processConfig.copy(extraEnv = processConfig.extraEnv ++ extraEnv)
         val controller = context.actorOf(
           LanguageServerController
             .props(
@@ -69,7 +72,7 @@ class LanguageServerRegistry(
               supervisionConfig,
               timeoutConfig,
               distributionConfiguration,
-              processConfig,
+              mainProcessConfig,
               loggingServiceDescriptor,
               executor
             ),

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -111,7 +111,8 @@ object ProjectManagementApi {
       projectsDirectory: Option[String],
       missingComponentAction: Option[
         MissingComponentActions.MissingComponentAction
-      ]
+      ],
+      cloudProjectDirectoryPath: Option[String]
     )
 
     case class Result(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
@@ -51,11 +51,12 @@ class ProjectOpenHandler[F[+_, +_]: Exec: CovariantFlatMap: Sync](
       projectsDirectory <-
         Sync[F].effect(params.projectsDirectory.map(Files.getAbsoluteFile))
       server <- projectService.openProject(
-        progressTracker        = self,
-        clientId               = clientId,
-        projectId              = params.projectId,
-        missingComponentAction = missingComponentAction,
-        projectsDirectory      = projectsDirectory
+        progressTracker           = self,
+        clientId                  = clientId,
+        projectId                 = params.projectId,
+        missingComponentAction    = missingComponentAction,
+        cloudProjectDirectoryPath = params.cloudProjectDirectoryPath,
+        projectsDirectory         = projectsDirectory
       )
     } yield ProjectOpen.Result(
       engineVersion                     = server.engineVersion,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -300,6 +300,7 @@ class ProjectService[
     clientId: UUID,
     projectId: UUID,
     missingComponentAction: MissingComponentActions.MissingComponentAction,
+    cloudProjectDirectoryPath: Option[String],
     projectsDirectory: Option[File]
   ): F[ProjectServiceFailure, RunningLanguageServerInfo] = {
     for {
@@ -311,11 +312,15 @@ class ProjectService[
       _ <- repo.update(updated).mapError(toServiceFailure)
       projectWithDefaultEdition =
         updated.copy(edition = Some(DefaultEdition.getDefaultEdition))
+      extraEnv = cloudProjectDirectoryPath
+        .map(ProjectService.ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME -> _)
+        .toSeq
       sockets <- startServer(
         progressTracker,
         clientId,
         projectWithDefaultEdition,
-        missingComponentAction
+        missingComponentAction,
+        extraEnv
       )
     } yield sockets
   }
@@ -344,13 +349,14 @@ class ProjectService[
     progressTracker: ActorRef,
     clientId: UUID,
     project: Project,
-    missingComponentAction: MissingComponentActions.MissingComponentAction
+    missingComponentAction: MissingComponentActions.MissingComponentAction,
+    extraEnv: Seq[(String, String)]
   ): F[ProjectServiceFailure, RunningLanguageServerInfo] = for {
     _       <- log.debug("Preparing to start the Language Server for [{}].", project)
     version <- resolveProjectVersion(project)
     _       <- preinstallEngine(progressTracker, version, missingComponentAction)
     sockets <- languageServerGateway
-      .start(progressTracker, clientId, project, version)
+      .start(progressTracker, clientId, project, version, extraEnv)
       .mapError {
         case PreviousInstanceNotShutDown =>
           ProjectOpenFailed(
@@ -580,4 +586,8 @@ object ProjectService {
       created    = project.created,
       lastOpened = project.lastOpened
     )
+
+  /** The variable is used in stdlib to resolve relative paths. */
+  private val ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME =
+    "ENSO_CLOUD_PROJECT_DIRECTORY_PATH"
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
@@ -72,6 +72,7 @@ trait ProjectServiceApi[F[+_, +_]] {
     clientId: UUID,
     projectId: UUID,
     missingComponentAction: MissingComponentActions.MissingComponentAction,
+    cloudProjectDirectoryPath: Option[String],
     projectsDirectory: Option[File]
   ): F[ProjectServiceFailure, RunningLanguageServerInfo]
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
@@ -65,6 +65,7 @@ trait ProjectServiceApi[F[+_, +_]] {
     * @param clientId the requester id
     * @param projectId the project id
     * @param missingComponentAction specifies how to handle missing components
+    * @param cloudProjectDirectoryPath set cloud project directory when running project in hybrid mode
     * @return either failure or a socket of the Language Server
     */
   def openProject(

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
@@ -95,7 +95,8 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
       logLevel      = if (debugLogs) Level.TRACE else Level.ERROR,
       profilingPath = profilingPath,
       profilingTime = None,
-      jvmMode       = false
+      jvmMode       = false,
+      extraEnv      = Seq()
     )
 
   val testClock =

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -10,7 +10,6 @@ import org.slf4j.event.Level
 import java.net.URI
 import org.enso.runtimeversionmanager.components.{Engine, RuntimeVersionManager}
 import org.enso.runtimeversionmanager.config.GlobalRunnerConfigurationManager
-import org.enso.runtimeversionmanager.runner.Runner.ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME
 
 import java.nio.file.Path
 
@@ -105,7 +104,8 @@ class Runner(
       version,
       logLevel,
       logMasking,
-      additionalArguments
+      additionalArguments,
+      Seq()
     )
   }
 
@@ -116,7 +116,8 @@ class Runner(
     version: SemVer,
     logLevel: Level,
     logMasking: Boolean,
-    additionalArguments: Seq[String]
+    additionalArguments: Seq[String],
+    extraEnv: Seq[(String, String)]
   ): Try[RunSettings] =
     Try {
       val arguments = Seq(
@@ -150,9 +151,7 @@ class Runner(
         arguments ++ additionalArguments,
         workingDirectory         = Some(projectDirectory.getParent),
         connectLoggerIfAvailable = true,
-        extraEnv = Seq(
-          ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME -> projectDirectory.toString
-        )
+        extraEnv                 = extraEnv
       )
     }
 
@@ -328,8 +327,4 @@ class Runner(
 object Runner {
 
   private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
-
-  /** The variable is used in stdlib to resolve relative paths. */
-  private val ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME =
-    "ENSO_CLOUD_PROJECT_DIRECTORY_PATH"
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #12650 
followup to #12547

Cloud project directory is an `enso://` path set by GUI when running projects in hybrid mode.

Changelog:
- update: Project Manager API to set `cloudProjectDirectoryPath` that translates to `ENSO_CLOUD_PROJECT_DIRECTORY_PATH` environment variable
- update: Runner is able to set extra environment variables when starting the language server
- update: GUI sets `cloudProjectDirectoryPath` when starting projects in hybrid mode

### Important Notes

Manually checked that the `ENSO_CLOUD_PROJECT_DIRECTORY_PATH` environment variable is present during the language server start

> [TRACE] [2025-03-31T20:29:54.984] [org.enso.projectmanager.infrastructure.languageserver.ExecutorWithUnlimitedPool] Starting Language Server Process [JAVA_HOME="/home/dbushev/.local/share/enso/runtime/graalvm-ce-java21.0.2-24.0.0" ENSO_DATA_DIRECTORY="/home/dbushev/.local/share/enso" ENSO_AUXILIARY_LIBRARY_CACHES="/home/dbushev/.local/share/enso/dist/0.0.0-dev/lib" ENSO_RUNTIME_DIRECTORY="/run/user/1000/enso" ENSO_EDITION_PATH="/home/dbushev/enso/editions" ENSO_CONFIG_DIRECTORY="/home/dbushev/.config/enso" ENSO_HOME="/home/dbushev/enso" ENSO_LOG_DIRECTORY="/home/dbushev/.local/share/enso/log" ENSO_LIBRARY_PATH="/home/dbushev/enso/libraries" ENSO_CLOUD_PROJECT_DIRECTORY_PATH="enso://Users/dbushev" "/home/dbushev/.local/share/enso/runtime/graalvm-ce-java21.0.2-24.0.0/bin/java" "-Dgraal.PrintGraph=Network" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--module-path" "/home/dbushev/.local/share/enso/dist/0.0.0-dev/component" "-m" "org.enso.runner/org.enso.runner.Main" "--logger-connect" "//localhost:6000" "--server" "--root-id" "5072965a-6fcb-47aa-932b-95427c466ab4" "--project-id" "c2560905-0215-4839-a125-26b34297e411" "--path" "/home/dbushev/Documents/enso-projects/cloud-project-2tXDofs9BuAMLsksN54kXXWDiTJ/project_root/project_root" "--interface" "127.0.0.1" "--rpc-port" "64794" "--data-port" "50925" "--log-level" "TRACE" "--no-log-masking"]

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
