### PR TITLE
Resources in truffle-api jar need to be signed

### DIFF
--- a/app/ide-desktop/client/tasks/signArchivesMacOs.ts
+++ b/app/ide-desktop/client/tasks/signArchivesMacOs.ts
@@ -81,6 +81,13 @@ async function ensoPackageSignables(resourcesDir: string): Promise<Signable[]> {
       ],
     ],
     [
+      'component/truffle-api-*.jar',
+      [
+        'META-INF/resources/engine/libtruffleattach/darwin/amd64/bin/libtruffleattach.dylib',
+        'META-INF/resources/engine/libtruffleattach/darwin/aarch64/bin/libtruffleattach.dylib',
+      ],
+    ],
+    [
       'component/truffle-nfi-libffi-*.jar',
       ['META-INF/resources/nfi-native/libnfi/darwin/*/bin/libtrufflenfi.dylib'],
     ],
@@ -91,6 +98,7 @@ async function ensoPackageSignables(resourcesDir: string): Promise<Signable[]> {
         'META-INF/resources/engine/libtruffleattach/darwin/aarch64/bin/libtruffleattach.dylib',
       ],
     ],
+
     ['component/jna-*.jar', ['com/sun/jna/*/libjnidispatch.jnilib']],
     [
       'component/jline-native-*.jar',


### PR DESCRIPTION
Follow up on #12500
