### PR TITLE
Check changed files when calculating outcome of CI job

### DIFF
--- a/.github/workflows/engine-pull-request.yml
+++ b/.github/workflows/engine-pull-request.yml
@@ -44,15 +44,24 @@ jobs:
   required-checks:
     name: Engine Required Checks
     runs-on: ubuntu-latest
-    needs: [engine-checks, stdlib-api-changes-label]
+    needs: [engine-changed-files, engine-checks, stdlib-api-changes-label]
     if: always()
     steps:
       - name: Checks Summary
         run: |
           echo "Engine Checks: ${{ needs.engine-checks.result }}"
 
-          if [[ "${{ needs.engine-checks.result }}" == "failure" ]]; then
-            exit 1
-          fi
+          any_changed='${{ needs.engine-changed-files.outputs.any_changed }}'
+
+          case '${{ needs.engine-checks.result }}' in
+            'failure')
+              exit 1
+              ;;
+            'skipped' | 'cancelled')
+              if [[ "$any_changed" == 'true' ]]; then
+                exit 1
+              fi
+              ;;
+          esac
 
           echo "Success!"

--- a/.github/workflows/gui-pull-request.yml
+++ b/.github/workflows/gui-pull-request.yml
@@ -95,7 +95,7 @@ jobs:
               'failure')
                 exit 1
                 ;;
-              'skipped')
+              'skipped' | 'cancelled')
                 if [[ '${{ needs.gui-changed-files.outputs.any_changed }}' == 'true' ]]; then
                   exit 1
                 fi

--- a/.github/workflows/gui-pull-request.yml
+++ b/.github/workflows/gui-pull-request.yml
@@ -76,7 +76,7 @@ jobs:
   required-checks:
     name: GUI Required Checks
     runs-on: ubuntu-latest
-    needs: [prettier, gui-checks, storybook]
+    needs: [gui-changed-files, prettier, gui-checks, storybook]
     if: always()
     steps:
       - name: Checks Summary
@@ -91,9 +91,16 @@ jobs:
           checks+=("${{ needs.storybook.result }}")
 
           for result in "${checks[@]}"; do
-            if [[ "$result" == "failure" ]]; then
-              exit 1
-            fi
+            case "$result" in
+              'failure')
+                exit 1
+                ;;
+              'skipped')
+                if [[ '${{ needs.gui-changed-files.outputs.any_changed }}' == 'true' ]]; then
+                  exit 1
+                fi
+                ;;
+            esac
           done
 
           echo "Success!"

--- a/.github/workflows/gui-pull-request.yml
+++ b/.github/workflows/gui-pull-request.yml
@@ -85,6 +85,8 @@ jobs:
           echo "GUI Checks: ${{ needs.gui-checks.result }}"
           echo "Storybook: ${{ needs.storybook.result }}"
 
+          any_changed='${{ needs.gui-changed-files.outputs.any_changed }}'
+
           declare -a checks
           checks+=("${{ needs.prettier.result }}")
           checks+=("${{ needs.gui-checks.result }}")
@@ -96,7 +98,7 @@ jobs:
                 exit 1
                 ;;
               'skipped' | 'cancelled')
-                if [[ '${{ needs.gui-changed-files.outputs.any_changed }}' == 'true' ]]; then
+                if [[ "$any_changed" == 'true' ]]; then
                   exit 1
                 fi
                 ;;

--- a/.github/workflows/ide-pull-request.yml
+++ b/.github/workflows/ide-pull-request.yml
@@ -45,15 +45,27 @@ jobs:
   required-checks:
     name: IDE Required Checks
     runs-on: ubuntu-latest
-    needs: [ide-packaging]
+    needs: [gui-changed-files, ide-changed-files, ide-packaging]
     if: always()
     steps:
       - name: Checks Summary
         run: |
           echo "IDE: ${{ needs.ide-packaging.result }}"
 
-          if [[ "${{ needs.ide-packaging.result }}" == "failure" ]]; then
-            exit 1
+          any_changed=false
+          if [[ "${{ needs.gui-changed-files.outputs.any_changed }}" == 'true' || "${{ needs.ide-changed-files.outputs.any_changed }}" == 'true' ]]; then
+            any_changed=true
           fi
+
+          case '${{ needs.ide-packaging.result }}' in
+            'failure')
+              exit 1
+              ;;
+            'skipped' | 'cancelled')
+              if [[ "$any_changed" == 'true' ]]; then
+                exit 1
+              fi
+              ;;
+          esac
 
           echo "Success!"

--- a/.github/workflows/wasm-pull-request.yml
+++ b/.github/workflows/wasm-pull-request.yml
@@ -28,15 +28,24 @@ jobs:
   required-checks:
     name: WASM Required Checks
     runs-on: ubuntu-latest
-    needs: [wasm-checks]
+    needs: [wasm-changed-files, wasm-checks]
     if: always()
     steps:
       - name: Checks Summary
         run: |
           echo "WASM Checks: ${{ needs.wasm-checks.result }}"
 
-          if [[ "${{ needs.wasm-checks.result }}" == "failure" ]]; then
-            exit 1
-          fi
+          any_changed='${{ needs.wasm-changed-files.outputs.any_changed }}'
+
+          case '${{ needs.wasm-checks.result }}' in
+            'failure')
+              exit 1
+              ;;
+            'skipped' | 'cancelled')
+              if [[ "$any_changed" == 'true' ]]; then
+                exit 1
+              fi
+              ;;
+          esac
 
           echo "Success!"


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #12028

Previously, if you canceled a GitHub workflow, the outcome was still a success. Now the outcome will take into account changed files, and cancelled workflows will be marked as failed.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
