### PR TITLE
Further bump max memory on mac build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3916,7 +3916,7 @@ lazy val `engine-runner` = project
         // Limit max memory limit
         val macArmOnCI =
           sys.env.get("CI").isDefined && Platform.isMacOS && Platform.isArm64
-        val maxLimit = if (macArmOnCI) Some(10240) else Some(15608)
+        val maxLimit = if (macArmOnCI) Some(12288) else Some(15608)
         NativeImage
           .buildNativeImage(
             "enso",


### PR DESCRIPTION
### Pull Request Description

Another attempt to workaround CI problems. Looks like 10GB leads to deadlocks when building NI.