### PR TITLE
Bump enso4igv runner

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_linux_parser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
         build_mac_arm_parser,
         build_windows_parser,
       ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`ubuntu-20.04` is being deprecated.
Closes #12704.
