### PR TITLE
12% faster `ManyLocalVars` bench by using map in `resolveUsage`

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameAnalysisMeta.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameAnalysisMeta.java
@@ -94,8 +94,9 @@ public sealed interface FrameAnalysisMeta extends ProcessingPass.Metadata
         : "The given scope must contain the given Def occurrence";
 
     var allDefs = scope.allDefinitions();
+    var it = allDefs.iterator();
     for (int i = 0; i < allDefs.size(); i++) {
-      GraphOccurrence.Def def = allDefs.get(i);
+      GraphOccurrence.Def def = it.next();
       if (def.id() == defOcc.id()) {
         return i + LocalScope.internalSlotsSize();
       }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameAnalysisMeta.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/FrameAnalysisMeta.java
@@ -93,13 +93,14 @@ public sealed interface FrameAnalysisMeta extends ProcessingPass.Metadata
     assert scope.allDefinitions().contains(defOcc)
         : "The given scope must contain the given Def occurrence";
 
-    var allDefs = scope.allDefinitions();
-    var it = allDefs.iterator();
-    for (int i = 0; i < allDefs.size(); i++) {
-      GraphOccurrence.Def def = it.next();
+    var it = scope.allDefinitions().iterator();
+    var i = 0;
+    while (it.hasNext()) {
+      var def = it.next();
       if (def.id() == defOcc.id()) {
         return i + LocalScope.internalSlotsSize();
       }
+      i++;
     }
     throw new IllegalStateException("Def occurrence must be in the given scope");
   }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
@@ -1,6 +1,7 @@
 package org.enso.compiler.pass.analyse.alias.graph;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Builder of {@link Graph}. Separates the concerns of building a graph of local symbol definitions
@@ -95,15 +96,20 @@ public final class GraphBuilder {
     return def;
   }
 
-  /** Factory method to create new [GraphOccurrence.Use]. */
+  /**
+   * Factory method to create new [GraphOccurrence.Use].
+   *
+   * @param symbol symbol of the usage
+   * @param identifier identifier or null
+   * @param externalId external ID or null
+   * @param resolve search for a {@link GraphOccurrence.Def} pair for this usage
+   * @return
+   */
   public GraphOccurrence.Use newUse(
-      String symbol,
-      java.util.UUID identifier,
-      scala.Option<java.util.UUID> externalId,
-      boolean resolve) {
+      String symbol, UUID identifier, scala.Option<UUID> externalId, boolean resolve) {
     var use = GraphOccurrence.createUse(scope, graph.nextId(scope), symbol, identifier, externalId);
     if (resolve) {
-      graph.resolveLocalUsage(use, null);
+      graph.resolveLocalUsage(use);
     }
     return use;
   }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
@@ -131,17 +131,14 @@ public final class GraphBuilder {
       if (scope.parent().isDefined()) {
         fillInDefinitions(scope.parent().get(), defs);
       }
-      scope
-          ._occurrences()
-          .values()
-          .foreach(
-              o -> {
-                if (o instanceof GraphOccurrence.Def d) {
-                  assert d.scope() == scope;
-                  defs.put(d.symbol(), d);
-                }
-                return null;
-              });
+      scope.forEachOccurenceDefinition(
+          o -> {
+            if (o instanceof GraphOccurrence.Def d) {
+              assert d.scope() == scope;
+              defs.put(d.symbol(), d);
+            }
+            return null;
+          });
     }
   }
 }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
