### PR TITLE
Enso_File fixes and support for ~

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Text/Regex.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Text/Regex.md
@@ -9,6 +9,7 @@
     - escape expression:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - find self input:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
     - find_all self input:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
+    - from_glob expression:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Regex.Regex
     - group_count self -> Standard.Base.Any.Any
     - group_nums_to_names self -> Standard.Base.Any.Any
     - iterator self input:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -2,6 +2,7 @@ import project.Any.Any
 import project.Data.Array.Array
 import project.Data.Dictionary.Dictionary
 import project.Data.Filter_Condition.Filter_Condition
+import project.Data.Hashset.Hashset
 import project.Data.Json.JS_Object
 import project.Data.Numbers.Integer
 import project.Data.Range.Range
@@ -427,6 +428,33 @@ type Regex
             should_recompile = self.case_insensitive != case_insensitive
             if should_recompile.not then self else
                 Regex.compile self.pattern case_insensitive
+
+    ## Create a Regex from a glob string
+
+       Arguments:
+       - expression: The glob string to compile into a regex.
+    from_glob : Text -> Regex
+    from_glob expression:Text -> Regex =
+        to_escape = Hashset.from_vector ["/", "$", "^", "+", ".", "(", ")", "=", "|", "\"]
+        characters = expression.characters
+        step pattern:Text index:Integer in_group:Boolean = if index == characters.length then pattern else
+            char = characters.at index
+            new_index = if (char != '*') || (characters.get index+1 != '*') then index+1 else
+                characters.index_of (..Not_Equal '*') index . if_nothing characters.length
+            new_in_group = if char == '{' then True else (if char == '}' then False else in_group)
+            new_pattern = if to_escape.contains char then pattern + "\" + char else case char of
+                '!' -> if characters.get index-1 == '[' then '^' else pattern + "\!"
+                '?' -> pattern + "."
+                '{' -> pattern + "("
+                '}' -> pattern + ")"
+                ',' -> pattern + (if in_group then "|" else ",")
+                '*' -> if new_index == index + 1 then pattern + ".*" else
+                    ## Multiple * so need to match 0 or more segments
+                    pattern + "((.*?(\/|\\|$))*)"
+                _ -> pattern + char
+            @Tail_Call step new_pattern new_index new_in_group
+        pattern = step "" 0 False
+        Regex.compile pattern
 
 ## PRIVATE
    Convert the polyglot map to a Dictionary.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -443,7 +443,7 @@ type Regex
                 characters.index_of (..Not_Equal '*') index . if_nothing characters.length
             new_in_group = if char == '{' then True else (if char == '}' then False else in_group)
             new_pattern = if to_escape.contains char then pattern + "\" + char else case char of
-                '!' -> if characters.get index-1 == '[' then '^' else pattern + "\!"
+                '!' -> if characters.get index-1 == '[' then pattern + '^' else pattern + "\!"
                 '?' -> pattern + "."
                 '{' -> pattern + "("
                 '}' -> pattern + ")"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -277,7 +277,7 @@ type Enso_File
        - color: The color of the label to create.
     create_label : Text -> Color -> Nothing
     create_label (name : Text) (color : Color) -> Nothing =
-        # TODO once cloud also checks for tag existance, if the Write context is enabled we could avoid this check as cloud will do it anyway - then we'll have only one request instead of 2 each time
+        # TODO once cloud also checks for tag existence, if the Write context is enabled we could avoid this check as cloud will do it anyway - then we'll have only one request instead of 2 each time
         # Cloud ticket: https://github.com/enso-org/cloud-v2/issues/1544
         if does_tag_exist name then Error.throw (Illegal_Argument.Error "A label with name "+name+" already exists.") else
             Context.Output.if_enabled disabled_message="Cannot create a label when writing is disabled. Press the Write button ▶ to perform the operation." panic=False <|
@@ -292,7 +292,7 @@ type Enso_File
          link is a directory.
     is_directory : Boolean
     is_directory self = Data_Link_Helpers.is_directory self <|
-        Existing_Enso_Asset.get_asset_reference_for self . asset_type == Enso_Asset_Type.Directory
+        self.asset_type == Enso_Asset_Type.Directory
 
     ## GROUP Metadata
        ICON metadata
@@ -303,23 +303,12 @@ type Enso_File
          link is a regular file.
     is_regular_file : Boolean
     is_regular_file self = Data_Link_Helpers.is_regular_file self <|
-        Existing_Enso_Asset.get_asset_reference_for self . asset_type == Enso_Asset_Type.File
+        self.asset_type == Enso_Asset_Type.File
 
     ## PRIVATE
+       Check if the Enso_File is a data link.
     is_data_link self -> Boolean =
-        ## Checking the `asset_type` requires actually fetching the metadata from the cloud.
-           To avoid performing requests for every part of a path that we are resolving,
-           we rely on the assumption that every data link has a name ending with the `.datalink` extension.
-           Thus we perform the costly check only if we find a good potential candidate for the data link.
-        may_be_data_link = Data_Link.is_data_link_name self.name
-        if may_be_data_link.not then False else
-            # We catch `File_Error` which means that the asset just does not exist.
-            asset_type = self.asset_type.catch File_Error _->Nothing
-            ## If the file does not exist, we treat it as a 'possible data link' to allow creating new data links with
-               that `Enso_File` as the data link location. Thus we return True.
-               If the asset already exists, we rely on its type.
-            if asset_type.is_nothing then True else
-                self.asset_type == Enso_Asset_Type.Data_Link
+        self.asset_type == Enso_Asset_Type.Data_Link
 
     ## GROUP Metadata
        ICON folder

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -118,7 +118,7 @@ type Enso_File
 
        ? Data Links
          If the file is a data link, this checks if the data link itself exists. 
-         It does not tell anything about existence of the data link target.       
+         It does not tell anything about existence of the data link target.
     exists : Boolean
     exists self =
         r = Existing_Enso_Asset.get_asset_reference_for self . if_not_error True

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -306,7 +306,9 @@ type Enso_File
     ## PRIVATE
        Check if the Enso_File is a data link.
     is_data_link self -> Boolean =
-        self.asset_type == Enso_Asset_Type.Data_Link
+        if self.exists then self.asset_type == Enso_Asset_Type.Data_Link else
+            ## We know doesn't exist so check if `.datalink`.
+            Data_Link.is_data_link_name self.name
 
     ## GROUP Metadata
        ICON folder

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -4,6 +4,7 @@ import project.Data.Json.JS_Object
 import project.Data.Numbers.Integer
 import project.Data.Ordering.Vector_Lexicographic_Order
 import project.Data.Text.Encoding.Encoding
+import project.Data.Text.Regex.Regex
 import project.Data.Text.Text
 import project.Data.Time.Date_Time.Date_Time
 import project.Data.Time.Date_Time_Formatter.Date_Time_Formatter
@@ -50,9 +51,6 @@ from project.Enso_Cloud.Public_Utils import get_required_field
 from project.System.File import find_extension_from_name
 from project.System.File_Format import Auto_Detect, Bytes, File_Format, Plain_Text_Format
 from project.System.File.Generic.File_Write_Strategy import generic_copy
-
-polyglot java import java.nio.file.Path
-polyglot java import org.enso.base.file_system.File_Utils
 
 type Enso_File
     ## ICON data_input
@@ -481,10 +479,9 @@ type Enso_File
                     # Remove secrets from the list - they are handled separately in `Enso_Secret.list`.
                     assets = list_assets self . filter f-> f.asset_type != Enso_Asset_Type.Secret
                     filtered_assets = if name_filter == "" then assets else
-                        used_filter = if recursive.not || name_filter.contains "**" then name_filter else
-                            (if name_filter.starts_with "*" then "*" else "{**/,}") + name_filter
-                        matcher = File_Utils.matchPath "glob:"+used_filter
-                        assets.filter a-> matcher.matches (Path.of (a.name.drop Enso_Path.protocol_prefix.length))
+                        ## Does NOT support recursive matching
+                        name_regex = Regex.from_glob name_filter
+                        assets.filter a-> a.name.match name_regex
                     results = filtered_assets.map asset->
                         file = Enso_File.Value (self.enso_path.resolve asset.name)
                         Asset_Cache.update file asset

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
@@ -24,7 +24,7 @@ type Enso_Path
     parse (path : Text) -> Enso_Path =
         if path.starts_with Enso_Path.protocol_prefix . not then Error.throw (Illegal_Argument.Error "Invalid path - it should start with `enso://`.") else
             raw_segments = if path.match ".*%\d\d.*" . not then path.drop Enso_Path.protocol_prefix.length . split Enso_Path.delimiter else
-                uri = URI.parse.path
+                uri = URI.parse path
                 [if path.starts_with "enso://~" then "~" else uri.host] + (uri.path.split Enso_Path.delimiter)
             if raw_segments.is_empty then Error.throw (Illegal_Argument.Error "Invalid path - it should contain at least one segment.") else
                 segments = raw_segments.filter s-> s.is_empty.not

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
@@ -106,9 +106,10 @@ type Existing_Enso_Asset
     ## PRIVATE
     list_directory self =
         if self.asset_type != Enso_Asset_Type.Directory then Error.throw (Illegal_Argument.Error "Only directories can be listed.") else
-             response = Utils.http_request_as_json HTTP_Method.Get self.internal_uri
-             assets = get_required_field "assets" response expected_type=Vector
-             assets.map Existing_Enso_Asset.from_json
+            if self.id == "" then Error.throw (Illegal_Argument.Error "Cannot list the Users or Teams directory.") else
+                 response = Utils.http_request_as_json HTTP_Method.Get self.internal_uri
+                 assets = get_required_field "assets" response expected_type=Vector
+                 assets.map Existing_Enso_Asset.from_json
 
     ## PRIVATE
     from_json json -> Existing_Enso_Asset =
@@ -181,14 +182,17 @@ type Asset_Cache
 ## PRIVATE
    Returns the cached reference or fetches it from the cloud.
 fetch_asset_reference (file : Enso_File) (want_metadata : Boolean) -> Existing_Enso_Asset ! File_Error = file.if_not_error <|
-    path = file.enso_path.to_text
-    on_not_found =
-        Error.throw (File_Error.Not_Found file)
-    r = Utils.get_cached (Asset_Cache.asset_key file) cache_duration=Cloud_Caching_Settings.get_file_cache_ttl <|
-        Existing_Enso_Asset.resolve_path path if_not_found=on_not_found
+    case file.enso_path.to_text of
+        "enso://Users" -> Existing_Enso_Asset.Value "Users" "" Enso_Asset_Type.Directory (Asset_Metadata.Value (Date_Time.new 2024 1 1) "Enso User home directories." [] Nothing)
+        "enso://Teams" -> Existing_Enso_Asset.Value "Teams" "" Enso_Asset_Type.Directory (Asset_Metadata.Value (Date_Time.new 2024 1 1) "Enso Team home directories." [] Nothing)
+        path ->
+            on_not_found =
+                Error.throw (File_Error.Not_Found file)
+            r = Utils.get_cached (Asset_Cache.asset_key file) cache_duration=Cloud_Caching_Settings.get_file_cache_ttl <|
+                Existing_Enso_Asset.resolve_path path if_not_found=on_not_found
 
-    needs_refetch = want_metadata && r.metadata.is_nothing
-    if needs_refetch.not then r else
-        with_metadata = Existing_Enso_Asset.resolve_path path if_not_found=on_not_found
-        Asset_Cache.update file with_metadata
-        with_metadata
+            needs_refetch = want_metadata && r.metadata.is_nothing
+            if needs_refetch.not then r else
+                with_metadata = Existing_Enso_Asset.resolve_path path if_not_found=on_not_found
+                Asset_Cache.update file with_metadata
+                with_metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
@@ -183,6 +183,7 @@ type Asset_Cache
    Returns the cached reference or fetches it from the cloud.
 fetch_asset_reference (file : Enso_File) (want_metadata : Boolean) -> Existing_Enso_Asset ! File_Error = file.if_not_error <|
     case file.enso_path.to_text of
+        "enso://" -> Existing_Enso_Asset.Value "" "" Enso_Asset_Type.Directory (Asset_Metadata.Value (Date_Time.new 2024 1 1) "Enso root directory." [] Nothing)
         "enso://Users" -> Existing_Enso_Asset.Value "Users" "" Enso_Asset_Type.Directory (Asset_Metadata.Value (Date_Time.new 2024 1 1) "Enso User home directories." [] Nothing)
         "enso://Teams" -> Existing_Enso_Asset.Value "Teams" "" Enso_Asset_Type.Directory (Asset_Metadata.Value (Date_Time.new 2024 1 1) "Enso Team home directories." [] Nothing)
         path ->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -903,7 +903,11 @@ resolve_local_file (path : Text) = handle_invalid_path path <|
         parts = Path_Helpers.split_path path
         # Special case - if there are no parts, it means path was "", so we use that as base.
         base_part = parts.get 0 if_missing=""
-        base = get_file base_part
+
+        # Handle special case when starts with ~
+        base = if base_part != '~' then get_file base_part else
+            if Enso_File.cloud_project_parent_directory == Nothing then File.home else Enso_File.home
+
         rest = parts.drop 1
         rest.fold base acc-> part-> acc.resolve_single_part part
 

--- a/test/Base_Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Regex_Spec.enso
@@ -53,6 +53,34 @@ add_specs suite_builder =
         group_builder.specify "should escape an expression for use as a literal" <|
             Regex.escape "[a-z\d]+" . should_equal '\\[a-z\\d\\]\\+'
 
+    suite_builder.group "From Glob" group_builder->
+        group_builder.specify "should make convert simple glob patterns" <|
+            Regex.from_glob "*" . pattern . should_equal ".*"
+            Regex.from_glob "a*" . pattern . should_equal "a.*"
+            Regex.from_glob "a*b" . pattern . should_equal "a.*b"
+            Regex.from_glob "a?b" . pattern . should_equal "a.b"
+            Regex.from_glob "a?b?" . pattern . should_equal "a.b."
+            Regex.from_glob "a?b*" . pattern . should_equal "a.b.*"
+
+        group_builder.specify "should make convert glob patterns with brackets" <|
+            Regex.from_glob "[a-z]" . pattern . should_equal "[a-z]"
+            Regex.from_glob "[a-z]*" . pattern . should_equal "[a-z].*"
+            Regex.from_glob "[a-z]?" . pattern . should_equal "[a-z]."
+            Regex.from_glob "[!a-z]?" . pattern . should_equal "[^a-z]."
+
+        group_builder.specify "should escape regex special characters" <|
+            Regex.from_glob "$" . pattern . should_equal "\$"
+            Regex.from_glob "^" . pattern . should_equal "\^"
+            Regex.from_glob "|" . pattern . should_equal "\|"
+            Regex.from_glob "." . pattern . should_equal "\."
+            Regex.from_glob "Hello World (Full).csv" . pattern . should_equal "Hello World \(Full\)\.csv"
+
+        group_builder.specify "should allow braces" <|
+            Regex.from_glob "{a,b}" . pattern . should_equal "(a|b)"
+            Regex.from_glob "{a,b}*" . pattern . should_equal "(a|b).*"
+            Regex.from_glob "{a,b}?" . pattern . should_equal "(a|b)."
+            Regex.from_glob "{a,b}c" . pattern . should_equal "(a|b)c"
+
     suite_builder.group "Pattern.matches" group_builder->
         group_builder.specify "should return True when the pattern matches against the input" <|
             pattern = Regex.compile "(.. .. )(?<letters>.+)()??(?<empty>)??"


### PR DESCRIPTION
### Pull Request Description

- Support `~` if `File.new`. If local mode will point to user's home folder. If hybrid or cloud then will be the user's cloud home.
![image](https://github.com/user-attachments/assets/ffc3637a-4d9a-49d7-93b9-ad976a96a514)

- `enso://Users` and `enso://Teams` now report that they exist and are directories. Attempting to list them results in an error currently (to be improved later).
![image](https://github.com/user-attachments/assets/f470a177-faf1-48a6-aa28-d351cda0c991)

- Changed the `is_data_link` function on `Enso_File` to use the `asset_type` to determine if a data link. This means that can use enso paths without the `.datalink` suffix.
![image](https://github.com/user-attachments/assets/eb9e3d86-5e47-4a44-947b-ebf3d841eb10)

- Fix bug decoding `%20` in enso paths.

- Added `Regex.from_glob` and moved away from Path and glob matcher for `Enso_File`.
![image](https://github.com/user-attachments/assets/8e3163ab-cfeb-4df5-ad5e-0219eb8780b1)

![image](https://github.com/user-attachments/assets/cb1a3856-1949-45e9-85d5-12dd848ddb42)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
