### PR TITLE
Ensure correct BouncyCastle initialization for NI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3995,8 +3995,16 @@ lazy val `engine-runner` = project
               "io.opencensus",
               "net.snowflake.client",
               "com.sun.jna",
-              "com.tableau.hyperapi"
-            )
+              "com.tableau.hyperapi",
+              // See https://github.com/HarrDevY/native-register-bouncy-castle
+              "org.bouncycastle.jcajce.provider.drbg.DRBG$Default",
+              "org.bouncycastle.jcajce.provider.drbg.DRBG$NonceAndIV"
+            ),
+            initializeAtBuildtime = NativeImage.defaultBuildTimeInitClasses ++
+              Seq(
+                "org.bouncycastle",
+                "org.enso.snowflake.BouncyCastleInitializer"
+              )
           )
       }
       .dependsOn(NativeImage.additionalCp)
@@ -4839,7 +4847,7 @@ lazy val `enso-test-java-helpers` = project
     frgaalJavaCompilerSetting,
     autoScalaLibrary := false,
     Compile / packageBin / artifactPath :=
-      file("test/Base_Tests/polyglot/java/helpers.jar"),
+      file("test/Base_Tests/polyglot/java/base-test-java-helpers.jar"),
     libraryDependencies ++= Seq(
       "org.graalvm.polyglot" % "polyglot" % graalMavenPackagesVersion % "provided"
     ),
