### PR TITLE
Handle empty text in URI.parse

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -51,8 +51,8 @@ type URI
 
              example_parse = URI.parse "http://example.com"
     parse : Text -> URI ! Syntax_Error
-    parse uri:Text =
-        Panic.catch URISyntaxException (URI.Value (Java_URI.new uri) []) caught_panic->
+    parse uri:Text = if uri == "" then Error.throw (Syntax_Error.Error "URI cannot be empty.") else
+        raw_uri = Panic.catch URISyntaxException (URI.Value (Java_URI.new uri) []) caught_panic->
             query_index = uri.index_of '?'
             result = if query_index.is_nothing then Nothing else
                 new_uri = (uri.take query_index+1) + (URITransformer.encodeQuery (uri.drop query_index+1))
@@ -64,6 +64,8 @@ type URI
                 truncated = if message.is_nothing || message.length > 100 then "Invalid URI '" + uri.to_display_text + "'" else
                     "URI syntax error: " + message
                 Error.throw (Syntax_Error.Error truncated)
+        if raw_uri.scheme == Nothing then URI.parse ("https://" + uri) else
+            raw_uri
 
     ## GROUP Metadata
        ICON metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -64,7 +64,7 @@ type URI
                 truncated = if message.is_nothing || message.length > 100 then "Invalid URI '" + uri.to_display_text + "'" else
                     "URI syntax error: " + message
                 Error.throw (Syntax_Error.Error truncated)
-        if raw_uri.scheme == Nothing then URI.parse ("https://" + uri) else
+        if raw_uri.scheme == Nothing && (uri.starts_with "/" . not) then URI.parse ("https://" + uri) else
             raw_uri
 
     ## GROUP Metadata

--- a/test/Base_Tests/src/Network/Http_Spec.enso
+++ b/test/Base_Tests/src/Network/Http_Spec.enso
@@ -578,30 +578,30 @@ add_specs suite_builder =
     suite_builder.group "Header resolution" group_builder->
         group_builder.specify "Default content type and encoding" <|
             expected = [Header.content_type "text/plain; charset=UTF-8"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [] (Request_Body.Text "")) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [] (Request_Body.Text "")) . should_equal_ignoring_order expected
 
         group_builder.specify "Content type specified in body" <|
             expected = [Header.content_type "application/json; charset=UTF-8"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [] (Request_Body.Text "" content_type="application/json")) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [] (Request_Body.Text "" content_type="application/json")) . should_equal_ignoring_order expected
 
         group_builder.specify "Content type specified in header list" <|
             expected = [Header.content_type "application/json"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [Header.content_type "application/json"] (Request_Body.Text "")) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [Header.content_type "application/json"] (Request_Body.Text "")) . should_equal_ignoring_order expected
 
         group_builder.specify "Text encoding specified in body" <|
             expected = [Header.content_type "text/plain; charset=UTF-16LE"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [] (Request_Body.Text "" encoding=Encoding.utf_16_le)) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [] (Request_Body.Text "" encoding=Encoding.utf_16_le)) . should_equal_ignoring_order expected
 
         group_builder.specify "Can't specify content type in both places" <|
-            _resolve_headers (Request.new HTTP_Method.Get "" [Header.content_type "application/json"] (Request_Body.Text "" content_type="text/plain")) . should_fail_with Illegal_Argument
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [Header.content_type "application/json"] (Request_Body.Text "" content_type="text/plain")) . should_fail_with Illegal_Argument
 
         group_builder.specify "Custom header" <|
             expected = [Header.new "some" "header", Header.content_type "application/json; charset=UTF-8"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [Header.new "some" "header"] (Request_Body.Text "" content_type="application/json")) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [Header.new "some" "header"] (Request_Body.Text "" content_type="application/json")) . should_equal_ignoring_order expected
 
         group_builder.specify "Multiple content types in header list are ok" <|
             expected = [Header.content_type "application/json", Header.content_type "text/plain"]
-            _resolve_headers (Request.new HTTP_Method.Get "" [Header.content_type "application/json", Header.content_type "text/plain"] (Request_Body.Text "")) . should_equal_ignoring_order expected
+            _resolve_headers (Request.new HTTP_Method.Get "www.enso.org" [Header.content_type "application/json", Header.content_type "text/plain"] (Request_Body.Text "")) . should_equal_ignoring_order expected
 
     suite_builder.group "Http Error handling" group_builder->
         group_builder.specify "should be able to handle request errors" <|

--- a/test/Base_Tests/src/Network/Http_Spec.enso
+++ b/test/Base_Tests/src/Network/Http_Spec.enso
@@ -181,7 +181,7 @@ add_specs suite_builder =
 
         group_builder.specify "Fails on a bad URL scheme" <|
             Data.fetch "zxcv://bad.scheme" . should_fail_with Illegal_Argument
-            Data.fetch "" . should_fail_with Illegal_Argument
+            Data.fetch "" . should_fail_with Syntax_Error
 
         group_builder.specify "can select the version" <| Test.with_retries <|
             req = Request.get url_get

--- a/test/Base_Tests/src/Network/URI_Spec.enso
+++ b/test/Base_Tests/src/Network/URI_Spec.enso
@@ -33,6 +33,17 @@ add_specs suite_builder =
             addr.query.should_equal "key=val"
             addr.fragment.should_equal Nothing
 
+        group_builder.specify "should assume http:// if no scheme" <|
+            addr = URI.parse "example.com/foo/bar?key=val"
+            addr.scheme.should_equal "https"
+            addr.user_info.should_equal Nothing
+            addr.host.should_equal "example.com"
+            addr.authority.should_equal "example.com"
+            addr.port.should_equal Nothing
+            addr.path.should_equal "/foo/bar"
+            addr.query.should_equal "key=val"
+            addr.fragment.should_equal Nothing
+
         group_builder.specify "should allow to convert a text to URI" <|
             addr2 = URI.from "https://example.org:1234/?a=b&c=d+e#line=10,20"
             addr2.should_be_a URI
@@ -83,6 +94,12 @@ add_specs suite_builder =
             r.should_fail_with Syntax_Error
             r.catch.to_display_text . should_contain "a b c"
             URI.from "a b c" . should_fail_with Syntax_Error
+
+        group_builder.specify "should return Syntax_Error when parsing empty URI" <|
+            r = URI.parse ""
+            r.should_fail_with Syntax_Error
+            r.catch.to_display_text . should_contain "empty"
+            URI.from "" . should_fail_with Syntax_Error
 
         group_builder.specify "should allow a URI without scheme or authority" <|
             uri = URI.parse "//a/b/c"

--- a/test/Base_Tests/src/Network/URI_Spec.enso
+++ b/test/Base_Tests/src/Network/URI_Spec.enso
@@ -33,7 +33,7 @@ add_specs suite_builder =
             addr.query.should_equal "key=val"
             addr.fragment.should_equal Nothing
 
-        group_builder.specify "should assume http:// if no scheme" <|
+        group_builder.specify "should assume https:// if no scheme" <|
             addr = URI.parse "example.com/foo/bar?key=val"
             addr.scheme.should_equal "https"
             addr.user_info.should_equal Nothing


### PR DESCRIPTION
### Pull Request Description

More graceful error when an empty URI is passed.
Default to https if no scheme passed.

![image](https://github.com/user-attachments/assets/30596442-363b-483b-a458-fbb89cdafcac)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
