### PR TITLE
Limit max memory on MacOS Arm NI builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3907,11 +3907,16 @@ lazy val `engine-runner` = project
     },
     rebuildNativeImage := Def
       .taskDyn {
+        // Limit max memory limit
+        val macArmOnCI =
+          sys.env.get("CI").isDefined && Platform.isMacOS && Platform.isArm64
+        val maxLimit = if (macArmOnCI) Some(10240) else Some(15608)
         NativeImage
           .buildNativeImage(
             "enso",
-            targetDir     = engineDistributionRoot.value / "bin",
-            staticOnLinux = false,
+            buildMemoryLimitMegabytes = maxLimit,
+            targetDir                 = engineDistributionRoot.value / "bin",
+            staticOnLinux             = false,
             // sqlite-jdbc includes `--enable-url-protocols=jar` in its native-image.properites file,
             // which breaks all our class loading. We still want to run `SqliteJdbcFeature` which extracts a proper
             // native library from the jar.


### PR DESCRIPTION
### Pull Request Description

Temporary workaround to self-hosted CI machine with constrained memory resources. Builds will take longer but they _should_ finish instead of blowing up with out of memory error.

### Important Notes

As per build report:
```
 INFO ide_ci::program::command: sbt ℹ️ [2/8] Performing analysis...  [********]                                                              (342,3s @ 10,86GB)
 INFO ide_ci::program::command: sbt ℹ️    82.622 reachable types   (92,4% of   89.384 total)
 INFO ide_ci::program::command: sbt ℹ️   130.041 reachable fields  (63,0% of  206.487 total)
 INFO ide_ci::program::command: sbt ℹ️   503.657 reachable methods (61,0% of  825.175 total)
 INFO ide_ci::program::command: sbt ℹ️     6.085 runtime compiled methods ( 0,7% of  825.175 total)
 INFO ide_ci::program::command: sbt ℹ️    45.572 types, 3.435 fields, and 109.293 methods registered for reflection
 INFO ide_ci::program::command: sbt ℹ️       160 types,   250 fields, and   136 methods registered for JNI access
 INFO ide_ci::program::command: sbt ℹ️         5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z
 INFO ide_ci::program::command: sbt ℹ️ [3/8] Building universe...                                                                             (117,8s @ 8,66GB)
 INFO ide_ci::program::command: sbt ℹ️ [4/8] Parsing methods...      [*******]                                                                (45,4s @ 10,87GB)
 INFO ide_ci::program::command: sbt ℹ️ Error: Image build request for 'enso' (pid: 10083, path: /Volumes/Second/deployed-ci/enso-org-engine-poseidon-0/_work/enso/enso/built-distribution/enso-engine-2025.1.1-nightly.2025.4.1-macos-aarch64/enso-2025.1.1-nightly.2025.4.1/bin) failed with exit status 137
 ```

We will improve our memory usage but this is really bad timing for nightlies to fail.
