### PR TITLE
Text widget: Newline binding is Alt+Enter

### DIFF
--- a/app/gui/integration-test/project-view/keyboard.ts
+++ b/app/gui/integration-test/project-view/keyboard.ts
@@ -1,4 +1,4 @@
 import os from 'os'
 
-export const CONTROL_KEY = os.platform() === 'darwin' ? 'Meta' : 'Control'
+export const CONTROL_KEY = 'ControlOrMeta'
 export const DELETE_KEY = os.platform() === 'darwin' ? 'Backspace' : 'Delete'

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -82,6 +82,25 @@ test('Widget in plain AST', async ({ page }) => {
   await expect(textWidget.getByTestId('widget-text-content')).toHaveText('test')
 })
 
+test('Text widget: Convert to multiline', async ({ page }) => {
+  await actions.goToGraph(page)
+  const textNode = locate.graphNodeByBinding(page, 'text')
+  const textWidget = textNode.locator('.WidgetText')
+  await expect(textWidget).toBeVisible()
+  await expect(textWidget.getByTestId('widget-text-content')).toHaveText('test')
+  await textWidget.click()
+  await expect(textWidget.getByTestId('widget-text-content')).toBeFocused()
+  await page.keyboard.press('ArrowRight')
+  await page.keyboard.press('Alt+Enter')
+  await page.keyboard.insertText('Next line')
+  await page.keyboard.press('Enter')
+  await expect(textWidget.getByTestId('widget-text-content')).not.toBeFocused()
+  await expect(textWidget.getByTestId('widget-text-content').locator('.cm-line')).toHaveText([
+    'test',
+    'Next line',
+  ])
+})
+
 test('Multi-selection widget', async ({ page }) => {
   await actions.goToGraph(page)
   await mockMethodCallInfo(page, 'selected', {

--- a/app/gui/src/project-view/bindings.ts
+++ b/app/gui/src/project-view/bindings.ts
@@ -21,29 +21,18 @@ export const textEditorsBindings = defineKeybinds('text-editors', {
   openLink: ['Mod+PointerMain'],
 })
 
-/**
- * Bindings applicable to all text editors, that are handled by the browser's default behavior (and
- * therefore cannot be changed to a different key).
- */
-export const textEditorsStandardCommonBindings = defineKeybinds('text-editors-standard-bindings', {
+export const textEditorsCommonBindings = defineKeybinds('text-editors-common-bindings', {
   moveLeft: ['ArrowLeft'],
   moveRight: ['ArrowRight'],
   deleteBack: ['Backspace'],
   deleteForward: ['Delete'],
 })
 
-/**
- * Bindings applicable to multiline text editors, that are handled by the browser's default behavior
- * (and therefore cannot be changed to a different key).
- */
-export const textEditorsStandardMultilineBindings = defineKeybinds(
-  'text-editors-standard-multiline-bindings',
-  {
-    moveUp: ['ArrowUp'],
-    moveDown: ['ArrowDown'],
-    newline: ['Enter'],
-  },
-)
+export const textEditorsMultilineBindings = defineKeybinds('text-editors-multiline-bindings', {
+  moveUp: ['ArrowUp'],
+  moveDown: ['ArrowDown'],
+  newline: ['Alt+Enter'],
+})
 
 export const listBindings = defineKeybinds('list', {
   moveUp: ['ArrowUp'],

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
@@ -193,7 +193,7 @@ export const widgetDefinition = defineWidget(
       ref="editorRoot"
       :data-syntax-language="syntaxLanguage"
       @focusin="editing.start()"
-      @keydown.enter.capture="onEnter"
+      @keydown.enter="onEnter"
       @keydown.tab.stop.capture="accepted"
       @keydown.up.stop
       @keydown.down.stop

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -1,8 +1,4 @@
-import {
-  textEditorsBindings,
-  textEditorsStandardCommonBindings,
-  textEditorsStandardMultilineBindings,
-} from '@/bindings'
+import { textEditorsBindings, textEditorsMultilineBindings } from '@/bindings'
 import CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
 import { type VueHost } from '@/components/VueHostRender.vue'
 import { injectKeyboard } from '@/providers/keyboard'
@@ -11,12 +7,13 @@ import {
   contentFocusedExt,
   setContentFocused,
 } from '@/util/codemirror/contentFocusedExt'
+import { baseKeymap, handlerToKeyBinding, verticalMovementKeymap } from '@/util/codemirror/keymap'
 import { useCompartment, useDispatch, useStateEffect } from '@/util/codemirror/reactivity'
 import { setVueHost } from '@/util/codemirror/vueHostExt'
 import { yCollab } from '@/util/codemirror/yCollab'
 import { elementHierarchy } from '@/util/dom'
 import { ToValue } from '@/util/reactivity'
-import { standardKeymap } from '@codemirror/commands'
+import { insertNewlineKeepIndent } from '@codemirror/commands'
 import {
   Compartment,
   EditorState,
@@ -95,7 +92,7 @@ export function useCodeMirror(
   const sync = content ? useYTextOrReadonlySync(content) : undefined
   const extrasCompartment = new Compartment()
   const bindingsCompartment = useCompartment(view, () =>
-    keyBindings({ lineMode: toValue(lineMode) }),
+    keyBindings(view, { lineMode: toValue(lineMode) }),
   )
   const singleLineState = computed(() => {
     const mode = toValue(lineMode)
@@ -318,91 +315,40 @@ function lastEffect<T>(
   }
 }
 
-function handlerToKeyBinding(handler: (event: KeyboardEvent, stopAndPrevent: boolean) => boolean) {
+const stopEvent = (event: Event) => {
+  event.stopImmediatePropagation()
+  return false
+}
+function bindStandardBindings(view: EditorView) {
+  const autoOrMultiHandlers = handlerToKeyBinding(
+    textEditorsMultilineBindings.handler({
+      newline: (e) => {
+        e.stopImmediatePropagation()
+        return insertNewlineKeepIndent(view)
+      },
+    }),
+  )
   return {
-    any: (_view: EditorView, event: KeyboardEvent) => {
-      handler(event, false)
-      // Allow other handlers to override the default behavior.
-      return false
-    },
+    multiline: [autoOrMultiHandlers, ...verticalMovementKeymap(view)] satisfies KeyBinding[],
+    singleline: [],
+    autoline: [autoOrMultiHandlers] satisfies KeyBinding[],
   }
 }
-const stopEvent = (event: Event) => event.stopImmediatePropagation()
-const standardBindings = {
-  common: [
-    handlerToKeyBinding(
-      textEditorsStandardCommonBindings.handler({
-        moveLeft: stopEvent,
-        moveRight: stopEvent,
-        deleteBack: stopEvent,
-        deleteForward: stopEvent,
-      }),
-    ),
-  ] satisfies KeyBinding[],
-  multiline: [
-    handlerToKeyBinding(
-      textEditorsStandardMultilineBindings.handler({
-        moveUp: stopEvent,
-        moveDown: stopEvent,
-        newline: stopEvent,
-      }),
-    ),
-    {
-      // This is handled by `standardKeymap`, but it doesn't `stop` handled events.
-      key: 'Shift-Enter',
-      stopPropagation: true,
-    },
-  ] satisfies KeyBinding[],
-  singleline: [
-    {
-      key: 'Enter',
-      run: (view) => {
-        view.contentDOM.blur()
-        return true
-      },
-      preventDefault: true,
-      stopPropagation: false,
-    },
-    {
-      key: 'Shift-Enter',
-      run: (view) => {
-        view.contentDOM.blur()
-        return true
-      },
-      preventDefault: true,
-      stopPropagation: false,
-    },
-  ] satisfies KeyBinding[],
-  autoline: [
-    {
-      key: 'Enter',
-      run: (view) => {
-        view.contentDOM.blur()
-        return true
-      },
-      preventDefault: true,
-    },
-    {
-      // This is handled by `standardKeymap`, but it doesn't `stop` handled events.
-      key: 'Shift-Enter',
-      stopPropagation: true,
-    },
-  ] satisfies KeyBinding[],
-}
 
-function keyBindings({
-  lineMode,
-}: { lineMode?: 'single' | 'multi' | 'auto' | undefined } = {}): Extension {
+function keyBindings(
+  view: EditorView,
+  { lineMode }: { lineMode?: 'single' | 'multi' | 'auto' | undefined } = {},
+): Extension {
   const mode = lineMode ?? 'multi'
+  const standardBindings = bindStandardBindings(view)
   return [
-    Prec.lowest(keymap.of(standardKeymap)),
+    Prec.lowest(keymap.of(baseKeymap(view))),
     Prec.low(
-      keymap.of([
-        ...standardBindings.common,
-        ...(mode === 'multi' ? standardBindings.multiline
+      keymap.of(
+        mode === 'multi' ? standardBindings.multiline
         : mode === 'auto' ? standardBindings.autoline
-        : standardBindings.singleline),
-      ]),
+        : standardBindings.singleline,
+      ),
     ),
     ...(mode === 'multi' ?
       [

--- a/app/gui/src/project-view/util/codemirror/keymap.ts
+++ b/app/gui/src/project-view/util/codemirror/keymap.ts
@@ -1,0 +1,255 @@
+import { textEditorsCommonBindings } from '@/bindings'
+import * as commands from '@codemirror/commands'
+import { EditorView, type Command, type KeyBinding } from '@codemirror/view'
+import * as objects from 'enso-common/src/utilities/data/object'
+
+/**
+ * Create a {@link KeyBinding} from an event handler compatible with those defined with our
+ * `defineKeybinds` function.
+ */
+export function handlerToKeyBinding(
+  handler: (event: KeyboardEvent, stopAndPrevent: boolean) => boolean,
+  stopAndPrevent: boolean = false,
+) {
+  return {
+    any: (_view: EditorView, event: KeyboardEvent) => handler(event, stopAndPrevent),
+  }
+}
+
+function bindCommands<T extends string>(
+  bindings: Record<T, Command>,
+  view: EditorView,
+): Record<T, () => boolean> {
+  return objects.mapEntries(bindings, (_binding, command) => () => command(view))
+}
+
+/** @returns Key bindings applicable to all CodeMirror instances. */
+export function baseKeymap(view: EditorView): KeyBinding[] {
+  return [
+    handlerToKeyBinding(
+      textEditorsCommonBindings.handler(
+        bindCommands(
+          {
+            moveLeft: commands.cursorCharLeft,
+            moveRight: commands.cursorCharRight,
+            deleteBack: commands.deleteCharBackward,
+            deleteForward: commands.deleteCharForward,
+          },
+          view,
+        ),
+      ),
+      true,
+    ),
+    {
+      key: 'ArrowLeft',
+      shift: commands.selectCharLeft,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      key: 'Mod-ArrowLeft',
+      mac: 'Alt-ArrowLeft',
+      run: commands.cursorGroupLeft,
+      shift: commands.selectGroupLeft,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      mac: 'Cmd-ArrowLeft',
+      run: commands.cursorLineBoundaryLeft,
+      shift: commands.selectLineBoundaryLeft,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'ArrowRight',
+      shift: commands.selectCharRight,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      key: 'Mod-ArrowRight',
+      mac: 'Alt-ArrowRight',
+      run: commands.cursorGroupRight,
+      shift: commands.selectGroupRight,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      mac: 'Cmd-ArrowRight',
+      run: commands.cursorLineBoundaryRight,
+      shift: commands.selectLineBoundaryRight,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+
+    {
+      mac: 'Cmd-ArrowUp',
+      run: commands.cursorDocStart,
+      shift: commands.selectDocStart,
+      stopPropagation: true,
+    },
+
+    {
+      mac: 'Cmd-ArrowDown',
+      run: commands.cursorDocEnd,
+      shift: commands.selectDocEnd,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'Home',
+      run: commands.cursorLineBoundaryBackward,
+      shift: commands.selectLineBoundaryBackward,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      key: 'Mod-Home',
+      run: commands.cursorDocStart,
+      shift: commands.selectDocStart,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'End',
+      run: commands.cursorLineBoundaryForward,
+      shift: commands.selectLineBoundaryForward,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      key: 'Mod-End',
+      run: commands.cursorDocEnd,
+      shift: commands.selectDocEnd,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'Enter',
+      run: (view) => {
+        view.contentDOM.blur()
+        return true
+      },
+      preventDefault: true,
+      stopPropagation: false,
+    },
+
+    { key: 'Mod-a', run: commands.selectAll, stopPropagation: true },
+
+    {
+      key: 'Mod-Backspace',
+      mac: 'Alt-Backspace',
+      run: commands.deleteGroupBackward,
+      stopPropagation: true,
+    },
+    {
+      key: 'Mod-Delete',
+      mac: 'Alt-Delete',
+      run: commands.deleteGroupForward,
+      stopPropagation: true,
+    },
+    { mac: 'Mod-Backspace', run: commands.deleteLineBoundaryBackward, stopPropagation: true },
+    { mac: 'Mod-Delete', run: commands.deleteLineBoundaryForward, stopPropagation: true },
+
+    {
+      key: 'Ctrl-b',
+      run: commands.cursorCharLeft,
+      shift: commands.selectCharLeft,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      key: 'Ctrl-f',
+      run: commands.cursorCharRight,
+      shift: commands.selectCharRight,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'Ctrl-a',
+      run: commands.cursorLineStart,
+      shift: commands.selectLineStart,
+      stopPropagation: true,
+    },
+    {
+      key: 'Ctrl-e',
+      run: commands.cursorLineEnd,
+      shift: commands.selectLineEnd,
+      stopPropagation: true,
+    },
+
+    { key: 'Ctrl-d', run: commands.deleteCharForward, stopPropagation: true },
+    { key: 'Ctrl-h', run: commands.deleteCharBackward, stopPropagation: true },
+    { key: 'Ctrl-k', run: commands.deleteToLineEnd, stopPropagation: true },
+    { key: 'Ctrl-Alt-h', run: commands.deleteGroupBackward, stopPropagation: true },
+
+    { key: 'Ctrl-t', run: commands.transposeChars, stopPropagation: true },
+  ]
+}
+
+/**
+ * @returns Key bindings applicable to any CodeMirror instance that may be rendered as multi-line,
+ * including both actual multi-line text and single-line text with the `lineWrapping` extension
+ * enabled.
+ */
+export function verticalMovementKeymap(_view: EditorView): KeyBinding[] {
+  return [
+    {
+      key: 'ArrowUp',
+      run: commands.cursorLineUp,
+      shift: commands.selectLineUp,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      mac: 'Ctrl-ArrowUp',
+      run: commands.cursorPageUp,
+      shift: commands.selectPageUp,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'ArrowDown',
+      run: commands.cursorLineDown,
+      shift: commands.selectLineDown,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+    {
+      mac: 'Ctrl-ArrowDown',
+      run: commands.cursorPageDown,
+      shift: commands.selectPageDown,
+      stopPropagation: true,
+    },
+    {
+      key: 'PageUp',
+      run: commands.cursorPageUp,
+      shift: commands.selectPageUp,
+      stopPropagation: true,
+    },
+    {
+      key: 'PageDown',
+      run: commands.cursorPageDown,
+      shift: commands.selectPageDown,
+      stopPropagation: true,
+    },
+
+    {
+      key: 'Ctrl-p',
+      run: commands.cursorLineUp,
+      shift: commands.selectLineUp,
+      stopPropagation: true,
+    },
+    {
+      key: 'Ctrl-n',
+      run: commands.cursorLineDown,
+      shift: commands.selectLineDown,
+      stopPropagation: true,
+    },
+
+    { key: 'Ctrl-o', run: commands.splitLine, stopPropagation: true },
+    { key: 'Ctrl-v', run: commands.cursorPageDown, stopPropagation: true },
+  ]
+}


### PR DESCRIPTION
### Pull Request Description

In a text literal, Alt+Enter creates a new line, as in Excel--requested by @jdunkerley. This replaces the `Shift+Enter` binding, which we use for another action in the CB.

### Important Notes

Other changes:
- Start migrating CM "standard" keybindings to our binding system
- Add integration test for inserting newlines in text widget, and accepting with Enter

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
