### PR TITLE
Fix root ids for Cloud categories

### DIFF
--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -317,7 +317,7 @@ export function useListDirectoryRefetchInterval() {
 export interface ListDirectoryQueryOptions {
   readonly backend: Backend
   readonly filterBy?: FilterBy | null | undefined
-  readonly parentId: DirectoryId
+  readonly parentId: DirectoryId | null
   readonly category: Category
   /**
    * When using React, use {@link useListDirectoryRefetchInterval} to 0.
@@ -361,7 +361,7 @@ export function listDirectoryQueryOptions(options: ListDirectoryQueryOptions) {
             labels: null,
             recentProjects: category.type === 'recent',
           },
-          parentId,
+          parentId ?? '(unknown)',
         )
       } catch (error) {
         if (error instanceof Error) {

--- a/app/gui/src/dashboard/layouts/Drive/Categories/Category.ts
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/Category.ts
@@ -26,12 +26,15 @@ const DIRECTORY_ID_SCHEMA = z.string().refine((s): s is DirectoryId => true)
 const EACH_CATEGORY_SCHEMA = z.object({
   label: z.string(),
   icon: z.string(),
-  homeDirectoryId: DIRECTORY_ID_SCHEMA,
 })
 
 /** A category corresponding to the root of the user or organization. */
 const CLOUD_CATEGORY_SCHEMA = z
-  .object({ type: z.literal('cloud'), id: z.literal('cloud') })
+  .object({
+    type: z.literal('cloud'),
+    id: z.literal('cloud'),
+    homeDirectoryId: DIRECTORY_ID_SCHEMA,
+  })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
 /** A category corresponding to the root of the user or organization. */
@@ -39,7 +42,11 @@ export type CloudCategory = z.infer<typeof CLOUD_CATEGORY_SCHEMA>
 
 /** A category containing recently opened Cloud projects. */
 const RECENT_CATEGORY_SCHEMA = z
-  .object({ type: z.literal('recent'), id: z.literal('recent') })
+  .object({
+    type: z.literal('recent'),
+    id: z.literal('recent'),
+    homeDirectoryId: z.null(),
+  })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
 /** A category containing recently opened Cloud projects. */
@@ -47,7 +54,11 @@ export type RecentCategory = z.infer<typeof RECENT_CATEGORY_SCHEMA>
 
 /** A category containing recently deleted Cloud items. */
 const TRASH_CATEGORY_SCHEMA = z
-  .object({ type: z.literal('trash'), id: z.literal('trash') })
+  .object({
+    type: z.literal('trash'),
+    id: z.literal('trash'),
+    homeDirectoryId: z.null(),
+  })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
 /** A category containing recently deleted Cloud items. */
@@ -60,6 +71,7 @@ export const USER_CATEGORY_SCHEMA = z
     user: z.custom<User>(() => true),
     id: z.custom<UserId>(() => true),
     rootPath: PATH_SCHEMA,
+    homeDirectoryId: DIRECTORY_ID_SCHEMA,
   })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
@@ -72,6 +84,7 @@ export const TEAM_CATEGORY_SCHEMA = z
     id: z.custom<UserGroupId>(() => true),
     team: z.custom<UserGroup>(() => true),
     rootPath: PATH_SCHEMA,
+    homeDirectoryId: DIRECTORY_ID_SCHEMA,
   })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
@@ -85,6 +98,7 @@ const LOCAL_CATEGORY_SCHEMA = z
     type: z.literal('local'),
     id: z.literal('local'),
     rootPath: PATH_SCHEMA,
+    homeDirectoryId: DIRECTORY_ID_SCHEMA,
   })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()
@@ -97,6 +111,7 @@ export const LOCAL_DIRECTORY_CATEGORY_SCHEMA = z
     type: z.literal('local-directory'),
     id: z.custom<DirectoryId>(() => true),
     rootPath: PATH_SCHEMA,
+    homeDirectoryId: DIRECTORY_ID_SCHEMA,
   })
   .merge(EACH_CATEGORY_SCHEMA)
   .readonly()

