### PR TITLE
Project-manager-shim creates directory when recovering project metadata

### DIFF
--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -351,7 +351,8 @@ export default function projectManagerShimMiddleware(
                                 created: new Date().toISOString(),
                                 lastOpened: null,
                               }
-                              fs.writeFile(projectMetadataPath, JSON.stringify(projectMetadataJson))
+                              await fs.mkdir(path.dirname(projectMetadataPath), { recursive: true })
+                              await fs.writeFile(projectMetadataPath, JSON.stringify(projectMetadataJson))
                             } else {
                               throw e
                             }

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -352,7 +352,10 @@ export default function projectManagerShimMiddleware(
                                 lastOpened: null,
                               }
                               await fs.mkdir(path.dirname(projectMetadataPath), { recursive: true })
-                              await fs.writeFile(projectMetadataPath, JSON.stringify(projectMetadataJson))
+                              await fs.writeFile(
+                                projectMetadataPath,
+                                JSON.stringify(projectMetadataJson),
+                              )
                             } else {
                               throw e
                             }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Fixes the issue when the project-manager-shim tried to write `.enso/project.json` metadata when `.enso` directory does not exist.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
