### PR TITLE
Fix layout when editing existing node

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser.vue
@@ -45,6 +45,7 @@ const COMPONENT_EDITOR_PADDING = NODE_CONTENT_PADDING
 const ICON_WIDTH = 24
 // Component editor is larger than a typical node, so the edge should touch it a bit higher.
 const EDGE_Y_OFFSET = -8
+const MIN_WIDTH = 295
 
 const cssComponentEditorPadding = `${COMPONENT_EDITOR_PADDING}px`
 
@@ -160,6 +161,13 @@ const transform = computed(() => {
   const y = Math.round(screenPosition.y)
 
   return `translate(${x}px, ${y}px)`
+})
+
+const minWidth = computed(() => {
+  if (props.usage.type !== 'editNode') return `${MIN_WIDTH}px`
+  const rect = graphStore.nodeRects.get(props.usage.node)
+  if (rect == null) return `${MIN_WIDTH}px`
+  return `${rect.width * props.navigator.scale}px`
 })
 
 // === Selection ===
@@ -375,7 +383,7 @@ const listsHandler = listBindings.handler({
   <div
     ref="cbRoot"
     class="ComponentBrowser"
-    :style="{ transform }"
+    :style="{ transform, minWidth }"
     :data-self-argument="input.selfArgument"
     tabindex="-1"
     @focusout="handleDefocus"
@@ -442,7 +450,6 @@ const listsHandler = listBindings.handler({
   --radius-default: 20px;
   --background-color: #fff;
   --doc-panel-bottom-clip: 4px;
-  min-width: 295px;
   width: min-content;
   color: rgba(0, 0, 0, 0.6);
   font-size: 11.5px;

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -731,6 +731,8 @@ onWindowBlur(() => {
   cursor: grabbing !important;
 }
 
+/* We use this instead of "v-show", because we want the node content being still laid out,
+   so the edges won't jump. */
 .edited {
   visibility: hidden;
 }

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -430,6 +430,7 @@ const nodeClass = computed(() => {
     outputNode: props.node.type === 'output',
     menuVisible: menuVisible.value,
     menuFull: menuFull.value,
+    edited: props.edited,
   }
 })
 
@@ -489,7 +490,6 @@ onWindowBlur(() => {
 
 <template>
   <div
-    v-show="!edited"
     ref="rootNode"
     class="GraphNode define-node-colors"
     :style="nodeStyle"
@@ -729,5 +729,10 @@ onWindowBlur(() => {
 
 .dragged {
   cursor: grabbing !important;
+}
+
+.edited {
+  opacity: 0;
+  pointer-events: none;
 }
 </style>

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -732,7 +732,6 @@ onWindowBlur(() => {
 }
 
 .edited {
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

Fixes #12760 

The issue is addressed by keeping WidgetPorts rects when starting editing + make minimum width of Component Browser, so no edges will be dangling.


https://github.com/user-attachments/assets/cdd4bb70-54e1-4174-85ec-4d2b31892986



### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
