### PR TITLE
Run enso exec directly rather than via shell

### DIFF
--- a/.github/workflows/std-libs-labels.yml
+++ b/.github/workflows/std-libs-labels.yml
@@ -89,6 +89,31 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: -libs-API-change-Database
+  stdlib-api-check-Generic_JDBC-linux-amd64:
+    name: Generic_JDBC-change-labels
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          fetch-depth: 2
+      - id: Generic_JDBC-changed-files
+        name: Generic_JDBC-changed-files
+        uses: step-security/changed-files@v45
+        with:
+          files: distribution/lib/Standard/Generic_JDBC/**/docs/api/**/**.md
+      - name: List all changed files in Generic_JDBC
+        run: "\n        if [[ \"${{ steps.Generic_JDBC-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
+        env:
+          ALL_CHANGED_FILES: ${{ steps.Generic_JDBC-changed-files.outputs.all_changed_files }}
+      - if: steps.Generic_JDBC-changed-files.outputs.any_changed == 'true'
+        name: Append -libs-API-change-Generic_JDBC label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: -libs-API-change-Generic_JDBC
   stdlib-api-check-Google_Api-linux-amd64:
     name: Google_Api-change-labels
     runs-on:
@@ -289,30 +314,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: -libs-API-change-Visualization
-  stdlib-api-check-Generic_JDBC-linux-amd64:
-    name: Generic_JDBC-change-labels
-    runs-on:
-      - ubuntu-latest
-    steps:
-      - name: Checking out the repository
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          fetch-depth: 2
-      - id: Generic_JDBC-changed-files
-        name: Generic_JDBC-changed-files
-        uses: step-security/changed-files@v45
-        with:
-          files: distribution/lib/Standard/Generic_JDBC/**/docs/api/**.md
-      - name: List all changed files in Generic_JDBC
-        run: "\n        if [[ \"${{ steps.Generic_JDBC-changed-files.outputs.any_changed }}\" == \"true\" ]]; then\n            echo \"Files changed:\"\n        fi\n        for file in ${ALL_CHANGED_FILES}; do\n            echo \"$file\"\n        done\n        "
-        env:
-          ALL_CHANGED_FILES: ${{ steps.Generic_JDBC-changed-files.outputs.all_changed_files }}
-      - if: steps.Generic_JDBC-changed-files.outputs.any_changed == 'true'
-        name: Append -libs-API-change-Generic_JDBC label
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: -libs-API-change-Generic_JDBC
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"

--- a/build.sbt
+++ b/build.sbt
@@ -3845,9 +3845,23 @@ lazy val `engine-runner` = project
         `std-tableau-polyglot-root`
           .listFiles("*.jar")
           .map(_.getAbsolutePath())
-
-      core ++ stdLibsJars
+      core ++ stdLibsJars ++ extraNITestLibs.value
     },
+    extraNITestLibs := Def.taskDyn {
+      if (GraalVM.EnsoLauncher.test) Def.task {
+        Seq(
+          (`enso-test-java-helpers` / Compile / packageBin).value
+            .getAbsolutePath(),
+          (`snowflake-test-java-helpers` / Compile / packageBin).value
+            .getAbsolutePath()
+        )
+      }
+      else {
+        Def.task {
+          Seq[String]()
+        }
+      }
+    }.value,
     buildSmallJdk := {
       val smallJdkDirectory = (target.value / "jdk").getAbsoluteFile()
       if (smallJdkDirectory.exists()) {
@@ -4014,10 +4028,15 @@ lazy val `engine-runner` = project
   .dependsOn(`logging-service-logback` % Runtime)
   .dependsOn(`engine-runner-common`)
   .dependsOn(`polyglot-api`)
-  .dependsOn(`enso-test-java-helpers`)
+//.dependsOn(`enso-test-java-helpers`)
 
 lazy val buildSmallJdk =
   taskKey[File]("Build a minimal JDK used for native image generation")
+
+lazy val extraNITestLibs =
+  taskKey[Seq[String]](
+    "List of extra test libraries to be included in Native Image"
+  )
 
 lazy val launcher = project
   .in(file("engine/launcher"))
@@ -4183,7 +4202,6 @@ lazy val `os-environment` =
     .settings(
       frgaalJavaCompilerSetting,
       scalaModuleDependencySetting,
-      javaModuleName := "org.enso.os.environment",
       libraryDependencies ++= Seq(
         "org.graalvm.sdk" % "nativeimage"     % graalMavenPackagesVersion % "provided",
         "org.graalvm.sdk" % "graal-sdk"       % graalMavenPackagesVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -4028,7 +4028,6 @@ lazy val `engine-runner` = project
   .dependsOn(`logging-service-logback` % Runtime)
   .dependsOn(`engine-runner-common`)
   .dependsOn(`polyglot-api`)
-//.dependsOn(`enso-test-java-helpers`)
 
 lazy val buildSmallJdk =
   taskKey[File]("Build a minimal JDK used for native image generation")

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -356,7 +356,7 @@ impl RunContext {
 
         match &self.config.test_standard_library {
             Some(selection) => {
-                enso.run_tests(IrCaches::No, &sbt, PARALLEL_ENSO_TESTS, selection.clone()).await?;
+                enso.run_tests(IrCaches::No, &sbt, PARALLEL_ENSO_TESTS, selection.clone(), self.config.build_native_runner).await?;
             }
             None => {}
         }

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -356,7 +356,14 @@ impl RunContext {
 
         match &self.config.test_standard_library {
             Some(selection) => {
-                enso.run_tests(IrCaches::No, &sbt, PARALLEL_ENSO_TESTS, selection.clone(), self.config.build_native_runner).await?;
+                enso.run_tests(
+                    IrCaches::No,
+                    &sbt,
+                    PARALLEL_ENSO_TESTS,
+                    selection.clone(),
+                    self.config.build_native_runner,
+                )
+                .await?;
             }
             None => {}
         }

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -101,7 +101,7 @@ impl BuiltEnso {
         test_path: impl AsRef<Path>,
         ir_caches: IrCaches,
         environment_overrides: Vec<(String, String)>,
-        native_image: bool
+        native_image: bool,
     ) -> Result<Command> {
         let mut command = if native_image {
             let enso = self.wrapper_script_path();

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -101,8 +101,14 @@ impl BuiltEnso {
         test_path: impl AsRef<Path>,
         ir_caches: IrCaches,
         environment_overrides: Vec<(String, String)>,
+        native_image: bool
     ) -> Result<Command> {
-        let mut command = self.cmd()?;
+        let mut command = if native_image {
+            let enso = self.wrapper_script_path();
+            Command::new(&enso)
+        } else {
+            self.cmd()?
+        };
         command
             .arg(ir_caches)
             .arg("--run")
@@ -133,6 +139,7 @@ impl BuiltEnso {
         sbt: &crate::engine::sbt::Context,
         async_policy: AsyncPolicy,
         test_selection: StandardLibraryTestsSelection,
+        native_image: bool,
     ) -> Result {
         let paths = &self.paths;
         // Environment for meta-tests. See:
@@ -244,12 +251,11 @@ impl BuiltEnso {
                 cloud_tests::env::test_controls::ENSO_RUN_REAL_CLOUD_TEST.name().to_string(),
                 "1".to_string(),
             ));
-            environment_overrides.push(("ENSO_LAUNCHER".to_string(), "native".to_string()));
         };
 
         let futures = std_tests.into_iter().map(|test_path| {
             let command: std::result::Result<Command, anyhow::Error> =
-                self.run_test(test_path, ir_caches, environment_overrides.clone());
+                self.run_test(test_path, ir_caches, environment_overrides.clone(), native_image);
             async move { command?.run_ok().await }
         });
 

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -217,7 +217,8 @@ following:
   - using `native,test` _enables assertions_ - e.g. it instructs
     `buildEngineDistribution` command to build native image with assertions
     enabled (`-ea`). Useful for running Enso tests in the _native mode_.
-  - using `native,debug` generates _debugging informations_ for VSCode _native
+    Also includes additional testing libraries in the target native image.
+  - using `native,debug` generates _debugging information_ for VSCode _native
     image debugger_
   - using `native,-ls` disables support for _language server_ in the generated
     binary

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -216,8 +216,8 @@ following:
     quickly
   - using `native,test` _enables assertions_ - e.g. it instructs
     `buildEngineDistribution` command to build native image with assertions
-    enabled (`-ea`). Useful for running Enso tests in the _native mode_.
-    Also includes additional testing libraries in the target native image.
+    enabled (`-ea`). Useful for running Enso tests in the _native mode_. Also
+    includes additional testing libraries in the target native image.
   - using `native,debug` generates _debugging information_ for VSCode _native
     image debugger_
   - using `native,-ls` disables support for _language server_ in the generated


### PR DESCRIPTION
### Pull Request Description

Tests have been executed via a default shell (bash on linux) which didn't play well with the (now successfully generated) native image.

### Important Notes

Some successful runs are available at https://github.com/enso-org/enso/actions/runs/14357676228/job/40256667523. Unfortunately building NI can still sometimes run out of memory. 
