### PR TITLE
Fix doc editor newlines

### DIFF
--- a/app/ydoc-shared/src/ast/__tests__/documentation.test.ts
+++ b/app/ydoc-shared/src/ast/__tests__/documentation.test.ts
@@ -118,6 +118,10 @@ describe('Function documentation (Markdown)', () => {
       markdown: 'My function\nSecond paragraph',
     },
     {
+      source: '## # Header\n   Paragraph',
+      markdown: '# Header\nParagraph',
+    },
+    {
       source: '## Trailing whitespace \n\n   Second paragraph',
       markdown: 'Trailing whitespace \nSecond paragraph',
     },
@@ -181,15 +185,18 @@ describe('Function documentation (Markdown)', () => {
     },
   ]
 
-  test.each(cases)('Enso source comments to prerendered markdown', ({ source, markdown }) => {
-    const moduleSource = `${source}\nmain =\n    x = 1`
-    const topLevel = parseModule(moduleSource)
-    topLevel.module.setRoot(topLevel)
-    const main = iter.first(topLevel.statements())
-    assert(main instanceof MutableFunctionDef)
-    expect(main.name.code()).toBe('main')
-    expect(main.mutableDocumentationMarkdown().toJSON()).toBe(markdown)
-  })
+  test.each(cases)(
+    'Enso source comments to prerendered markdown (`abstractMarkdown`)',
+    ({ source, markdown }) => {
+      const moduleSource = `${source}\nmain =\n    x = 1`
+      const topLevel = parseModule(moduleSource)
+      topLevel.module.setRoot(topLevel)
+      const main = iter.first(topLevel.statements())
+      assert(main instanceof MutableFunctionDef)
+      expect(main.name.code()).toBe('main')
+      expect(main.mutableDocumentationMarkdown().toJSON()).toBe(markdown)
+    },
+  )
 
   test.each(cases)('Markdown to Enso source', ({ source, markdown, normalized }) => {
     const functionCode = 'main =\n    x = 1'

--- a/app/ydoc-shared/src/ast/__tests__/ensoMarkdown.test.ts
+++ b/app/ydoc-shared/src/ast/__tests__/ensoMarkdown.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { type DebugTree, debugTree } from '../../util/lezer'
-import { ensoMarkdownParser } from '../ensoMarkdown'
+import { ensoMarkdownParser, ensoStandardMarkdownParser } from '../ensoMarkdown'
 
 function checkTree({
   source,
@@ -767,3 +767,31 @@ test.each([
     expected: ['Document', ['FencedCode', ['CodeMark', '```'], ['CodeText', 'Code']]],
   },
 ])('Markdown syntax tree: $source', checkTree)
+
+// === Standard markdown, standard representation ===
+
+// These cases test the behavior of the parser for our (CommonMark-compatible) serialization format.
+// Some of them cover behavior that the CommonMark standard leaves implementation-defined, and
+// otherwise they serve to document the nodes of the parser's tree.
+
+describe('Soft breaks', () => {
+  test.each([
+    'Paragraph\ncontinuation',
+    '- Bullet list\ncontinuation',
+    '1. Numbered list\ncontinuation',
+  ])('Soft break continues element: $source', (source) => {
+    const blockElements = debugTree(ensoStandardMarkdownParser.parse(source), source).length - 1
+    expect(blockElements).toBe(1)
+  })
+
+  test.each([
+    '# Header\nParagraph',
+    '```\nFenced code\n```\nParagraph',
+    '    Indented code\nParagraph',
+    '    Block quote\nParagraph',
+    '- List\n# Header',
+  ])('Soft break ends element: $source', (source) => {
+    const blockElements = debugTree(ensoStandardMarkdownParser.parse(source), source).length - 1
+    expect(blockElements).toBe(2)
+  })
+})

--- a/app/ydoc-shared/src/ast/documentation.ts
+++ b/app/ydoc-shared/src/ast/documentation.ts
@@ -118,6 +118,35 @@ function toRawMarkdown(elements: undefined | TextToken<ConcreteRefs>[]): {
 // === Markdown ===
 
 /**
+ * @returns Whether following text after a soft break will be interpreted as a continuation of the
+ * node, rather than a separate paragraph node.
+ *
+ * This must match the behavior covered by the "Soft break" tests in `ensoMarkdown.test.ts`.
+ */
+function requiresNewlineBeforeFollowingParagraph(nodeType: string) {
+  switch (nodeType) {
+    case 'ATXHeading1':
+    case 'ATXHeading2':
+    case 'ATXHeading3':
+    case 'ATXHeading4':
+    case 'ATXHeading5':
+    case 'ATXHeading6':
+    case 'Blockquote':
+    case 'FencedCode':
+    case 'Table':
+      return false
+    case 'Paragraph':
+    case 'BulletList':
+    case 'OrderedList':
+      return true
+    default:
+      // The safer default is to treat the newline as creating a new element, not a wrapped
+      // continuation of the previous element.
+      return false
+  }
+}
+
+/**
  * Convert the Markdown input to a format with "prerendered" linebreaks: Hard-wrapped lines within
  * a paragraph will be joined, and only a single linebreak character is used to separate paragraphs.
  */
@@ -131,7 +160,13 @@ export function prerenderMarkdown(markdown: string): string {
     if (prevTo < cursor.from) {
       const textBetween = markdown.slice(prevTo, cursor.from)
       prerendered +=
-        cursor.name === 'Paragraph' && prevName !== 'Table' ? textBetween.slice(0, -1) : textBetween
+        (
+          cursor.name === 'Paragraph' &&
+          prevName &&
+          requiresNewlineBeforeFollowingParagraph(prevName)
+        ) ?
+          textBetween.slice(0, -1)
+        : textBetween
     }
     const text = markdown.slice(cursor.from, cursor.to)
     prerendered += cursor.name === 'Paragraph' ? text.replaceAll(/ *\n */g, ' ') : text


### PR DESCRIPTION
### Pull Request Description

Documentation editor: Fix bug affecting interpretation of newlines between some block elements.

Fixes #12719.

### Important Notes

The new test in `documentation.test.ts` fails without this fix. Add some tests to `ensoMarkdown.test.ts` documenting which block elements may be separated by a single newline in the serialized representation; correct the implementation's handling of a few block type sequences.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