--- a/app/gui/src/dashboard/layouts/Drive/Categories/categoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/categoriesHooks.tsx
@@ -22,8 +22,9 @@ import { useBackend, useLocalBackend, useRemoteBackend } from '#/providers/Backe
 import { useLocalStorageState } from '#/providers/LocalStorageProvider'
 import { useText } from '#/providers/TextProvider'
 import type Backend from '#/services/Backend'
-import { DirectoryId, Path, Plan } from '#/services/Backend'
+import { Path, type DirectoryId } from '#/services/Backend'
 import { newDirectoryId } from '#/services/LocalBackend'
+import { organizationIdToDirectoryId } from '#/services/RemoteBackend'
 import { getFileName } from '#/utilities/fileInfo'
 import LocalStorage from '#/utilities/LocalStorage'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -92,27 +93,15 @@ export function useCloudCategoryList() {
     queryFn: () => backend.getOrganization(),
   })
 
-  const homeDirectoryId = (() => {
-    switch (user.plan) {
-      case Plan.free:
-      case Plan.solo: {
-        return user.rootDirectoryId
-      }
-      case Plan.team:
-      case Plan.enterprise: {
-        return organization == null ?
-            user.rootDirectoryId
-          : DirectoryId(`directory-${organization.id.replace(/^organization-/, '')}` as const)
-      }
-    }
-  })()
+  const organizationRootId =
+    organization != null ? organizationIdToDirectoryId(organization.id) : user.rootDirectoryId
 
   const cloudCategory: CloudCategory = {
     type: 'cloud',
     id: 'cloud',
     label: getText('cloudCategory'),
     icon: CloudIcon,
-    homeDirectoryId,
+    homeDirectoryId: user.rootDirectoryId,
   }
 
   const recentCategory: RecentCategory = {
@@ -120,7 +109,7 @@ export function useCloudCategoryList() {
     id: 'recent',
     label: getText('recentCategory'),
     icon: RecentIcon,
-    homeDirectoryId,
+    homeDirectoryId: organizationRootId,
   }
 
   const trashCategory: TrashCategory = {
@@ -128,7 +117,7 @@ export function useCloudCategoryList() {
     id: 'trash',
     label: getText('trashCategory'),
     icon: Trash2Icon,
-    homeDirectoryId,
+    homeDirectoryId: organizationRootId,
   }
 
   const predefinedCloudCategories: AnyCloudCategory[] = [

--- a/app/gui/src/dashboard/layouts/Drive/Categories/categoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/categoriesHooks.tsx
@@ -18,16 +18,14 @@ import { useUser } from '#/providers/AuthProvider'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useOffline } from '#/hooks/offlineHooks'
 import { useSearchParamsState } from '#/hooks/searchParamsStateHooks'
-import { useBackend, useLocalBackend, useRemoteBackend } from '#/providers/BackendProvider'
+import { useBackend, useLocalBackend } from '#/providers/BackendProvider'
 import { useLocalStorageState } from '#/providers/LocalStorageProvider'
 import { useText } from '#/providers/TextProvider'
 import type Backend from '#/services/Backend'
 import { Path, type DirectoryId } from '#/services/Backend'
 import { newDirectoryId } from '#/services/LocalBackend'
-import { organizationIdToDirectoryId } from '#/services/RemoteBackend'
 import { getFileName } from '#/utilities/fileInfo'
 import LocalStorage from '#/utilities/LocalStorage'
-import { useSuspenseQuery } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { createContext, useContext } from 'react'
 import invariant from 'tiny-invariant'
@@ -87,14 +85,6 @@ export type CloudCategoryResult = ReturnType<typeof useCloudCategoryList>
 export function useCloudCategoryList() {
   const user = useUser()
   const { getText } = useText()
-  const backend = useRemoteBackend()
-  const { data: organization } = useSuspenseQuery({
-    queryKey: [backend.type, 'getOrganization'],
-    queryFn: () => backend.getOrganization(),
-  })
-
-  const organizationRootId =
-    organization != null ? organizationIdToDirectoryId(organization.id) : user.rootDirectoryId
 
   const cloudCategory: CloudCategory = {
     type: 'cloud',
@@ -109,7 +99,7 @@ export function useCloudCategoryList() {
     id: 'recent',
     label: getText('recentCategory'),
     icon: RecentIcon,
-    homeDirectoryId: organizationRootId,
+    homeDirectoryId: null,
   }
 
   const trashCategory: TrashCategory = {
@@ -117,7 +107,7 @@ export function useCloudCategoryList() {
     id: 'trash',
     label: getText('trashCategory'),
     icon: Trash2Icon,
-    homeDirectoryId: organizationRootId,
+    homeDirectoryId: null,
   }
 
   const predefinedCloudCategories: AnyCloudCategory[] = [

--- a/app/gui/src/dashboard/layouts/Drive/directoryIdsHooks.ts
+++ b/app/gui/src/dashboard/layouts/Drive/directoryIdsHooks.ts
@@ -1,5 +1,6 @@
 /** @file A hook returning the root directory id and expanded directory ids. */
 import type { Category } from '#/layouts/CategorySwitcher/Category'
+import { useUser } from '#/providers/AuthProvider'
 import { useCurrentDirectoryId, useSetCurrentDirectoryId } from '#/providers/DriveProvider'
 
 /** Options for {@link useDirectoryIds}. */
@@ -10,7 +11,8 @@ export interface UseDirectoryIdsOptions {
 /** A hook returning the root directory id and expanded directory ids. */
 export function useDirectoryIds(options: UseDirectoryIdsOptions) {
   const { category } = options
-  const rootDirectoryId = category.homeDirectoryId
+  const user = useUser()
+  const rootDirectoryId = category.homeDirectoryId ?? user.rootDirectoryId
   const currentDirectoryId = useCurrentDirectoryId().current ?? rootDirectoryId
   const parentDirectoryId = useCurrentDirectoryId().parent ?? rootDirectoryId
   const setCurrentDirectoryId = useSetCurrentDirectoryId()

--- a/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarToolbar.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarToolbar.tsx
@@ -49,7 +49,6 @@ import { useInputBindings } from '#/providers/InputBindingsProvider'
 import { useSetModal } from '#/providers/ModalProvider'
 import { useText } from '#/providers/TextProvider'
 import type Backend from '#/services/Backend'
-import type { DirectoryId } from '#/services/Backend'
 import type AssetQuery from '#/utilities/AssetQuery'
 import * as sanitizedEventTargets from '#/utilities/sanitizedEventTargets'
 import { useMutationCallback } from '#/utilities/tanstackQuery'
@@ -81,7 +80,7 @@ export function DriveBarToolbar(props: DriveBarToolbarProps) {
   const { isOffline } = useOffline()
   const canDownload = useCanDownload()
 
-  const { currentDirectoryId, rootDirectoryId } = useDirectoryIds({ category })
+  const { currentDirectoryId } = useDirectoryIds({ category })
 
   const shouldBeDisabled = isCloud && isOffline
 
@@ -186,7 +185,6 @@ export function DriveBarToolbar(props: DriveBarToolbarProps) {
             shouldBeDisabled={shouldBeDisabled}
             backend={backend}
             category={category}
-            rootDirectoryId={rootDirectoryId}
           >
             {pasteDataStatus}
             {searchBar}
@@ -298,20 +296,19 @@ interface TrashFolderToolbarProps extends PropsWithChildren {
   readonly shouldBeDisabled: boolean
   readonly backend: Backend
   readonly category: Category
-  readonly rootDirectoryId: DirectoryId
 }
 
 /**
  * A toolbar for the trash folder.
  */
 function TrashFolderToolbar(props: TrashFolderToolbarProps) {
-  const { shouldBeDisabled, backend, category, rootDirectoryId, children } = props
+  const { shouldBeDisabled, backend, category, children } = props
   const { getText } = useText()
 
   const rootDirectoryQueryOptions = listDirectoryQueryOptions({
     backend,
     category,
-    parentId: rootDirectoryId,
+    parentId: null,
     refetchInterval: null,
   })
 


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1887
  - Fix "Cloud" category to always display user's home directory

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
