### PR TITLE
Refresh token in telemetry appender

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1152,7 +1152,13 @@ lazy val `logging-service-telemetry` = project
       "org.slf4j"                              % "slf4j-api"               % slf4jVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"   % jsoniterVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"     % jsoniterVersion,
-      "org.netbeans.api"                       % "org-openide-util-lookup" % netbeansApiVersion % "provided"
+      "org.netbeans.api"                       % "org-openide-util-lookup" % netbeansApiVersion % "provided",
+      "junit"                                  % "junit"                   % junitVersion       % Test,
+      "com.github.sbt"                         % "junit-interface"         % junitIfVersion     % Test,
+      "org.hamcrest"                           % "hamcrest-all"            % hamcrestVersion    % Test,
+      "com.fasterxml.jackson.core"             % "jackson-core"            % jacksonVersion     % Test,
+      "com.fasterxml.jackson.core"             % "jackson-annotations"     % jacksonVersion     % Test,
+      "com.fasterxml.jackson.core"             % "jackson-databind"        % jacksonVersion     % Test
     ),
     Compile / javaModuleName := "org.enso.logging.service.telemetry",
     Compile / moduleDependencies ++= logbackPkg ++ Seq(
@@ -1165,6 +1171,8 @@ lazy val `logging-service-telemetry` = project
     )
   )
   .dependsOn(`logging-service-logback`)
+  .dependsOn(`http-test-helper` % "test->test")
+  .dependsOn(testkit % "test->test")
 
 lazy val `logging-utils-akka` = project
   .in(file("lib/scala/logging-utils-akka"))

--- a/build.sbt
+++ b/build.sbt
@@ -1148,6 +1148,8 @@ lazy val `logging-service-telemetry` = project
     scalaModuleDependencySetting,
     mixedJavaScalaProjectSetting,
     version := "0.1",