@@ -42,7 +42,7 @@ public final class GraphPersistance {
     protected void writeObject(ScopeImpl obj, Output out) throws IOException {
       out.writeInline(scala.collection.immutable.List.class, obj.childScopes());
       out.writeObject(obj.occurrences().values().toSet());
-      out.writeInline(java.util.List.class, obj.allDefinitions());
+      out.writeInline(java.util.List.class, new java.util.ArrayList<>(obj.allDefinitions()));
     }
   }
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
@@ -38,11 +38,8 @@ public final class GraphPersistance {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void writeObject(ScopeImpl obj, Output out) throws IOException {
-      out.writeInline(scala.collection.immutable.List.class, obj.childScopes());
-      out.writeObject(obj.occurrences().values().toSet());
-      out.writeInline(java.util.List.class, new java.util.ArrayList<>(obj.allDefinitions()));
+      obj.writeObject(out);
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
@@ -6,7 +6,6 @@ import org.enso.compiler.pass.analyse.FramePointer
 import org.enso.compiler.pass.analyse.FrameVariableNames
 import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.alias.graph.{
-  GraphOccurrence,
   GraphBuilder,
   Graph => AliasGraph
 }
@@ -163,13 +162,11 @@ class LocalScope(
       .flatMap(scope => Some(scope.flattenBindingsWithLevel(level + 1)))
       .getOrElse(Map())
 
-    scope.occurrences.foreach {
-      case (id, x: GraphOccurrence.Def) =>
-        parentResult += x.symbol -> new FramePointer(
-          level,
-          allFrameSlotIdxs(id)
-        )
-      case _ =>
+    scope.forEachOccurenceDefinition { x =>
+      parentResult += x.symbol -> new FramePointer(
+        level,
+        allFrameSlotIdxs(x.id)
+      )
     }
     parentResult
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
@@ -44,7 +44,7 @@ object Graph {
 
   abstract class Scope {
     def parent:         Option[Scope]
-    def allDefinitions: java.util.List[GraphOccurrence.Def]
+    def allDefinitions: java.util.Collection[GraphOccurrence.Def]
     def occurrences:    Map[Id, GraphOccurrence]
 
     def deepCopy(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
@@ -43,9 +43,9 @@ object Graph {
   )
 
   abstract class Scope {
-    def parent:         Option[Scope]
-    def allDefinitions: java.util.Collection[GraphOccurrence.Def]
-    def occurrences:    Map[Id, GraphOccurrence]
+    def parent:                                                    Option[Scope]
+    def allDefinitions:                                            java.util.Collection[GraphOccurrence.Def]
+    def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit
 
     def deepCopy(
       mapping: mutable.Map[Graph.Scope, Graph.Scope] = mutable.Map()

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
@@ -4,6 +4,7 @@ package alias.graph
 
 import org.enso.compiler.debug.Debug
 
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.annotation.unused
@@ -315,9 +316,14 @@ sealed private[graph] class GraphImpl(
     def getShadowedIds(
       scope: ScopeImpl
     ): Set[GraphOccurrence] = {
-      scope.occurrences.values.collect {
-        case d: GraphOccurrence.Def if d.symbol == definition.symbol => d
-      } ++ scope.parent.map(getShadowedIds).getOrElse(Set())
+      scope._occurrences.values.stream
+        .filter {
+          case d: GraphOccurrence.Def if d.symbol == definition.symbol => true
+          case _                                                       => false
+        }
+        .toList
+        .asScala
+        .toSet ++ scope.parent.map(getShadowedIds).getOrElse(Set())
     }.toSet
 
     definition match {

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
@@ -4,7 +4,6 @@ package alias.graph
 
 import org.enso.compiler.debug.Debug
 
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.annotation.unused
@@ -316,14 +315,9 @@ sealed private[graph] class GraphImpl(
     def getShadowedIds(
       scope: ScopeImpl
     ): Set[GraphOccurrence] = {
-      scope._occurrences.values.stream
-        .filter {
-          case d: GraphOccurrence.Def if d.symbol == definition.symbol => true
-          case _                                                       => false
-        }
-        .toList
-        .asScala
-        .toSet ++ scope.parent.map(getShadowedIds).getOrElse(Set())
+      val withSymbol: Set[GraphOccurrence.Def] =
+        scope.getOccurrences(definition.symbol)
+      withSymbol ++ scope.parent.map(getShadowedIds).getOrElse(Set())
     }.toSet
 
     definition match {

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
@@ -7,12 +7,13 @@ import org.enso.compiler.debug.Debug
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.annotation.unused
+import scala.jdk.CollectionConverters._
 
 /** A graph containing aliasing information for a given root scope in Enso. */
 sealed private[graph] class GraphImpl(
   private val rootScopeImpl: Graph.Scope = new ScopeImpl(),
   private var _nextIdCounter: Int        = 0,
-  private var links: Set[Graph.Link]     = Set()
+  _links: Set[Graph.Link]                = null
 ) extends Graph {
   private var sourceLinks
     : java.util.Map[GraphImpl.Id, java.util.LinkedHashSet[Graph.Link]] =
@@ -22,12 +23,19 @@ sealed private[graph] class GraphImpl(
     new java.util.HashMap()
   private val toScope: java.util.Map[GraphImpl.Id, ScopeImpl] =
     new java.util.HashMap()
+  private var links: java.util.Set[Graph.Link] = {
+    if (_links == null) {
+      new java.util.HashSet()
+    } else {
+      new java.util.HashSet(_links.asJava)
+    }
+  }
 
   final def rootScope: ScopeImpl =
     this.rootScopeImpl.asInstanceOf[ScopeImpl]
 
   {
-    links.foreach(addSourceTargetLink)
+    links.forEach(addSourceTargetLink)
   }
 
   /** @return the next counter value
@@ -61,7 +69,7 @@ sealed private[graph] class GraphImpl(
     copy
   }
 
-  private[analyse] def getLinks(): Set[Graph.Link] = links
+  private[analyse] def getLinks(): Set[Graph.Link] = links.asScala.toSet
 
   final def freeze(): Unit = {
     _nextIdCounter = -1
@@ -123,7 +131,7 @@ sealed private[graph] class GraphImpl(
     Option(occurrence.scope()).flatMap(
       _.asInstanceOf[ScopeImpl].resolveUsage(occurrence).map { link =>
         addSourceTargetLink(link)
-        links += link
+        links.add(link)
         link
       }
     )
@@ -199,9 +207,11 @@ sealed private[graph] class GraphImpl(
   ): Set[Graph.Link] = {
     val idsForSym = rootScope.symbolToIds[T](symbol)
 
-    links.filter(l =>
-      idsForSym.contains(l.source) || idsForSym.contains(l.target)
-    )
+    links.stream
+      .filter(l => idsForSym.contains(l.source) || idsForSym.contains(l.target))
+      .toList
+      .asScala
+      .toSet
   }
 
   /** Obtains the occurrence for a given ID, from whichever scope in which it

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/GraphImpl.scala
@@ -118,11 +118,10 @@ sealed private[graph] class GraphImpl(
     * @return the link, if it exists
     */
   final def resolveLocalUsage(
-    occurrence: GraphOccurrence.Use,
-    df: GraphOccurrence.Def
+    occurrence: GraphOccurrence.Use
   ): Option[Graph.Link] = {
     Option(occurrence.scope()).flatMap(
-      _.asInstanceOf[ScopeImpl].resolveUsage(occurrence, df).map { link =>
+      _.asInstanceOf[ScopeImpl].resolveUsage(occurrence).map { link =>
         addSourceTargetLink(link)
         links += link
         link

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -163,11 +163,10 @@ sealed private[graph] class ScopeImpl(
       )
     } else {
       occurrencesById.put(occurrence.id, occurrence)
-      if (occurrence.isInstanceOf[GraphOccurrence.Def]) {
-        defsBySymbol.put(
-          occurrence.symbol,
-          occurrence.asInstanceOf[GraphOccurrence.Def]
-        )
+      occurrence match {
+        case d: GraphOccurrence.Def =>
+          defsBySymbol.put(occurrence.symbol, d)
+        case  _ =>
       }
     }
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -166,7 +166,7 @@ sealed private[graph] class ScopeImpl(
       occurrence match {
         case d: GraphOccurrence.Def =>
           defsBySymbol.put(occurrence.symbol, d)
-        case  _ =>
+        case _ =>
       }
     }
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -36,7 +36,7 @@ sealed private[graph] class ScopeImpl(
       new java.util.HashMap[GraphImpl.Symbol, GraphOccurrence.Def]()
     allOccurrences().stream
       .filter(_.isInstanceOf[GraphOccurrence.Def])
-      .map(d => {
+      .forEach(d => {
         bySymbol.put(d.symbol, d.asInstanceOf[GraphOccurrence.Def])
       })
     bySymbol

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -21,30 +21,18 @@ sealed private[graph] class ScopeImpl(
     HashMap(),
   _defs: java.util.Collection[GraphOccurrence.Def] = null
 ) extends Graph.Scope {
-  private[graph] val _allDefinitions: java.util.Map[
-    Graph.Symbol,
+  private[graph] val _allDefinitions: java.util.List[
     GraphOccurrence.Def
-  ] = toDefinitionsMap(_defs)
-
-  private def toDefinitionsMap(
-    defs: java.util.Collection[GraphOccurrence.Def]
-  ) = {
-    val map = new java.util.TreeMap[Graph.Symbol, GraphOccurrence.Def]()
-    if (defs != null) {
-        defs.forEach { d =>
-          val c = d.withScope(this)
-          map.put(c.symbol, c)
-        }
-    }
-    map
-  }
+  ] =
+    if (_defs == null) new java.util.ArrayList()
+    else new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
 
   private[graph] var _parent: ScopeImpl = null
 
   def childScopes = _childScopes
   def occurrences = _occurrences
   def allDefinitions =
-    java.util.Collections.unmodifiableCollection(_allDefinitions.values)
+    java.util.Collections.unmodifiableCollection(_allDefinitions)
   def parent: Option[ScopeImpl] =
     if (this._parent eq null) None else Some(_parent)
 
@@ -94,7 +82,7 @@ sealed private[graph] class ScopeImpl(
           new ScopeImpl(
             childScopeCopies.toList,
             occurrences,
-            _allDefinitions.values
+            new java.util.ArrayList(_allDefinitions)
           )
         mapping.put(this, newScope)
         newScope
@@ -153,7 +141,7 @@ sealed private[graph] class ScopeImpl(
     * @param definition The definition to add.
     */
   private[graph] def addDefinition(definition: GraphOccurrence.Def): Unit = {
-    _allDefinitions.put(definition.symbol, definition)
+    _allDefinitions.add(definition)
   }
 
   /** Finds an occurrence for the provided ID in the current scope, if it
@@ -211,11 +199,22 @@ sealed private[graph] class ScopeImpl(
     hint: GraphOccurrence.Def,
     parentCounter: Int = 0
   ): Option[Graph.Link] = {
-    val target = _allDefinitions.get(occurrence.symbol)
-    if (target == null) {
-      parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
-    } else {
-      Some(Graph.Link(occurrence.id, parentCounter, target.id()))
+    val definition =
+      if (hint != null && (hint.scope() eq this)) {
+        Some(hint)
+      } else {
+        occurrences.values.find {
+          case GraphOccurrence.Def(_, name, _, _, _) =>
+            name == occurrence.symbol
+          case _ => false
+        }
+      }
+
+    definition match {
+      case None =>
+        parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
+      case Some(target) =>
+        Some(Graph.Link(occurrence.id, parentCounter, target.id()))
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -4,6 +4,8 @@ package alias.graph
 
 import org.enso.compiler.core.CompilerError
 
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -16,9 +18,9 @@ import scala.reflect.ClassTag
   *                       Note that there may not be a link for all these definitions.
   */
 sealed private[graph] class ScopeImpl(
-  private[graph] var _childScopes: List[ScopeImpl] = List(),
-  _occurs: Map[GraphImpl.Id, GraphOccurrence]      = HashMap(),
-  _defs: java.util.Collection[GraphOccurrence.Def] = null
+  private[graph] var _childScopes: List[ScopeImpl]             = List(),
+  _occurs: scala.collection.Map[GraphImpl.Id, GraphOccurrence] = HashMap(),
+  _defs: java.util.Collection[GraphOccurrence.Def]             = null
 ) extends Graph.Scope {
   private[graph] val _allDefinitions: java.util.List[
     GraphOccurrence.Def
@@ -26,21 +28,28 @@ sealed private[graph] class ScopeImpl(
     if (_defs == null) new java.util.ArrayList()
     else new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
 
-  private[graph] var _parent: ScopeImpl                        = null
-  private var _occurrences: Map[GraphImpl.Id, GraphOccurrence] = _occurs
+  private[graph] var _parent: ScopeImpl = null
+  private[graph] val _occurrences
+    : java.util.Map[GraphImpl.Id, GraphOccurrence] =
+    new java.util.HashMap(_occurs.asJava)
 
   def childScopes = _childScopes
 
   def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit = {
-    _occurrences.foreach {
-      case (id, x: GraphOccurrence.Def) =>
-        assert(id == x.id)
-        fn(x)
-      case _ =>
+    _occurrences.values.forEach {
+      case x: GraphOccurrence.Def => fn(x)
+      case _                      =>
     }
   }
 
-  def occurrences = _occurrences
+  private[graph] def writeObject(
+    out: org.enso.persist.Persistance.Output
+  ): Unit = {
+    out.writeInline(classOf[scala.collection.immutable.List[_]], childScopes);
+    out.writeObject(_occurrences.values().asScala.toSet);
+    out.writeInline(classOf[java.util.List[_]], _allDefinitions);
+  }
+
   def allDefinitions =
     java.util.Collections.unmodifiableCollection(_allDefinitions)
   def parent: Option[ScopeImpl] =
@@ -91,7 +100,7 @@ sealed private[graph] class ScopeImpl(
         val newScope =
           new ScopeImpl(
             childScopeCopies.toList,
-            occurrences,
+            _occurrences.asScala,
             new java.util.ArrayList(_allDefinitions)
           )
         mapping.put(this, newScope)
@@ -110,7 +119,7 @@ sealed private[graph] class ScopeImpl(
         if (this.childScopes.length == that.childScopes.length) {
           val childScopesEqual =
             this.childScopes.zip(that.childScopes).forall(t => t._1 == t._2)
-          val occurrencesEqual = this.occurrences == that.occurrences
+          val occurrencesEqual = this._occurrences == that._occurrences
 
           childScopesEqual && occurrencesEqual
         } else {
@@ -136,12 +145,12 @@ sealed private[graph] class ScopeImpl(
     * @param occurrence the occurrence to add
     */
   private[graph] def add(occurrence: GraphOccurrence): Unit = {
-    if (occurrences.contains(occurrence.id)) {
+    if (_occurrences.containsKey(occurrence.id)) {
       throw new CompilerError(
         s"Multiple occurrences found for ID ${occurrence.id}."
       )
     } else {
-      _occurrences += ((occurrence.id, occurrence))
+      _occurrences.put(occurrence.id, occurrence)
     }
   }
 
@@ -163,7 +172,7 @@ sealed private[graph] class ScopeImpl(
   private[analyse] def getOccurrence(
     id: GraphImpl.Id
   ): Option[GraphOccurrence] = {
-    occurrences.get(id)
+    Option(_occurrences.get(id))
   }
 
   /** Finds any occurrences for the provided symbol in the current scope, if
@@ -176,9 +185,14 @@ sealed private[graph] class ScopeImpl(
   private[analyse] def getOccurrences[T <: GraphOccurrence: ClassTag](
     symbol: GraphImpl.Symbol
   ): Set[GraphOccurrence] = {
-    occurrences.values.collect {
-      case o: T if o.symbol == symbol => o
-    }.toSet
+    _occurrences.values.stream
+      .filter {
+        case o: T if o.symbol == symbol => true
+        case _                          => false
+      }
+      .toList
+      .asScala
+      .toSet
   }
 
   /** Checks whether a symbol occurs in a given role in the current scope.
@@ -191,9 +205,7 @@ sealed private[graph] class ScopeImpl(
   final def hasSymbolOccurrenceAs[T <: GraphOccurrence: ClassTag](
     symbol: GraphImpl.Symbol
   ): Boolean = {
-    occurrences.values.collectFirst {
-      case x: T if x.symbol == symbol => x
-    }.nonEmpty
+    getOccurrences(symbol).nonEmpty
   }
 
   /** Resolves usages of symbols into links where possible, creating an edge
@@ -213,11 +225,14 @@ sealed private[graph] class ScopeImpl(
       if (hint != null && (hint.scope() eq this)) {
         Some(hint)
       } else {
-        occurrences.values.find {
-          case GraphOccurrence.Def(_, name, _, _, _) =>
-            name == occurrence.symbol
-          case _ => false
-        }
+        _occurrences.values.stream
+          .filter {
+            case GraphOccurrence.Def(_, name, _, _, _) =>
+              name == occurrence.symbol
+            case _ => false
+          }
+          .findFirst
+          .toScala
       }
 
     definition match {
@@ -233,7 +248,7 @@ sealed private[graph] class ScopeImpl(
     * @return a string representation of `this`
     */
   override def toString: String =
-    s"Scope(occurrences = ${occurrences.values}, childScopes = $childScopes)"
+    s"Scope(occurrences = ${_occurrences.values}, childScopes = $childScopes)"
 
   /** Counts the number of scopes in this scope.
     *
@@ -258,7 +273,7 @@ sealed private[graph] class ScopeImpl(
     * @return the scope where `id` occurs
     */
   private[analyse] def scopeFor(id: GraphImpl.Id): Option[ScopeImpl] = {
-    if (!occurrences.contains(id)) {
+    if (!_occurrences.containsKey(id)) {
       if (childScopes.isEmpty) {
         None
       } else {
@@ -328,7 +343,8 @@ sealed private[graph] class ScopeImpl(
     * @return the set of symbols
     */
   private[analyse] def symbols: Set[GraphImpl.Symbol] = {
-    val symbolsInThis        = occurrences.values.map(_.symbol).toSet
+    val symbolsInThis =
+      _occurrences.values.stream.map(_.symbol).toList.asScala.toSet
     val symbolsInChildScopes = childScopes.flatMap(_.symbols)
 
     symbolsInThis ++ symbolsInChildScopes

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -19,19 +19,32 @@ sealed private[graph] class ScopeImpl(
   private[graph] var _childScopes: List[ScopeImpl] = List(),
   private[graph] var _occurrences: Map[GraphImpl.Id, GraphOccurrence] =
     HashMap(),
-  _defs: java.util.List[
-    GraphOccurrence.Def
-  ] = new java.util.ArrayList()
+  _defs: java.util.Collection[GraphOccurrence.Def] = null
 ) extends Graph.Scope {
-  private[graph] val _allDefinitions: java.util.List[
+  private[graph] val _allDefinitions: java.util.Map[
+    Graph.Symbol,
     GraphOccurrence.Def
-  ] = new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
+  ] = toDefinitionsMap(_defs)
+
+  private def toDefinitionsMap(
+    defs: java.util.Collection[GraphOccurrence.Def]
+  ) = {
+    val map = new java.util.TreeMap[Graph.Symbol, GraphOccurrence.Def]()
+    if (defs != null) {
+        defs.forEach { d =>
+          val c = d.withScope(this)
+          map.put(c.symbol, c)
+        }
+    }
+    map
+  }
 
   private[graph] var _parent: ScopeImpl = null
 
-  def childScopes    = _childScopes
-  def occurrences    = _occurrences
-  def allDefinitions = java.util.Collections.unmodifiableList(_allDefinitions)
+  def childScopes = _childScopes
+  def occurrences = _occurrences
+  def allDefinitions =
+    java.util.Collections.unmodifiableCollection(_allDefinitions.values)
   def parent: Option[ScopeImpl] =
     if (this._parent eq null) None else Some(_parent)
 
@@ -81,7 +94,7 @@ sealed private[graph] class ScopeImpl(
           new ScopeImpl(
             childScopeCopies.toList,
             occurrences,
-            new java.util.ArrayList(_allDefinitions)
+            _allDefinitions.values
           )
         mapping.put(this, newScope)
         newScope
@@ -140,7 +153,7 @@ sealed private[graph] class ScopeImpl(
     * @param definition The definition to add.
     */
   private[graph] def addDefinition(definition: GraphOccurrence.Def): Unit = {
-    _allDefinitions.add(definition)
+    _allDefinitions.put(definition.symbol, definition)
   }
 
   /** Finds an occurrence for the provided ID in the current scope, if it
@@ -198,22 +211,11 @@ sealed private[graph] class ScopeImpl(
     hint: GraphOccurrence.Def,
     parentCounter: Int = 0
   ): Option[Graph.Link] = {
-    val definition =
-      if (hint != null && (hint.scope() eq this)) {
-        Some(hint)
-      } else {
-        occurrences.values.find {
-          case GraphOccurrence.Def(_, name, _, _, _) =>
-            name == occurrence.symbol
-          case _ => false
-        }
-      }
-
-    definition match {
-      case None =>
-        parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
-      case Some(target) =>
-        Some(Graph.Link(occurrence.id, parentCounter, target.id()))
+    val target = _allDefinitions.get(occurrence.symbol)
+    if (target == null) {
+      parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
+    } else {
+      Some(Graph.Link(occurrence.id, parentCounter, target.id()))
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -30,6 +30,16 @@ sealed private[graph] class ScopeImpl(
   private[graph] var _parent: ScopeImpl = null
 
   def childScopes = _childScopes
+
+  def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit = {
+    _occurrences.foreach {
+      case (id, x: GraphOccurrence.Def) =>
+        assert(id == x.id)
+        fn(x)
+      case _ =>
+    }
+  }
+
   def occurrences = _occurrences
   def allDefinitions =
     java.util.Collections.unmodifiableCollection(_allDefinitions)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -29,8 +29,7 @@ sealed private[graph] class ScopeImpl(
     else new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
 
   private[graph] var _parent: ScopeImpl = null
-  private[graph] val _occurrences
-    : java.util.Map[GraphImpl.Id, GraphOccurrence] =
+  private val _occurrences: java.util.Map[GraphImpl.Id, GraphOccurrence] =
     new java.util.HashMap(_occurs.asJava)
 
   def childScopes = _childScopes
@@ -184,7 +183,7 @@ sealed private[graph] class ScopeImpl(
     */
   private[analyse] def getOccurrences[T <: GraphOccurrence: ClassTag](
     symbol: GraphImpl.Symbol
-  ): Set[GraphOccurrence] = {
+  ): Set[T] = {
     _occurrences.values.stream
       .filter {
         case o: T if o.symbol == symbol => true
@@ -192,6 +191,7 @@ sealed private[graph] class ScopeImpl(
       }
       .toList
       .asScala
+      .map(_.asInstanceOf[T])
       .toSet
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -5,7 +5,6 @@ package alias.graph
 import org.enso.compiler.core.CompilerError
 
 import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters._
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -29,13 +28,24 @@ sealed private[graph] class ScopeImpl(
     else new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
 
   private[graph] var _parent: ScopeImpl = null
-  private val _occurrences: java.util.Map[GraphImpl.Id, GraphOccurrence] =
+  private val occurrencesById: java.util.Map[GraphImpl.Id, GraphOccurrence] =
     new java.util.HashMap(_occurs.asJava)
+  private val defsBySymbol
+    : java.util.Map[GraphImpl.Symbol, GraphOccurrence.Def] = {
+    val bySymbol =
+      new java.util.HashMap[GraphImpl.Symbol, GraphOccurrence.Def]()
+    allOccurrences().stream
+      .filter(_.isInstanceOf[GraphOccurrence.Def])
+      .map(d => {
+        bySymbol.put(d.symbol, d.asInstanceOf[GraphOccurrence.Def])
+      })
+    bySymbol
+  }
 
   def childScopes = _childScopes
 
   def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit = {
-    _occurrences.values.forEach {
+    allOccurrences().forEach {
       case x: GraphOccurrence.Def => fn(x)
       case _                      =>
     }
@@ -45,9 +55,12 @@ sealed private[graph] class ScopeImpl(
     out: org.enso.persist.Persistance.Output
   ): Unit = {
     out.writeInline(classOf[scala.collection.immutable.List[_]], childScopes);
-    out.writeObject(_occurrences.values().asScala.toSet);
+    out.writeObject(allOccurrences().asScala.toSet);
     out.writeInline(classOf[java.util.List[_]], _allDefinitions);
   }
+
+  private def allOccurrences(): java.util.Collection[GraphOccurrence] =
+    occurrencesById.values
 
   def allDefinitions =
     java.util.Collections.unmodifiableCollection(_allDefinitions)
@@ -99,7 +112,7 @@ sealed private[graph] class ScopeImpl(
         val newScope =
           new ScopeImpl(
             childScopeCopies.toList,
-            _occurrences.asScala,
+            occurrencesById.asScala,
             new java.util.ArrayList(_allDefinitions)
           )
         mapping.put(this, newScope)
@@ -118,7 +131,7 @@ sealed private[graph] class ScopeImpl(
         if (this.childScopes.length == that.childScopes.length) {
           val childScopesEqual =
             this.childScopes.zip(that.childScopes).forall(t => t._1 == t._2)
-          val occurrencesEqual = this._occurrences == that._occurrences
+          val occurrencesEqual = this.occurrencesById == that.occurrencesById
 
           childScopesEqual && occurrencesEqual
         } else {
@@ -144,12 +157,18 @@ sealed private[graph] class ScopeImpl(
     * @param occurrence the occurrence to add
     */
   private[graph] def add(occurrence: GraphOccurrence): Unit = {
-    if (_occurrences.containsKey(occurrence.id)) {
+    if (occurrencesById.containsKey(occurrence.id)) {
       throw new CompilerError(
         s"Multiple occurrences found for ID ${occurrence.id}."
       )
     } else {
-      _occurrences.put(occurrence.id, occurrence)
+      occurrencesById.put(occurrence.id, occurrence)
+      if (occurrence.isInstanceOf[GraphOccurrence.Def]) {
+        defsBySymbol.put(
+          occurrence.symbol,
+          occurrence.asInstanceOf[GraphOccurrence.Def]
+        )
+      }
     }
   }
 
@@ -171,7 +190,7 @@ sealed private[graph] class ScopeImpl(
   private[analyse] def getOccurrence(
     id: GraphImpl.Id
   ): Option[GraphOccurrence] = {
-    Option(_occurrences.get(id))
+    Option(occurrencesById.get(id))
   }
 
   /** Finds any occurrences for the provided symbol in the current scope, if
@@ -184,7 +203,7 @@ sealed private[graph] class ScopeImpl(
   private[analyse] def getOccurrences[T <: GraphOccurrence: ClassTag](
     symbol: GraphImpl.Symbol
   ): Set[T] = {
-    _occurrences.values.stream
+    allOccurrences().stream
       .filter {
         case o: T if o.symbol == symbol => true
         case _                          => false
@@ -221,20 +240,7 @@ sealed private[graph] class ScopeImpl(
     hint: GraphOccurrence.Def,
     parentCounter: Int = 0
   ): Option[Graph.Link] = {
-    val definition =
-      if (hint != null && (hint.scope() eq this)) {
-        Some(hint)
-      } else {
-        _occurrences.values.stream
-          .filter {
-            case GraphOccurrence.Def(_, name, _, _, _) =>
-              name == occurrence.symbol
-            case _ => false
-          }
-          .findFirst
-          .toScala
-      }
-
+    val definition = Option(defsBySymbol.get(occurrence.symbol))
     definition match {
       case None =>
         parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
@@ -248,7 +254,7 @@ sealed private[graph] class ScopeImpl(
     * @return a string representation of `this`
     */
   override def toString: String =
-    s"Scope(occurrences = ${_occurrences.values}, childScopes = $childScopes)"
+    s"Scope(occurrences = ${allOccurrences()}, childScopes = $childScopes)"
 
   /** Counts the number of scopes in this scope.
     *
@@ -273,7 +279,7 @@ sealed private[graph] class ScopeImpl(
     * @return the scope where `id` occurs
     */
   private[analyse] def scopeFor(id: GraphImpl.Id): Option[ScopeImpl] = {
-    if (!_occurrences.containsKey(id)) {
+    if (!occurrencesById.containsKey(id)) {
       if (childScopes.isEmpty) {
         None
       } else {
@@ -344,7 +350,7 @@ sealed private[graph] class ScopeImpl(
     */
   private[analyse] def symbols: Set[GraphImpl.Symbol] = {
     val symbolsInThis =
-      _occurrences.values.stream.map(_.symbol).toList.asScala.toSet
+      allOccurrences().stream.map(_.symbol).toList.asScala.toSet
     val symbolsInChildScopes = childScopes.flatMap(_.symbols)
 
     symbolsInThis ++ symbolsInChildScopes

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -200,7 +200,7 @@ sealed private[graph] class ScopeImpl(
     * @tparam T the role for the symbol
     * @return the occurrences for `name`, if they exist
     */
-  private[analyse] def getOccurrences[T <: GraphOccurrence: ClassTag](
+  private[graph] def getOccurrences[T <: GraphOccurrence: ClassTag](
     symbol: GraphImpl.Symbol
   ): Set[T] = {
     allOccurrences().stream
@@ -237,13 +237,12 @@ sealed private[graph] class ScopeImpl(
     */
   private[analyse] def resolveUsage(
     occurrence: GraphOccurrence.Use,
-    hint: GraphOccurrence.Def,
     parentCounter: Int = 0
   ): Option[Graph.Link] = {
     val definition = Option(defsBySymbol.get(occurrence.symbol))
     definition match {
       case None =>
-        parent.flatMap(_.resolveUsage(occurrence, hint, parentCounter + 1))
+        parent.flatMap(_.resolveUsage(occurrence, parentCounter + 1))
       case Some(target) =>
         Some(Graph.Link(occurrence.id, parentCounter, target.id()))
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -17,8 +17,7 @@ import scala.reflect.ClassTag
   */
 sealed private[graph] class ScopeImpl(
   private[graph] var _childScopes: List[ScopeImpl] = List(),
-  private[graph] var _occurrences: Map[GraphImpl.Id, GraphOccurrence] =
-    HashMap(),
+  _occurs: Map[GraphImpl.Id, GraphOccurrence]      = HashMap(),
   _defs: java.util.Collection[GraphOccurrence.Def] = null
 ) extends Graph.Scope {
   private[graph] val _allDefinitions: java.util.List[
@@ -27,7 +26,8 @@ sealed private[graph] class ScopeImpl(
     if (_defs == null) new java.util.ArrayList()
     else new java.util.ArrayList(_defs.stream.map(_.withScope(this)).toList)
 
-  private[graph] var _parent: ScopeImpl = null
+  private[graph] var _parent: ScopeImpl                        = null
+  private var _occurrences: Map[GraphImpl.Id, GraphOccurrence] = _occurs
 
   def childScopes = _childScopes
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/pass/analyse/test/GraphBuilderTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/pass/analyse/test/GraphBuilderTest.java
@@ -55,7 +55,7 @@ public class GraphBuilderTest {
     assertEquals("One child scope", 1, s.childScopes().size());
     var chScope = s.childScopes().apply(0);
     assertEquals("One variable in child", 1, chScope.allDefinitions().size());
-    var def = chScope.allDefinitions().get(0);
+    var def = chScope.allDefinitions().iterator().next();
     assertSame(chScope, def.scope());
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/pass/analyse/alias/graph/test/AliasAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/pass/analyse/alias/graph/test/AliasAnalysisTest.scala
@@ -160,10 +160,10 @@ class AliasAnalysisTest extends CompilerTest {
       childOfChild
         .toScope()
         .asInstanceOf[ScopeImpl]
-        .resolveUsage(bUse, null) shouldEqual Some(
+        .resolveUsage(bUse) shouldEqual Some(
         Link(bUseId, 0, bDefId)
       )
-      childOfChildOfChild.resolveUsage(aUse, null) shouldEqual Some(
+      childOfChildOfChild.resolveUsage(aUse) shouldEqual Some(
         Link(aUseId, 3, aDefId)
       )
     }
@@ -269,9 +269,9 @@ class AliasAnalysisTest extends CompilerTest {
     val cUse   = childScope.newUse("c", genId, None, false)
     val cUseId = cUse.id
 
-    val use1Link = graph.resolveLocalUsage(aUse1, null)
-    val use2Link = graph.resolveLocalUsage(aUse2, null)
-    val cUseLink = graph.resolveLocalUsage(cUse, null)
+    val use1Link = graph.resolveLocalUsage(aUse1)
+    val use2Link = graph.resolveLocalUsage(aUse2)
+    val cUseLink = graph.resolveLocalUsage(cUse)
 
     "allow itself to be deep copied" in {
       val graphCopy = graph.copy

--- a/lib/java/scala-libs-wrapper/src/main/java/org/enso/scala/wrapper/ScalaConversions.java
+++ b/lib/java/scala-libs-wrapper/src/main/java/org/enso/scala/wrapper/ScalaConversions.java
@@ -1,5 +1,6 @@
 package org.enso.scala.wrapper;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import scala.Option;
@@ -32,7 +33,7 @@ public class ScalaConversions {
     return CollectionConverters.asJava(list);
   }
 
-  public static <T> scala.collection.immutable.List<T> asScala(List<T> list) {
+  public static <T> scala.collection.immutable.List<T> asScala(Collection<T> list) {
     return CollectionConverters.asScala(list).toList();
   }
 


### PR DESCRIPTION
### Pull Request Description

Closes #9235 by speeding `AliasAnalysis` up benchmarks again.

![12% in ManyLocalVarsBenchmark](https://github.com/user-attachments/assets/acb9f7b4-56ee-499d-ab83-d5f1a79825e7)

The blue point on the graph shows additional **12%** speedup:
- together with previous efforts of last week:
- #12720
- #12748
- there is now **73%** speed up in the `ManyLocalVarsBenchmark` 
 
That's a good enough improvement since Apr 4, 2025.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
- [x] Benchmarks ([first run](https://github.com/enso-org/enso/actions/runs/14357802794), [2nd run](https://github.com/enso-org/enso/actions/runs/14359186456), [all engine benchmarks](https://github.com/enso-org/enso/actions/runs/14367044585)) are good
