### PR TITLE
Do not abort Base tests in offline mode

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
@@ -46,12 +46,13 @@ polyglot java import org.enso.base.enso_cloud.AuthenticationProvider
    and a new one will be returned. Because of that, this method may make network
    requests.
 get_access_token : Text
-get_access_token = AuthenticationProvider.INSTANCE.getAccessToken
+get_access_token = Panic.recover Enso_Cloud_Error <|
+    AuthenticationProvider.INSTANCE.getAccessToken
 
 ## PRIVATE
    Forcibly refreshes the access token.
 refresh_access_token : Nothing
-refresh_access_token =
+refresh_access_token = Panic.recover Enso_Cloud_Error <|
     AuthenticationProvider.INSTANCE.getAuthenticationServiceEnsoInstance.force_refresh
 
 ## PRIVATE

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_Cloud_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_Cloud_Spec.enso
@@ -150,8 +150,8 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 . locally_expired
                 . set_refresh_token "GET-MALFORMED-RESPONSE"
             Cloud_Tests_Setup.run_with_mock_cloud custom_credentials=credentials <|
-                err = Test.expect_panic Enso_Cloud_Error <|
-                    Enso_User.list
+                err = Enso_User.list
+                err.should_fail_with Enso_Cloud_Error
                 err.to_display_text . should_contain "response from Enso Cloud could not be parsed"
                 err.to_display_text . should_contain "Expected field `TokenType` to be of type Text, but got Integer."
 

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -399,7 +399,6 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
 
 add_data_specs suite_builder root =
     my_dir = (root / "data_specs-").create_directory
-    my_dir.should_succeed
     file_maker path_element:Text = my_dir / (path_element+".txt")
     Data_Spec.add_specs "(Enso_File) " suite_builder file_maker
 


### PR DESCRIPTION
### Pull Request Description

Running `Base_Tests` in offline mode with `ENSO_RUN_REAL_CLOUD_TEST` enabled led to the test suite failing to even fully run as panics were thrown out of test setup logic.

Instead, the panics are turned to dataflow errors so that the errors are deferred to the test suites. The Cloud tests will still obviously fail as they do require a network connection, but at least they will not prevent other tests from running.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
