### PR TITLE
Fix path for cloud url transformer in documentation editor

### DIFF
--- a/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import { useLogger } from '#/providers/LoggerProvider'
 import { useText } from '#/providers/TextProvider'
+import { resolveDocImageUrl } from '@/components/DocumentationEditor/images'
 import { type UrlTransformer } from '@/components/MarkdownEditor/imageUrlTransformer'
 import { Err, Ok } from '@/util/data/result'
 import { type TestIdProps } from '../AriaComponents'
@@ -34,12 +35,12 @@ export function MarkdownViewer(props: MarkdownViewerProps) {
   const transformImageUrl: UrlTransformer = (path: string) => {
     // In Enso Documentation, the relative paths are from module's directory
     // Here we always display docs from `src/Main.enso` module
-    const appliedUrl = new URL(path, 'file:///src')
-    if (appliedUrl.protocol !== 'file:') {
-      return Promise.resolve(Ok({ url: path }))
+    const resolvedUrl = resolveDocImageUrl(['src'], path)
+    if (!resolvedUrl.ok) return Promise.resolve(resolvedUrl)
+    if (resolvedUrl.value.type === 'url') {
+      return Promise.resolve(Ok({ url: resolvedUrl.value.url.toString() }))
     } else {
-      // Omit the starting '/'.
-      return imgUrlResolver(appliedUrl.pathname.substring(1)).then(
+      return imgUrlResolver(resolvedUrl.value.path).then(
         (url) => Ok({ url }),
         (error) => {
           logger.error(error)

--- a/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/app/gui/src/dashboard/components/MarkdownViewer/MarkdownViewer.tsx
@@ -31,16 +31,23 @@ export function MarkdownViewer(props: MarkdownViewerProps) {
   const logger = useLogger()
   const { getText } = useText()
 
-  const transformImageUrl: UrlTransformer = (path: string) =>
-    /^https?:/.test(path) ?
-      Promise.resolve(Ok({ url: path }))
-    : imgUrlResolver(path).then(
+  const transformImageUrl: UrlTransformer = (path: string) => {
+    // In Enso Documentation, the relative paths are from module's directory
+    // Here we always display docs from `src/Main.enso` module
+    const appliedUrl = new URL(path, 'file:///src')
+    if (appliedUrl.protocol !== 'file:') {
+      return Promise.resolve(Ok({ url: path }))
+    } else {
+      // Omit the starting '/'.
+      return imgUrlResolver(appliedUrl.pathname.substring(1)).then(
         (url) => Ok({ url }),
         (error) => {
           logger.error(error)
           return Err(getText('arbitraryFetchImageError'))
         },
       )
+    }
+  }
 
   return (
     <LazyMarkdownEditor

--- a/app/gui/src/project-view/components/DocumentationEditor/images.ts
+++ b/app/gui/src/project-view/components/DocumentationEditor/images.ts
@@ -45,6 +45,26 @@ function pathDebugRepr(path: Path) {
   return pathUniqueId(path)
 }
 
+/**
+ * Based of given location of the module, return the location of image based on imageUrl.
+ * @returns path relative to project's root, or the full URL with schema.
+ */
+export function resolveDocImageUrl(modulePathSegments: string[], imageUrl: string) {
+  const appliedUrl = URL.parse(imageUrl, `file:///${modulePathSegments.join('/')}}`)
+  switch (appliedUrl?.protocol) {
+    case null:
+      return Err('Invalid image url')
+    case 'file:':
+      // Omit the starting '/'..
+      return Ok({ type: 'projectPath' as const, path: decodeURI(appliedUrl.pathname).substring(1) })
+    case 'http:':
+    case 'https:':
+      return Ok({ type: 'url' as const, url: appliedUrl })
+    default:
+      return Err('Unsupported protocol')
+  }
+}
+
 /** Supports loading and uploading project images. */
 export function useDocumentationImages(
   markdownEditor: ToValue<
@@ -64,13 +84,13 @@ export function useDocumentationImages(
     if (!modulePathValue) {
       return Err('Current module path is unknown.')
     }
-    const appliedUrl = new URL(url, `file:///${modulePathValue.segments.join('/')}`)
-    if (appliedUrl.protocol === 'file:') {
-      // The pathname starts with '/', so we remove "" segment.
-      const segments = decodeURI(appliedUrl.pathname).split('/').slice(1)
+    const resolvedUrl = resolveDocImageUrl(modulePathValue.segments, url)
+    if (!resolvedUrl.ok) return resolvedUrl
+    if (resolvedUrl.value.type === 'projectPath') {
+      const segments = resolvedUrl.value.path.split('/')
       return Ok({ rootId: modulePathValue.rootId, segments })
     } else {
-      // Not a relative URL, custom fetching not needed.
+      // Custom fetching not needed.
       return undefined
     }
   }


### PR DESCRIPTION
### Pull Request Description

Part of the fix for #12800 

It is visible in network tab (in this case we don't put additional `/`)
![image](https://github.com/user-attachments/assets/78a2722f-3708-4a05-a2d8-407e13514ea4)

However, as seen in this image, cloud still doesn't handle it: @PabloBuchu is working on that. Nevertheless, this won't hurt and may be merged.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
