### PR TITLE
Hide temporary directories of projects running in Hybrid mode

### DIFF
--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -592,10 +592,24 @@ function extractProjectMetadata(yamlObj: unknown, jsonObj: unknown): ProjectMeta
 }
 
 /**
- * Checks if files that start with the dot.
- * Note on Windows does not check the hidden property.
+ * Check whether the file entry should be hidden from the user.
  */
 function isHidden(filePath: string): boolean {
+  return isDotfile(filePath) || isCloudProject(filePath)
+}
+
+/**
+ * Check if files that start with the dot.
+ * Note on Windows does not check the hidden property.
+ */
+function isDotfile(filePath: string): boolean {
   const dotfile = /(^|[\\/])\.[^\\/]+$/g
   return dotfile.test(filePath)
+}
+
+/**
+ * Check if the path is a temporary path for cloud project running in hybrid mode.
+ */
+function isCloudProject(filePath: string): boolean {
+  return filePath.includes('cloud-project-')
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/command/filesystem/FileSystemListCommand.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/command/filesystem/FileSystemListCommand.scala
@@ -55,6 +55,9 @@ object FileSystemListCommand {
     new FileSystemListCommand[F](service, path)
   }
 
+  /** Prefix for the temporary directory of a cloud project running in hybrid mode. */
+  private val CLOUD_PROJECT_PREFIX = "cloud-project-"
+
   /** Filters the files system entries that are not hidden.
     *
     * @param entries the file system entries
@@ -63,7 +66,7 @@ object FileSystemListCommand {
   private def filterNotHidden(
     entries: Seq[FileSystemEntry]
   ): Seq[FileSystemEntry] =
-    entries.filterNot(isHidden)
+    entries.filterNot(entry => isHidden(entry) || isTempCloudProject(entry))
 
   /** Checks whether the provided entry is hidden.
     *
@@ -75,5 +78,16 @@ object FileSystemListCommand {
     */
   private def isHidden(entry: FileSystemEntry): Boolean = {
     entry.path.isHidden || entry.path.getName.startsWith(".")
+  }
+
+  /** Check whether the provided entry is a temporary directory for a cloud
+    * project running in hybrid mode.
+    *
+    * @param entry the file system entry
+    * @return `true` if the entry is a temporary cloud project directory
+    */
+  private def isTempCloudProject(entry: FileSystemEntry): Boolean = {
+    entry.path.isDirectory &&
+    entry.path.getName.startsWith(CLOUD_PROJECT_PREFIX)
   }
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- update: GUI project manager shim filters out directories starting with `cloud-project-`
- update: project manager filters out directories starting with `cloud-project-`

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
