### PR TITLE
Methods from multiple types in component browser

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import CodeMirrorInlineRoot from '@/components/CodeMirrorInlineRoot.vue'
+import ComponentEditorLabel from '@/components/ComponentBrowser/ComponentEditorLabel.vue'
 import type { ComponentBrowserMode, Usage } from '@/components/ComponentBrowser/input'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useGraphStore } from '@/stores/graph'
 import { useCodeMirror, useStringSync } from '@/util/codemirror'
 import { DEFAULT_ICON, iconOfNode, suggestionEntryToIcon } from '@/util/getIconName'
-import { qnLastSegment } from '@/util/qualifiedName'
 import { computed, useTemplateRef, watch, type ComponentInstance, type DeepReadonly } from 'vue'
 import { Range } from 'ydoc-shared/util/data/range'
 
@@ -55,16 +55,6 @@ const icon = computed(() => {
   return DEFAULT_ICON
 })
 
-const label = computed(() => {
-  if (props.mode.mode !== 'componentBrowsing') return undefined
-  if (props.mode.filter.selfArg == null) return 'Input Components'
-  if (props.mode.filter.selfArg.type === 'known' && props.mode.filter.selfArg.typename.path) {
-    return `${qnLastSegment(props.mode.filter.selfArg.typename.path)} Components`
-  }
-
-  return undefined
-})
-
 const focus = editorView.focus.bind(editorView)
 
 defineExpose({
@@ -91,8 +81,15 @@ const rootStyle = computed(() => {
     <div :class="{ componentEditorIcon: true, port: props.mode.mode !== 'componentBrowsing' }">
       <SvgIcon :name="icon" />
     </div>
-    <span v-if="label" class="selfArgInfo" data-testid="component-editor-label" v-text="label" />
-    <SvgIcon v-if="label" class="selfArgInfoArrow" name="folder_closed" />
+    <ComponentEditorLabel
+      v-if="props.mode.mode === 'componentBrowsing'"
+      :selfArg="props.mode.filter.selfArg"
+    />
+    <SvgIcon
+      v-if="props.mode.mode === 'componentBrowsing'"
+      class="selfArgInfoArrow"
+      name="folder_closed"
+    />
     <CodeMirrorInlineRoot ref="editorRoot" />
   </div>
 </template>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -6,14 +6,14 @@ import { computed } from 'vue'
 
 const props = defineProps<{ selfArg?: SelfArg | undefined }>()
 
-type AdditionalTypes =
+type DisplayedAdditionalTypes =
   | null
   | { kind: 'single'; type: string }
   | { kind: 'multiple'; types: string[] }
 
-const additionalTypes = computed<AdditionalTypes>(() => {
+const additionalTypes = computed<DisplayedAdditionalTypes>(() => {
   if (props.selfArg?.type === 'known') {
-    const additionalTypes = props.selfArg.hiddenTypes.flatMap((type) =>
+    const additionalTypes = props.selfArg.additionalTypes.flatMap((type) =>
       type.path ? qnLastSegment(type.path) : [],
     )
     if (additionalTypes.length === 0) return null

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { SelfArg } from '@/components/ComponentBrowser/filtering'
+import TooltipTrigger from '@/components/TooltipTrigger.vue'
+import { qnLastSegment } from '@/util/qualifiedName'
+import { computed } from 'vue'
+
+const props = defineProps<{ selfArg?: SelfArg | undefined }>()
+
+type AdditionalTypes =
+  | null
+  | { kind: 'single'; type: string }
+  | { kind: 'multiple'; types: string[] }
+
+const additionalTypes = computed<AdditionalTypes>(() => {
+  if (props.selfArg?.type === 'known') {
+    const additionalTypes = props.selfArg.hiddenTypes.flatMap((type) =>
+      type.path ? qnLastSegment(type.path) : [],
+    )
+    if (additionalTypes.length === 0) return null
+    if (additionalTypes.length === 1 && additionalTypes[0]) {
+      return { kind: 'single', type: additionalTypes[0] }
+    } else {
+      return { kind: 'multiple', types: additionalTypes }
+    }
+  }
+  return null
+})
+
+const label = computed(() => {
+  if (props.selfArg == null) return 'Input'
+  if (props.selfArg.type === 'known' && props.selfArg.typename.path) {
+    return qnLastSegment(props.selfArg.typename.path)
+  }
+
+  return undefined
+})
+</script>
+
+<template>
+  <div v-if="label" data-testid="component-editor-label">
+    <span v-if="additionalTypes?.kind === 'single'" v-text="`${label} & ${additionalTypes.type}`" />
+    <template v-else-if="additionalTypes?.kind === 'multiple'">
+      <span v-text="`${label} & `" />
+      <TooltipTrigger>
+        <template #default="triggerProps">
+          <span
+            class="additionalTypesPlaceholder"
+            v-bind="triggerProps"
+            v-text="`${additionalTypes.types.length} more`"
+          />
+        </template>
+        <template #tooltip>
+          <div style="display: flex; flex-direction: column">
+            <span v-for="type in additionalTypes.types" :key="type" v-text="type" />
+          </div>
+        </template>
+      </TooltipTrigger>
+    </template>
+    <span v-else v-text="label" />
+    <span> Components</span>
+  </div>
+</template>
+
+<style scoped>
+.additionalTypesPlaceholder {
+  background-color: rgba(0, 0, 0, 0.1);
+  padding: 1px 2px;
+  border-radius: 2px;
+}
+</style>

--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/component.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/component.test.ts
@@ -14,6 +14,8 @@ import {
   makeStaticMethod,
 } from '@/stores/suggestionDatabase/mockSuggestion'
 import { allRanges } from '@/util/data/range'
+import { ProjectPath } from '@/util/projectPath'
+import { QualifiedName } from '@/util/qualifiedName'
 import shuffleSeed from 'shuffle-seed'
 import { expect, test } from 'vitest'
 
@@ -24,7 +26,18 @@ test.each([
   [makeConstructor('Standard.Table.Join_Kind.Join_Kind.Inner'), 'Join_Kind.Inner'],
   [makeModuleMethod('local.Mock_Project.main'), 'Main.main'],
 ])("$name Component's label is valid", (suggestion, expected) => {
-  expect(labelOfEntry(suggestion, { score: 0 }).label).toBe(expected)
+  expect(labelOfEntry(suggestion, { score: 0, fromType: undefined }).label).toBe(expected)
+})
+
+test.each([
+  [makeMethod('Standard.Base.Table.at'), undefined, 'at'],
+  [
+    makeMethod('Standard.Base.Table.at'),
+    ProjectPath.create('Standard.Base' as QualifiedName, 'Table' as QualifiedName),
+    ':Table.at',
+  ],
+])("Component's label with fromType is valid", (suggestion, fromType, expected) => {
+  expect(labelOfEntry(suggestion, { score: 0, fromType }).label).toBe(expected)
 })
 
 test('Suggestions are ordered properly', () => {
@@ -32,42 +45,53 @@ test('Suggestions are ordered properly', () => {
     {
       id: 100,
       entry: makeModuleMethod('local.Mock_Project.Z.best_score'),
-      match: { score: 0 },
+      match: { score: 0, fromType: undefined },
     },
     {
       id: 90,
       entry: { ...makeModuleMethod('local.Mock_Project.Z.b'), groupIndex: 0 },
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
     {
       id: 91,
       entry: { ...makeModuleMethod('local.Mock_Project.Z.a'), groupIndex: 0 },
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
     {
       id: 89,
       entry: { ...makeModuleMethod('local.Mock_Project.A.foo'), groupIndex: 1 },
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
     {
       id: 88,
       entry: { ...makeModuleMethod('local.Mock_Project.B.another_module'), groupIndex: 1 },
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
     {
       id: 87,
       entry: { ...makeModule('local.Mock_Project.A'), groupIndex: 1 },
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
+    },
+    {
+      id: 30,
+      entry: makeMethod('local.Mock_Project.Table.method'),
+      match: {
+        score: 50,
+        fromType: ProjectPath.create(
+          'local.Mock_Project' as QualifiedName,
+          'Table' as QualifiedName,
+        ),
+      },
     },
     {
       id: 50,
       entry: makeModuleMethod('local.Mock_Project.Z.module_content'),
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
     {
       id: 49,
       entry: makeModule('local.Mock_Project.Z.Module'),
-      match: { score: 50 },
+      match: { score: 50, fromType: undefined },
     },
   ]
   const expectedOrdering = Array.from(sortedEntries, (entry) => entry.id)
@@ -93,21 +117,48 @@ test.each`
   ${'bar'}                       | ${['xyz_foo_abc_bar_xyz']}       | ${'Main.bar (xyz_<foo>_abc<_bar>_xyz)'}
   ${'bar'}                       | ${['xyz_fooabc_abc_barabc_xyz']} | ${'Main.bar (xyz_<foo>abc_abc<_bar>abc_xyz)'}
 `('Matched ranges of $highlighted are correct', ({ name, aliases, highlighted }) => {
-  function replaceMatches(component: Component) {
-    if (!component.matchedRanges) return component.label
-    const parts: string[] = []
-    for (const range of allRanges(component.matchedRanges, component.label.length)) {
-      const text = range.slice(component.label)
-      parts.push(range.isMatch ? `<${text}>` : text)
-    }
-    return parts.join('')
-  }
-
   const pattern = 'foo_bar'
   const entry = makeModuleMethod(`local.Mock_Project.${name}`, { aliases: aliases ?? [] })
   const filtering = new Filtering({ pattern })
-  const match = filtering.filter(entry, [])
+  const match = filtering.filter(entry)
   expect(match).not.toBeNull()
   const componentInfo = { id: 0, entry, match: match! }
   expect(replaceMatches(makeComponent(componentInfo))).toEqual(highlighted)
 })
+
+test.each`
+  name                      | aliases                      | highlighted
+  ${'Table.foo_bar'}        | ${[]}                        | ${':Table.<foo><_bar>'}
+  ${'Table.foo_xyz_barabc'} | ${[]}                        | ${':Table.<foo>_xyz<_bar>abc'}
+  ${'Table.fooabc_barabc'}  | ${[]}                        | ${':Table.<foo>abc<_bar>abc'}
+  ${'Table.bar'}            | ${['foo_bar', 'foo']}        | ${':Table.bar (<foo><_bar>)'}
+  ${'Table.bar'}            | ${['foo', 'foo_xyz_barabc']} | ${':Table.bar (<foo>_xyz<_bar>abc)'}
+`(
+  'Matched ranges of $highlighted with additional type are correct',
+  ({ name, aliases, highlighted }) => {
+    const pattern = 'foo_bar'
+    const entry = makeMethod(`local.Mock_Project.${name}`, { aliases: aliases ?? [] })
+    const filtering = new Filtering({
+      pattern,
+      selfArg: {
+        type: 'known',
+        typename: ProjectPath.create(undefined, 'Column' as QualifiedName),
+        additionalTypes: [ProjectPath.create(undefined, 'Table' as QualifiedName)],
+      },
+    })
+    const match = filtering.filter(entry)
+    expect(match).not.toBeNull()
+    const componentInfo = { id: 0, entry, match: match! }
+    expect(replaceMatches(makeComponent(componentInfo))).toEqual(highlighted)
+  },
+)
+
+function replaceMatches(component: Component) {
+  if (!component.matchedRanges) return component.label
+  const parts: string[] = []
+  for (const range of allRanges(component.matchedRanges, component.label.length)) {
+    const text = range.slice(component.label)
+    parts.push(range.isMatch ? `<${text}>` : text)
+  }
+  return parts.join('')
+}

--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -25,7 +25,7 @@ test.each([
   makeStaticMethod('local.Project.Internalization.internalize'),
 ])('$name entry is in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry, [])).not.toBeNull()
+  expect(filtering.filter(entry)).not.toBeNull()
 })
 
 test.each([
@@ -37,7 +37,7 @@ test.each([
   makeStaticMethod('Standard.Base.Internal.Foo.bar'), // Internal method
 ])('$name entry is not in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry, [])).toBeNull()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 function stdPath(path: string) {
@@ -52,19 +52,19 @@ test('An Instance method is shown when self arg matches', () => {
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
-      hiddenTypes: [],
+      additionalTypes: [],
     },
   })
-  expect(filteringWithSelfType.filter(entry1, [])).not.toBeNull()
-  expect(filteringWithSelfType.filter(entry2, [])).toBeNull()
+  expect(filteringWithSelfType.filter(entry1)).not.toBeNull()
+  expect(filteringWithSelfType.filter(entry2)).toBeNull()
   const filteringWithAnySelfType = new Filtering({
     selfArg: { type: 'unknown' },
   })
-  expect(filteringWithAnySelfType.filter(entry1, [])).not.toBeNull()
-  expect(filteringWithAnySelfType.filter(entry2, [])).not.toBeNull()
+  expect(filteringWithAnySelfType.filter(entry1)).not.toBeNull()
+  expect(filteringWithAnySelfType.filter(entry2)).not.toBeNull()
   const filteringWithoutSelfType = new Filtering({ pattern: 'get' })
-  expect(filteringWithoutSelfType.filter(entry1, [])).toBeNull()
-  expect(filteringWithoutSelfType.filter(entry2, [])).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry1)).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry2)).toBeNull()
 })
 
 test('`Any` type methods taken into account when filtering', () => {
@@ -74,37 +74,34 @@ test('`Any` type methods taken into account when filtering', () => {
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
-      hiddenTypes: [],
+      additionalTypes: [],
     },
   })
-  expect(filtering.filter(entry1, [])).not.toBeNull()
-  expect(filtering.filter(entry2, [])).not.toBeNull()
+  expect(filtering.filter(entry1)).not.toBeNull()
+  expect(filtering.filter(entry2)).not.toBeNull()
 
   const filteringWithoutSelfType = new Filtering({})
-  expect(filteringWithoutSelfType.filter(entry1, [])).toBeNull()
-  expect(filteringWithoutSelfType.filter(entry2, [])).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry1)).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry2)).toBeNull()
 })
 
 test('Additional self types are taken into account when filtering', () => {
   const entry1 = makeMethod('Standard.Base.Data.Numbers.Float.abs')
   const entry2 = makeMethod('Standard.Base.Data.Numbers.Number.sqrt')
   const additionalSelfType = stdPath('Standard.Base.Data.Numbers.Number')
-  const filtering = new Filtering({
+  const filteringWithAdditionalSelfType = new Filtering({
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Numbers.Float'),
-      hiddenTypes: [],
+      additionalTypes: [additionalSelfType],
     },
   })
-  expect(filtering.filter(entry1, [additionalSelfType])).not.toBeNull()
-  expect(filtering.filter(entry2, [additionalSelfType])).not.toBeNull()
-  expect(filtering.filter(entry2, [])).toBeNull()
+  expect(filteringWithAdditionalSelfType.filter(entry1)).not.toBeNull()
+  expect(filteringWithAdditionalSelfType.filter(entry2)).not.toBeNull()
 
   const filteringWithoutSelfType = new Filtering({})
-  expect(filteringWithoutSelfType.filter(entry1, [additionalSelfType])).toBeNull()
-  expect(filteringWithoutSelfType.filter(entry2, [additionalSelfType])).toBeNull()
-  expect(filteringWithoutSelfType.filter(entry1, [])).toBeNull()
-  expect(filteringWithoutSelfType.filter(entry2, [])).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry1)).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry2)).toBeNull()
 })
 
 test.each([
@@ -120,10 +117,10 @@ test.each([
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
-      hiddenTypes: [],
+      additionalTypes: [],
     },
   })
-  expect(filtering.filter(entry, [])).toBeNull()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 test.each`
@@ -138,7 +135,7 @@ test.each`
 `('$name is not matched by pattern $pattern', ({ name, pattern }) => {
   const entry = makeModuleMethod(`local.Project.${name}`)
   const filtering = new Filtering({ pattern })
-  expect(filtering.filter(entry, [])).toBeNull()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 function matchedText(ownerName: string, name: string, matchResult: MatchResult) {
@@ -246,7 +243,7 @@ test.each<MatchingTestCase>([
   const matchedSortedEntries = matchedSorted.map(({ name, aliases, module }) =>
     makeModuleMethod(`${module ?? 'local.Project'}.${name}`, { aliases: aliases ?? [] }),
   )
-  const matchResults = matchedSortedEntries.map((entry) => filtering.filter(entry, []))
+  const matchResults = matchedSortedEntries.map((entry) => filtering.filter(entry))
   // Checking matching entries
   function checkResult(entry: SuggestionEntry, result: Opt<MatchResult>) {
     expect(result, `Matching entry ${JSON.stringify(entry.definitionPath)}`).not.toBeNull()
@@ -281,6 +278,6 @@ test.each<MatchingTestCase>([
     const entry = makeModuleMethod(`${module ?? 'local.Project'}.${name}`, {
       aliases: aliases ?? [],
     })
-    expect(filtering.filter(entry, []), JSON.stringify(entry.definitionPath)).toBeNull()
+    expect(filtering.filter(entry), JSON.stringify(entry.definitionPath)).toBeNull()
   }
 })

--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -52,6 +52,7 @@ test('An Instance method is shown when self arg matches', () => {
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
+      hiddenTypes: [],
     },
   })
   expect(filteringWithSelfType.filter(entry1, [])).not.toBeNull()
@@ -73,6 +74,7 @@ test('`Any` type methods taken into account when filtering', () => {
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
+      hiddenTypes: [],
     },
   })
   expect(filtering.filter(entry1, [])).not.toBeNull()
@@ -88,7 +90,11 @@ test('Additional self types are taken into account when filtering', () => {
   const entry2 = makeMethod('Standard.Base.Data.Numbers.Number.sqrt')
   const additionalSelfType = stdPath('Standard.Base.Data.Numbers.Number')
   const filtering = new Filtering({
-    selfArg: { type: 'known', typename: stdPath('Standard.Base.Data.Numbers.Float') },
+    selfArg: {
+      type: 'known',
+      typename: stdPath('Standard.Base.Data.Numbers.Float'),
+      hiddenTypes: [],
+    },
   })
   expect(filtering.filter(entry1, [additionalSelfType])).not.toBeNull()
   expect(filtering.filter(entry2, [additionalSelfType])).not.toBeNull()
@@ -114,6 +120,7 @@ test.each([
     selfArg: {
       type: 'known',
       typename: stdPath('Standard.Base.Data.Vector.Vector'),
+      hiddenTypes: [],
     },
   })
   expect(filtering.filter(entry, [])).toBeNull()

--- a/app/gui/src/project-view/components/ComponentBrowser/component.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/component.ts
@@ -11,13 +11,15 @@ import { compareOpt } from '@/util/compare'
 import { isSome } from '@/util/data/opt'
 import { displayedIconOf } from '@/util/getIconName'
 import { type Icon } from '@/util/iconMetadata/iconName'
-import { type ProjectPath } from '@/util/projectPath'
+import { ProjectPath } from '@/util/projectPath'
 import { qnLastSegment } from '@/util/qualifiedName'
 import * as map from 'lib0/map'
 import { Range } from 'ydoc-shared/util/data/range'
 
 interface ComponentLabelInfo {
   label: string
+  /** Offset already applied to `matchedRanges`. */
+  appliedOffset?: number | undefined
   matchedAlias?: string | undefined
   matchedRanges?: Range[] | undefined
 }
@@ -41,10 +43,7 @@ export interface SuggestedComponent extends Component {
 /** @returns the displayed label of given suggestion entry with information of highlighted ranges. */
 export function labelOfEntry(entry: SuggestionEntry, match: MatchResult): ComponentLabelInfo {
   if (entryIsStatic(entry)) {
-    const label =
-      match.fromType?.path ?
-        ':' + qnLastSegment(match.fromType.path) + '.' + entryDisplayPath(entry)
-      : entryDisplayPath(entry)
+    const label = entryDisplayPath(entry)
     if ((!match.ownerNameRanges && !match.nameRanges) || match.matchedAlias) {
       return {
         label,
@@ -61,20 +60,37 @@ export function labelOfEntry(entry: SuggestionEntry, match: MatchResult): Compon
         ...(match.nameRanges ?? []).map((range) => range.shift(nameOffset)),
       ],
     }
+  } else if (match.fromType != null) {
+    const label = displayTypeCasted(match.fromType, entry)
+    const appliedOffset = typeCastedNameRangesOffset(match.fromType)
+    const matchedRanges =
+      match.nameRanges != null ? match.nameRanges.map((range) => range.shift(appliedOffset)) : null
+    return matchedRanges != null ?
+        { label, appliedOffset, matchedAlias: match.matchedAlias, matchedRanges }
+      : { label, appliedOffset, matchedAlias: match.matchedAlias }
   } else {
-    const label =
-      match.fromType?.path ?
-        ':' + qnLastSegment(match.fromType.path) + '.' + entry.name
-      : entry.name
-    return match.nameRanges ?
-        { label, matchedAlias: match.matchedAlias, matchedRanges: match.nameRanges }
+    const label = entry.name
+    const matchedRanges = match.nameRanges
+    return matchedRanges != null ?
+        { label, matchedAlias: match.matchedAlias, matchedRanges }
       : { label, matchedAlias: match.matchedAlias }
   }
 }
 
+function displayTypeCasted(fromType: ProjectPath, entry: SuggestionEntry): string {
+  if (fromType.path == null) return entry.name
+  return `:${qnLastSegment(fromType.path)}.${entry.name}`
+}
+
+function typeCastedNameRangesOffset(fromType: ProjectPath): number {
+  if (fromType.path == null) return 0
+  // Length of the type name + 2 for `:` and `.`
+  return qnLastSegment(fromType.path).length + 2
+}
+
 function formatLabel(labelInfo: ComponentLabelInfo): ComponentLabel {
   const shift = labelInfo.label.length + 2
-  const shiftRange = (range: Range) => range.shift(shift)
+  const shiftRange = (range: Range) => range.shift(shift - (labelInfo.appliedOffset ?? 0))
   return !labelInfo.matchedAlias ?
       { label: labelInfo.label, matchedRanges: labelInfo.matchedRanges }
     : {
@@ -128,18 +144,9 @@ export function makeComponentLists(
   filtering: Filtering,
 ): Map<GroupId, ReadonlyArray<Component>> {
   function* matchSuggestions() {
-    const additionalSelfTypes: ProjectPath[] = []
-    if (filtering.selfArg?.type === 'known') {
-      const entry = db.getEntryByProjectPath(filtering.selfArg.typename)
-      if (entry) additionalSelfTypes.push(...db.ancestors(entry))
-      if (filtering.selfArg.hiddenTypes) {
-        additionalSelfTypes.push(...filtering.selfArg.hiddenTypes)
-      }
-    }
-
     for (const [id, entry] of db.entries()) {
       if (!entry) continue
-      const match = filtering.filter(entry, additionalSelfTypes)
+      const match = filtering.filter(entry)
       if (isSome(match)) {
         const component = makeComponent({ id, entry, match })
         yield { id, entry, match, component }

--- a/app/gui/src/project-view/components/ComponentBrowser/component.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/component.ts
@@ -12,6 +12,7 @@ import { isSome } from '@/util/data/opt'
 import { displayedIconOf } from '@/util/getIconName'
 import { type Icon } from '@/util/iconMetadata/iconName'
 import { type ProjectPath } from '@/util/projectPath'
+import { qnLastSegment } from '@/util/qualifiedName'
 import * as map from 'lib0/map'
 import { Range } from 'ydoc-shared/util/data/range'
 
@@ -40,7 +41,10 @@ export interface SuggestedComponent extends Component {
 /** @returns the displayed label of given suggestion entry with information of highlighted ranges. */
 export function labelOfEntry(entry: SuggestionEntry, match: MatchResult): ComponentLabelInfo {
   if (entryIsStatic(entry)) {
-    const label = entryDisplayPath(entry)
+    const label =
+      match.fromType?.path ?
+        ':' + qnLastSegment(match.fromType.path) + '.' + entryDisplayPath(entry)
+      : entryDisplayPath(entry)
     if ((!match.ownerNameRanges && !match.nameRanges) || match.matchedAlias) {
       return {
         label,
@@ -57,10 +61,15 @@ export function labelOfEntry(entry: SuggestionEntry, match: MatchResult): Compon
         ...(match.nameRanges ?? []).map((range) => range.shift(nameOffset)),
       ],
     }
-  } else
+  } else {
+    const label =
+      match.fromType?.path ?
+        ':' + qnLastSegment(match.fromType.path) + '.' + entry.name
+      : entry.name
     return match.nameRanges ?
-        { label: entry.name, matchedAlias: match.matchedAlias, matchedRanges: match.nameRanges }
-      : { label: entry.name, matchedAlias: match.matchedAlias }
+        { label, matchedAlias: match.matchedAlias, matchedRanges: match.nameRanges }
+      : { label, matchedAlias: match.matchedAlias }
+  }
 }
 
 function formatLabel(labelInfo: ComponentLabelInfo): ComponentLabel {
@@ -123,6 +132,9 @@ export function makeComponentLists(
     if (filtering.selfArg?.type === 'known') {
       const entry = db.getEntryByProjectPath(filtering.selfArg.typename)
       if (entry) additionalSelfTypes.push(...db.ancestors(entry))
+      if (filtering.selfArg.hiddenTypes) {
+        additionalSelfTypes.push(...filtering.selfArg.hiddenTypes)
+      }
     }
 
     for (const [id, entry] of db.entries()) {

--- a/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
@@ -9,6 +9,7 @@ export type SelfArg =
   | {
       type: 'known'
       typename: ProjectPath
+      hiddenTypes: ProjectPath[]
     }
   | { type: 'unknown' }
 
@@ -44,6 +45,7 @@ interface MatchedParts {
 
 export interface MatchResult extends MatchedParts {
   score: number
+  fromType: ProjectPath | undefined
 }
 
 class FilteringName {
@@ -179,7 +181,12 @@ class FilteringWithPattern {
     return null
   }
 
-  tryMatch(name: string, aliases: string[], memberOf: ProjectPath): MatchResult | null {
+  tryMatch(
+    name: string,
+    aliases: string[],
+    memberOf: ProjectPath,
+    additionalSelfTypes: ProjectPath[],
+  ): MatchResult | null {
     const nameMatch: (NameMatchResult & { alias?: string }) | null =
       this.nameFilter.tryMatch(name) ?? this.firstMatchingAlias(aliases)
     const ownerNameMatch = this.ownerNameFilter.tryMatch(
@@ -188,7 +195,8 @@ class FilteringWithPattern {
     if (!nameMatch && !ownerNameMatch) return null
     if (this.bothFiltersMustMatch && (!nameMatch || !ownerNameMatch)) return null
 
-    const result: MatchResult = { score: 0 }
+    const fromType = additionalSelfTypes.find((t) => t.equals(memberOf)) ? memberOf : undefined
+    const result: MatchResult = { score: 0, fromType }
     if (nameMatch) {
       result.score += nameMatch.score
       if ('alias' in nameMatch) {
@@ -251,15 +259,18 @@ export class Filtering {
   private selfTypeMatches(
     entry: SuggestionEntry,
     additionalSelfTypes: ProjectPath[],
-  ): { score: number } | null {
+  ): { score: number; fromType: ProjectPath | undefined } | null {
     if (this.selfArg == null)
-      return entry.kind !== SuggestionKind.Method || entry.selfType == null ? { score: 0 } : null
+      return entry.kind !== SuggestionKind.Method || entry.selfType == null ?
+          { score: 0, fromType: undefined }
+        : null
     if (entry.kind !== SuggestionKind.Method || entry.selfType == null) return null
-    if (this.selfArg.type !== 'known') return { score: 0 }
+    if (this.selfArg.type !== 'known') return { score: 0, fromType: undefined }
     const entrySelfType = entry.selfType
-    if (entrySelfType.equals(this.selfArg.typename)) return { score: 0 }
-    if (entrySelfType.equals(ANY_TYPE) || additionalSelfTypes.some((t) => entrySelfType.equals(t)))
-      return { score: DIFFERENT_TYPE_PENALTY }
+    if (entrySelfType.equals(this.selfArg.typename)) return { score: 0, fromType: undefined }
+    const additionalSelfType = additionalSelfTypes.find((t) => entrySelfType.equals(t))
+    if (entrySelfType.equals(ANY_TYPE) || additionalSelfType != null)
+      return { score: DIFFERENT_TYPE_PENALTY, fromType: additionalSelfType }
     return null
   }
 
@@ -271,7 +282,7 @@ export class Filtering {
   private mainViewFilter(entry: SuggestionEntry): MatchResult | null {
     const hasGroup = entry.groupIndex != null
     const isInTopModule = entry.definedIn.isTopElement()
-    if (hasGroup || isInTopModule) return { score: 0 }
+    if (hasGroup || isInTopModule) return { score: 0, fromType: entry.definedIn }
     else return null
   }
 
@@ -286,7 +297,12 @@ export class Filtering {
     const selfTypeMatch = this.selfTypeMatches(entry, additionalSelfTypes)
     if (selfTypeMatch == null) return null
     if (this.pattern) {
-      const patternMatch = this.pattern.tryMatch(entry.name, entry.aliases, entry.memberOf)
+      const patternMatch = this.pattern.tryMatch(
+        entry.name,
+        entry.aliases,
+        entry.memberOf,
+        additionalSelfTypes,
+      )
       if (!patternMatch) return null
       if (this.isLocal(entry)) patternMatch.score *= 2
       patternMatch.score += selfTypeMatch.score

--- a/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
@@ -153,11 +153,28 @@ class FilteringName {
 }
 
 class FilteringWithPattern {
-  nameFilter: FilteringName
+  nameFilter: FilteringName | null
   ownerNameFilter: FilteringName
   bothFiltersMustMatch: boolean
 
   constructor(pattern: string) {
+    if (pattern.startsWith(':')) {
+      pattern = pattern.slice(1)
+      const split = pattern.lastIndexOf('.')
+      if (split >= 0) {
+        // If there is a dot in the pattern, the segment before must match owner name,
+        // and the segment after - the entry name
+        this.nameFilter = new FilteringName(pattern.slice(split + 1))
+        this.ownerNameFilter = new FilteringName(pattern.slice(0, split))
+        this.bothFiltersMustMatch = true
+      } else {
+        // the pattern has to match the owner name
+        this.nameFilter = null
+        this.ownerNameFilter = new FilteringName(pattern)
+        this.bothFiltersMustMatch = false
+      }
+      return
+    }
     const split = pattern.lastIndexOf('.')
     if (split >= 0) {
       // If there is a dot in the pattern, the segment before must match owner name,
@@ -175,7 +192,7 @@ class FilteringWithPattern {
 
   private firstMatchingAlias(aliases: string[]) {
     for (const alias of aliases) {
-      const match = this.nameFilter.tryMatch(alias)
+      const match = this.nameFilter?.tryMatch(alias)
       if (match != null) return { alias, ...match }
     }
     return null
@@ -188,7 +205,7 @@ class FilteringWithPattern {
     additionalSelfTypes: ProjectPath[],
   ): MatchResult | null {
     const nameMatch: (NameMatchResult & { alias?: string }) | null =
-      this.nameFilter.tryMatch(name) ?? this.firstMatchingAlias(aliases)
+      this.nameFilter?.tryMatch(name) ?? this.firstMatchingAlias(aliases)
     const ownerNameMatch = this.ownerNameFilter.tryMatch(
       memberOf.path ? qnLastSegment(memberOf.path) : 'Main',
     )
@@ -282,7 +299,7 @@ export class Filtering {
   private mainViewFilter(entry: SuggestionEntry): MatchResult | null {
     const hasGroup = entry.groupIndex != null
     const isInTopModule = entry.definedIn.isTopElement()
-    if (hasGroup || isInTopModule) return { score: 0, fromType: entry.definedIn }
+    if (hasGroup || isInTopModule) return { score: 0, fromType: undefined }
     else return null
   }
 

--- a/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
@@ -8,8 +8,10 @@ import { Range } from 'ydoc-shared/util/data/range'
 export type SelfArg =
   | {
       type: 'known'
+      /** Type of the self argument. */
       typename: ProjectPath
-      hiddenTypes: ProjectPath[]
+      /** Additional (or ‘hidden’) types of the self argument. E.g. `Column` for single-column table.*/
+      additionalTypes: ProjectPath[]
     }
   | { type: 'unknown' }
 
@@ -45,6 +47,7 @@ interface MatchedParts {
 
 export interface MatchResult extends MatchedParts {
   score: number
+  /** Populated only if matched entry is provided by ‘additional’ type of the self argument, like methods of `Column` type for single-column table. */
   fromType: ProjectPath | undefined
 }
 
@@ -158,23 +161,8 @@ class FilteringWithPattern {
   bothFiltersMustMatch: boolean
 
   constructor(pattern: string) {
-    if (pattern.startsWith(':')) {
-      pattern = pattern.slice(1)
-      const split = pattern.lastIndexOf('.')
-      if (split >= 0) {
-        // If there is a dot in the pattern, the segment before must match owner name,
-        // and the segment after - the entry name
-        this.nameFilter = new FilteringName(pattern.slice(split + 1))
-        this.ownerNameFilter = new FilteringName(pattern.slice(0, split))
-        this.bothFiltersMustMatch = true
-      } else {
-        // the pattern has to match the owner name
-        this.nameFilter = null
-        this.ownerNameFilter = new FilteringName(pattern)
-        this.bothFiltersMustMatch = false
-      }
-      return
-    }
+    const isTypeFiltering = pattern.startsWith(':')
+    if (isTypeFiltering) pattern = pattern.slice(1)
     const split = pattern.lastIndexOf('.')
     if (split >= 0) {
       // If there is a dot in the pattern, the segment before must match owner name,
@@ -182,6 +170,11 @@ class FilteringWithPattern {
       this.nameFilter = new FilteringName(pattern.slice(split + 1))
       this.ownerNameFilter = new FilteringName(pattern.slice(0, split))
       this.bothFiltersMustMatch = true
+    } else if (isTypeFiltering) {
+      // the pattern has to match the owner name
+      this.nameFilter = null
+      this.ownerNameFilter = new FilteringName(pattern)
+      this.bothFiltersMustMatch = false
     } else {
       // the pattern has to match name or the owner name
       this.nameFilter = new FilteringName(pattern)
@@ -275,7 +268,6 @@ export class Filtering {
 
   private selfTypeMatches(
     entry: SuggestionEntry,
-    additionalSelfTypes: ProjectPath[],
   ): { score: number; fromType: ProjectPath | undefined } | null {
     if (this.selfArg == null)
       return entry.kind !== SuggestionKind.Method || entry.selfType == null ?
@@ -285,6 +277,7 @@ export class Filtering {
     if (this.selfArg.type !== 'known') return { score: 0, fromType: undefined }
     const entrySelfType = entry.selfType
     if (entrySelfType.equals(this.selfArg.typename)) return { score: 0, fromType: undefined }
+    const additionalSelfTypes = this.selfArg.additionalTypes
     const additionalSelfType = additionalSelfTypes.find((t) => entrySelfType.equals(t))
     if (entrySelfType.equals(ANY_TYPE) || additionalSelfType != null)
       return { score: DIFFERENT_TYPE_PENALTY, fromType: additionalSelfType }
@@ -308,12 +301,13 @@ export class Filtering {
   }
 
   /** TODO: Add docs */
-  filter(entry: SuggestionEntry, additionalSelfTypes: ProjectPath[]): MatchResult | null {
+  filter(entry: SuggestionEntry): MatchResult | null {
     if (entry.isPrivate || entry.kind != SuggestionKind.Method) return null
     if (this.selfArg == null && isInternal(entry)) return null
-    const selfTypeMatch = this.selfTypeMatches(entry, additionalSelfTypes)
+    const selfTypeMatch = this.selfTypeMatches(entry)
     if (selfTypeMatch == null) return null
     if (this.pattern) {
+      const additionalSelfTypes = this.selfArg?.type === 'known' ? this.selfArg.additionalTypes : []
       const patternMatch = this.pattern.tryMatch(
         entry.name,
         entry.aliases,

--- a/app/gui/src/project-view/components/ComponentBrowser/input.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/input.ts
@@ -138,8 +138,12 @@ export function useComponentBrowserInput(
     const info = graphDb.getExpressionInfo(definition)
     if (info == null) return null
     const typename = info.typename
-    const hiddenTypes = info.hiddenTypes
-    return typename ? { type: 'known', typename, hiddenTypes } : { type: 'unknown' }
+    const additionalTypes = info.hiddenTypes
+    if (typename != null) {
+      const entry = suggestionDb.getEntryByProjectPath(typename)
+      if (entry) additionalTypes.push(...suggestionDb.ancestors(entry))
+    }
+    return typename ? { type: 'known', typename, additionalTypes } : { type: 'unknown' }
   })
 
   /** Apply given suggested entry to the input. */
@@ -172,37 +176,29 @@ export function useComponentBrowserInput(
     newText: string
     requiredImport: ProjectPath | undefined
   } {
-    const makeOwnerPath = (owner: ProjectPath) => {
+    const displayOwner = (owner: ProjectPath) => {
       if (owner.path) return qnLastSegment(owner.path)
       if (owner.project) return qnLastSegment(owner.project)
       return 'Main' as Ast.Identifier
     }
-    if (sourceNodeIdentifier.value) {
-      if (sourceNodeType.value?.type === 'known') {
-        const sourceType = sourceNodeType.value.typename
-        const owner = entry.kind === SuggestionKind.Method ? entry.memberOf : undefined
-        if (owner && owner.path && !sourceType.equals(owner)) {
-          return {
-            newText: ':' + makeOwnerPath(owner) + ' . ' + entry.name + ' ',
-            requiredImport: owner,
-          }
-        } else {
-          return {
-            newText: entry.name + ' ',
-            requiredImport: undefined,
-          }
-        }
-      } else {
+    if (sourceNodeIdentifier.value && sourceNodeType.value?.type === 'known') {
+      const sourceType = sourceNodeType.value.typename
+      const owner = entry.kind === SuggestionKind.Method ? entry.memberOf : undefined
+      if (owner && owner.path && !sourceType.equals(owner)) {
         return {
-          newText: entry.name + ' ',
-          requiredImport: undefined,
+          newText: ':' + displayOwner(owner) + ' . ' + entry.name + ' ',
+          requiredImport: owner,
         }
+      }
+      return {
+        newText: entry.name + ' ',
+        requiredImport: undefined,
       }
     } else {
       // Perhaps we will add cases for Type/Con imports, but they are not displayed as suggestion ATM.
       const owner = entryIsStatic(entry) ? entry.memberOf.normalized() : undefined
       return {
-        newText: (owner ? qnJoin(makeOwnerPath(owner), entry.name) : entry.name) + ' ',
+        newText: (owner ? qnJoin(displayOwner(owner), entry.name) : entry.name) + ' ',
         requiredImport: owner,
       }
     }

--- a/app/gui/src/project-view/components/ComponentBrowser/input.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/input.ts
@@ -6,6 +6,7 @@ import { requiredImportEquals, requiredImports, type RequiredImport } from '@/st
 import { useSuggestionDbStore, type SuggestionDb } from '@/stores/suggestionDatabase'
 import {
   entryIsStatic,
+  SuggestionKind,
   type SuggestionEntry,
   type SuggestionId,
 } from '@/stores/suggestionDatabase/entry'
@@ -171,24 +172,37 @@ export function useComponentBrowserInput(
     newText: string
     requiredImport: ProjectPath | undefined
   } {
+    const makeOwnerPath = (owner: ProjectPath) => {
+      if (owner.path) return qnLastSegment(owner.path)
+      if (owner.project) return qnLastSegment(owner.project)
+      return 'Main' as Ast.Identifier
+    }
     if (sourceNodeIdentifier.value) {
-      return {
-        newText: entry.name + ' ',
-        requiredImport: undefined,
+      if (sourceNodeType.value?.type === 'known') {
+        const sourceType = sourceNodeType.value.typename
+        const owner = entry.kind === SuggestionKind.Method ? entry.memberOf : undefined
+        if (owner && owner.path && !sourceType.equals(owner)) {
+          return {
+            newText: ':' + makeOwnerPath(owner) + ' . ' + entry.name + ' ',
+            requiredImport: owner,
+          }
+        } else {
+          return {
+            newText: entry.name + ' ',
+            requiredImport: undefined,
+          }
+        }
+      } else {
+        return {
+          newText: entry.name + ' ',
+          requiredImport: undefined,
+        }
       }
     } else {
       // Perhaps we will add cases for Type/Con imports, but they are not displayed as suggestion ATM.
       const owner = entryIsStatic(entry) ? entry.memberOf.normalized() : undefined
       return {
-        newText:
-          (owner ?
-            qnJoin(
-              owner.path ? qnLastSegment(owner.path)
-              : owner.project ? qnLastSegment(owner.project)
-              : ('Main' as Ast.Identifier),
-              entry.name,
-            )
-          : entry.name) + ' ',
+        newText: (owner ? qnJoin(makeOwnerPath(owner), entry.name) : entry.name) + ' ',
         requiredImport: owner,
       }
     }

--- a/app/gui/src/project-view/components/ComponentBrowser/input.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/input.ts
@@ -134,8 +134,11 @@ export function useComponentBrowserInput(
     if (!sourceNodeIdentifier.value) return null
     const definition = graphDb.getIdentDefiningNode(sourceNodeIdentifier.value)
     if (definition == null) return null
-    const typename = graphDb.getExpressionInfo(definition)?.typename
-    return typename ? { type: 'known', typename } : { type: 'unknown' }
+    const info = graphDb.getExpressionInfo(definition)
+    if (info == null) return null
+    const typename = info.typename
+    const hiddenTypes = info.hiddenTypes
+    return typename ? { type: 'known', typename, hiddenTypes } : { type: 'unknown' }
   })
 
   /** Apply given suggested entry to the input. */

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -13,9 +13,11 @@ import type {
   MethodCall as LSMethodCall,
   ProfilingInfo,
 } from 'ydoc-shared/languageServerTypes'
+import { isSome } from 'ydoc-shared/util/data/opt'
 
 export interface ExpressionInfo {
   typename: ProjectPath | undefined
+  hiddenTypes: ProjectPath[]
   rawTypename: string | undefined
   methodCall: MethodCall | undefined
   payload: ExpressionUpdatePayload
@@ -79,6 +81,7 @@ function updateInfo(
 ) {
   const newInfo = combineInfo(info, update, projectNames)
   if (newInfo.typename !== info.typename) info.typename = newInfo.typename
+  if (newInfo.hiddenTypes !== info.hiddenTypes) info.hiddenTypes = newInfo.hiddenTypes
   if (newInfo.rawTypename !== info.rawTypename) info.rawTypename = newInfo.rawTypename
   if (newInfo.methodCall !== info.methodCall) info.methodCall = newInfo.methodCall
   if (newInfo.payload !== info.payload) info.payload = newInfo.payload
@@ -86,6 +89,7 @@ function updateInfo(
   // Ensure new fields can't be added to `ExpressionInfo` without this code being updated.
   const _allFieldsHandled = {
     typename: newInfo.typename,
+    hiddenTypes: newInfo.hiddenTypes,
     rawTypename: newInfo.rawTypename,
     methodCall: newInfo.methodCall,
     payload: newInfo.payload,
@@ -127,6 +131,17 @@ function combineInfo(
   if (typename && !typename.ok) {
     typename.error.log('Discarding invalid type in expression update')
   }
+  if (update.hiddenType.length > 0) {
+    console.log('Hidden types', update.hiddenType, update.expressionId)
+  }
+  const hiddenTypes = update.hiddenType.map((t) => {
+    const path = projectNames.parseProjectPathRaw(t)
+    if (!path.ok) {
+      path.error.log('Discarding invalid type in expression update')
+      return undefined
+    }
+    return path.value
+  })
   const newMethodCall =
     update.methodCall ? translateMethodCall(update.methodCall, projectNames) : undefined
   if (newMethodCall && !newMethodCall.ok) {
@@ -134,6 +149,7 @@ function combineInfo(
   }
   return {
     typename: typename ? unwrapOr(typename, undefined) : undefined,
+    hiddenTypes: hiddenTypes.filter(isSome),
     rawTypename,
     methodCall:
       newMethodCall?.ok ? newMethodCall.value

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -131,13 +131,10 @@ function combineInfo(
   if (typename && !typename.ok) {
     typename.error.log('Discarding invalid type in expression update')
   }
-  if (update.hiddenType.length > 0) {
-    console.log('Hidden types', update.hiddenType, update.expressionId)
-  }
   const hiddenTypes = update.hiddenType.map((t) => {
     const path = projectNames.parseProjectPathRaw(t)
     if (!path.ok) {
-      path.error.log('Discarding invalid type in expression update')
+      path.error.log('Discarding invalid additional type in expression update')
       return undefined
     }
     return path.value

--- a/app/rust-ffi/src/lib.rs
+++ b/app/rust-ffi/src/lib.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 
+use enso_parser::lexer::test::TokenOperatorProperties;
 use enso_parser::Parser;
 
 
@@ -61,9 +62,10 @@ pub fn self_arg_separator(code: &str) -> i32 {
         [token] => (token, 1),
         [] => return -1,
     };
-    match token.variant {
-        enso_parser::syntax::token::Variant::Operator(_) => right_spacing as i32,
-        _ => -1,
+    if token.operator_properties().is_some() {
+        return right_spacing as i32;
+    } else {
+        return -1;
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

Part two of #12312, including #12693

Closes #12693 
Closes #12312

This PR contains changes to Component Browser filtering and visuals to accommodate multiple additional types of the self argument.

It is based on #12751, but is largely independent.


https://github.com/user-attachments/assets/47aeadcf-7b69-4e02-bf50-91261b37d0ca


### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
