### PR TITLE
Clone builder to prevent `EnsoSecretHelper` from leaking secrets

### DIFF
--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -71,7 +71,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
   /** Makes a request with secrets in the query string or headers. * */
   public static EnsoHttpResponse makeRequest(
       HttpClient client,
-      Builder builder,
+      Builder origBuilder,
       URIWithSecrets uri,
       List<Pair<String, HideableValue>> headers,
       boolean useCache)
@@ -79,6 +79,8 @@ public final class EnsoSecretHelper extends SecretValueResolver {
           IOException,
           InterruptedException,
           ResponseTooLargeException {
+    // Clone incoming builder so we can't leak secrets through it
+    var builder = origBuilder.copy();
 
     // Build a new URI with the query arguments.
     URI resolvedURI = resolveURI(uri);


### PR DESCRIPTION
It's possible to get `EnsoSecretHelper` to reveal the value of URL secrets by passing in a `HttpRequest.Builder` to `makeRequest`. Copying the builder at the top of the method prevents this.

This is technically unnecessary since the private constructor of `HTTP` makes it impossible to leak secrets using an `HttpRequest.Builder`, but I would prefer that the constructor privacy is not the only thing preventing this.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
