### PR TITLE
snwoflake-jdbc-thin forced update of signed archives

### DIFF
--- a/app/ide-desktop/client/tasks/signArchivesMacOs.ts
+++ b/app/ide-desktop/client/tasks/signArchivesMacOs.ts
@@ -119,15 +119,11 @@ async function ensoPackageSignables(resourcesDir: string): Promise<Signable[]> {
     ],
     [
       'lib/Standard/Snowflake/*/polyglot/java/conscript-openjdk-uber-*.jar',
-      [
-        'META-INF/native/libconscrypt_openjdk_jni-osx-*.dylib',
-      ],
+      ['META-INF/native/libconscrypt_openjdk_jni-osx-*.dylib'],
     ],
     [
       'lib/Standard/Snowflake/*/polyglot/java/grpc-netty-shaded-*.jar',
-      [
-        'META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_*.jnilib',
-      ],
+      ['META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_*.jnilib'],
     ],
     [
       'lib/Standard/Google_Api/*/polyglot/java/grpc-netty-shaded-*.jar',

--- a/app/ide-desktop/client/tasks/signArchivesMacOs.ts
+++ b/app/ide-desktop/client/tasks/signArchivesMacOs.ts
@@ -118,9 +118,14 @@ async function ensoPackageSignables(resourcesDir: string): Promise<Signable[]> {
       ],
     ],
     [
-      'lib/Standard/Snowflake/*/polyglot/java/snowflake-jdbc-*.jar',
+      'lib/Standard/Snowflake/*/polyglot/java/conscript-openjdk-uber-*.jar',
       [
         'META-INF/native/libconscrypt_openjdk_jni-osx-*.dylib',
+      ],
+    ],
+    [
+      'lib/Standard/Snowflake/*/polyglot/java/grpc-netty-shaded-*.jar',
+      [
         'META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_*.jnilib',
       ],
     ],


### PR DESCRIPTION
### Pull Request Description

We no longer use Snowflake's fat jar, meaning that native libraries are in their respective dependencies.

### Important Notes

This update will fix the nightly's build.
