### PR TITLE
Fix opening new project

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -315,6 +315,7 @@ export interface BaseProject {
 export interface CreatedProject extends BaseProject {
   readonly state: ProjectStateType
   readonly packageName: string
+  readonly ensoPath?: EnsoPath
 }
 
 /** A `Project` returned by the `listProjects` endpoint. */

--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -599,7 +599,8 @@ export function useNewProject(backend: Backend, category: Category) {
             id: createdProject.projectId,
             parentId: placeholderItem.parentId,
             title: createdProject.name,
-          }
+            ...(createdProject.ensoPath != null ? { ensoPath: createdProject.ensoPath } : {}),
+          } satisfies Partial<backendModule.ProjectAsset>
           if (runLocally) {
             // Open in background.
             void openProjectLocally(openProjectParams, backend.type)


### PR DESCRIPTION
### Pull Request Description
- Fix #12810
  - Provide `ensoPath` (from backend) when running new project otherwise Hybrid execution crashes
- Fix https://github.com/enso-org/cloud-v2/issues/1889
  - Same as above

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
