### PR TITLE
TelemetryAppender is not stopped on first encountered failure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1144,7 +1144,7 @@ lazy val `logging-service-telemetry` = project
   .enablePlugins(JPMSPlugin)
   .configs(Test)
   .settings(
-    customFrgaalJavaCompilerSettings("21"),
+    frgaalJavaCompilerSetting,
     scalaModuleDependencySetting,
     mixedJavaScalaProjectSetting,
     version := "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1144,7 +1144,7 @@ lazy val `logging-service-telemetry` = project
   .enablePlugins(JPMSPlugin)
   .configs(Test)
   .settings(
-    frgaalJavaCompilerSetting,
+    customFrgaalJavaCompilerSettings("21"),
     scalaModuleDependencySetting,
     mixedJavaScalaProjectSetting,
     version := "0.1",

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/LogJobsProcessor.java
@@ -41,13 +41,6 @@ public final class LogJobsProcessor {
   private AuthenticationData authenticationData;
   private HttpClient httpClient;
 
-  /**
-   * Set to true once an error is encountered when sending a request. In such case, it is most
-   * probably that no further requests will be successful. This flag is used to terminate the
-   * background thread.
-   */
-  private boolean requestSendingFailure;
-
   public LogJobsProcessor(
       ThreadPoolExecutor executor,
       URI endpoint,
@@ -56,7 +49,7 @@ public final class LogJobsProcessor {
     this.backgroundThreadService = Objects.requireNonNull(executor);
     this.endpoint = Objects.requireNonNull(endpoint);
     this.authenticationData = Objects.requireNonNull(authenticationData);
-    this.tokenRefresher = tokenRefresher;
+    this.tokenRefresher = Objects.requireNonNull(tokenRefresher);
   }
 
   /*
@@ -76,9 +69,7 @@ public final class LogJobsProcessor {
       // It is possible that a job was already running, but adding a new one will not hurt - once
       // the queue is empty, the currently running job will finish and any additional jobs will also
       // terminate immediately.
-      if (!requestSendingFailure) {
-        backgroundThreadService.execute(this::logThreadEntryPoint);
-      }
+      backgroundThreadService.execute(this::logThreadEntryPoint);
     }
   }
 
@@ -93,13 +84,22 @@ public final class LogJobsProcessor {
         // `logQueue.enqueue` will return 1, thus ensuring that at least one new job is scheduled.
         return;
       }
-      try {
-        sendBatch(pendingMessages);
-      } catch (RequestFailureException e) {
-        LOGGER.warn("Stopping the Telemetry appender - requests cannot be send", e);
-        requestSendingFailure = true;
-        return;
+
+      if (accessTokenNeedsRefresh()) {
+        LOGGER.debug("Refreshing access token");
+        var refreshedAuthData = fetchNewAccessToken();
+        if (refreshedAuthData != null) {
+          authenticationData = refreshedAuthData;
+          LOGGER.trace(
+              "Token refreshed successfully. New expiration: {}", authenticationData.expireAt());
+        } else {
+          notifyJobsAboutFailure(
+              pendingMessages, new RequestFailureException("Failed to refresh token", null));
+          return;
+        }
       }
+      assert authenticationData != null;
+      sendBatch(pendingMessages);
     }
   }
 
@@ -108,22 +108,9 @@ public final class LogJobsProcessor {
    *
    * <p>The batch must not be empty and all messages must share the same request config.
    */
-  private void sendBatch(List<LogJob> batch) throws RequestFailureException {
+  private void sendBatch(List<LogJob> batch) {
     assert !batch.isEmpty() : "The batch must not be empty.";
-
-    if (accessTokenNeedsRefresh()) {
-      LOGGER.debug("Refreshing access token");
-      var refreshedAuthData = tokenRefresher.fetchNewAccessToken();
-      if (refreshedAuthData != null) {
-        authenticationData = refreshedAuthData;
-        LOGGER.trace(
-            "Token refreshed successfully. New expiration: {}", authenticationData.expireAt());
-      } else {
-        throw new RequestFailureException("Failed to refresh token", null);
-      }
-    }
     assert authenticationData != null;
-
     try {
       var request = buildRequest(batch);
       if (request == null) {
@@ -218,6 +205,18 @@ public final class LogJobsProcessor {
         sendLogRequest(request, retryCount - 1);
       }
     }
+  }
+
+  private AuthenticationData fetchNewAccessToken() {
+    for (int i = 0; i < MAX_RETRIES; i++) {
+      var refreshedAuthData = tokenRefresher.fetchNewAccessToken();
+      if (refreshedAuthData != null) {
+        return refreshedAuthData;
+      } else {
+        LOGGER.warn("Failed to refresh token. Retrying... (attempt {}/{})", i + 1, MAX_RETRIES);
+      }
+    }
+    return null;
   }
 
   private boolean accessTokenNeedsRefresh() {

--- a/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
+++ b/lib/java/logging-service-telemetry/src/main/java/org/enso/logging/service/telemetry/TokenRefresher.java
@@ -23,7 +23,7 @@ public final class TokenRefresher {
 
   /**
    * The amount of time before the token expiration that we pro-actively refresh it to reduce the
-   * cahnce of it expiring during a request.
+   * chance of it expiring during a request.
    */
   private static final Duration TOKEN_EARLY_REFRESH_PERIOD = Duration.ofMinutes(2);
 

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/ConsumeLogs.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/ConsumeLogs.java
@@ -1,0 +1,79 @@
+package org.enso.logging.service.telemetry.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A custom jUnit {@link TestRule} that captures all the logs and prints them only if there is a
+ * test failure.
+ */
+public final class ConsumeLogs implements TestRule {
+  private static final Level LOG_LEVEL = Level.TRACE;
+  private final MemoryAppender appender = new MemoryAppender();
+
+  public ConsumeLogs() {
+    var context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    appender.setContext(context);
+    appender.setName("MemoryAppender");
+    var rootLogger = context.getLogger(Logger.ROOT_LOGGER_NAME);
+    rootLogger.detachAndStopAllAppenders();
+    rootLogger.addAppender(appender);
+    rootLogger.setLevel(LOG_LEVEL);
+    appender.start();
+  }
+
+  @Override
+  public Statement apply(Statement statement, Description description) {
+    return new CustomStatement(statement, description);
+  }
+
+  private final class CustomStatement extends Statement {
+    private final Statement base;
+    private final Description description;
+
+    private CustomStatement(Statement base, Description description) {
+      this.base = base;
+      this.description = description;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+      try {
+        base.evaluate();
+      } catch (Throwable e) {
+        System.err.println(
+            "Test "
+                + description.getDisplayName()
+                + " failed with "
+                + e.getClass().getName()
+                + ". Captured output from the logs:");
+        for (var event : appender.getEvents()) {
+          System.err.println("  " + event.getFormattedMessage());
+        }
+        throw e;
+      }
+    }
+  }
+
+  private static final class MemoryAppender extends AppenderBase<ILoggingEvent> {
+    private final List<ILoggingEvent> events = new ArrayList<>();
+
+    public List<ILoggingEvent> getEvents() {
+      return events;
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+      events.add(eventObject);
+    }
+  }
+}

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -29,7 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestTelemetry {
-  @Rule public RetryTestRule retry = new RetryTestRule(3);
+  @Rule public final ConsumeLogs consumeLogs = new ConsumeLogs();
+  @Rule public final RetryTestRule retry = new RetryTestRule(3);
 
   private static final int port = 8083;
   private static final URI logUri = Utils.logUri(port);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetry.java
@@ -6,16 +6,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -26,9 +21,7 @@ import org.enso.logging.service.telemetry.LogJob;
 import org.enso.logging.service.telemetry.LogJobsProcessor;
 import org.enso.logging.service.telemetry.LogMessage;
 import org.enso.logging.service.telemetry.TokenRefresher;
-import org.enso.shttp.HTTPTestHelperServer;
 import org.enso.shttp.HybridHTTPServer;
-import org.enso.shttp.cloud_mock.CloudMockSetup;
 import org.enso.testkit.RetryTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -39,28 +32,22 @@ public class TestTelemetry {
   @Rule public RetryTestRule retry = new RetryTestRule(3);
 
   private static final int port = 8083;
-  private static final URI baseUri = URI.create("http://localhost:" + port + "/enso-cloud-mock");
-  private static final URI logUri = URI.create(baseUri + "/logs");
-  private static final URI refreshUri =
-      URI.create("http://localhost:" + port + "/enso-cloud-auth-renew");
+  private static final URI logUri = Utils.logUri(port);
+  private static final URI refreshUri = Utils.refreshUri(port);
   private static final long APPENDER_KEEP_ALIVE = 20;
-  private static final Credentials credentials = mockCredentials();
+  private static final Credentials credentials = Utils.mockCredentials(port);
 
   private HybridHTTPServer server;
-  private ExecutorService serverExecutor;
   private ThreadPoolExecutor logProcessorExecutor;
   private LogJobsProcessor logJobsProcessor;
   private TokenRefresher tokenRefresher;
 
   @Before
-  public void initServer() throws URISyntaxException, IOException {
-    serverExecutor = Executors.newSingleThreadExecutor();
+  public void initServer() {
     logProcessorExecutor =
         new ThreadPoolExecutor(
             0, 1, APPENDER_KEEP_ALIVE, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-    var cloudMockSetup = new CloudMockSetup(false);
-    server =
-        HTTPTestHelperServer.createServer("localhost", port, serverExecutor, false, cloudMockSetup);
+    server = Utils.createMockServer(port);
     tokenRefresher =
         new TokenRefresher(refreshUri, credentials.clientId(), credentials.refreshToken());
     var authData = AuthenticationData.fromCredentials(credentials);
@@ -73,9 +60,6 @@ public class TestTelemetry {
     if (server != null) {
       server.stop();
     }
-    if (serverExecutor != null) {
-      serverExecutor.shutdown();
-    }
     if (logProcessorExecutor != null) {
       logProcessorExecutor.shutdown();
     }
@@ -87,7 +71,7 @@ public class TestTelemetry {
     var notification = new CompletableFuture<Void>();
     var job = new LogJob(message, notification);
     logJobsProcessor.enqueueMessage(job);
-    assertCompletedSuccessfully(job);
+    Utils.assertCompletedSuccessfully(job);
     var receivedLogs = server.getLogs();
     assertThat(receivedLogs.size(), is(1));
     var receivedLog = receivedLogs.get(0);
@@ -126,7 +110,7 @@ public class TestTelemetry {
                 })
             .toList();
     logJobs.forEach(logJobsProcessor::enqueueMessage);
-    assertCompletedSuccessfully(logJobs);
+    Utils.assertCompletedSuccessfully(logJobs);
     var logs = server.getLogs();
     for (int i = 0; i < logs.size(); i++) {
       var log = logs.get(i);
@@ -180,41 +164,16 @@ public class TestTelemetry {
     var message1 = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
     var job1 = new LogJob(message1, new CompletableFuture<>());
     logJobsProcessor.enqueueMessage(job1);
-    assertCompletedSuccessfully(job1);
+    Utils.assertCompletedSuccessfully(job1);
 
     var job2 =
         new LogJob(
             new LogMessage("TestLogger", "msg2: name={}", new Object[] {"Pavel"}),
             new CompletableFuture<>());
     logJobsProcessor.enqueueMessage(job2);
-    assertCompletedSuccessfully(job2);
+    Utils.assertCompletedSuccessfully(job2);
 
     assertThat("Token was refreshed just once", server.getRefreshedTokensCount(), is(1));
-  }
-
-  private static void assertCompletedSuccessfully(List<LogJob> jobs) {
-    for (LogJob logJob : jobs) {
-      try {
-        logJob.completionNofitication().get();
-      } catch (InterruptedException e) {
-        throw new AssertionError("Should not be interrupted", e);
-      } catch (ExecutionException e) {
-        throw new AssertionError("Should not fail", e);
-      }
-    }
-  }
-
-  private static void assertCompletedSuccessfully(LogJob job) {
-    assertCompletedSuccessfully(List.of(job));
-  }
-
-  private static Credentials mockCredentials() {
-    var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
-    var refreshUrl = refreshUri.toString();
-    var accessToken = "TEST-ENSO-TOKEN-caffee";
-    var refreshToken = "TEST-ENSO-REFRESH-caffee";
-    var clientId = "TEST-ENSO-CLIENT-ID";
-    return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
   }
 
   private static Credentials invalidCredentials() {

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
@@ -1,0 +1,115 @@
+package org.enso.logging.service.telemetry.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpHandlers;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.enso.logging.service.telemetry.AuthenticationData;
+import org.enso.logging.service.telemetry.LogJob;
+import org.enso.logging.service.telemetry.LogJobsProcessor;
+import org.enso.logging.service.telemetry.LogMessage;
+import org.enso.logging.service.telemetry.TokenRefresher;
+import org.enso.testkit.RetryTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestTelemetryBrokenServer {
+  @Rule public RetryTestRule retry = new RetryTestRule(3);
+  private static final int port = 8098;
+  private static final long APPENDER_KEEP_ALIVE = 20;
+  private ThreadPoolExecutor logProcessorExecutor;
+  private LogJobsProcessor logJobsProcessor;
+  private TokenRefresher tokenRefresher;
+
+  @Before
+  public void before() {
+    logProcessorExecutor =
+        new ThreadPoolExecutor(
+            0, 1, APPENDER_KEEP_ALIVE, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    var credentials = Utils.mockCredentials(port);
+    tokenRefresher =
+        new TokenRefresher(
+            Utils.refreshUri(port), credentials.clientId(), credentials.refreshToken());
+    var authData = AuthenticationData.fromCredentials(credentials);
+    logJobsProcessor =
+        new LogJobsProcessor(logProcessorExecutor, Utils.logUri(port), authData, tokenRefresher);
+  }
+
+  @After
+  public void after() {
+    if (logProcessorExecutor != null) {
+      logProcessorExecutor.shutdown();
+    }
+  }
+
+  @Test
+  public void continueSendingAfterFirstFailure() throws InterruptedException {
+    var brokenServer = new BrokenServer();
+    brokenServer.start();
+
+    var message1 = new LogMessage("TestLogger", "msg: name={}", new Object[] {"Pavel"});
+    var notification1 = new CompletableFuture<Void>();
+    logJobsProcessor.enqueueMessage(new LogJob(message1, notification1));
+    try {
+      notification1.get();
+      fail("First message should fail");
+    } catch (ExecutionException e) {
+      // nop - expected
+    } catch (InterruptedException e) {
+      throw new AssertionError("Should not reach here", e);
+    }
+
+    brokenServer.stop();
+    // Give the broken server some time to properly shutdown
+    Thread.sleep(30);
+    var server = Utils.createMockServer(port);
+    server.start();
+
+    var message2 = new LogMessage("TestLogger", "msg2: name={}", new Object[] {"Pavel"});
+    var job2 = new LogJob(message2, new CompletableFuture<>());
+    logJobsProcessor.enqueueMessage(job2);
+    Utils.assertCompletedSuccessfully(job2);
+
+    var logs = server.getLogs();
+    assertThat(logs.size(), is(1));
+
+    server.stop();
+  }
+
+  private static final class BrokenServer {
+    private final HttpServer server;
+
+    private BrokenServer() {
+      var address = new InetSocketAddress("localhost", port);
+      try {
+        server = HttpServer.create(address, 0);
+      } catch (IOException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    void start() {
+      var handler =
+          HttpHandlers.of(
+              500, Headers.of("Content-Type", "application/text"), "Internal server error");
+      server.createContext("/", handler);
+      server.start();
+    }
+
+    void stop() {
+      server.stop(0);
+    }
+  }
+}

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
@@ -4,8 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
-import com.sun.net.httpserver.Headers;
-import com.sun.net.httpserver.HttpHandlers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -106,8 +106,15 @@ public class TestTelemetryBrokenServer {
 
     void start() {
       var handler =
-          HttpHandlers.of(
-              500, Headers.of("Content-Type", "application/text"), "Internal server error");
+          new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+              var bodyBytes = "Internal server error".getBytes();
+              exchange.getResponseHeaders().add("Content-Type", "application/text");
+              exchange.getResponseBody().write(bodyBytes);
+              exchange.sendResponseHeaders(500, bodyBytes.length);
+            }
+          };
       server.createContext("/", handler);
       server.start();
     }

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTelemetryBrokenServer.java
@@ -26,7 +26,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestTelemetryBrokenServer {
-  @Rule public RetryTestRule retry = new RetryTestRule(3);
+  @Rule public final ConsumeLogs consumeLogs = new ConsumeLogs();
+  @Rule public final RetryTestRule retry = new RetryTestRule(3);
+
   private static final int port = 8098;
   private static final long APPENDER_KEEP_ALIVE = 20;
   private ThreadPoolExecutor logProcessorExecutor;
@@ -72,6 +74,8 @@ public class TestTelemetryBrokenServer {
     }
 
     brokenServer.stop();
+    brokenServer = null;
+
     // Give the broken server some time to properly shutdown
     Thread.sleep(30);
     var server = Utils.createMockServer(port);

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/TestTokenRefresh.java
@@ -21,7 +21,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestTokenRefresh {
-  @Rule public RetryTestRule retry = new RetryTestRule(3);
+  @Rule public final ConsumeLogs consumeLogs = new ConsumeLogs();
+  @Rule public final RetryTestRule retry = new RetryTestRule(3);
 
   private static final int port = 8085;
   private static final URI refreshUri =

--- a/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/Utils.java
+++ b/lib/java/logging-service-telemetry/src/test/java/org/enso/logging/service/telemetry/test/Utils.java
@@ -1,0 +1,74 @@
+package org.enso.logging.service.telemetry.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import org.enso.logging.service.telemetry.Credentials;
+import org.enso.logging.service.telemetry.LogJob;
+import org.enso.shttp.HTTPTestHelperServer;
+import org.enso.shttp.HybridHTTPServer;
+import org.enso.shttp.cloud_mock.CloudMockSetup;
+
+final class Utils {
+  private Utils() {}
+
+  static URI logUri(int port) {
+    try {
+      return new URI("http://localhost:" + port + "/enso-cloud-mock/logs");
+    } catch (URISyntaxException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static URI refreshUri(int port) {
+    try {
+      return new URI("http://localhost:" + port + "/enso-cloud-auth-renew");
+    } catch (URISyntaxException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static HybridHTTPServer createMockServer(int port) {
+    var serverExecutor = Executors.newSingleThreadExecutor();
+    var cloudMockSetup = new CloudMockSetup(false);
+    HybridHTTPServer server = null;
+    try {
+      server =
+          HTTPTestHelperServer.createServer(
+              "localhost", port, serverExecutor, false, cloudMockSetup);
+    } catch (URISyntaxException | IOException e) {
+      throw new AssertionError(e);
+    }
+    return server;
+  }
+
+  static Credentials mockCredentials(int port) {
+    var expireAt = ZonedDateTime.now().plusYears(1).format(DateTimeFormatter.ISO_INSTANT);
+    var refreshUrl = refreshUri(port).toString();
+    var accessToken = "TEST-ENSO-TOKEN-caffee";
+    var refreshToken = "TEST-ENSO-REFRESH-caffee";
+    var clientId = "TEST-ENSO-CLIENT-ID";
+    return new Credentials(clientId, accessToken, refreshToken, refreshUrl, expireAt);
+  }
+
+  static void assertCompletedSuccessfully(List<LogJob> jobs) {
+    for (LogJob logJob : jobs) {
+      try {
+        logJob.completionNofitication().get();
+      } catch (InterruptedException e) {
+        throw new AssertionError("Should not be interrupted", e);
+      } catch (ExecutionException e) {
+        throw new AssertionError("Should not fail", e);
+      }
+    }
+  }
+
+  static void assertCompletedSuccessfully(LogJob job) {
+    assertCompletedSuccessfully(List.of(job));
+  }
+}


### PR DESCRIPTION
Closes #12561

### Pull Request Description

TelemetryAppender is not stopped on first encountered failure.

### Important Notes

Failure to send a batch of log messages may occur:
- When `MAX_RETRIES` attempts to refresh an access token fails - cloud returns unexpected response.
- When `MAX_RETRIES` attempts to send the batch fails - cloud returns unexpected response.

In those cases, the batch is just dropped, and a warning is logged. The service continues to run and tries to send another batch.

Optimally, retries should be sent with a binary back off. I have not implemented the binary back off yet to keep this PR simple.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