@@ -4847,7 +4855,7 @@ lazy val `enso-test-java-helpers` = project
       val result          = (Compile / packageBin).value
       val primaryLocation = (Compile / packageBin / artifactPath).value
       val secondaryLocations = Seq(
-        file("test/Table_Tests/polyglot/java/helpers.jar")
+        file("test/Table_Tests/polyglot/java/base-test-java-helpers.jar")
       )
       secondaryLocations.foreach { target =>
         IO.copyFile(primaryLocation, target)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
@@ -274,7 +274,7 @@ class ReentrantLocking extends Locking {
       if (lockTimestamp != 0) {
         releaseFileLock(file)
         logger.debug(
-          s"Kept file lock [{}] for {1}ms",
+          s"Kept file lock [{}] for {}ms",
           where.getSimpleName,
           System.currentTimeMillis - lockTimestamp
         )

--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -26,7 +26,7 @@ object NativeImage {
     * One wildcard could theoretically be used instead of the list, but to make things
     * more explicit, we use the list.
     */
-  private val defaultBuildTimeInitClasses = Seq(
+  val defaultBuildTimeInitClasses = Seq(
     "org",
     "org.enso",
     "scala",

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
@@ -5,7 +5,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class BouncyCastleInitializer {
   static {
-    System.out.println("TEST KEY GENERATOR IS RUN AT BUILD TIME!");
     Security.addProvider(new BouncyCastleProvider());
   }
 }

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
@@ -1,0 +1,11 @@
+package org.enso.snowflake;
+
+import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+public class BouncyCastleInitializer {
+  static {
+    System.out.println("TEST KEY GENERATOR IS RUN AT BUILD TIME!");
+    Security.addProvider(new BouncyCastleProvider());
+  }
+}

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
@@ -3,7 +3,8 @@ package org.enso.snowflake;
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-public class BouncyCastleInitializer {
+public final class BouncyCastleInitializer {
+  private BouncyCastleInitializer() {}
   static {
     Security.addProvider(new BouncyCastleProvider());
   }

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/BouncyCastleInitializer.java
@@ -5,6 +5,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public final class BouncyCastleInitializer {
   private BouncyCastleInitializer() {}
+
   static {
     Security.addProvider(new BouncyCastleProvider());
   }

--- a/std-bits/snowflake/src/main/resources/META-INF/native-image/org/enso/snowflake/reflect-config.json
+++ b/std-bits/snowflake/src/main/resources/META-INF/native-image/org/enso/snowflake/reflect-config.json
@@ -365,850 +365,472 @@
         ]
     },
     {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.DH$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.DSTU4145$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.Dilithium$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.EXTERNAL$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.ElGamal$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.Falcon$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.GM$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.GOST$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.IES$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.LMS$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.NTRU$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.SPHINCSPlus$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.asymmetric.X509$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Blake2b$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Blake2s$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Blake3$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.DSTU7564$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.GOST3411$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Haraka$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Keccak$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.MD2$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.MD4$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.MD5$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.RIPEMD128$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.RIPEMD160$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.RIPEMD256$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.RIPEMD320$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA1$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA224$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA256$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA3$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA384$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SHA512$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.SM3$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Skein$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Tiger$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.digest.Whirlpool$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.keystore.BC$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.ARC4$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.ARIA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Blowfish$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.CAST5$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.CAST6$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Camellia$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.DES$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.DESede$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.DSTU7624$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.GOST28147$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.GOST3412_2015$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Grain128$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Grainv1$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.HC128$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.HC256$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Noekeon$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Poly1305$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.RC2$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.RC5$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.RC6$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Rijndael$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.SCRYPT$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.SEED$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.SM4$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Salsa20$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Serpent$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Shacal2$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.SipHash$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.SipHash128$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Skipjack$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.TEA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.TLSKDF$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Threefish$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Twofish$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.VMPC$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.VMPCKSA3$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.XSalsa20$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.XTEA$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jcajce.provider.symmetric.Zuc$Mappings",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
-    },
-    {
-        "name": "net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider",
-        "methods": [
-            {
-                "name": "<init>",
-                "parameterTypes": []
-            }
-        ]
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.CompositeSignatures$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.DH$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.DSTU4145$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.Dilithium$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.EXTERNAL$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.ElGamal$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.Falcon$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.GM$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.GOST$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.IES$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.LMS$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.NTRU$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.SPHINCSPlus$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.X509$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyFactorySpi",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Blake2b$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Blake2s$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Blake3$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.DSTU7564$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.GOST3411$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Haraka$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Keccak$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.MD2$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.MD4$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.MD5$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD128$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD160$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD256$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.RIPEMD320$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA1$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA224$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA256$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA3$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA384$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SHA512$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.SM3$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Skein$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Tiger$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.digest.Whirlpool$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.keystore.BC$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.AES$AlgParamGen",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.AES$AlgParams",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.AES$ECB",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.ARC4$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.ARIA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Blowfish$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.CAST5$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.CAST6$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Camellia$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.DES$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.DESede$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.DSTU7624$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.GOST28147$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.GOST3412_2015$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Grain128$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Grainv1$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.HC128$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.HC256$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Noekeon$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$PBKDF2with8BIT",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Poly1305$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.RC2$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.RC5$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.RC6$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Rijndael$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.SCRYPT$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.SEED$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.SM4$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Salsa20$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Serpent$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Shacal2$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.SipHash$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.SipHash128$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Skipjack$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.TEA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.TLSKDF$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Threefish$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Twofish$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.VMPC$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.VMPCKSA3$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.XSalsa20$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.XTEA$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jcajce.provider.symmetric.Zuc$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.jce.provider.BouncyCastleProvider",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.BIKE$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.CMCE$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Dilithium$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Falcon$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Frodo$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.HQC$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Kyber$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.LMS$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.NH$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.NTRU$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.NTRUPrime$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Picnic$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.Rainbow$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.SABER$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.SPHINCS$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.SPHINCSPlus$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.bouncycastle.pqc.jcajce.provider.XMSS$Mappings",
+        "methods":[{"name":"<init>","parameterTypes":[] }]
     },
     {
         "name": "net.snowflake.client.jdbc.internal.snowflake.common.core.ClientAuthnDTO",
@@ -1250,6 +872,9 @@
     {
         "name": "org.enso.snowflake_helpers.TestKeyGenerator",
         "allPublicMethods": true
+    },
+    {
+        "name": "org.enso.snowflake.BouncyCastleInitializer"
     },
     {
         "name": "net.snowflake.client.jdbc.telemetry.TelemetryClient",

--- a/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
+++ b/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
@@ -1061,7 +1061,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.SstDocument"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1075,7 +1078,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1086,7 +1092,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1097,7 +1106,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1108,7 +1120,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1128,7 +1143,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellStyleXfId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1139,7 +1157,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1150,7 +1171,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1161,7 +1185,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STComments$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STComments.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1169,7 +1193,10 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1180,7 +1207,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1202,7 +1232,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationErrorStyle"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationImeMode$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationImeMode.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1210,7 +1240,10 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1221,7 +1254,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1232,7 +1268,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1246,7 +1285,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDxfId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFieldSortType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFieldSortType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1272,7 +1311,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFormula"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1283,7 +1325,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1294,7 +1339,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1308,7 +1356,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STNumFmtId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1319,7 +1370,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOleUpdate$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOleUpdate.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1327,7 +1378,10 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1338,7 +1392,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1349,7 +1406,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1360,7 +1420,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1377,7 +1440,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPatternType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticAlignment$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticAlignment.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1385,7 +1448,7 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1394,6 +1457,9 @@
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPrintError.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPrintError$Enum"
@@ -1433,7 +1499,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSheetViewType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STShowDataAs$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STShowDataAs.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1441,7 +1507,7 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortBy$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortBy.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1449,7 +1515,7 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortMethod$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortMethod.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1457,7 +1523,10 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1471,7 +1540,10 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSqref"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType$Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1482,7 +1554,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType$Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType.Enum",
         "fields": [
             {
                 "name": "table"
@@ -1490,7 +1562,7 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTargetScreenSize$Enum"
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTargetScreenSize.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTextRotation$Member2"

--- a/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
+++ b/std-bits/table/src/main/resources/META-INF/native-image/org/enso/table/reflect-config.json
@@ -1061,15 +1061,15 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.SstDocument"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STAxis"
@@ -1078,57 +1078,57 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STBorderStyle"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellComments"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellFormulaType"
@@ -1143,49 +1143,49 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellStyleXfId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STCfvoType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STComments.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STComments$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1193,29 +1193,32 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator$Enum"
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STComments.Enum"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STConditionalFormattingOperator"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataConsolidateFunction"
@@ -1232,7 +1235,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationErrorStyle"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationImeMode.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationImeMode$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1240,43 +1243,46 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator$Enum"
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationImeMode.Enum"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationOperator"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDataValidationType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDvAspect"
@@ -1285,12 +1291,15 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STDxfId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFieldSortType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFieldSortType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFieldSortType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFillId"
@@ -1311,43 +1320,43 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STFormula"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STHorizontalAlignment"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STIconSetType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STItemType"
@@ -1356,21 +1365,21 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STNumFmtId"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STObjects"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOleUpdate.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOleUpdate$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1378,57 +1387,60 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation$Enum"
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOleUpdate.Enum"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STOrientation"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPageOrder"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPane"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPaneState"
@@ -1440,7 +1452,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPatternType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticAlignment.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticAlignment$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1448,12 +1460,18 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticAlignment.Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STPhoneticType"
@@ -1499,7 +1517,7 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSheetViewType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STShowDataAs.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STShowDataAs$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1507,7 +1525,21 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortBy.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STShowDataAs.Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortBy$Enum",
+        "fields": [
+            {
+                "name": "table"
+            }
+        ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortBy.Enum"
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortMethod$Enum",
         "fields": [
             {
                 "name": "table"
@@ -1523,15 +1555,15 @@
         ]
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSourceType"
@@ -1540,26 +1572,29 @@
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STSqref"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType$Enum"
-    },
-    {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableStyleType"
     },
     {
-        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType.Enum",
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType$Enum",
         "fields": [
             {
                 "name": "table"
             }
         ]
+    },
+    {
+        "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType.Enum"
     },
     {
         "name": "org.openxmlformats.schemas.spreadsheetml.x2006.main.STTargetScreenSize.Enum"

--- a/test/Snowflake_Tests/polyglot-sources/snowflake-test-java-helpers/src/main/java/org/enso/snowflake_helpers/TestKeyGenerator.java
+++ b/test/Snowflake_Tests/polyglot-sources/snowflake-test-java-helpers/src/main/java/org/enso/snowflake_helpers/TestKeyGenerator.java
@@ -19,6 +19,13 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.OutputEncryptor;
 
 public class TestKeyGenerator {
+
+  static {
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+  }
+
   public static void generateKeyPairForTest(
       String privateKeyPath, String publicKeyPath, String passphrase)
       throws NoSuchAlgorithmException, IOException, OperatorCreationException {
@@ -59,7 +66,6 @@ public class TestKeyGenerator {
 
   private static void savePrivateKeyEncrypted(PrivateKey key, File destination, String passphrase)
       throws IOException, OperatorCreationException {
-    Security.addProvider(new BouncyCastleProvider());
     var encryptorBuilder = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.AES_256_CBC);
     encryptorBuilder.setPassword(passphrase.toCharArray().clone());
     OutputEncryptor encryptor = encryptorBuilder.build();


### PR DESCRIPTION
### Pull Request Description

BouncyCastle hardly works out-of-the-box in NI. Instead one has to make sure that it is initialized at build time, with an exception of some classes that need to be done during runtime.
This change fixes key generation issues in `Auth_Spec`.

Cleaned up warnings related to wrong entries in nested enums:
```
...
[info] Warning: Could not register complete reflection metadata for org.openxmlformats.schemas.spreadsheetml.x2006.main.STSortMethod$Enum. Reason(s): java.lang.NoClassDefFoundError: org/openxmlformats/schemas/spreadsheetml/x2006/main/STSortMethod.
[info] Warning: Could not register complete reflection metadata for org.openxmlformats.schemas.spreadsheetml.x2006.main.STTableType$Enum. Reason(s): java.lang.NoClassDefFoundError: org/openxmlformats/schemas/spreadsheetml/x2006/main/STTableType.
...
```

Follow up  to #12804.  Closes #12813. 

### Important Notes

Snowflake's and other tests appear to be fixed.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
