### PR TITLE
Fix table viz stuck loading 

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -97,7 +97,7 @@ export function useVisualizationData({
 
   const executeExpression = async (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-    timeoutMs = 5000, // optional timeout parameter
+    timeoutMs = 5000,
   ) => {
     const dataSourceValue = toValue(dataSource)
     if (dataSourceValue?.type !== 'node') return

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -16,6 +16,7 @@ import { Ast } from '@/util/ast'
 import { toError } from '@/util/data/error'
 import type { ToValue } from '@/util/reactivity'
 import { computedAsync } from '@vueuse/core'
+import { wait } from 'lib0/promise.js'
 import {
   computed,
   onErrorCaptured,
@@ -28,7 +29,7 @@ import {
 } from 'vue'
 import { isIdentifier } from 'ydoc-shared/ast'
 import type { Opt } from 'ydoc-shared/util/data/opt'
-import type { Result } from 'ydoc-shared/util/data/result'
+import { Err, type Result } from 'ydoc-shared/util/data/result'
 import type { VisualizationIdentifier } from 'ydoc-shared/yjsModel'
 
 /** Used for testing. */
@@ -112,26 +113,14 @@ export function useVisualizationData({
       graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
     if (contextId === undefined) return
 
-    try {
-      const expression = expressionFunction(identifier)
+    const expression = expressionFunction(identifier)
 
-      const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(
-          () => reject(new Error(`executeExpression timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        ),
-      )
+    const result = await Promise.race([
+      projectStore.executeExpression(contextId, expression.code()),
+      wait(timeoutMs).then(() => Err('Expression timeout')),
+    ])
 
-      const result = await Promise.race([
-        projectStore.executeExpression(contextId, expression.code()),
-        timeoutPromise,
-      ])
-
-      return result
-    } catch (e) {
-      console.error(e)
-      throw e
-    }
+    return result
   }
 
   const currentType = computed(() => {

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -97,20 +97,37 @@ export function useVisualizationData({
 
   const executeExpression = async (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
+    timeoutMs = 5000, // optional timeout parameter
   ) => {
     const dataSourceValue = toValue(dataSource)
     if (dataSourceValue?.type !== 'node') return
+
     const graphDb = graph.db
     const nodeFirstOurputPort = graphDb.getNodeFirstOutputPort(dataSourceValue.nodeId as NodeId)
     const identifier = graphDb.getOutputPortIdentifier(nodeFirstOurputPort)
     if (identifier === undefined) return
+
     const contextId =
       dataSourceValue.nodeId &&
       graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
     if (contextId === undefined) return
+
     try {
       const expression = expressionFunction(identifier)
-      return projectStore.executeExpression(contextId, expression.code())
+
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`executeExpression timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        ),
+      )
+
+      const result = await Promise.race([
+        projectStore.executeExpression(contextId, expression.code()),
+        timeoutPromise,
+      ])
+
+      return result
     } catch (e) {
       console.error(e)
       throw e

--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -151,7 +151,11 @@ function onGridReady(event: GridReadyEvent<TData>) {
 const rowModelType = computed(() => (props.isServerSideModel ? 'serverSide' : 'clientSide'))
 
 const gridKeyIncrement = ref(0)
-const gridKey = computed(() => props.gridIdHash ? `${props.gridIdHash}-${gridKeyIncrement.value}` : `grid-${gridKeyIncrement.value}`)
+const gridKey = computed(() =>
+  props.gridIdHash ?
+    `${props.gridIdHash}-${gridKeyIncrement.value}`
+  : `grid-${gridKeyIncrement.value}`,
+)
 
 const forceGridRefresh = () => {
   //when using the ag grid severSide model this forces the grid to 'refresh' and call getRows

--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -142,9 +142,6 @@ useAutoBlur(() => grid.value?.$el)
 
 function onGridReady(event: GridReadyEvent<TData>) {
   gridApi.value = event.api
-  if (rowModelType.value === 'serverSide') {
-    gridApi.value.retryServerSideLoads()
-  }
 }
 
 const rowModelType = computed(() => (props.isServerSideModel ? 'serverSide' : 'clientSide'))

--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -123,7 +123,7 @@ const props = defineProps<{
   datasource?: IServerSideDatasource | boolean
   rowCount?: number
   isServerSideModel?: boolean
-  gridIdHash: string | null
+  gridIdHash?: string | null
 }>()
 const emit = defineEmits<{
   cellEditingStarted: [event: CellEditingStartedEvent]

--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -123,6 +123,7 @@ const props = defineProps<{
   datasource?: IServerSideDatasource | boolean
   rowCount?: number
   isServerSideModel?: boolean
+  gridIdHash: string | null
 }>()
 const emit = defineEmits<{
   cellEditingStarted: [event: CellEditingStartedEvent]
@@ -142,15 +143,19 @@ useAutoBlur(() => grid.value?.$el)
 
 function onGridReady(event: GridReadyEvent<TData>) {
   gridApi.value = event.api
+  if (rowModelType.value === 'serverSide') {
+    gridApi.value.retryServerSideLoads()
+  }
 }
 
 const rowModelType = computed(() => (props.isServerSideModel ? 'serverSide' : 'clientSide'))
 
-const gridKey = ref(0)
+const gridKeyIncrement = ref(0)
+const gridKey = computed(() => props.gridIdHash ? `${props.gridIdHash}-${gridKeyIncrement.value}` : `grid-${gridKeyIncrement.value}`)
 
 const forceGridRefresh = () => {
   //when using the ag grid severSide model this forces the grid to 'refresh' and call getRows
-  gridKey.value++
+  gridKeyIncrement.value++
 }
 
 watch(

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -390,13 +390,19 @@ function createServer() {
   }
 }
 
+interface Response {
+  data: unknown[][]
+  success: boolean
+  rowCount: number
+}
 function createServerSideDatasource(): IServerSideDatasource {
   return {
     getRows: async (params) => {
       const server = ssrmServer.value
       if (server) {
-        const response = await server.getData(params.request)
-        if (response && response.success) {
+        const serverResponse = await server.getData(params.request)
+        const response: Response = serverResponse ? serverResponse : {data: [], success: false, rowCount: 0}
+        if (response.success) {
           const rows = createRowsForTable(response.data, 0, true)
           params.success({ rowData: rows, rowCount: response.rowCount })
         } else {

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -321,6 +321,8 @@ async function getFilterValues(params: SetFilterValuesFuncParams) {
   }
 }
 
+const attepmtedCalls = ref(0)
+
 function createServer() {
   return {
     getSetFilterValues: async (columnIndex?: number) => {
@@ -364,9 +366,10 @@ function createServer() {
           valueList as string[] | 'Nothing',
         )
 
-        const response = await config.executeExpression(expressionFunction, 5000) // 5s timeout
+        const response = await config.executeExpression(expressionFunction) // 5s timeout
 
         if (response.ok) {
+          attepmtedCalls.value = 0
           return {
             success: true,
             data: response.value.rows,
@@ -376,6 +379,10 @@ function createServer() {
           throw new Error('Expression execution failed')
         }
       } catch (err) {
+        if (attepmtedCalls.value < 3) {
+          grid.value?.gridApi?.refreshServerSide({ purge: true })
+          attepmtedCalls.value++
+        }
         console.error('Error loading rows:', err)
         return {
           success: false,
@@ -1039,6 +1046,7 @@ config.setToolbar(
         :rowCount="allRowCount"
         :isServerSideModel="isSSRM"
         :statusBar="statusBar"
+        :gridIdHash="tableVersionHash"
         @sortOrFilterUpdated="(e) => checkSortAndFilter(e)"
       />
     </Suspense>

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -338,52 +338,48 @@ function createServer() {
       }
     },
     getData: async (request: IServerSideGetRowsRequest) => {
-      try {
-        const columnHeaders =
-          typeof props.data === 'object' && 'header' in props.data ? (props.data.header ?? []) : []
+      const columnHeaders =
+        typeof props.data === 'object' && 'header' in props.data ? (props.data.header ?? []) : []
 
-        const { sortColIndexes, sortDirections } = convertSortModel(request, columnHeaders)
-        const { filterColumnIndexList, filterActions, valueList } = convertFilterModel(
-          request,
-          columnHeaders,
-          colTypeMap.value,
-        )
+      const { sortColIndexes, sortDirections } = convertSortModel(request, columnHeaders)
+      const { filterColumnIndexList, filterActions, valueList } = convertFilterModel(
+        request,
+        columnHeaders,
+        colTypeMap.value,
+      )
 
-        const expressionFunction = createExpressionRowTemplate(
-          'Standard.Visualization.Table.Visualization',
-          'get_rows_for_table',
-          //the index of the next bucket of rows to get
-          `${request.startRow}`,
-          //column indexes that require a sort
-          sortColIndexes as string[] | 'Nothing',
-          //direction (Ascending/Descending) for the sorts
-          sortDirections as string[] | 'Nothing',
-          //column indexes that require a filter
-          filterColumnIndexList as string[] | 'Nothing',
-          //column actions i.e Greater Than, Between...
-          filterActions as string[] | 'Nothing',
-          //values to filter on
-          valueList as string[] | 'Nothing',
-        )
+      const expressionFunction = createExpressionRowTemplate(
+        'Standard.Visualization.Table.Visualization',
+        'get_rows_for_table',
+        //the index of the next bucket of rows to get
+        `${request.startRow}`,
+        //column indexes that require a sort
+        sortColIndexes as string[] | 'Nothing',
+        //direction (Ascending/Descending) for the sorts
+        sortDirections as string[] | 'Nothing',
+        //column indexes that require a filter
+        filterColumnIndexList as string[] | 'Nothing',
+        //column actions i.e Greater Than, Between...
+        filterActions as string[] | 'Nothing',
+        //values to filter on
+        valueList as string[] | 'Nothing',
+      )
 
-        const response = await config.executeExpression(expressionFunction) // 5s timeout
+      const response = await config.executeExpression(expressionFunction)
 
-        if (response.ok) {
-          attepmtedCalls.value = 0
-          return {
-            success: true,
-            data: response.value.rows,
-            rowCount: response.value.row_count,
-          }
-        } else {
-          throw new Error('Expression execution failed')
+      if (response.ok) {
+        return {
+          success: true,
+          data: response.value.rows,
+          rowCount: response.value.row_count,
         }
-      } catch (err) {
+      } else {
         if (attepmtedCalls.value < 3) {
           grid.value?.gridApi?.refreshServerSide({ purge: true })
           attepmtedCalls.value++
+          return
         }
-        console.error('Error loading rows:', err)
+        console.error('Error loading rows:', response.error)
         return {
           success: false,
           data: null,
@@ -394,19 +390,14 @@ function createServer() {
   }
 }
 
-interface Response {
-  data: unknown[][]
-  rowCount: number
-  success: boolean
-}
 function createServerSideDatasource(): IServerSideDatasource {
   return {
     getRows: async (params) => {
       const server = ssrmServer.value
       if (server) {
-        const response: Response = await server.getData(params.request)
-        const rows = createRowsForTable(response.data, 0, true)
-        if (response.success) {
+        const response = await server.getData(params.request)
+        if (response && response.success) {
+          const rows = createRowsForTable(response.data, 0, true)
           params.success({ rowData: rows, rowCount: response.rowCount })
         } else {
           params.fail()

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -401,7 +401,8 @@ function createServerSideDatasource(): IServerSideDatasource {
       const server = ssrmServer.value
       if (server) {
         const serverResponse = await server.getData(params.request)
-        const response: Response = serverResponse ? serverResponse : {data: [], success: false, rowCount: 0}
+        const response: Response =
+          serverResponse ? serverResponse : { data: [], success: false, rowCount: 0 }
         if (response.success) {
           const rows = createRowsForTable(response.data, 0, true)
           params.success({ rowData: rows, rowCount: response.rowCount })

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -336,47 +336,51 @@ function createServer() {
       }
     },
     getData: async (request: IServerSideGetRowsRequest) => {
-      const columnHeaders =
-        typeof props.data === 'object' && 'header' in props.data ?
-          props.data.header ?
-            props.data.header
-          : []
-        : []
+      try {
+        const columnHeaders =
+          typeof props.data === 'object' && 'header' in props.data ? (props.data.header ?? []) : []
 
-      const { sortColIndexes, sortDirections } = convertSortModel(request, columnHeaders)
+        const { sortColIndexes, sortDirections } = convertSortModel(request, columnHeaders)
+        const { filterColumnIndexList, filterActions, valueList } = convertFilterModel(
+          request,
+          columnHeaders,
+          colTypeMap.value,
+        )
 
-      const { filterColumnIndexList, filterActions, valueList } = convertFilterModel(
-        request,
-        columnHeaders,
-        colTypeMap.value,
-      )
+        const expressionFunction = createExpressionRowTemplate(
+          'Standard.Visualization.Table.Visualization',
+          'get_rows_for_table',
+          //the index of the next bucket of rows to get
+          `${request.startRow}`,
+          //column indexes that require a sort
+          sortColIndexes as string[] | 'Nothing',
+          //direction (Ascending/Descending) for the sorts
+          sortDirections as string[] | 'Nothing',
+          //column indexes that require a filter
+          filterColumnIndexList as string[] | 'Nothing',
+          //column actions i.e Greater Than, Between...
+          filterActions as string[] | 'Nothing',
+          //values to filter on
+          valueList as string[] | 'Nothing',
+        )
 
-      const expressionFunction = createExpressionRowTemplate(
-        'Standard.Visualization.Table.Visualization',
-        'get_rows_for_table',
-        //the index of the next bucket of rows to get
-        `${request.startRow}`,
-        //column indexes that require a sort
-        sortColIndexes as string[] | 'Nothing',
-        //direction (Ascending/Descending) for the sorts
-        sortDirections as string[] | 'Nothing',
-        //column indexes that require a filter
-        filterColumnIndexList as string[] | 'Nothing',
-        //column actions i.e Greater Than, Between...
-        filterActions as string[] | 'Nothing',
-        //values to filter on
-        valueList as string[] | 'Nothing',
-      )
-      const response = await config.executeExpression(expressionFunction)
-      if (response.ok) {
-        return {
-          success: true,
-          data: response.value.rows,
+        const response = await config.executeExpression(expressionFunction, 5000) // 5s timeout
+
+        if (response.ok) {
+          return {
+            success: true,
+            data: response.value.rows,
+            rowCount: response.value.row_count,
+          }
+        } else {
+          throw new Error('Expression execution failed')
         }
-      } else {
+      } catch (err) {
+        console.error('Error loading rows:', err)
         return {
           success: false,
           data: null,
+          rowCount: undefined,
         }
       }
     },
@@ -385,6 +389,7 @@ function createServer() {
 
 interface Response {
   data: unknown[][]
+  rowCount: number
   success: boolean
 }
 function createServerSideDatasource(): IServerSideDatasource {
@@ -394,9 +399,8 @@ function createServerSideDatasource(): IServerSideDatasource {
       if (server) {
         const response: Response = await server.getData(params.request)
         const rows = createRowsForTable(response.data, 0, true)
-
         if (response.success) {
-          params.success({ rowData: rows })
+          params.success({ rowData: rows, rowCount: response.rowCount })
         } else {
           params.fail()
         }
@@ -805,6 +809,7 @@ watchEffect(() => {
           ...dataHeader,
         ]
       : dataHeader
+
     if (!data_.is_using_server_sort_and_filter) {
       const hasIndexRow =
         config.nodeType === TABLE_NODE_TYPE ||

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -288,7 +288,7 @@ get_rows_for_table table_or_column start_number sort_col_index_list=Nothing sort
     get_vector c         = Warning.set (Vector.new bucket_size i-> make_json_for_value (c.get (i + start_number))) []
     columns              = sorted_table.columns
     rows = columns.map get_vector
-    result = JS_Object.from_pairs [["rows", rows]]
+    result = JS_Object.from_pairs [["rows", rows], ["row_count", all_rows_count]]
     result.to_text
 
 ## PRIVATE


### PR DESCRIPTION
The table Viz was sometime stuck with a loading spinner as the getRows request was stuck with a pending promise. This adds a timeout to that request so ag gris can re trigger a request. 

It also adds unique grid keys. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
