### PR TITLE
Generate per package Persistables class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3287,10 +3287,9 @@ lazy val `runtime-parser` =
       commands += WithDebugCommand.withDebug,
       fork := true,
       libraryDependencies ++= Seq(
-        "junit"            % "junit"                   % junitVersion       % Test,
-        "com.github.sbt"   % "junit-interface"         % junitIfVersion     % Test,
-        "org.scalatest"   %% "scalatest"               % scalatestVersion   % Test,
-        "org.netbeans.api" % "org-openide-util-lookup" % netbeansApiVersion % "provided"
+        "junit"          % "junit"           % junitVersion     % Test,
+        "com.github.sbt" % "junit-interface" % junitIfVersion   % Test,
+        "org.scalatest" %% "scalatest"       % scalatestVersion % Test
       ),
       Compile / moduleDependencies ++= Seq(
         "org.netbeans.api" % "org-openide-util-lookup" % netbeansApiVersion

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -28,7 +28,6 @@ import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
-import org.openide.util.lookup.ServiceProvider;
 
 @Persistable(clazz = CachePreferenceAnalysis.WeightInfo.class, id = 1111)
 @Persistable(clazz = DataflowAnalysis.DependencyInfo.class, id = 1112)
@@ -72,7 +71,7 @@ import org.openide.util.lookup.ServiceProvider;
 public final class PassPersistance {
   private PassPersistance() {}
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 1101)
   public static final class PersistState extends Persistance<IgnoredBindings.State> {
     public PersistState() {
       super(IgnoredBindings.State.class, true, 1101);
@@ -93,7 +92,7 @@ public final class PassPersistance {
     }
   }
 
-  @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
+  @Persistable(id = 1289)
   public static final class PersistCachePreferences
       extends Persistance<org.enso.common.CachePreferences> {
     public PersistCachePreferences() {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
@@ -1,13 +1,14 @@
 package org.enso.compiler.pass.analyse.alias.graph;
 
 import java.io.IOException;
+import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
 import scala.collection.immutable.HashMap;
 
 public final class GraphPersistance {
   private GraphPersistance() {}
 
-  @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
+  @Persistable(id = 1267)
   public static final class PersistAliasAnalysisGraphScope extends Persistance<GraphImpl.Scope> {
     public PersistAliasAnalysisGraphScope() {
       super(GraphImpl.Scope.class, false, 1267);
@@ -45,7 +46,7 @@ public final class GraphPersistance {
     }
   }
 
-  @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
+  @Persistable(id = 1268)
   public static final class PersistAliasAnalysisGraph extends Persistance<GraphImpl> {
     public PersistAliasAnalysisGraph() {
       super(GraphImpl.class, false, 1268);

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
@@ -9,9 +9,16 @@ import java.util.UUID;
 import java.util.function.Function;
 import org.enso.common.CachePreferences;
 import org.enso.persist.Persistance;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class PassPersistanceTest {
+  @BeforeClass
+  public static void initializePersistables() {
+    org.enso.compiler.core.ir.Persistables.initialize();
+    org.enso.compiler.pass.analyse.Persistables.initialize();
+  }
+
   @Test
   public void cachePreferences() throws Exception {
     var idSelf = UUID.randomUUID();

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -18,7 +18,6 @@ import org.enso.compiler.core.ir.module.scope.imports.Polyglot;
 import org.enso.compiler.core.ir.type.Set;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
-import org.openide.util.lookup.ServiceProvider;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.immutable.List;
@@ -75,7 +74,7 @@ import scala.collection.immutable.Seq;
 public final class IrPersistance {
   private IrPersistance() {}
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 11259)
   public static final class PersistIdentifiedLocation extends Persistance<IdentifiedLocation> {
 
     private static final int EMPTY_LOCATION = -1;
@@ -109,7 +108,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 473)
   public static final class PersistUUID extends Persistance<UUID> {
     public PersistUUID() {
       super(UUID.class, false, 473);
@@ -138,7 +137,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4431)
   public static final class PersistScalaOption extends Persistance<Option> {
     public PersistScalaOption() {
       super(Option.class, true, 4431);
@@ -156,7 +155,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4437)
   public static final class PersistString extends Persistance<String> {
     public PersistString() {
       super(String.class, true, 4437);
@@ -174,7 +173,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4438)
   public static final class PersistLong extends Persistance<Long> {
     public PersistLong() {
       super(Long.class, true, 4438);
@@ -192,7 +191,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4439)
   public static final class PersistDouble extends Persistance<Double> {
     public PersistDouble() {
       super(Double.class, true, 4439);
@@ -218,7 +217,7 @@ public final class IrPersistance {
    * implementations, we want to ensure that the format of both is compatible. Seq is generally
    * preferred as it can be lazy.
    */
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4432)
   public static final class PersistScalaList extends Persistance<List> {
     public PersistScalaList() {
       super(List.class, true, 4432);
@@ -250,7 +249,7 @@ public final class IrPersistance {
    *
    * <p>When reading back, the deserialization is done lazily.
    */
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 34011)
   public static final class PersistJavaListLazy extends Persistance<java.util.List> {
     public PersistJavaListLazy() {
       super(java.util.List.class, true, 34011);
@@ -296,7 +295,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4444)
   public static final class PersistScalaMap extends Persistance<scala.collection.immutable.Map> {
     public PersistScalaMap() {
       super(scala.collection.immutable.Map.class, true, 4444);
@@ -325,7 +324,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4949)
   public static final class PersistScalaMutableMap
       extends Persistance<scala.collection.mutable.Map> {
     public PersistScalaMutableMap() {
@@ -361,7 +360,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4445)
   public static final class PersistScalaSet extends Persistance<scala.collection.immutable.Set> {
     public PersistScalaSet() {
       super(scala.collection.immutable.Set.class, true, 4445);
@@ -393,7 +392,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4440)
   public static final class PersistMap extends Persistance<Map> {
     public PersistMap() {
       super(Map.class, true, 4440);
@@ -418,7 +417,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 4433)
   public static final class PersistScalaSeq extends Persistance<Seq> {
     public PersistScalaSeq() {
       super(Seq.class, true, 4433);
@@ -446,7 +445,7 @@ public final class IrPersistance {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 302)
   public static final class PersistDiagnosticStorage extends Persistance<DiagnosticStorage> {
     public PersistDiagnosticStorage() {
       super(DiagnosticStorage.class, false, 302);

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
@@ -17,15 +17,21 @@ import org.enso.compiler.core.ir.Name;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openide.util.lookup.ServiceProvider;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.immutable.List;
 import scala.collection.immutable.Seq;
 
 public class IrPersistanceTest {
+  @BeforeClass
+  public static void initializeIrPersistance() {
+    org.enso.compiler.core.ir.Persistables.initialize();
+    org.enso.compiler.core.Persistables.initialize();
+  }
+
   @Before
   public void resetDebris() {
     LazyString.forbidden = false;
@@ -505,7 +511,7 @@ public class IrPersistanceTest {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 432432)
   public static final class PersistLazyString extends Persistance<LazyString> {
 
     public PersistLazyString() {
@@ -530,7 +536,7 @@ public class IrPersistanceTest {
     private Singleton() {}
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 432433)
   public static final class PersistSingleton extends Persistance<Singleton> {
 
     public PersistSingleton() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -22,7 +22,6 @@ import org.enso.persist.Persistance;
 import org.enso.pkg.QualifiedName;
 import org.enso.pkg.SourceFile;
 import org.enso.version.BuildVersion;
-import org.openide.util.lookup.ServiceProvider;
 
 public final class ImportExportCache
     implements Cache.Spi<ImportExportCache.CachedBindings, ImportExportCache.Metadata> {
@@ -147,7 +146,7 @@ public final class ImportExportCache
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 3642)
   public static final class PersistMapToBindings extends Persistance<MapToBindings> {
     public PersistMapToBindings() {
       super(MapToBindings.class, false, 3642);
@@ -214,7 +213,7 @@ public final class ImportExportCache
   @Persistable(clazz = BindingsMap.ExtensionMethod.class, id = 33023)
   @Persistable(clazz = BindingsMap.ConversionMethod.class, id = 33024)
   @Persistable(clazz = BindingsMap.Argument.class, id = 33025)
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 33055)
   public static final class PersistBindingsMap extends Persistance<BindingsMap> {
     public PersistBindingsMap() {
       super(BindingsMap.class, false, 33005);

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
@@ -7,7 +7,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import org.apache.commons.lang3.StringUtils;
@@ -140,7 +140,7 @@ public final class SuggestionsCache
    * @param libraryName
    * @param suggestions Must not be null.
    */
-  public record CachedSuggestions(LibraryName libraryName, ArrayList<Suggestion> suggestions) {}
+  public record CachedSuggestions(LibraryName libraryName, List<Suggestion> suggestions) {}
 
   public record Metadata(String sourceHash, String blobHash) {
     byte[] toBytes() throws IOException {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/SerializationPool.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/SerializationPool.java
@@ -29,6 +29,14 @@ import org.enso.pkg.QualifiedName;
  * priority. Future rewrites of this class may optimize towards such direction.
  */
 final class SerializationPool {
+  static {
+    org.enso.compiler.core.ir.Persistables.initialize();
+    org.enso.compiler.pass.analyse.Persistables.initialize();
+    org.enso.compiler.pass.analyse.types.Persistables.initialize();
+    org.enso.compiler.pass.analyse.alias.graph.Persistables.initialize();
+    org.enso.interpreter.caches.Persistables.initialize();
+  }
+
   private final TruffleCompilerContext context;
 
   /**

--- a/engine/runtime/src/test/java/org/enso/runtime/test/TypeMetadataPersistanceTest.java
+++ b/engine/runtime/src/test/java/org/enso/runtime/test/TypeMetadataPersistanceTest.java
@@ -9,6 +9,7 @@ import org.enso.compiler.pass.analyse.types.TypeRepresentation;
 import org.enso.persist.Persistance;
 import org.enso.pkg.QualifiedName;
 import org.enso.scala.wrapper.ScalaConversions;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -16,6 +17,12 @@ import org.junit.Test;
  * indexing.
  */
 public class TypeMetadataPersistanceTest {
+  @BeforeClass
+  public static void initializePersistance() {
+    org.enso.compiler.core.ir.Persistables.initialize();
+    org.enso.compiler.pass.analyse.types.Persistables.initialize();
+  }
+
   private static <T> T serde(Class<T> clazz, T l) throws IOException {
     var arr = Persistance.write(l, null);
     var ref = Persistance.read(arr, null);

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -116,12 +116,7 @@ public class PersistableProcessor extends AbstractProcessor {
     var tu = processingEnv.getTypeUtils();
     var Persistance = eu.getTypeElement("org.enso.persist.Persistance");
     var PersistanceRaw = tu.erasure(Persistance.asType());
-    if (tu.isSubtype(orig.asType(), PersistanceRaw)) {
-      registerPersistablesClass(orig, anno);
-      return true;
-    }
-    String typeElemName = readAnnoValue(anno, "clazz");
-    var canInline = !"false".equals(readAnnoValue(anno, "allowInlining"));
+    var typeElemName = readAnnoValue(anno, "clazz");
     if (typeElemName == null) {
       typeElemName = ((TypeElement) orig).getQualifiedName().toString();
     }
@@ -130,6 +125,12 @@ public class PersistableProcessor extends AbstractProcessor {
       processingEnv.getMessager().printMessage(Kind.ERROR, "Cannot find type for " + typeElemName);
       return false;
     }
+
+    if (tu.isSubtype(typeElem.asType(), PersistanceRaw)) {
+      registerPersistablesClass(typeElem, anno);
+      return true;
+    }
+    var canInline = !"false".equals(readAnnoValue(anno, "allowInlining"));
     var richerConstructor =
         new Comparator<Object>() {
           @Override

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
@@ -32,6 +34,8 @@ import org.openide.util.lookup.ServiceProvider;
 @SupportedAnnotationTypes({"org.enso.persist.Persistable", "org.enso.persist.Persistable.Group"})
 @ServiceProvider(service = Processor.class)
 public class PersistableProcessor extends AbstractProcessor {
+  private final Map<String, Map<Integer, String>> registeredClasses = new TreeMap<>();
+
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -41,6 +45,7 @@ public class PersistableProcessor extends AbstractProcessor {
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     var ok = true;
     var eu = processingEnv.getElementUtils();
+    var tu = processingEnv.getTypeUtils();
     var Persistable = eu.getTypeElement("org.enso.persist.Persistable");
     var PersistableGroup = eu.getTypeElement("org.enso.persist.Persistable.Group");
     try {
@@ -57,6 +62,33 @@ public class PersistableProcessor extends AbstractProcessor {
     } catch (IOException e) {
       ok = false;
       processingEnv.getMessager().printMessage(Kind.ERROR, e.getMessage());
+    }
+    if (roundEnv.processingOver()) {
+      for (var entry : registeredClasses.entrySet()) {
+        try {
+          var cn = entry.getKey() + ".Persistables";
+          var src = processingEnv.getFiler().createSourceFile(cn);
+          try (java.io.Writer w = src.openWriter()) {
+            w.append("package " + entry.getKey() + ";\n");
+            w.append("public final class Persistables {\n");
+            w.append("  private Persistables() {}\n");
+            w.append("  public static void initialize() {\n");
+            w.append("  }\n");
+            for (var idName : entry.getValue().entrySet()) {
+              w.append(
+                  "  private static final org.enso.persist.Persistance PERSIST_"
+                      + idName.getKey()
+                      + " = new "
+                      + idName.getValue()
+                      + "();\n");
+            }
+            w.append("}\n");
+          }
+        } catch (IOException ex) {
+          processingEnv.getMessager().printMessage(Kind.ERROR, ex.getMessage());
+          ok = false;
+        }
+      }
     }
     return ok;
   }
@@ -82,6 +114,12 @@ public class PersistableProcessor extends AbstractProcessor {
   private boolean generatePersistance(Element orig, AnnotationMirror anno) throws IOException {
     var eu = processingEnv.getElementUtils();
     var tu = processingEnv.getTypeUtils();
+    var Persistance = eu.getTypeElement("org.enso.persist.Persistance");
+    var PersistanceRaw = tu.erasure(Persistance.asType());
+    if (tu.isSubtype(orig.asType(), PersistanceRaw)) {
+      registerPersistablesClass(orig, anno);
+      return true;
+    }
     String typeElemName = readAnnoValue(anno, "clazz");
     var canInline = !"false".equals(readAnnoValue(anno, "allowInlining"));
     if (typeElemName == null) {
@@ -155,17 +193,18 @@ public class PersistableProcessor extends AbstractProcessor {
     var className = "Persist" + findNameInPackage(typeElem).replace(".", "_");
     var fo = processingEnv.getFiler().createSourceFile(pkgName + "." + className, orig);
     try (var w = fo.openWriter()) {
+      var id = readAnnoValue(anno, "id");
+      registerPersistablesClass(pkgName, className, Integer.parseInt(id));
+
       w.append("package ").append(pkgName).append(";\n");
       w.append("import java.io.IOException;\n");
       w.append("import org.enso.persist.Persistance;\n");
-      w.append("@org.openide.util.lookup.ServiceProvider(service=Persistance.class)\n");
       w.append("public final class ")
           .append(className)
           .append(" extends Persistance<")
           .append(typeElemName)
           .append("> {\n");
       w.append("  public ").append(className).append("() {\n");
-      var id = readAnnoValue(anno, "id");
       w.append("    super(")
           .append(typeElemName)
           .append(".class, false, ")
@@ -272,6 +311,33 @@ public class PersistableProcessor extends AbstractProcessor {
       w.append("}\n");
     }
     return true;
+  }
+
+  private void registerPersistablesClass(Element elem, AnnotationMirror anno) {
+    StringBuilder name = new StringBuilder();
+    for (; ; ) {
+      if (elem instanceof PackageElement pkg) {
+        var id = readAnnoValue(anno, "id");
+        registerPersistablesClass(pkg.toString(), name.toString(), Integer.parseInt(id));
+        break;
+      } else {
+        var sn = elem.getSimpleName().toString();
+        if (!name.isEmpty()) {
+          name.insert(0, '.');
+        }
+        name.insert(0, sn);
+        elem = elem.getEnclosingElement();
+      }
+    }
+  }
+
+  private void registerPersistablesClass(String pkgName, String className, int id) {
+    var pkg = registeredClasses.get(pkgName);
+    if (pkg == null) {
+      pkg = new TreeMap<>();
+      registeredClasses.put(pkgName, pkg);
+    }
+    pkg.put(id, className);
   }
 
   private boolean isVisibleFrom(Element e, Element from) {

--- a/lib/java/persistance/src/main/java/module-info.java
+++ b/lib/java/persistance/src/main/java/module-info.java
@@ -1,5 +1,4 @@
 module org.enso.persistance {
-  requires org.openide.util.lookup.RELEASE180;
   requires org.slf4j;
 
   exports org.enso.persist;

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
@@ -6,20 +6,31 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.openide.util.lookup.Lookups;
 
 final class PerMap {
+  private static final class AllPersistables extends ClassValue<Persistance[]> {
+    @Override
+    protected Persistance[] computeValue(Class<?> type) {
+      return new Persistance[1];
+    }
+  }
+
+  private static final AllPersistables CACHE = new AllPersistables();
 
   private static final int serialVersionUID = 8652; // Use PR number
-  private static final Collection<? extends Persistance> ALL;
+  private static final Collection<Persistance> ALL = new ArrayList<>();
 
   static {
-    var loader = PerMap.class.getClassLoader();
-    var lookup = Lookups.metaInfServices(loader);
-    var all = new ArrayList<Persistance>();
-    all.add(PerReferencePeristance.INSTANCE);
-    all.addAll(lookup.lookupAll(Persistance.class));
-    ALL = all;
+    registerPersistance(PerReferencePeristance.INSTANCE);
+  }
+
+  static void registerPersistance(Persistance p) {
+    var arr = CACHE.get(p.getClass());
+    if (arr[0] == null) {
+      synchronized (ALL) {
+        ALL.add(arr[0] = p);
+      }
+    }
   }
 
   private final Map<Integer, Persistance<?>> ids = new HashMap<>();

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -21,8 +21,8 @@ import java.util.function.Function;
  *
  * Unlike typical Java serialization (which tries to make things automatic), this framework requires
  * one to implement the persistance manually. For each class that one wants to support, one has to
- * implement subclass {@link Persistance} and implement its {@link Persistance#writeObject} and
- * {@link Persistance#readObject} method. <br>
+ * subclass {@link Persistance} and implement its {@link Persistance#writeObject} and {@link
+ * Persistance#readObject} method. <br>
  * {@snippet file="org/enso/persist/PersistanceTest.java" region="manual"} <br>
  * There is a semi-automatic way to generate such subclasses of {@link Persistance} via the {@link
  * Persistable @Persistable} annotation.

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -57,6 +57,7 @@ public abstract class Persistance<T> implements Cloneable {
     this.clazz = clazz;
     this.includingSubclasses = includingSubclasses;
     this.id = id;
+    PerMap.registerPersistance(this);
   }
 
   final Persistance<?> newClone() {

--- a/lib/java/persistance/src/test/java/org/enso/persist/PersistanceTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/PersistanceTest.java
@@ -161,7 +161,7 @@ public class PersistanceTest {
   }
 
   // @start region="annotation"
-  @Persistable(clazz = Service.class, id = 432434)
+  @Persistable(id = 432434)
   @Persistable(clazz = IntegerSupply.class, id = 432435)
   public record Service(int value) implements Supplier<Integer> {
     @Override

--- a/lib/java/persistance/src/test/java/org/enso/persist/PersistanceTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/PersistanceTest.java
@@ -9,10 +9,15 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.openide.util.lookup.ServiceProvider;
 
 public class PersistanceTest {
+  @BeforeClass
+  public static void initPersistables() {
+    Persistables.initialize();
+  }
+
   @Test
   public void testUUIDPersistance() throws Exception {
     // @start region="write"
@@ -110,7 +115,7 @@ public class PersistanceTest {
   }
 
   // @start region="manual"
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 328439)
   public static final class PersistUUID extends Persistance<UUID> {
 
     public PersistUUID() {
@@ -139,7 +144,7 @@ public class PersistanceTest {
     private Singleton() {}
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 432433)
   public static final class PersistSingleton extends Persistance<Singleton> {
 
     public PersistSingleton() {

--- a/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsInlineTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsInlineTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import org.enso.persist.Persistance.Reference;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.openide.util.lookup.ServiceProvider;
 
 /**
  * This test case verifies the order of writing references down. There are two tests. One creates
@@ -21,6 +21,11 @@ import org.openide.util.lookup.ServiceProvider;
  * ReferenceAsObjectTest} for similar yet different test.
  */
 public class ReferenceAsInlineTest {
+  @BeforeClass
+  public static void initPersistables() {
+    Persistables.initialize();
+  }
+
   private static Chain eagerChain(String id, int[] counter, Chain next) {
     Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, false);
     return new Chain(id, counter, ref);
@@ -112,7 +117,7 @@ public class ReferenceAsInlineTest {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 54288453)
   public static final class ChainPersistance extends Persistance<Chain> {
 
     public ChainPersistance() {

--- a/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsObjectTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsObjectTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import org.enso.persist.Persistance.Reference;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.openide.util.lookup.ServiceProvider;
 
 /**
  * This test case verifies the order of writing references down. There are two tests. One creates
@@ -21,6 +21,11 @@ import org.openide.util.lookup.ServiceProvider;
  * ReferenceAsInlineTest} for similar yet different test.
  */
 public final class ReferenceAsObjectTest {
+  @BeforeClass
+  public static void initPersistables() {
+    Persistables.initialize();
+  }
+
   private static Chain eagerChain(String id, int[] counter, Chain next) {
     Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, false);
     return new Chain(id, counter, ref);
@@ -112,7 +117,7 @@ public final class ReferenceAsObjectTest {
     }
   }
 
-  @ServiceProvider(service = Persistance.class)
+  @Persistable(id = 54288435)
   public static final class ChainPersistance extends Persistance<Chain> {
 
     public ChainPersistance() {


### PR DESCRIPTION
### Pull Request Description

Fixes #10972 by removing `@ServiceProvider`  registrations and using `@Persistable` annotation instead. It generates `Persistables` class per package which needs to be initialized before its registrations become active. Various tests had to be modified to call necessary `Persistables.initialize()` - otherwise the usage remains the same.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
