### PR TITLE
Fix Columns in Table Viz

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -769,7 +769,7 @@ watchEffect(() => {
         ]
       : dataHeader
     if (!data_.is_using_server_sort_and_filter) {
-      const hasIndexRow = config.nodeType === TABLE_NODE_TYPE
+      const hasIndexRow = config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE
       const shift = hasIndexRow ? 1 : 0
       rowData.value =
         data_.data ?

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -769,7 +769,8 @@ watchEffect(() => {
         ]
       : dataHeader
     if (!data_.is_using_server_sort_and_filter) {
-      const hasIndexRow = config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE
+      const hasIndexRow =
+        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE
       const shift = hasIndexRow ? 1 : 0
       rowData.value =
         data_.data ?

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -173,7 +173,7 @@ const statusBar = computed(() =>
   allRowCount.value ?
     {
       statusPanels:
-        config.nodeType === TABLE_NODE_TYPE ?
+        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE ?
           [
             {
               statusPanel: TableVizStatusBar,
@@ -770,7 +770,9 @@ watchEffect(() => {
       : dataHeader
     if (!data_.is_using_server_sort_and_filter) {
       const hasIndexRow =
-        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE
+        config.nodeType === TABLE_NODE_TYPE ||
+        config.nodeType === COLUMN_NODE_TYPE ||
+        config.nodeType === DB_TABLE_NODE_TYPE
       const shift = hasIndexRow ? 1 : 0
       rowData.value =
         data_.data ?

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -770,7 +770,7 @@ watchEffect(() => {
       : dataHeader
     if (!data_.is_using_server_sort_and_filter) {
       const hasIndexRow =
-        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE
+        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE
       const shift = hasIndexRow ? 1 : 0
       rowData.value =
         data_.data ?

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
@@ -3,7 +3,7 @@
 - apply_filter_to_table table:Standard.Base.Any.Any i:Standard.Base.Any.Any filter_cols:Standard.Base.Any.Any filter_conditions:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - apply_sort_to_table table:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any sort_direction_list:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - get_distinct_values_for_column table:Standard.Base.Any.Any column_index:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- get_rows_for_table table:Standard.Base.Any.Any start_number:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any= sort_direction_list:Standard.Base.Any.Any= filter_col:Standard.Base.Any.Any= filter_condition:Standard.Base.Any.Any= -> Standard.Base.Any.Any
+- get_rows_for_table x:Standard.Base.Any.Any start_number:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any= sort_direction_list:Standard.Base.Any.Any= filter_col:Standard.Base.Any.Any= filter_condition:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_json_for_dictionary dict:Standard.Base.Any.Any max_items:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_error error:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_js_object js_object:Standard.Base.Any.Any max_items:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
@@ -3,7 +3,7 @@
 - apply_filter_to_table table:Standard.Base.Any.Any i:Standard.Base.Any.Any filter_cols:Standard.Base.Any.Any filter_conditions:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - apply_sort_to_table table:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any sort_direction_list:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - get_distinct_values_for_column table:Standard.Base.Any.Any column_index:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- get_rows_for_table x:Standard.Base.Any.Any start_number:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any= sort_direction_list:Standard.Base.Any.Any= filter_col:Standard.Base.Any.Any= filter_condition:Standard.Base.Any.Any= -> Standard.Base.Any.Any
+- get_rows_for_table table_or_column:Standard.Base.Any.Any start_number:Standard.Base.Any.Any sort_col_index_list:Standard.Base.Any.Any= sort_direction_list:Standard.Base.Any.Any= filter_col:Standard.Base.Any.Any= filter_condition:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_json_for_dictionary dict:Standard.Base.Any.Any max_items:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_error error:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_js_object js_object:Standard.Base.Any.Any max_items:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -264,7 +264,12 @@ apply_filter_to_table table i filter_cols filter_conditions =
    Prepares the row data table for visualizations using the server side row model.
 
    Arguments:
-   - start_number: the start index of the next 100 rows to get
+   - x: a table or column to get the rows for 
+   - start_number: the start index of the next 1000 rows to get
+   - sort_col_index_list: list of column indexes that have a sort applied 
+   - sort_direction_list: direction of the sort for the columns 
+   - filter_col: list of column indexes that have a filter applied 
+   - filter_condition: list f filter conditions for the columns 
 get_rows_for_table : Any -> Integer -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> JS_Object
 get_rows_for_table x start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
     max_rows=1000

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -271,11 +271,11 @@ apply_filter_to_table table i filter_cols filter_conditions =
    - filter_col: list of column indexes that have a filter applied 
    - filter_condition: list f filter conditions for the columns 
 get_rows_for_table : Any -> Integer -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> JS_Object
-get_rows_for_table x start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
+get_rows_for_table table_or_column start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
     max_rows=1000
-    table = case x of
+    table = case table_or_column of
         c : Column -> c.to_table
-        _ -> x
+        _ -> table_or_column
     col_name = table.make_temp_column_name
     table_with_index = table.add_row_number col_name
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -266,8 +266,11 @@ apply_filter_to_table table i filter_cols filter_conditions =
    Arguments:
    - start_number: the start index of the next 100 rows to get
 get_rows_for_table : Any -> Integer -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> JS_Object
-get_rows_for_table table start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
+get_rows_for_table x start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
     max_rows=1000
+    table = case x of
+        c : Column -> c.to_table
+        _ -> x
     col_name = table.make_temp_column_name
     table_with_index = table.add_row_number col_name
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns


### PR DESCRIPTION
- fixes #12762 

- casts a column to a table in get rows function to allow method `make_temp_column_name` for index column
- uses correct shift in make rows function 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