+    commands += WithDebugCommand.withDebug,
+    Test / fork := true,
     libraryDependencies ++= Seq(
       "org.slf4j"                              % "slf4j-api"               % slf4jVersion,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"   % jsoniterVersion,

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/AuthenticationData.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/AuthenticationData.java
@@ -1,0 +1,5 @@
+package org.enso.logging.service.telemetry;
+
+import java.time.LocalDateTime;
+
+public record AuthenticationData(String accessToken, LocalDateTime expireAt) {}

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/AuthenticationData.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/AuthenticationData.java
@@ -1,5 +1,18 @@
 package org.enso.logging.service.telemetry;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
-public record AuthenticationData(String accessToken, LocalDateTime expireAt) {}
+public record AuthenticationData(String accessToken, ZonedDateTime expireAt) {
+  public static AuthenticationData fromCredentials(Credentials credentials) {
+    ZonedDateTime expireAt;
+    try {
+      expireAt = Instant.parse(credentials.expireAt()).atZone(ZoneId.of("UTC"));
+    } catch (DateTimeParseException e) {
+      throw new AssertionError("Should not reach here", e);
+    }
+    return new AuthenticationData(credentials.accessToken(), expireAt);
+  }
+}

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJob.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJob.java
@@ -1,0 +1,12 @@
+package org.enso.logging.service.telemetry;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Wrapper for {@link LogMessage} with an optional completable future for notification.
+ *
+ * @param message
+ * @param completionNofitication May be null if no one wants to listen to the completion of the job.
+ *     If not null, it will be completed when the job is finished.
+ */
+public record LogJob(LogMessage message, CompletableFuture<Void> completionNofitication) {}

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -2,14 +2,16 @@ package org.enso.logging.service.telemetry;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.enso.logging.service.telemetry.ApiMessage.Log;
 import org.slf4j.Logger;
@@ -26,11 +28,17 @@ public final class LogJobsProcessor {
   private static final int MAX_RETRIES = 5;
   private static final Logger LOGGER = LoggerFactory.getLogger(LogJobsProcessor.class);
 
+  /**
+   * The amount of time before the token expiration. Determines whether the token should be
+   * proactively refreshed early, so that it does not expire during a request.
+   */
+  private static final Duration TOKEN_EARLY_REFRESH_PERIOD = Duration.ofMinutes(2);
+
   private final ThreadPoolExecutor backgroundThreadService;
   private final URI endpoint;
-  private final AuthenticationData authenticationData;
   private final LogJobsQueue logQueue = new LogJobsQueue();
   private final TokenRefresher tokenRefresher;
+  private AuthenticationData authenticationData;
   private HttpClient httpClient;
 
   /**
@@ -40,7 +48,11 @@ public final class LogJobsProcessor {
    */
   private boolean requestSendingFailure;
 
-  public LogJobsProcessor(ThreadPoolExecutor executor, URI endpoint, AuthenticationData authenticationData, TokenRefresher tokenRefresher) {
+  public LogJobsProcessor(
+      ThreadPoolExecutor executor,
+      URI endpoint,
+      AuthenticationData authenticationData,
+      TokenRefresher tokenRefresher) {
     this.backgroundThreadService = Objects.requireNonNull(executor);
     this.endpoint = Objects.requireNonNull(endpoint);
     this.authenticationData = Objects.requireNonNull(authenticationData);
@@ -98,6 +110,23 @@ public final class LogJobsProcessor {
    */
   private void sendBatch(List<LogJob> batch) throws RequestFailureException {
     assert !batch.isEmpty() : "The batch must not be empty.";
+
+    if (accessTokenNeedsRefresh()) {
+      var refreshTokenTask = tokenRefresher.fetchNewAccessToken();
+      AuthenticationData refreshedAuthData;
+      try {
+        // We cannot proceed until a new, refreshed, token is received.
+        refreshedAuthData = refreshTokenTask.get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RequestFailureException("Error during token refresh", e);
+      }
+      if (refreshedAuthData != null) {
+        authenticationData = refreshedAuthData;
+      } else {
+        throw new RequestFailureException("Failed to refresh token", null);
+      }
+    }
+    assert authenticationData != null;
 
     try {
       var request = buildRequest(batch);
@@ -191,6 +220,12 @@ public final class LogJobsProcessor {
         sendLogRequest(request, retryCount - 1);
       }
     }
+  }
+
+  private boolean accessTokenNeedsRefresh() {
+    var inEarlyFuture = ZonedDateTime.now().plus(TOKEN_EARLY_REFRESH_PERIOD);
+    var expiration = authenticationData.expireAt();
+    return inEarlyFuture.compareTo(expiration) > 0;
   }
 
   private static final class RequestFailureException extends Exception {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -44,8 +44,18 @@ public final class LogJobsProcessor {
     this.credentials = Objects.requireNonNull(credentials);
   }
 
-  public void enqueueMessage(LogMessage message) {
-    int queuedJobs = logQueue.enqueue(message);
+  /*
+   * Liveness is guaranteed, because the queue size always increments exactly by 1,
+   * so `enqueue` returns 1 if and only if the queue was empty beforehand.
+   *
+   * If the queue was empty before adding a message, we always schedule a `logThreadEntryPoint` to run,
+   * unless it was already pending on the job queue.
+   *
+   * Any running `logThreadEntryPoint` will not finish until the queue is empty.
+   * So after every append, either a job is already running or scheduled to be run.
+   */
+  public void enqueueMessage(LogJob logJob) {
+    int queuedJobs = logQueue.enqueue(logJob);
     if (queuedJobs == 1 && backgroundThreadService.getQueue().isEmpty()) {
       // If we are the first message in the queue, we need to start the background thread.
       // It is possible that a job was already running, but adding a new one will not hurt - once
@@ -55,23 +65,12 @@ public final class LogJobsProcessor {
         backgroundThreadService.execute(this::logThreadEntryPoint);
       }
     }
-
-    /*
-     * Liveness is guaranteed, because the queue size always increments exactly by 1,
-     * so `enqueue` returns 1 if and only if the queue was empty beforehand.
-     *
-     * If the queue was empty before adding a message, we always schedule a `logThreadEntryPoint` to run,
-     * unless it was already pending on the job queue.
-     *
-     * Any running `logThreadEntryPoint` will not finish until the queue is empty.
-     * So after every append, either a job is already running or scheduled to be run.
-     */
   }
 
   /** Runs as long as there are any pending log messages queued and sends them in batches. */
   private void logThreadEntryPoint() {
     while (true) {
-      List<LogMessage> pendingMessages = logQueue.popEnqueuedJobs(MAX_BATCH_SIZE);
+      List<LogJob> pendingMessages = logQueue.popEnqueuedJobs(MAX_BATCH_SIZE);
       if (pendingMessages.isEmpty()) {
         // If there are no more pending messages, we can stop the thread for now.
         // If during this teardown a new message is added, it will see no elements on `logQueue` and
@@ -94,18 +93,39 @@ public final class LogJobsProcessor {
    *
    * <p>The batch must not be empty and all messages must share the same request config.
    */
-  private void sendBatch(List<LogMessage> batch) throws RequestFailureException {
+  private void sendBatch(List<LogJob> batch) throws RequestFailureException {
     assert !batch.isEmpty() : "The batch must not be empty.";
 
-    var request = buildRequest(batch);
-    if (request == null) {
-      LOGGER.warn("Failed to build request for log messages. Skipping {} messages", batch.size());
-    } else {
+    try {
+      var request = buildRequest(batch);
+      if (request == null) {
+        LOGGER.warn("Failed to build request for log messages. Skipping {} messages", batch.size());
+        throw new RequestFailureException("Cannot build request", null);
+      }
       sendLogRequest(request, MAX_RETRIES);
+      notifyJobsAboutSuccess(batch);
+    } catch (RequestFailureException e) {
+      notifyJobsAboutFailure(batch, e);
     }
   }
 
-  private HttpRequest buildRequest(List<LogMessage> logEvents) throws RequestFailureException {
+  private void notifyJobsAboutFailure(List<LogJob> logJobs, RequestFailureException exception) {
+    for (var job : logJobs) {
+      if (job.completionNofitication() != null) {
+        job.completionNofitication().completeExceptionally(exception);
+      }
+    }
+  }
+
+  private void notifyJobsAboutSuccess(List<LogJob> logJobs) {
+    for (var logJob : logJobs) {
+      if (logJob.completionNofitication() != null) {
+        logJob.completionNofitication().complete(null);
+      }
+    }
+  }
+
+  private HttpRequest buildRequest(List<LogJob> logEvents) throws RequestFailureException {
     var payload = buildPayload(logEvents);
     if (payload != null) {
       return HttpRequest.newBuilder()
@@ -123,15 +143,15 @@ public final class LogJobsProcessor {
    *
    * @return null if none of the log events could be transformed into a payload.
    */
-  private String buildPayload(List<LogMessage> messages) {
+  private String buildPayload(List<LogJob> logJobs) {
     var logs = new ArrayList<Log>();
-    for (var logMessage : messages) {
-      var payloadForLogEvent = LogFormatter.transform(logMessage);
+    for (var logJob : logJobs) {
+      var payloadForLogEvent = LogFormatter.transform(logJob.message());
       if (payloadForLogEvent != null) {
         logs.add(payloadForLogEvent);
       }
     }
-    if (logs.size() != messages.size()) {
+    if (logs.size() != logJobs.size()) {
       LOGGER.warn("Failed to build payload for some log events");
     }
     if (logs.isEmpty()) {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -1,0 +1,178 @@
+package org.enso.logging.service.telemetry;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.enso.logging.service.telemetry.ApiMessage.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsible for sending {@link LogMessage} to the endpoint asynchronously. */
+public final class LogJobsProcessor {
+  /**
+   * We still want to limit the batch size to some reasonable number - sending too many logs in one
+   * request could also be problematic.
+   */
+  private static final int MAX_BATCH_SIZE = 100;
+
+  private static final int MAX_RETRIES = 5;
+  private static final Logger LOGGER = LoggerFactory.getLogger(LogJobsProcessor.class);
+
+  private final ThreadPoolExecutor backgroundThreadService;
+  private final URI endpoint;
+  private final Credentials credentials;
+  private final LogJobsQueue logQueue = new LogJobsQueue();
+  private HttpClient httpClient;
+
+  /**
+   * Set to true once an error is encountered when sending a request. In such case, it is most
+   * probably that no further requests will be successful. This flag is used to terminate the
+   * background thread.
+   */
+  private boolean requestSendingFailure;
+
+  public LogJobsProcessor(ThreadPoolExecutor executor, URI endpoint, Credentials credentials) {
+    this.backgroundThreadService = Objects.requireNonNull(executor);
+    this.endpoint = Objects.requireNonNull(endpoint);
+    this.credentials = Objects.requireNonNull(credentials);
+  }
+
+  public void enqueueMessage(LogMessage message) {
+    int queuedJobs = logQueue.enqueue(message);
+    if (queuedJobs == 1 && backgroundThreadService.getQueue().isEmpty()) {
+      // If we are the first message in the queue, we need to start the background thread.
+      // It is possible that a job was already running, but adding a new one will not hurt - once
+      // the queue is empty, the currently running job will finish and any additional jobs will also
+      // terminate immediately.
+      if (!requestSendingFailure) {
+        backgroundThreadService.execute(this::logThreadEntryPoint);
+      }
+    }
+
+    /*
+     * Liveness is guaranteed, because the queue size always increments exactly by 1,
+     * so `enqueue` returns 1 if and only if the queue was empty beforehand.
+     *
+     * If the queue was empty before adding a message, we always schedule a `logThreadEntryPoint` to run,
+     * unless it was already pending on the job queue.
+     *
+     * Any running `logThreadEntryPoint` will not finish until the queue is empty.
+     * So after every append, either a job is already running or scheduled to be run.
+     */
+  }
+
+  /** Runs as long as there are any pending log messages queued and sends them in batches. */
+  private void logThreadEntryPoint() {
+    while (true) {
+      List<LogMessage> pendingMessages = logQueue.popEnqueuedJobs(MAX_BATCH_SIZE);
+      if (pendingMessages.isEmpty()) {
+        // If there are no more pending messages, we can stop the thread for now.
+        // If during this teardown a new message is added, it will see no elements on `logQueue` and
+        // thus,
+        // `logQueue.enqueue` will return 1, thus ensuring that at least one new job is scheduled.
+        return;
+      }
+      try {
+        sendBatch(pendingMessages);
+      } catch (RequestFailureException e) {
+        LOGGER.warn("Stopping the Telemetry appender - requests cannot be send", e);
+        requestSendingFailure = true;
+        return;
+      }
+    }
+  }
+
+  /**
+   * Sends a batch of log messages.
+   *
+   * <p>The batch must not be empty and all messages must share the same request config.
+   */
+  private void sendBatch(List<LogMessage> batch) throws RequestFailureException {
+    assert !batch.isEmpty() : "The batch must not be empty.";
+
+    var request = buildRequest(batch);
+    if (request == null) {
+      LOGGER.warn("Failed to build request for log messages. Skipping {} messages", batch.size());
+    } else {
+      sendLogRequest(request, MAX_RETRIES);
+    }
+  }
+
+  private HttpRequest buildRequest(List<LogMessage> logEvents) throws RequestFailureException {
+    var payload = buildPayload(logEvents);
+    if (payload != null) {
+      return HttpRequest.newBuilder()
+          .uri(endpoint)
+          .header("Authorization", "Bearer " + credentials.accessToken())
+          .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+          .build();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Transforms the given log events into JSON payloads.
+   *
+   * @return null if none of the log events could be transformed into a payload.
+   */
+  private String buildPayload(List<LogMessage> messages) {
+    var logs = new ArrayList<Log>();
+    for (var logMessage : messages) {
+      var payloadForLogEvent = LogFormatter.transform(logMessage);
+      if (payloadForLogEvent != null) {
+        logs.add(payloadForLogEvent);
+      }
+    }
+    if (logs.size() != messages.size()) {
+      LOGGER.warn("Failed to build payload for some log events");
+    }
+    if (logs.isEmpty()) {
+      return null;
+    } else {
+      var payload = ApiMessage.createPayload(logs);
+      return ApiMessage.serializePayload(payload);
+    }
+  }
+
+  private void sendLogRequest(HttpRequest request, int retryCount) throws RequestFailureException {
+    assert request != null;
+    try {
+      try {
+        if (httpClient == null) {
+          httpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS).build();
+        }
+        HttpResponse<String> response =
+            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+          throw new RequestFailureException(
+              "Unexpected status code: " + response.statusCode() + " " + response.body(), null);
+        }
+      } catch (IOException | InterruptedException e) {
+        var errorMessage = e.getMessage() != null ? e.getMessage() : e.toString();
+        throw new RequestFailureException("Failed to send log messages: " + errorMessage, e);
+      }
+    } catch (RequestFailureException e) {
+      if (retryCount < 0) {
+        LOGGER.debug("Failed to send log messages after retrying", e);
+        throw e;
+      } else {
+        LOGGER.debug("Exception when sending log messages. Retrying...", e);
+        sendLogRequest(request, retryCount - 1);
+      }
+    }
+  }
+
+  private static final class RequestFailureException extends Exception {
+    public RequestFailureException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -113,6 +113,7 @@ public final class LogJobsProcessor {
     assert !batch.isEmpty() : "The batch must not be empty.";
 
     if (accessTokenNeedsRefresh()) {
+      LOGGER.debug("Refreshing access token");
       var refreshTokenTask = tokenRefresher.fetchNewAccessToken();
       AuthenticationData refreshedAuthData;
       try {
@@ -123,6 +124,7 @@ public final class LogJobsProcessor {
       }
       if (refreshedAuthData != null) {
         authenticationData = refreshedAuthData;
+        LOGGER.trace("Token refreshed successfully: {}", authenticationData);
       } else {
         throw new RequestFailureException("Failed to refresh token", null);
       }
@@ -143,6 +145,7 @@ public final class LogJobsProcessor {
   }
 
   private void notifyJobsAboutFailure(List<LogJob> logJobs, RequestFailureException exception) {
+    LOGGER.warn("Failed to send {} log messages", logJobs.size(), exception);
     for (var job : logJobs) {
       if (job.completionNofitication() != null) {
         job.completionNofitication().completeExceptionally(exception);
@@ -151,6 +154,7 @@ public final class LogJobsProcessor {
   }
 
   private void notifyJobsAboutSuccess(List<LogJob> logJobs) {
+    LOGGER.trace("Successfully sent {} log messages", logJobs.size());
     for (var logJob : logJobs) {
       if (logJob.completionNofitication() != null) {
         logJob.completionNofitication().complete(null);
@@ -227,7 +231,13 @@ public final class LogJobsProcessor {
     var now = Instant.now().atZone(ZoneId.of("UTC"));
     var inEarlyFuture = now.plus(TOKEN_EARLY_REFRESH_PERIOD);
     var expiration = authenticationData.expireAt();
-    return inEarlyFuture.compareTo(expiration) > 0;
+    var res = inEarlyFuture.compareTo(expiration) > 0;
+    LOGGER.trace(
+        "Token needs refresh: {}. Current time (plus early refresh period): {}, expiration: {}",
+        res,
+        inEarlyFuture,
+        expiration);
+    return res;
   }
 
   private static final class RequestFailureException extends Exception {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -12,7 +12,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.enso.logging.service.telemetry.ApiMessage.Log;
 import org.slf4j.Logger;
@@ -114,14 +113,7 @@ public final class LogJobsProcessor {
 
     if (accessTokenNeedsRefresh()) {
       LOGGER.debug("Refreshing access token");
-      var refreshTokenTask = tokenRefresher.fetchNewAccessToken();
-      AuthenticationData refreshedAuthData;
-      try {
-        // We cannot proceed until a new, refreshed, token is received.
-        refreshedAuthData = refreshTokenTask.get();
-      } catch (InterruptedException | ExecutionException e) {
-        throw new RequestFailureException("Error during token refresh", e);
-      }
+      var refreshedAuthData = tokenRefresher.fetchNewAccessToken();
       if (refreshedAuthData != null) {
         authenticationData = refreshedAuthData;
         LOGGER.trace(

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -124,7 +124,8 @@ public final class LogJobsProcessor {
       }
       if (refreshedAuthData != null) {
         authenticationData = refreshedAuthData;
-        LOGGER.trace("Token refreshed successfully: {}", authenticationData);
+        LOGGER.trace(
+            "Token refreshed successfully. New expiration: {}", authenticationData.expireAt());
       } else {
         throw new RequestFailureException("Failed to refresh token", null);
       }

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -7,7 +7,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -223,7 +224,8 @@ public final class LogJobsProcessor {
   }
 
   private boolean accessTokenNeedsRefresh() {
-    var inEarlyFuture = ZonedDateTime.now().plus(TOKEN_EARLY_REFRESH_PERIOD);
+    var now = Instant.now().atZone(ZoneId.of("UTC"));
+    var inEarlyFuture = now.plus(TOKEN_EARLY_REFRESH_PERIOD);
     var expiration = authenticationData.expireAt();
     return inEarlyFuture.compareTo(expiration) > 0;
   }

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -2,6 +2,7 @@ package org.enso.logging.service.telemetry;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -27,8 +28,9 @@ public final class LogJobsProcessor {
 
   private final ThreadPoolExecutor backgroundThreadService;
   private final URI endpoint;
-  private final Credentials credentials;
+  private final AuthenticationData authenticationData;
   private final LogJobsQueue logQueue = new LogJobsQueue();
+  private final TokenRefresher tokenRefresher;
   private HttpClient httpClient;
 
   /**
@@ -38,10 +40,11 @@ public final class LogJobsProcessor {
    */
   private boolean requestSendingFailure;
 
-  public LogJobsProcessor(ThreadPoolExecutor executor, URI endpoint, Credentials credentials) {
+  public LogJobsProcessor(ThreadPoolExecutor executor, URI endpoint, AuthenticationData authenticationData, TokenRefresher tokenRefresher) {
     this.backgroundThreadService = Objects.requireNonNull(executor);
     this.endpoint = Objects.requireNonNull(endpoint);
-    this.credentials = Objects.requireNonNull(credentials);
+    this.authenticationData = Objects.requireNonNull(authenticationData);
+    this.tokenRefresher = tokenRefresher;
   }
 
   /*
@@ -130,7 +133,7 @@ public final class LogJobsProcessor {
     if (payload != null) {
       return HttpRequest.newBuilder()
           .uri(endpoint)
-          .header("Authorization", "Bearer " + credentials.accessToken())
+          .header("Authorization", "Bearer " + authenticationData.accessToken())
           .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
           .build();
     } else {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsQueue.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsQueue.java
@@ -1,18 +1,17 @@
 package org.enso.logging.service.telemetry;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
 final class LogJobsQueue {
-  private final Deque<ILoggingEvent> queue = new LinkedList<>();
+  private final Deque<LogMessage> queue = new LinkedList<>();
 
   /** Enqueues a log message to be sent and returns the number of messages in the queue. */
-  synchronized int enqueue(ILoggingEvent job) {
+  synchronized int enqueue(LogMessage message) {
     int previousSize = queue.size();
-    queue.addLast(job);
+    queue.addLast(message);
     int newSize = queue.size();
     assert newSize == previousSize + 1
         : "Appending to queue is synchronized, so the size is always incremented exactly by 1.";
@@ -20,14 +19,14 @@ final class LogJobsQueue {
   }
 
   /** Removes and returns up to {@code limit} enqueued jobs. */
-  synchronized List<ILoggingEvent> popEnqueuedJobs(int limit) {
+  synchronized List<LogMessage> popEnqueuedJobs(int limit) {
     assert limit > 0;
     if (queue.isEmpty()) {
       return List.of();
     }
 
     int n = Math.min(limit, queue.size());
-    List<ILoggingEvent> result = new ArrayList<>(n);
+    List<LogMessage> result = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
       result.add(queue.removeFirst());
     }

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsQueue.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsQueue.java
@@ -6,10 +6,10 @@ import java.util.LinkedList;
 import java.util.List;
 
 final class LogJobsQueue {
-  private final Deque<LogMessage> queue = new LinkedList<>();
+  private final Deque<LogJob> queue = new LinkedList<>();
 
   /** Enqueues a log message to be sent and returns the number of messages in the queue. */
-  synchronized int enqueue(LogMessage message) {
+  synchronized int enqueue(LogJob message) {
     int previousSize = queue.size();
     queue.addLast(message);
     int newSize = queue.size();
@@ -19,14 +19,14 @@ final class LogJobsQueue {
   }
 
   /** Removes and returns up to {@code limit} enqueued jobs. */
-  synchronized List<LogMessage> popEnqueuedJobs(int limit) {
+  synchronized List<LogJob> popEnqueuedJobs(int limit) {
     assert limit > 0;
     if (queue.isEmpty()) {
       return List.of();
     }
 
     int n = Math.min(limit, queue.size());
-    List<LogMessage> result = new ArrayList<>(n);
+    List<LogJob> result = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
       result.add(queue.removeFirst());
     }

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -22,7 +22,8 @@ import org.slf4j.LoggerFactory;
 @org.openide.util.lookup.ServiceProvider(service = TelemetryAppender.class)
 public final class TelemetryAppenderImpl extends TelemetryAppender {
   private static final String CREDENTIALS_FILE_ENV = "ENSO_CLOUD_CREDENTIALS_FILE";
-  private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryAppender.class.getName());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(TelemetryAppenderImpl.class.getName());
   private Credentials credentials;
   private boolean credentialsParseFailure;
   private LogJobsProcessor logJobsProcessor;

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -89,9 +89,16 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
         credentialsParseFailure = true;
         return;
       }
-      var tokenRefresher = new TokenRefresher(backgroundThreadService, refreshUri, credentials.clientId(), credentials.refreshToken());
+      var tokenRefresher =
+          new TokenRefresher(
+              backgroundThreadService,
+              refreshUri,
+              credentials.clientId(),
+              credentials.refreshToken());
       var authenticationData = AuthenticationData.fromCredentials(credentials);
-      logJobsProcessor = new LogJobsProcessor(backgroundThreadService, endpoint, authenticationData, tokenRefresher);
+      logJobsProcessor =
+          new LogJobsProcessor(
+              backgroundThreadService, endpoint, authenticationData, tokenRefresher);
     }
     var logMessage = logEventToMessage(logEvent);
     var logJob = new LogJob(logMessage, null);

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -80,7 +80,8 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
       logJobsProcessor = new LogJobsProcessor(backgroundThreadService, endpoint, credentials);
     }
     var logMessage = logEventToMessage(logEvent);
-    logJobsProcessor.enqueueMessage(logMessage);
+    var logJob = new LogJob(logMessage, null);
+    logJobsProcessor.enqueueMessage(logJob);
   }
 
   private static LogMessage logEventToMessage(ILoggingEvent logEvent) {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.concurrent.Executors;
 import org.enso.logging.service.logback.TelemetryAppender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
           "Failed to parse credentials from '{}'. Will not send telemetry", credentialsFile);
       return null;
     }
+    LOGGER.debug("Credentials read from '{}': {}", credentialsFile, credentials);
     return credentials;
   }
 

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.concurrent.Executors;
 import org.enso.logging.service.logback.TelemetryAppender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,13 +91,8 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
         credentialsParseFailure = true;
         return;
       }
-      var tokenRefresherExecutor = Executors.newSingleThreadExecutor();
       var tokenRefresher =
-          new TokenRefresher(
-              tokenRefresherExecutor,
-              refreshUri,
-              credentials.clientId(),
-              credentials.refreshToken());
+          new TokenRefresher(refreshUri, credentials.clientId(), credentials.refreshToken());
       var authenticationData = AuthenticationData.fromCredentials(credentials);
       logJobsProcessor =
           new LogJobsProcessor(

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -90,9 +90,10 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
         credentialsParseFailure = true;
         return;
       }
+      var tokenRefresherExecutor = Executors.newSingleThreadExecutor();
       var tokenRefresher =
           new TokenRefresher(
-              backgroundThreadService,
+              tokenRefresherExecutor,
               refreshUri,
               credentials.clientId(),
               credentials.refreshToken());

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -2,6 +2,8 @@ package org.enso.logging.service.telemetry;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import org.enso.logging.service.logback.TelemetryAppender;
 import org.slf4j.Logger;
@@ -77,7 +79,19 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
     }
     assert credentials != null;
     if (logJobsProcessor == null) {
-      logJobsProcessor = new LogJobsProcessor(backgroundThreadService, endpoint, credentials);
+      URI refreshUri;
+      try {
+        refreshUri = new URI(credentials.refreshUrl());
+      } catch (URISyntaxException e) {
+        LOGGER.error(
+            "Failed to parse refresh URL '{}'. Stopping the telemetry appender service",
+            credentials.refreshUrl());
+        credentialsParseFailure = true;
+        return;
+      }
+      var tokenRefresher = new TokenRefresher(backgroundThreadService, refreshUri, credentials.clientId(), credentials.refreshToken());
+      var authenticationData = AuthenticationData.fromCredentials(credentials);
+      logJobsProcessor = new LogJobsProcessor(backgroundThreadService, endpoint, authenticationData, tokenRefresher);
     }
     var logMessage = logEventToMessage(logEvent);
     var logJob = new LogJob(logMessage, null);

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TelemetryAppenderImpl.java
@@ -2,13 +2,7 @@ package org.enso.logging.service.telemetry;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import java.io.IOException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import org.enso.logging.service.logback.TelemetryAppender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,31 +20,31 @@ import org.slf4j.LoggerFactory;
 @org.openide.util.lookup.ServiceProvider(service = TelemetryAppender.class)
 public final class TelemetryAppenderImpl extends TelemetryAppender {
   private static final String CREDENTIALS_FILE_ENV = "ENSO_CLOUD_CREDENTIALS_FILE";
-
-  /**
-   * We still want to limit the batch size to some reasonable number - sending too many logs in one
-   * request could also be problematic.
-   */
-  private static final int MAX_BATCH_SIZE = 100;
-
-  private static final int MAX_RETRIES = 5;
   private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryAppender.class.getName());
-
   private Credentials credentials;
-  private final LogJobsQueue logQueue = new LogJobsQueue();
-
-  private HttpClient httpClient;
-
-  /**
-   * Set to true once an error is encountered when sending a request. In such case, it is most
-   * probably that no further requests will be successful. This flag is used to terminate the
-   * background thread.
-   */
-  private boolean requestSendingFailure;
+  private boolean credentialsParseFailure;
+  private LogJobsProcessor logJobsProcessor;
 
   @Override
   protected void append(ILoggingEvent eventObject) {
     enqueueJob(eventObject);
+  }
+
+  private static Credentials readCredentials() {
+    var credentialsFile = credentialsFile();
+    if (!credentialsFile.toFile().exists()) {
+      LOGGER.warn("Credentials file not found at '{}'. Will not send telemetry", credentialsFile);
+      return null;
+    }
+    Credentials credentials;
+    try {
+      credentials = parseCredentials(credentialsFile);
+    } catch (IOException e) {
+      LOGGER.warn(
+          "Failed to parse credentials from '{}'. Will not send telemetry", credentialsFile);
+      return null;
+    }
+    return credentials;
   }
 
   private static Path credentialsFile() {
@@ -69,153 +63,28 @@ public final class TelemetryAppenderImpl extends TelemetryAppender {
   }
 
   private void enqueueJob(ILoggingEvent logEvent) {
-    int queuedJobs = logQueue.enqueue(logEvent);
-    if (queuedJobs == 1 && backgroundThreadService.getQueue().isEmpty()) {
-      // If we are the first message in the queue, we need to start the background thread.
-      // It is possible that a job was already running, but adding a new one will not hurt - once
-      // the queue is empty, the currently running job will finish and any additional jobs will also
-      // terminate immediately.
-      if (!requestSendingFailure) {
-        backgroundThreadService.execute(this::logThreadEntryPoint);
-      }
+    if (credentialsParseFailure) {
+      return;
     }
-
-    /*
-     * Liveness is guaranteed, because the queue size always increments exactly by 1,
-     * so `enqueue` returns 1 if and only if the queue was empty beforehand.
-     *
-     * If the queue was empty before adding a message, we always schedule a `logThreadEntryPoint` to run,
-     * unless it was already pending on the job queue.
-     *
-     * Any running `logThreadEntryPoint` will not finish until the queue is empty.
-     * So after every append, either a job is already running or scheduled to be run.
-     */
-  }
-
-  /** Runs as long as there are any pending log messages queued and sends them in batches. */
-  private void logThreadEntryPoint() {
-    while (true) {
-      List<ILoggingEvent> pendingMessages = logQueue.popEnqueuedJobs(MAX_BATCH_SIZE);
-      if (pendingMessages.isEmpty()) {
-        // If there are no more pending messages, we can stop the thread for now.
-        // If during this teardown a new message is added, it will see no elements on `logQueue` and
-        // thus,
-        // `logQueue.enqueue` will return 1, thus ensuring that at least one new job is scheduled.
-        return;
-      }
-      try {
-        sendBatch(pendingMessages);
-      } catch (RequestFailureException e) {
-        LOGGER.warn("Stopping the Telemetry appender - requests cannot be send", e);
-        requestSendingFailure = true;
-        return;
-      }
-    }
-  }
-
-  /**
-   * Sends a batch of log messages.
-   *
-   * <p>The batch must not be empty and all messages must share the same request config.
-   */
-  private void sendBatch(List<ILoggingEvent> batch) throws RequestFailureException {
-    assert !batch.isEmpty() : "The batch must not be empty.";
-
-    var request = buildRequest(batch);
-    if (request == null) {
-      LOGGER.warn("Failed to build request for log messages. Skipping {} messages", batch.size());
-    } else {
-      sendLogRequest(request, MAX_RETRIES);
-    }
-  }
-
-  private HttpRequest buildRequest(List<ILoggingEvent> logEvents) throws RequestFailureException {
     if (credentials == null) {
-      var credentialsFile = credentialsFile();
-      if (!credentialsFile.toFile().exists()) {
-        LOGGER.warn("Credentials file not found at '{}'. Will not send telemetry", credentialsFile);
-        throw new RequestFailureException("Credentials file not found", null);
+      credentials = readCredentials();
+      if (credentials == null) {
+        // If credentials cannot be read, we cannot send anything - bailout.
+        LOGGER.error("Credentials cannot be read, stopping the telemetry appender service");
+        credentialsParseFailure = true;
+        return;
       }
-      try {
-        credentials = parseCredentials(credentialsFile);
-      } catch (IOException e) {
-        LOGGER.warn(
-            "Failed to parse credentials from '{}'. Will not send telemetry", credentialsFile);
-        throw new RequestFailureException("Failed to parse credentials", null);
-      }
-      assert credentials != null;
     }
-    var payload = buildPayload(logEvents);
-    if (payload != null) {
-      return HttpRequest.newBuilder()
-          .uri(endpoint)
-          .header("Authorization", "Bearer " + credentials.accessToken())
-          .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
-          .build();
-    } else {
-      return null;
+    assert credentials != null;
+    if (logJobsProcessor == null) {
+      logJobsProcessor = new LogJobsProcessor(backgroundThreadService, endpoint, credentials);
     }
+    var logMessage = logEventToMessage(logEvent);
+    logJobsProcessor.enqueueMessage(logMessage);
   }
 
-  /**
-   * Transforms the given log events into JSON payloads.
-   *
-   * @return null if none of the log events could be transformed into a payload.
-   */
-  private String buildPayload(List<ILoggingEvent> logEvents) {
-    var logs = new ArrayList<ApiMessage.Log>();
-    for (var logEvent : logEvents) {
-      var logMessage =
-          new LogMessage(
-              logEvent.getLoggerName(), logEvent.getMessage(), logEvent.getArgumentArray());
-      var payloadForLogEvent = LogFormatter.transform(logMessage);
-      if (payloadForLogEvent != null) {
-        logs.add(payloadForLogEvent);
-      }
-    }
-    if (logs.size() != logEvents.size()) {
-      LOGGER.warn("Failed to build payload for some log events");
-    }
-    if (logs.isEmpty()) {
-      return null;
-    } else {
-      var payload = ApiMessage.createPayload(logs);
-      return ApiMessage.serializePayload(payload);
-    }
-  }
-
-  private void sendLogRequest(HttpRequest request, int retryCount) throws RequestFailureException {
-    assert request != null;
-    try {
-      try {
-        if (httpClient == null) {
-          httpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS).build();
-        }
-        HttpResponse<String> response =
-            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() < 200 || response.statusCode() >= 300) {
-          throw new RequestFailureException(
-              "Unexpected status code: " + response.statusCode() + " " + response.body(), null);
-        }
-      } catch (IOException | InterruptedException e) {
-        // Promote a checked exception to a runtime exception to simplify the code.
-        var errorMessage = e.getMessage() != null ? e.getMessage() : e.toString();
-        throw new RequestFailureException("Failed to send log messages: " + errorMessage, e);
-      }
-    } catch (RequestFailureException e) {
-      if (retryCount < 0) {
-        LOGGER.debug("Failed to send log messages after retrying", e);
-        throw e;
-      } else {
-        LOGGER.debug("Exception when sending log messages. Retrying...", e);
-        sendLogRequest(request, retryCount - 1);
-      }
-    }
-  }
-
-  private static final class RequestFailureException extends Exception {
-    public RequestFailureException(String message, Throwable cause) {
-      super(message, cause);
-    }
+  private static LogMessage logEventToMessage(ILoggingEvent logEvent) {
+    return new LogMessage(
+        logEvent.getLoggerName(), logEvent.getMessage(), logEvent.getArgumentArray());
   }
 }

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -58,6 +58,11 @@ public final class TokenRefresher {
     var payload = RefreshTokenPayload.createRefreshTokenRequest(refreshToken, clientId);
     reqBldr.POST(BodyPublishers.ofString(payload));
     var req = reqBldr.build();
+    LOGGER.trace(
+        "Sending request to refresh token: POST uri:{}, headers:{}, body:{}",
+        req.uri(),
+        req.headers(),
+        payload);
     String body;
     try {
       var response = httpClient.send(req, HttpResponse.BodyHandlers.ofString());

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -20,7 +20,7 @@ public final class TokenRefresher {
   private static final Logger LOGGER = LoggerFactory.getLogger(TokenRefresher.class);
   private static final Map<String, String> HEADERS =
       Map.of(
-          "Content_Type", "application/x-amz-json-1.1",
+          "Content-Type", "application/x-amz-json-1.1",
           "X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth");
 
   /**

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -10,9 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,26 +27,24 @@ public final class TokenRefresher {
    */
   private static final Duration TOKEN_EARLY_REFRESH_PERIOD = Duration.ofMinutes(2);
 
-  private final Executor executor;
   private final URI refreshUri;
   private final String clientId;
   private final String refreshToken;
   private final HttpClient httpClient;
 
-  public TokenRefresher(Executor executor, URI refreshUri, String clientId, String refreshToken) {
-    this.executor = executor;
+  public TokenRefresher(URI refreshUri, String clientId, String refreshToken) {
     this.refreshUri = refreshUri;
     this.clientId = clientId;
     this.refreshToken = refreshToken;
-    var clientExecutor = Executors.newSingleThreadExecutor();
-    this.httpClient = HttpClient.newBuilder().executor(clientExecutor).build();
+    this.httpClient = HttpClient.newBuilder().build();
   }
 
-  public CompletableFuture<AuthenticationData> fetchNewAccessToken() {
-    return CompletableFuture.supplyAsync(this::doFetchNewAccessToken, executor);
-  }
-
-  private AuthenticationData doFetchNewAccessToken() {
+  /**
+   * Fetches the new refreshed access token and blocks until the response is received.
+   *
+   * @return null if the token could not be refreshed, otherwise the new access token.
+   */
+  public AuthenticationData fetchNewAccessToken() {
     var reqBldr = HttpRequest.newBuilder();
     reqBldr.uri(refreshUri);
     for (var entry : HEADERS.entrySet()) {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -1,0 +1,84 @@
+package org.enso.logging.service.telemetry;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Inspired from {@code Standard.Base.Enso_Cloud.Internal.Authentication} module. */
+public final class TokenRefresher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TokenRefresher.class);
+  private static final Map<String, String> HEADERS =
+      Map.of(
+          "Content_Type", "application/x-amz-json-1.1",
+          "X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth");
+
+  /**
+   * The amount of time before the token expiration that we pro-actively refresh it to reduce the
+   * cahnce of it expiring during a request.
+   */
+  private static final Duration TOKEN_EARLY_REFRESH_PERIOD = Duration.ofMinutes(2);
+
+  private final Executor executor;
+  private final URI refreshUri;
+  private final String clientId;
+  private final String refreshToken;
+  private final HttpClient httpClient;
+
+  public TokenRefresher(Executor executor, URI refreshUri, String clientId, String refreshToken) {
+    this.executor = executor;
+    this.refreshUri = refreshUri;
+    this.clientId = clientId;
+    this.refreshToken = refreshToken;
+    this.httpClient = HttpClient.newBuilder().executor(executor).build();
+  }
+
+  public CompletableFuture<AuthenticationData> fetchNewAccessToken() {
+    return CompletableFuture.supplyAsync(this::doFetchNewAccessToken, executor);
+  }
+
+  private AuthenticationData doFetchNewAccessToken() {
+    var reqBldr = HttpRequest.newBuilder();
+    reqBldr.uri(refreshUri);
+    for (var entry : HEADERS.entrySet()) {
+      reqBldr.header(entry.getKey(), entry.getValue());
+    }
+    var payload = RefreshTokenPayload.createRefreshTokenRequest(refreshToken, clientId);
+    reqBldr.POST(BodyPublishers.ofString(payload));
+    var req = reqBldr.build();
+    String body;
+    try {
+      var response = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        LOGGER.error("Failed to refresh token: [{}] {}", response.statusCode(), response.body());
+        return null;
+      }
+      body = response.body();
+    } catch (IOException | InterruptedException e) {
+      LOGGER.error("Failed to refresh token", e);
+      return null;
+    }
+    var resp = RefreshTokenPayload.decodeResponse(body);
+    var tokenLifeTime = Duration.ofSeconds(resp.authenticationResult().expiresIn());
+    if (tokenLifeTime.compareTo(TOKEN_EARLY_REFRESH_PERIOD) < 0) {
+      LOGGER.error(
+          "Token lifetime is too short: {}, smaller than our minimum lifetime of {}.",
+          tokenLifeTime,
+          TOKEN_EARLY_REFRESH_PERIOD);
+      return null;
+    }
+    var responseReceivedTime = LocalDateTime.now();
+    var expireAt = responseReceivedTime.plus(TOKEN_EARLY_REFRESH_PERIOD);
+    var accToken = resp.authenticationResult().accessToken();
+    return new AuthenticationData(accToken, expireAt);
+  }
+}

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -8,6 +8,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -76,7 +77,7 @@ public final class TokenRefresher {
           TOKEN_EARLY_REFRESH_PERIOD);
       return null;
     }
-    var responseReceivedTime = LocalDateTime.now();
+    var responseReceivedTime = ZonedDateTime.now();
     var expireAt = responseReceivedTime.plus(TOKEN_EARLY_REFRESH_PERIOD);
     var accToken = resp.authenticationResult().accessToken();
     return new AuthenticationData(accToken, expireAt);

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -7,11 +7,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,8 @@ public final class TokenRefresher {
     this.refreshUri = refreshUri;
     this.clientId = clientId;
     this.refreshToken = refreshToken;
-    this.httpClient = HttpClient.newBuilder().executor(executor).build();
+    var clientExecutor = Executors.newSingleThreadExecutor();
+    this.httpClient = HttpClient.newBuilder().executor(clientExecutor).build();
   }
 
   public CompletableFuture<AuthenticationData> fetchNewAccessToken() {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -7,7 +7,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -78,8 +79,8 @@ public final class TokenRefresher {
           TOKEN_EARLY_REFRESH_PERIOD);
       return null;
     }
-    var responseReceivedTime = ZonedDateTime.now();
-    var expireAt = responseReceivedTime.plus(TOKEN_EARLY_REFRESH_PERIOD);
+    var responseReceivedTime = Instant.now().atZone(ZoneId.of("UTC"));
+    var expireAt = responseReceivedTime.plus(tokenLifeTime);
     var accToken = resp.authenticationResult().accessToken();
     return new AuthenticationData(accToken, expireAt);
   }

--- a/lib/java/logging-service-telemetry/src/main/scala/org/enso/logging/service/telemetry/Credentials.scala
+++ b/lib/java/logging-service-telemetry/src/main/scala/org/enso/logging/service/telemetry/Credentials.scala
@@ -17,7 +17,19 @@ case class Credentials(
   refreshUrl: String,
   @named("expire_at")
   expireAt: String
-)
+) {
+  override def toString: String = {
+    s"Credentials{clientId: ${substr(clientId)}, " +
+    s"accessToken: ${substr(accessToken)}, " +
+    s"refreshToken: ${substr(refreshToken)}, " +
+    s"refreshUrl: $refreshUrl, " +
+    s"expireAt: $expireAt}"
+  }
+
+  private def substr(str: String): String = {
+    str.substring(0, Math.min(str.length, 8))
+  }
+}
 
 object Credentials {
   implicit val fileCodec: JsonValueCodec[Credentials] = {

--- a/lib/java/logging-service-telemetry/src/main/scala/org/enso/logging/service/telemetry/RefreshTokenPayload.scala
+++ b/lib/java/logging-service-telemetry/src/main/scala/org/enso/logging/service/telemetry/RefreshTokenPayload.scala
@@ -1,0 +1,87 @@
+package org.enso.logging.service.telemetry
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{
+  readFromString,
+  writeToString,
+  JsonValueCodec
+}
+import com.github.plokhotnyuk.jsoniter_scala.macros.{
+  named,
+  CodecMakerConfig,
+  JsonCodecMaker
+}
+
+object RefreshTokenPayload {
+  implicit val payloadCodec: JsonValueCodec[Payload] =
+    JsonCodecMaker.make[Payload](CodecMakerConfig.withAllowRecursiveTypes(true))
+
+  implicit val authParametersCodec: JsonValueCodec[AuthParameters] =
+    JsonCodecMaker.make[AuthParameters](
+      CodecMakerConfig.withAllowRecursiveTypes(true)
+    )
+
+  implicit val authenticationResultCodec: JsonValueCodec[AuthenticationResult] =
+    JsonCodecMaker.make[AuthenticationResult](
+      CodecMakerConfig.withAllowRecursiveTypes(true)
+    )
+
+  implicit val responseCodec: JsonValueCodec[Response] =
+    JsonCodecMaker.make[Response](
+      CodecMakerConfig.withAllowRecursiveTypes(true)
+    )
+
+  def createRefreshTokenRequest(
+    refreshToken: String,
+    clientId: String
+  ): String = {
+    val payload = Payload(
+      clientId = clientId,
+      authFlow = "REFRESH_TOKEN_AUTH",
+      authParameters = AuthParameters(
+        refreshToken = refreshToken,
+        deviceKey    = None
+      )
+    )
+    writeToString(payload)
+  }
+
+  def decodeResponse(
+    resp: String
+  ): Response = {
+    readFromString[Response](resp)
+  }
+
+  case class AuthParameters(
+    @named("REFRESH_TOKEN")
+    refreshToken: String,
+    @named("DEVICE_KEY")
+    deviceKey: Option[String]
+  )
+
+  case class Payload(
+    @named("ClientId")
+    clientId: String,
+    @named("AuthFlow")
+    authFlow: String,
+    @named("AuthParameters")
+    authParameters: AuthParameters
+  )
+
+  case class Response(
+    @named("AuthenticationResult")
+    authenticationResult: AuthenticationResult
+  )
+
+  /** @param accessToken
+    * @param tokenType
+    * @param expiresIn Expiration in seconds
+    */
+  case class AuthenticationResult(
+    @named("AccessToken")
+    accessToken: String,
+    @named("TokenType")
+    tokenType: String,
+    @named("ExpiresIn")
+    expiresIn: Int
+  )
+}

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -20,10 +20,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
+import org.enso.logging.service.telemetry.AuthenticationData;
 import org.enso.logging.service.telemetry.Credentials;
 import org.enso.logging.service.telemetry.LogJob;
 import org.enso.logging.service.telemetry.LogJobsProcessor;
 import org.enso.logging.service.telemetry.LogMessage;
+import org.enso.logging.service.telemetry.TokenRefresher;
 import org.enso.shttp.HTTPTestHelperServer;
 import org.enso.shttp.HybridHTTPServer;
 import org.enso.shttp.cloud_mock.CloudMockSetup;
@@ -47,6 +49,7 @@ public class TestTelemetry {
   private ExecutorService serverExecutor;
   private ThreadPoolExecutor logProcessorExecutor;
   private LogJobsProcessor logJobsProcessor;
+  private TokenRefresher tokenRefresher;
 
   @Before
   public void initServer() throws URISyntaxException, IOException {
@@ -57,15 +60,23 @@ public class TestTelemetry {
     var cloudMockSetup = new CloudMockSetup(false);
     server =
         HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
-    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, credentials);
+    tokenRefresher = new TokenRefresher(logProcessorExecutor, refreshUri, credentials.clientId(), credentials.refreshToken());
+    var authData = AuthenticationData.fromCredentials(credentials);
+    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, authData, tokenRefresher);
     server.start();
   }
 
   @After
   public void stopServer() {
-    server.stop();
-    serverExecutor.shutdown();
-    logProcessorExecutor.shutdown();
+    if (server != null) {
+      server.stop();
+    }
+    if (serverExecutor != null) {
+      serverExecutor.shutdown();
+    }
+    if (logProcessorExecutor != null) {
+      logProcessorExecutor.shutdown();
+    }
   }
 
   @Test
@@ -125,7 +136,9 @@ public class TestTelemetry {
 
   @Test
   public void failureToAuthenticate_InvalidToken() {
-    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, invalidCredentials());
+    var invalidCredentials = invalidCredentials();
+    tokenRefresher = new TokenRefresher(logProcessorExecutor, refreshUri, invalidCredentials.clientId(), invalidCredentials.refreshToken());
+    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, AuthenticationData.fromCredentials(invalidCredentials), tokenRefresher);
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     var notification = new CompletableFuture<Void>();
     var job = new LogJob(message, notification);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -104,6 +104,35 @@ public class TestTelemetry {
     assertThat(receivedLogs.isEmpty(), is(true));
   }
 
+  @Test
+  public void sendMultipleTelemetryLogs() {
+    var logJobs =
+        IntStream.range(0, 5)
+            .mapToObj(
+                i -> {
+                  var msg = new LogMessage("TestLogger-" + i, "msg: idx={}", new Object[] {i});
+                  return new LogJob(msg, new CompletableFuture<>());
+                })
+            .toList();
+    logJobs.forEach(logJobsProcessor::enqueueMessage);
+    for (LogJob logJob : logJobs) {
+      try {
+        logJob.completionNofitication().get();
+      } catch (InterruptedException e) {
+        throw new AssertionError("Should not be interrupted", e);
+      } catch (ExecutionException e) {
+        throw new AssertionError("Should not fail", e);
+      }
+    }
+    var logs = server.getLogs();
+    for (int i = 0; i < logs.size(); i++) {
+      var log = logs.get(i);
+      assertThat(log.message(), is("msg"));
+      assertThat(log.metadata().get("loggerName").asText(), containsString("TestLogger-" + i));
+      assertThat(log.metadata().get("idx").asInt(), is(i));
+    }
+  }
+
   private static Credentials mockCredentials() {
     var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
     var refreshUrl = refreshUri.toString();

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -4,19 +4,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -42,7 +36,6 @@ public class TestTelemetry {
   private static final URI baseUri = URI.create("http://localhost:" + port + "/enso-cloud-mock");
   private static final URI logUri = URI.create(baseUri + "/logs");
   private static final URI refreshUri = URI.create(baseUri + "/enso-cloud-auth-renew");
-  private static final URI getLogsUri = URI.create(baseUri + "/log_events");
   private static final long APPENDER_KEEP_ALIVE = 20;
 
   private static HybridHTTPServer server;
@@ -80,17 +73,17 @@ public class TestTelemetry {
   }
 
   @Test
-  public void sendSingleTelemetryLog() throws InterruptedException, IOException {
+  public void sendSingleTelemetryLog() {
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     logJobsProcessor.enqueueMessage(message);
     serverExecutor.waitForAllTasks();
-    var receivedLogs = getLogs();
+    var receivedLogs = server.getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
-    assertThat(receivedLog.projectId, is(nullValue()));
-    assertThat(receivedLog.message, is("msg"));
-    assertThat(receivedLog.metadata.get("name"), is("Pavel"));
-    assertThat(receivedLog.metadata.get("loggerName"), is(message.loggerName()));
+    assertThat(receivedLog.projectId(), is(nullValue()));
+    assertThat(receivedLog.message(), is("msg"));
+    assertThat(receivedLog.metadata().get("name").asText(), is("Pavel"));
+    assertThat(receivedLog.metadata().get("loggerName").asText(), is(message.loggerName()));
   }
 
   private static Credentials mockCredentials() {
@@ -100,42 +93,6 @@ public class TestTelemetry {
     var refreshToken = "TEST-ENSO-REFRESH-caffee";
     var clientId = "TEST-ENSO-CLIENT-ID";
     return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
-  }
-
-  /**
-   * Fetches log events from the mock server. See {@code org.enso.shttp.cloud_mock.EventsService}.
-   */
-  private List<ReceivedLogEvent> getLogs() throws IOException, InterruptedException {
-    var blockingExecutor = new BlockingExecutor();
-    var httpClient = HttpClient.newBuilder().executor(blockingExecutor).build();
-    var req =
-        HttpRequest.newBuilder(getLogsUri)
-            .header("Authorization", "Bearer " + credentials.accessToken())
-            .GET()
-            .build();
-    var resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-    assertThat(resp.statusCode(), is(200));
-    var mapper = new ObjectMapper();
-    var tree = mapper.readTree(resp.body());
-    var events = tree.get("events");
-    var receivedLogs = new ArrayList<ReceivedLogEvent>();
-    events.forEach(
-        event -> {
-          try {
-            var receivedLog = mapper.readValue(event.toString(), ReceivedLogEvent.class);
-            receivedLogs.add(receivedLog);
-          } catch (JsonProcessingException e) {
-            throw new AssertionError(e);
-          }
-        });
-    return receivedLogs;
-  }
-
-  private static final class BlockingExecutor implements Executor {
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
   }
 
   private static final class MockServerExecutor implements Executor {
@@ -183,12 +140,4 @@ public class TestTelemetry {
       }
     }
   }
-
-  private record ReceivedLogEvent(
-      String organizationId,
-      String userEmail,
-      String timestamp,
-      String message,
-      String projectId,
-      Map<String, String> metadata) {}
 }

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -62,8 +62,7 @@ public class TestTelemetry {
     server =
         HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
     tokenRefresher =
-        new TokenRefresher(
-            logProcessorExecutor, refreshUri, credentials.clientId(), credentials.refreshToken());
+        new TokenRefresher(refreshUri, credentials.clientId(), credentials.refreshToken());
     var authData = AuthenticationData.fromCredentials(credentials);
     logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, authData, tokenRefresher);
     server.start();
@@ -142,10 +141,7 @@ public class TestTelemetry {
     var invalidCredentials = invalidCredentials();
     tokenRefresher =
         new TokenRefresher(
-            logProcessorExecutor,
-            refreshUri,
-            invalidCredentials.clientId(),
-            invalidCredentials.refreshToken());
+            refreshUri, invalidCredentials.clientId(), invalidCredentials.refreshToken());
     logJobsProcessor =
         new LogJobsProcessor(
             logProcessorExecutor,
@@ -169,15 +165,9 @@ public class TestTelemetry {
   @Test
   public void refreshExpiredToken() {
     var expiredCredentials = expiredCredentials();
-    // Ensure that tokenRefresher has a different executor, so that there is no deadlock
-    // in the test.
-    var tokenRefreshExecutor = Executors.newSingleThreadExecutor();
     tokenRefresher =
         new TokenRefresher(
-            tokenRefreshExecutor,
-            refreshUri,
-            expiredCredentials.clientId(),
-            expiredCredentials.refreshToken());
+            refreshUri, expiredCredentials.clientId(), expiredCredentials.refreshToken());
     logJobsProcessor =
         new LogJobsProcessor(
             logProcessorExecutor,

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -154,6 +154,31 @@ public class TestTelemetry {
     }
   }
 
+  @Test
+  public void refreshExpiredToken() {
+    var expiredCredentials = expiredCredentials();
+    // Ensure that tokenRefresher has a different executor, so that there is no deadlock
+    // in the test.
+    var tokenRefreshExecutor = Executors.newSingleThreadExecutor();
+    tokenRefresher =
+        new TokenRefresher(
+            tokenRefreshExecutor,
+            refreshUri,
+            expiredCredentials.clientId(),
+            expiredCredentials.refreshToken());
+    logJobsProcessor =
+        new LogJobsProcessor(
+            logProcessorExecutor,
+            logUri,
+            AuthenticationData.fromCredentials(expiredCredentials),
+            tokenRefresher);
+    var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
+    var job = new LogJob(message, new CompletableFuture<>());
+    logJobsProcessor.enqueueMessage(job);
+    assertCompletedSuccessfully(job);
+    assertThat("Token was refreshed once", server.getRefreshedTokensCount(), is(1));
+  }
+
   private static void assertCompletedSuccessfully(List<LogJob> jobs) {
     for (LogJob logJob : jobs) {
       try {
@@ -183,6 +208,15 @@ public class TestTelemetry {
     var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
     var refreshUrl = refreshUri.toString();
     var accessToken = "XX - wrong access token - XX";
+    var refreshToken = "TEST-ENSO-REFRESH-caffee";
+    var clientId = "TEST-ENSO-CLIENT-ID";
+    return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
+  }
+
+  private Credentials expiredCredentials() {
+    var expireAt = ZonedDateTime.now().minusMonths(10).format(DateTimeFormatter.ISO_INSTANT);
+    var refreshUrl = refreshUri.toString();
+    var accessToken = "TEST-EXPIRED-TOKEN-beef";
     var refreshToken = "TEST-ENSO-REFRESH-caffee";
     var clientId = "TEST-ENSO-CLIENT-ID";
     return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -123,6 +123,23 @@ public class TestTelemetry {
     }
   }
 
+  @Test
+  public void failureToAuthenticate_InvalidToken() {
+    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, invalidCredentials());
+    var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
+    var notification = new CompletableFuture<Void>();
+    var job = new LogJob(message, notification);
+    logJobsProcessor.enqueueMessage(job);
+    try {
+      notification.get();
+      fail("Should end exceptionally");
+    } catch (InterruptedException e) {
+      throw new AssertionError("Should not be interrupted", e);
+    } catch (ExecutionException e) {
+      assertThat(e.getMessage(), containsString("401 Invalid token"));
+    }
+  }
+
   private static void assertCompletedSuccessfully(List<LogJob> jobs) {
     for (LogJob logJob : jobs) {
       try {
@@ -143,6 +160,15 @@ public class TestTelemetry {
     var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
     var refreshUrl = refreshUri.toString();
     var accessToken = "TEST-ENSO-TOKEN-caffee";
+    var refreshToken = "TEST-ENSO-REFRESH-caffee";
+    var clientId = "TEST-ENSO-CLIENT-ID";
+    return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
+  }
+
+  private static Credentials invalidCredentials() {
+    var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
+    var refreshUrl = refreshUri.toString();
+    var accessToken = "XX - wrong access token - XX";
     var refreshToken = "TEST-ENSO-REFRESH-caffee";
     var clientId = "TEST-ENSO-CLIENT-ID";
     return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -71,12 +72,9 @@ public class TestTelemetry {
   public void sendSingleTelemetryLog() {
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     var notification = new CompletableFuture<Void>();
-    logJobsProcessor.enqueueMessage(new LogJob(message, notification));
-    try {
-      notification.get();
-    } catch (InterruptedException | ExecutionException e) {
-      throw new AssertionError(e);
-    }
+    var job = new LogJob(message, notification);
+    logJobsProcessor.enqueueMessage(job);
+    assertCompletedSuccessfully(job);
     var receivedLogs = server.getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
@@ -115,7 +113,18 @@ public class TestTelemetry {
                 })
             .toList();
     logJobs.forEach(logJobsProcessor::enqueueMessage);
-    for (LogJob logJob : logJobs) {
+    assertCompletedSuccessfully(logJobs);
+    var logs = server.getLogs();
+    for (int i = 0; i < logs.size(); i++) {
+      var log = logs.get(i);
+      assertThat(log.message(), is("msg"));
+      assertThat(log.metadata().get("loggerName").asText(), containsString("TestLogger-" + i));
+      assertThat(log.metadata().get("idx").asInt(), is(i));
+    }
+  }
+
+  private static void assertCompletedSuccessfully(List<LogJob> jobs) {
+    for (LogJob logJob : jobs) {
       try {
         logJob.completionNofitication().get();
       } catch (InterruptedException e) {
@@ -124,13 +133,10 @@ public class TestTelemetry {
         throw new AssertionError("Should not fail", e);
       }
     }
-    var logs = server.getLogs();
-    for (int i = 0; i < logs.size(); i++) {
-      var log = logs.get(i);
-      assertThat(log.message(), is("msg"));
-      assertThat(log.metadata().get("loggerName").asText(), containsString("TestLogger-" + i));
-      assertThat(log.metadata().get("idx").asInt(), is(i));
-    }
+  }
+
+  private static void assertCompletedSuccessfully(LogJob job) {
+    assertCompletedSuccessfully(List.of(job));
   }
 
   private static Credentials mockCredentials() {

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -1,0 +1,147 @@
+package org.enso.logging.service.telemetry.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.enso.logging.service.telemetry.Credentials;
+import org.enso.logging.service.telemetry.LogJobsProcessor;
+import org.enso.logging.service.telemetry.LogMessage;
+import org.enso.shttp.HTTPTestHelperServer;
+import org.enso.shttp.HybridHTTPServer;
+import org.enso.shttp.cloud_mock.CloudMockSetup;
+import org.enso.testkit.RetryTestRule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestTelemetry {
+  private static final int port = 8083;
+  private static final URI baseUri = URI.create("http://localhost:" + port + "/enso-cloud-mock");
+  private static final URI logUri = URI.create(baseUri + "/logs");
+  private static final URI refreshUri = URI.create(baseUri + "/enso-cloud-auth-renew");
+  private static final URI getLogsUri = URI.create(baseUri + "/log_events");
+  private static final long APPENDER_KEEP_ALIVE = 20;
+
+  private static HybridHTTPServer server;
+  private static ExecutorService serverExecutor;
+  private static ThreadPoolExecutor appenderExecutor;
+  private static LogJobsProcessor logJobsProcessor;
+  private static Credentials credentials;
+
+  @Rule public RetryTestRule retry = new RetryTestRule(3);
+
+  @BeforeClass
+  public static void initServer() throws URISyntaxException, IOException {
+    serverExecutor = Executors.newSingleThreadExecutor();
+    appenderExecutor =
+        new ThreadPoolExecutor(
+            0, 1, APPENDER_KEEP_ALIVE, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    var cloudMockSetup = new CloudMockSetup(false);
+    server =
+        HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
+    credentials = mockCredentials();
+    logJobsProcessor = new LogJobsProcessor(appenderExecutor, logUri, credentials);
+    server.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    server.stop();
+    server = null;
+    serverExecutor.shutdown();
+    serverExecutor = null;
+    appenderExecutor.shutdown();
+    appenderExecutor = null;
+    logJobsProcessor = null;
+    credentials = null;
+  }
+
+  @Test
+  public void sendSingleTelemetryLog() throws InterruptedException, IOException {
+    var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
+    logJobsProcessor.enqueueMessage(message);
+    // TODO: Remove explicit thread sleep - add some monitor to SimpleHttpServer?
+    Thread.sleep(200);
+    var receivedLogs = getLogs();
+    assertThat(receivedLogs.size(), is(1));
+    var receivedLog = receivedLogs.get(0);
+    assertThat(receivedLog.projectId, is(nullValue()));
+    assertThat(receivedLog.message, is("msg"));
+    assertThat(receivedLog.metadata.get("name"), is("Pavel"));
+    assertThat(receivedLog.metadata.get("loggerName"), is(message.loggerName()));
+  }
+
+  private static Credentials mockCredentials() {
+    var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
+    var refreshUrl = refreshUri.toString();
+    var accessToken = "TEST-ENSO-TOKEN-caffee";
+    var refreshToken = "TEST-ENSO-REFRESH-caffee";
+    var clientId = "TEST-ENSO-CLIENT-ID";
+    return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
+  }
+
+  /**
+   * Fetches log events from the mock server. See {@code org.enso.shttp.cloud_mock.EventsService}.
+   */
+  private List<ReceivedLogEvent> getLogs() throws IOException, InterruptedException {
+    var blockingExecutor = new BlockingExecutor();
+    var httpClient = HttpClient.newBuilder().executor(blockingExecutor).build();
+    var req =
+        HttpRequest.newBuilder(getLogsUri)
+            .header("Authorization", "Bearer " + credentials.accessToken())
+            .GET()
+            .build();
+    var resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+    assertThat(resp.statusCode(), is(200));
+    var mapper = new ObjectMapper();
+    var tree = mapper.readTree(resp.body());
+    var events = tree.get("events");
+    var receivedLogs = new ArrayList<ReceivedLogEvent>();
+    events.forEach(
+        event -> {
+          try {
+            var receivedLog = mapper.readValue(event.toString(), ReceivedLogEvent.class);
+            receivedLogs.add(receivedLog);
+          } catch (JsonProcessingException e) {
+            throw new AssertionError(e);
+          }
+        });
+    return receivedLogs;
+  }
+
+  private static final class BlockingExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
+  }
+
+  private record ReceivedLogEvent(
+      String organizationId,
+      String userEmail,
+      String timestamp,
+      String message,
+      String projectId,
+      Map<String, String> metadata) {}
+}

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -41,7 +41,8 @@ public class TestTelemetry {
   private static final int port = 8083;
   private static final URI baseUri = URI.create("http://localhost:" + port + "/enso-cloud-mock");
   private static final URI logUri = URI.create(baseUri + "/logs");
-  private static final URI refreshUri = URI.create(baseUri + "/enso-cloud-auth-renew");
+  private static final URI refreshUri =
+      URI.create("http://localhost:" + port + "/enso-cloud-auth-renew");
   private static final long APPENDER_KEEP_ALIVE = 20;
   private static final Credentials credentials = mockCredentials();
 

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -184,11 +184,22 @@ public class TestTelemetry {
             logUri,
             AuthenticationData.fromCredentials(expiredCredentials),
             tokenRefresher);
-    var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
-    var job = new LogJob(message, new CompletableFuture<>());
-    logJobsProcessor.enqueueMessage(job);
-    assertCompletedSuccessfully(job);
-    assertThat("Token was refreshed once", server.getRefreshedTokensCount(), is(1));
+
+    // Ensure that the two messages are not sent in the batch - the two messages must be sent
+    // in different requests so that we really check that the token was not refreshed twice.
+    var message1 = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
+    var job1 = new LogJob(message1, new CompletableFuture<>());
+    logJobsProcessor.enqueueMessage(job1);
+    assertCompletedSuccessfully(job1);
+
+    var job2 =
+        new LogJob(
+            new LogMessage("TestLogger", "msg2: name={}", new Object[] {"Pavel"}),
+            new CompletableFuture<>());
+    logJobsProcessor.enqueueMessage(job2);
+    assertCompletedSuccessfully(job2);
+
+    assertThat("Token was refreshed just once", server.getRefreshedTokensCount(), is(1));
   }
 
   private static void assertCompletedSuccessfully(List<LogJob> jobs) {

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,8 +45,8 @@ public class TestTelemetry {
   private static final long APPENDER_KEEP_ALIVE = 20;
 
   private static HybridHTTPServer server;
-  private static ExecutorService serverExecutor;
-  private static ThreadPoolExecutor appenderExecutor;
+  private static MockServerExecutor serverExecutor;
+  private static ThreadPoolExecutor logProcessorExecutor;
   private static LogJobsProcessor logJobsProcessor;
   private static Credentials credentials;
 
@@ -53,15 +54,15 @@ public class TestTelemetry {
 
   @BeforeClass
   public static void initServer() throws URISyntaxException, IOException {
-    serverExecutor = Executors.newSingleThreadExecutor();
-    appenderExecutor =
+    serverExecutor = new MockServerExecutor();
+    logProcessorExecutor =
         new ThreadPoolExecutor(
             0, 1, APPENDER_KEEP_ALIVE, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
     var cloudMockSetup = new CloudMockSetup(false);
     server =
         HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
     credentials = mockCredentials();
-    logJobsProcessor = new LogJobsProcessor(appenderExecutor, logUri, credentials);
+    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, credentials);
     server.start();
   }
 
@@ -71,8 +72,8 @@ public class TestTelemetry {
     server = null;
     serverExecutor.shutdown();
     serverExecutor = null;
-    appenderExecutor.shutdown();
-    appenderExecutor = null;
+    logProcessorExecutor.shutdown();
+    logProcessorExecutor = null;
     logJobsProcessor = null;
     credentials = null;
   }
@@ -81,8 +82,7 @@ public class TestTelemetry {
   public void sendSingleTelemetryLog() throws InterruptedException, IOException {
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     logJobsProcessor.enqueueMessage(message);
-    // TODO: Remove explicit thread sleep - add some monitor to SimpleHttpServer?
-    Thread.sleep(200);
+    serverExecutor.waitForLastTask();
     var receivedLogs = getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
@@ -134,6 +134,42 @@ public class TestTelemetry {
     @Override
     public void execute(Runnable command) {
       command.run();
+    }
+  }
+
+  private static final class MockServerExecutor implements Executor {
+    private final ExecutorService underlyingExecutor = Executors.newSingleThreadExecutor();
+    private final CountDownLatch notifier = new CountDownLatch(1);
+
+    @Override
+    public void execute(Runnable command) {
+      Runnable wrappedRunnable =
+          () -> {
+            command.run();
+            notifier.countDown();
+          };
+      underlyingExecutor.submit(wrappedRunnable);
+    }
+
+    /** Block until last runnable is finished. Throws AssertionError if timeout occurs. */
+    public void waitForLastTask() {
+      try {
+        var ret = notifier.await(2, TimeUnit.SECONDS);
+        assertThat("Timeout should not occur - task should be normally finished", ret, is(true));
+      } catch (InterruptedException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    void shutdown() {
+      underlyingExecutor.shutdown();
+      try {
+        if (!underlyingExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+          underlyingExecutor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        underlyingExecutor.shutdownNow();
+      }
     }
   }
 

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -61,7 +61,9 @@ public class TestTelemetry {
     var cloudMockSetup = new CloudMockSetup(false);
     server =
         HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
-    tokenRefresher = new TokenRefresher(logProcessorExecutor, refreshUri, credentials.clientId(), credentials.refreshToken());
+    tokenRefresher =
+        new TokenRefresher(
+            logProcessorExecutor, refreshUri, credentials.clientId(), credentials.refreshToken());
     var authData = AuthenticationData.fromCredentials(credentials);
     logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, authData, tokenRefresher);
     server.start();
@@ -138,8 +140,18 @@ public class TestTelemetry {
   @Test
   public void failureToAuthenticate_InvalidToken() {
     var invalidCredentials = invalidCredentials();
-    tokenRefresher = new TokenRefresher(logProcessorExecutor, refreshUri, invalidCredentials.clientId(), invalidCredentials.refreshToken());
-    logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, AuthenticationData.fromCredentials(invalidCredentials), tokenRefresher);
+    tokenRefresher =
+        new TokenRefresher(
+            logProcessorExecutor,
+            refreshUri,
+            invalidCredentials.clientId(),
+            invalidCredentials.refreshToken());
+    logJobsProcessor =
+        new LogJobsProcessor(
+            logProcessorExecutor,
+            logUri,
+            AuthenticationData.fromCredentials(invalidCredentials),
+            tokenRefresher);
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     var notification = new CompletableFuture<Void>();
     var job = new LogJob(message, notification);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -1,25 +1,25 @@
 package org.enso.logging.service.telemetry.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.enso.logging.service.telemetry.Credentials;
+import org.enso.logging.service.telemetry.LogJob;
 import org.enso.logging.service.telemetry.LogJobsProcessor;
 import org.enso.logging.service.telemetry.LogMessage;
 import org.enso.shttp.HTTPTestHelperServer;
@@ -39,7 +39,7 @@ public class TestTelemetry {
   private static final long APPENDER_KEEP_ALIVE = 20;
 
   private static HybridHTTPServer server;
-  private static MockServerExecutor serverExecutor;
+  private static ExecutorService serverExecutor;
   private static ThreadPoolExecutor logProcessorExecutor;
   private static LogJobsProcessor logJobsProcessor;
   private static Credentials credentials;
@@ -48,7 +48,7 @@ public class TestTelemetry {
 
   @BeforeClass
   public static void initServer() throws URISyntaxException, IOException {
-    serverExecutor = new MockServerExecutor();
+    serverExecutor = Executors.newSingleThreadExecutor();
     logProcessorExecutor =
         new ThreadPoolExecutor(
             0, 1, APPENDER_KEEP_ALIVE, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
@@ -75,8 +75,13 @@ public class TestTelemetry {
   @Test
   public void sendSingleTelemetryLog() {
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
-    logJobsProcessor.enqueueMessage(message);
-    serverExecutor.waitForAllTasks();
+    var notification = new CompletableFuture<Void>();
+    logJobsProcessor.enqueueMessage(new LogJob(message, notification));
+    try {
+      notification.get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new AssertionError(e);
+    }
     var receivedLogs = server.getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
@@ -86,6 +91,24 @@ public class TestTelemetry {
     assertThat(receivedLog.metadata().get("loggerName").asText(), is(message.loggerName()));
   }
 
+  @Test
+  public void incorrectlyFormattedMessage_ShouldNotBeSent() {
+    var message =
+        new LogMessage("TestLogger", "XX - incorrect format - XX", new Object[] {"Pavel"});
+    var notification = new CompletableFuture<Void>();
+    logJobsProcessor.enqueueMessage(new LogJob(message, notification));
+    try {
+      notification.get();
+      fail("Should end exceptionally");
+    } catch (ExecutionException e) {
+      assertThat(e.getMessage(), containsString("Cannot build request"));
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
+    }
+    var receivedLogs = server.getLogs();
+    assertThat(receivedLogs.isEmpty(), is(true));
+  }
+
   private static Credentials mockCredentials() {
     var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
     var refreshUrl = refreshUri.toString();
@@ -93,51 +116,5 @@ public class TestTelemetry {
     var refreshToken = "TEST-ENSO-REFRESH-caffee";
     var clientId = "TEST-ENSO-CLIENT-ID";
     return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
-  }
-
-  private static final class MockServerExecutor implements Executor {
-    private final ExecutorService underlyingExecutor = Executors.newSingleThreadExecutor();
-    private final List<Future<?>> tasks = new ArrayList<>();
-
-    @Override
-    public void execute(Runnable command) {
-      var task = underlyingExecutor.submit(command);
-      synchronized (tasks) {
-        tasks.add(task);
-        tasks.notifyAll();
-      }
-    }
-
-    public void waitForAllTasks() {
-      synchronized (tasks) {
-        // There needs to be at least an initial task added to the list.
-        // If the list is empty, no work has yet been started.
-        while (tasks.isEmpty()) {
-          try {
-            tasks.wait();
-          } catch (InterruptedException e) {
-            throw new AssertionError(e);
-          }
-        }
-      }
-      for (var task : tasks) {
-        try {
-          task.get();
-        } catch (InterruptedException | ExecutionException e) {
-          throw new AssertionError(e);
-        }
-      }
-    }
-
-    void shutdown() {
-      underlyingExecutor.shutdown();
-      try {
-        if (!underlyingExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-          underlyingExecutor.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        underlyingExecutor.shutdownNow();
-      }
-    }
   }
 }

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.enso.logging.service.telemetry.Credentials;
 import org.enso.logging.service.telemetry.LogJob;
 import org.enso.logging.service.telemetry.LogJobsProcessor;
@@ -26,28 +27,28 @@ import org.enso.shttp.HTTPTestHelperServer;
 import org.enso.shttp.HybridHTTPServer;
 import org.enso.shttp.cloud_mock.CloudMockSetup;
 import org.enso.testkit.RetryTestRule;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TestTelemetry {
+  @Rule public RetryTestRule retry = new RetryTestRule(3);
+
   private static final int port = 8083;
   private static final URI baseUri = URI.create("http://localhost:" + port + "/enso-cloud-mock");
   private static final URI logUri = URI.create(baseUri + "/logs");
   private static final URI refreshUri = URI.create(baseUri + "/enso-cloud-auth-renew");
   private static final long APPENDER_KEEP_ALIVE = 20;
+  private static final Credentials credentials = mockCredentials();
 
-  private static HybridHTTPServer server;
-  private static ExecutorService serverExecutor;
-  private static ThreadPoolExecutor logProcessorExecutor;
-  private static LogJobsProcessor logJobsProcessor;
-  private static Credentials credentials;
+  private HybridHTTPServer server;
+  private ExecutorService serverExecutor;
+  private ThreadPoolExecutor logProcessorExecutor;
+  private LogJobsProcessor logJobsProcessor;
 
-  @Rule public RetryTestRule retry = new RetryTestRule(3);
-
-  @BeforeClass
-  public static void initServer() throws URISyntaxException, IOException {
+  @Before
+  public void initServer() throws URISyntaxException, IOException {
     serverExecutor = Executors.newSingleThreadExecutor();
     logProcessorExecutor =
         new ThreadPoolExecutor(
@@ -55,21 +56,15 @@ public class TestTelemetry {
     var cloudMockSetup = new CloudMockSetup(false);
     server =
         HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
-    credentials = mockCredentials();
     logJobsProcessor = new LogJobsProcessor(logProcessorExecutor, logUri, credentials);
     server.start();
   }
 
-  @AfterClass
-  public static void stopServer() {
+  @After
+  public void stopServer() {
     server.stop();
-    server = null;
     serverExecutor.shutdown();
-    serverExecutor = null;
     logProcessorExecutor.shutdown();
-    logProcessorExecutor = null;
-    logJobsProcessor = null;
-    credentials = null;
   }
 
   @Test

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -17,10 +17,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +83,7 @@ public class TestTelemetry {
   public void sendSingleTelemetryLog() throws InterruptedException, IOException {
     var message = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     logJobsProcessor.enqueueMessage(message);
-    serverExecutor.waitForLastTask();
+    serverExecutor.waitForAllTasks();
     var receivedLogs = getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
@@ -139,25 +140,35 @@ public class TestTelemetry {
 
   private static final class MockServerExecutor implements Executor {
     private final ExecutorService underlyingExecutor = Executors.newSingleThreadExecutor();
-    private final CountDownLatch notifier = new CountDownLatch(1);
+    private final List<Future<?>> tasks = new ArrayList<>();
 
     @Override
     public void execute(Runnable command) {
-      Runnable wrappedRunnable =
-          () -> {
-            command.run();
-            notifier.countDown();
-          };
-      underlyingExecutor.submit(wrappedRunnable);
+      var task = underlyingExecutor.submit(command);
+      synchronized (tasks) {
+        tasks.add(task);
+        tasks.notifyAll();
+      }
     }
 
-    /** Block until last runnable is finished. Throws AssertionError if timeout occurs. */
-    public void waitForLastTask() {
-      try {
-        var ret = notifier.await(2, TimeUnit.SECONDS);
-        assertThat("Timeout should not occur - task should be normally finished", ret, is(true));
-      } catch (InterruptedException e) {
-        throw new AssertionError(e);
+    public void waitForAllTasks() {
+      synchronized (tasks) {
+        // There needs to be at least an initial task added to the list.
+        // If the list is empty, no work has yet been started.
+        while (tasks.isEmpty()) {
+          try {
+            tasks.wait();
+          } catch (InterruptedException e) {
+            throw new AssertionError(e);
+          }
+        }
+      }
+      for (var task : tasks) {
+        try {
+          task.get();
+        } catch (InterruptedException | ExecutionException e) {
+          throw new AssertionError(e);
+        }
       }
     }
 

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
@@ -8,8 +8,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.enso.logging.service.telemetry.TokenRefresher;
@@ -50,19 +48,10 @@ public class TestTokenRefresh {
   }
 
   @Test
-  public void tokenRefresh() throws ExecutionException, InterruptedException {
-    var blockingExecutor = new BlockingExecutor();
-    var tokenRefresher = new TokenRefresher(blockingExecutor, refreshUri, clientId, refreshToken);
-    var fut = tokenRefresher.fetchNewAccessToken();
-    var authData = fut.get();
+  public void tokenRefresh() {
+    var tokenRefresher = new TokenRefresher(refreshUri, clientId, refreshToken);
+    var authData = tokenRefresher.fetchNewAccessToken();
     assertThat(authData, is(notNullValue()));
     assertThat(authData.accessToken(), containsString("TEST-RENEWED-0"));
-  }
-
-  private static final class BlockingExecutor implements Executor {
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
   }
 }

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
@@ -1,0 +1,68 @@
+package org.enso.logging.service.telemetry.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.enso.logging.service.telemetry.TokenRefresher;
+import org.enso.shttp.HTTPTestHelperServer;
+import org.enso.shttp.HybridHTTPServer;
+import org.enso.shttp.cloud_mock.CloudMockSetup;
+import org.enso.testkit.RetryTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestTokenRefresh {
+  @Rule public RetryTestRule retry = new RetryTestRule(3);
+
+  private static final int port = 8083;
+  private static final URI refreshUri =
+      URI.create("http://localhost:" + port + "/enso-cloud-auth-renew");
+  private static final String refreshToken = "TEST-ENSO-REFRESH-caffee";
+  private static final String clientId = "TEST-ENSO-CLIENT-ID";
+
+  private HybridHTTPServer server;
+  private ExecutorService serverExecutor;
+
+  @Before
+  public void initServer() throws URISyntaxException, IOException {
+    serverExecutor = Executors.newSingleThreadExecutor();
+    var cloudMockSetup = new CloudMockSetup(false);
+    server =
+        HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
+    server.start();
+  }
+
+  @After
+  public void stopServer() {
+    server.stop();
+    serverExecutor.shutdown();
+  }
+
+  @Test
+  public void tokenRefresh() throws ExecutionException, InterruptedException {
+    var blockingExecutor = new BlockingExecutor();
+    var tokenRefresher = new TokenRefresher(blockingExecutor, refreshUri, clientId, refreshToken);
+    var fut = tokenRefresher.fetchNewAccessToken();
+    var authData = fut.get();
+    assertThat(authData, is(notNullValue()));
+    assertThat(authData.accessToken(), containsString("TEST-RENEWED-0"));
+  }
+
+  private static final class BlockingExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
+  }
+}

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class TestTokenRefresh {
   @Rule public RetryTestRule retry = new RetryTestRule(3);
 
-  private static final int port = 8083;
+  private static final int port = 8085;
   private static final URI refreshUri =
       URI.create("http://localhost:" + port + "/enso-cloud-auth-renew");
   private static final String refreshToken = "TEST-ENSO-REFRESH-caffee";

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
@@ -105,6 +105,7 @@ public class HTTPTestHelperServer {
       var expiredTokensCounter = new ExpiredTokensCounter();
       server.addHandler("/COUNT-EXPIRED-TOKEN-FAILURES", expiredTokensCounter);
       CloudRoot cloudRoot = new CloudRoot(expiredTokensCounter, cloudMockSetup);
+      server.addCloudRoot(cloudRoot);
       server.addHandler(cloudRoot.prefix, cloudRoot);
       server.addHandler("/enso-cloud-auth-renew", new CloudAuthRenew());
     }

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
@@ -107,7 +107,9 @@ public class HTTPTestHelperServer {
       CloudRoot cloudRoot = new CloudRoot(expiredTokensCounter, cloudMockSetup);
       server.addCloudRoot(cloudRoot);
       server.addHandler(cloudRoot.prefix, cloudRoot);
-      server.addHandler("/enso-cloud-auth-renew", new CloudAuthRenew());
+      var cloudAuthRenew = new CloudAuthRenew();
+      server.addHandler("/enso-cloud-auth-renew", cloudAuthRenew);
+      server.addCloudAuthRenew(cloudAuthRenew);
     }
 
     // Data link helpers

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/HybridHTTPServer.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/HybridHTTPServer.java
@@ -12,6 +12,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
+import org.enso.shttp.cloud_mock.CloudAuthRenew;
 import org.enso.shttp.cloud_mock.CloudRoot;
 import org.enso.shttp.cloud_mock.EventsService.LogEvent;
 
@@ -22,6 +23,7 @@ public class HybridHTTPServer {
   private final Path keyStorePath;
   private volatile boolean isStarted = false;
   private CloudRoot cloudRoot;
+  private CloudAuthRenew cloudAuthRenew;
 
   HybridHTTPServer(
       String hostname,
@@ -47,6 +49,11 @@ public class HybridHTTPServer {
 
   public List<LogEvent> getLogs() {
     return cloudRoot.getEvents();
+  }
+
+  /** Returns count successful requests for token refresh. */
+  public int getRefreshedTokensCount() {
+    return cloudAuthRenew.getRefreshedTokensCount();
   }
 
   private static class SimpleHttpsConfigurator extends HttpsConfigurator {
@@ -162,5 +169,9 @@ public class HybridHTTPServer {
 
   void addCloudRoot(CloudRoot cloudRoot) {
     this.cloudRoot = cloudRoot;
+  }
+
+  void addCloudAuthRenew(CloudAuthRenew cloudAuthRenew) {
+    this.cloudAuthRenew = cloudAuthRenew;
   }
 }

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/HybridHTTPServer.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/HybridHTTPServer.java
@@ -6,11 +6,14 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.util.List;
 import java.util.concurrent.Executor;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
+import org.enso.shttp.cloud_mock.CloudRoot;
+import org.enso.shttp.cloud_mock.EventsService.LogEvent;
 
 public class HybridHTTPServer {
 
@@ -18,6 +21,7 @@ public class HybridHTTPServer {
   private final HttpsServer sslServer;
   private final Path keyStorePath;
   private volatile boolean isStarted = false;
+  private CloudRoot cloudRoot;
 
   HybridHTTPServer(
       String hostname,
@@ -39,6 +43,10 @@ public class HybridHTTPServer {
     } else {
       sslServer = null;
     }
+  }
+
+  public List<LogEvent> getLogs() {
+    return cloudRoot.getEvents();
   }
 
   private static class SimpleHttpsConfigurator extends HttpsConfigurator {
@@ -150,5 +158,9 @@ public class HybridHTTPServer {
     if (sslServer != null) {
       sslServer.createContext(path, handler);
     }
+  }
+
+  void addCloudRoot(CloudRoot cloudRoot) {
+    this.cloudRoot = cloudRoot;
   }
 }

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/CloudAuthRenew.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/CloudAuthRenew.java
@@ -30,6 +30,10 @@ public class CloudAuthRenew extends SimpleHttpHandler {
     }
   }
 
+  public int getRefreshedTokensCount() {
+    return counter;
+  }
+
   private void sendRenewedToken(HttpExchange exchange) throws IOException {
     String newToken = "TEST-RENEWED-" + (counter++);
     var response = new RenewResponse(new AuthenticationResult(newToken, "Bearer", 3600));

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/CloudRoot.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/CloudRoot.java
@@ -3,20 +3,22 @@ package org.enso.shttp.cloud_mock;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import org.enso.shttp.HttpMethod;
 import org.enso.shttp.auth.HandlerWithTokenAuth;
+import org.enso.shttp.cloud_mock.EventsService.LogEvent;
 
 public class CloudRoot extends HandlerWithTokenAuth {
   public final String prefix = "/enso-cloud-mock/";
 
   private final ExpiredTokensCounter expiredTokensCounter;
   private final CloudHandler[] handlers;
+  private final EventsService eventsService = new EventsService();
 
   public CloudRoot(ExpiredTokensCounter expiredTokensCounter, CloudMockSetup setup) {
     this.expiredTokensCounter = expiredTokensCounter;
     AssetStore assetStore = new AssetStore();
     UsersService usersService = new UsersService();
-    EventsService eventsService = new EventsService();
     this.handlers =
         new CloudHandler[] {
           new UsersHandler(usersService),
@@ -65,6 +67,10 @@ public class CloudRoot extends HandlerWithTokenAuth {
 
     System.err.println("No handler found for request: " + subPath);
     sendResponse(404, "No handler found for: " + subPath, exchange);
+  }
+
+  public List<LogEvent> getEvents() {
+    return eventsService.getEvents();
   }
 
   private CloudHandler.CloudExchange wrapExchange(String subPath, HttpExchange exchange) {

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/EventsService.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/EventsService.java
@@ -5,6 +5,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class EventsService {
+
+  /**
+   * @param organizationId
+   * @param userEmail
+   * @param timestamp
+   * @param metadata
+   * @param message
+   * @param projectId May be null
+   */
   public record LogEvent(
       String organizationId,
       String userEmail,

--- a/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/PostLogHandler.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/cloud_mock/PostLogHandler.java
@@ -94,7 +94,10 @@ public class PostLogHandler implements CloudHandler {
     String userEmail = usersService.currentUserEmail();
     String timestamp = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC")).toString();
     JsonNode metadata = json.get("metadata");
-    String projectId = json.get("projectId").asText();
+    String projectId = null;
+    if (json.has("projectId")) {
+      projectId = json.get("projectId").asText();
+    }
     return new EventsService.LogEvent(
         organizationId, userEmail, timestamp, metadata, message, projectId);
   }


### PR DESCRIPTION
Closes #12793

Follow-up of #12488

### Pull Request Description
TelemetryAppender refreshes the access token when it is about to expire. The functionality is basically copied from [Authentication.enso](https://github.com/enso-org/enso/blob/4a8274392738e5c3836efee6298c35fc0bd55214/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso) into [TokenRefresher](https://github.com/enso-org/enso/blob/239467c7539d13bf7dd6e8d8c490507c5f0dec67/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java)


### Important Notes

- Add tests for telemetry appender with `http-test-helper` mock server, that we already use for cloud mocking in `Base_Tests`.
  - [TestTelemetry](https://github.com/enso-org/enso/blob/7a22b8535dc978563b712123b52378e88ac37ca6/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java)
  - [TestTokenRefresh](https://github.com/enso-org/enso/blob/bfc1b3dc674b522f1306beeb11701ab966d7e4fc/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
