### PR TITLE
Properly implement `ScopeImpl` serde

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphBuilder.java
@@ -111,6 +111,7 @@ public final class GraphBuilder {
     if (resolve) {
       graph.resolveLocalUsage(use);
     }
+    scope.add(use);
     return use;
   }
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphOccurrence.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphOccurrence.java
@@ -150,9 +150,6 @@ public abstract sealed class GraphOccurrence permits GraphOccurrence.Def, GraphO
       this.symbol = symbol;
       this.externalId = externalId.nonEmpty() ? externalId.get() : null;
       this.identifier = identifier;
-      if (scope != null) {
-        scope.add(this);
-      }
     }
 
     Use(int id, String symbol, UUID identifier, scala.Option<UUID> externalId) {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/alias/graph/GraphPersistance.java
@@ -1,9 +1,9 @@
 package org.enso.compiler.pass.analyse.alias.graph;
 
 import java.io.IOException;
+import java.util.HashMap;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
-import scala.collection.immutable.HashMap;
 
 public final class GraphPersistance {
   private GraphPersistance() {}
@@ -20,7 +20,15 @@ public final class GraphPersistance {
       var childScopes = in.readInline(scala.collection.immutable.List.class);
       var occurrencesValues = (scala.collection.immutable.Set<GraphOccurrence>) in.readObject();
       var allDefinitions = in.readInline(java.util.List.class);
-      var parent = new ScopeImpl(childScopes, new HashMap<>(), allDefinitions);
+      var occurrencesMap = new HashMap<Object, GraphOccurrence>();
+      occurrencesValues.foreach(
+          v -> {
+            Integer key = v.id();
+            occurrencesMap.put(key, v);
+            return null;
+          });
+
+      var parent = new ScopeImpl(childScopes, occurrencesMap, allDefinitions);
       occurrencesValues.foreach(
           v -> {
             var associated = v.withScope(parent);

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/Graph.scala
@@ -43,9 +43,9 @@ object Graph {
   )
 
   abstract class Scope {
-    def parent:                                                    Option[Scope]
-    def allDefinitions:                                            java.util.Collection[GraphOccurrence.Def]
-    def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit
+    def parent:                                                        Option[Scope]
+    def allDefinitions:                                                java.util.Collection[GraphOccurrence.Def]
+    def forEachOccurenceDefinition(fn: (GraphOccurrence.Def => Unit)): Unit
 
     def deepCopy(
       mapping: mutable.Map[Graph.Scope, Graph.Scope] = mutable.Map()

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/alias/graph/ScopeImpl.scala
@@ -5,7 +5,6 @@ package alias.graph
 import org.enso.compiler.core.CompilerError
 
 import scala.jdk.CollectionConverters._
-import scala.collection.immutable.HashMap
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
@@ -17,9 +16,10 @@ import scala.reflect.ClassTag
   *                       Note that there may not be a link for all these definitions.
   */
 sealed private[graph] class ScopeImpl(
-  private[graph] var _childScopes: List[ScopeImpl]             = List(),
-  _occurs: scala.collection.Map[GraphImpl.Id, GraphOccurrence] = HashMap(),
-  _defs: java.util.Collection[GraphOccurrence.Def]             = null
+  private[graph] var _childScopes: List[ScopeImpl] = List(),
+  _occurs: java.util.Map[GraphImpl.Id, GraphOccurrence] =
+    new java.util.HashMap(),
+  _defs: java.util.Collection[GraphOccurrence.Def] = null
 ) extends Graph.Scope {
   private[graph] val _allDefinitions: java.util.List[
     GraphOccurrence.Def
@@ -29,7 +29,7 @@ sealed private[graph] class ScopeImpl(
 
   private[graph] var _parent: ScopeImpl = null
   private val occurrencesById: java.util.Map[GraphImpl.Id, GraphOccurrence] =
-    new java.util.HashMap(_occurs.asJava)
+    _occurs
   private val defsBySymbol
     : java.util.Map[GraphImpl.Symbol, GraphOccurrence.Def] = {
     val bySymbol =
@@ -44,7 +44,7 @@ sealed private[graph] class ScopeImpl(
 
   def childScopes = _childScopes
 
-  def forEachOccurenceDefinition(fn: (GraphOccurrence => Unit)): Unit = {
+  def forEachOccurenceDefinition(fn: (GraphOccurrence.Def => Unit)): Unit = {
     allOccurrences().forEach {
       case x: GraphOccurrence.Def => fn(x)
       case _                      =>
@@ -112,7 +112,7 @@ sealed private[graph] class ScopeImpl(
         val newScope =
           new ScopeImpl(
             childScopeCopies.toList,
-            occurrencesById.asScala,
+            new java.util.HashMap(occurrencesById),
             new java.util.ArrayList(_allDefinitions)
           )
         mapping.put(this, newScope)

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
@@ -4,19 +4,25 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.function.Function;
 import org.enso.common.CachePreferences;
+import org.enso.compiler.pass.analyse.alias.graph.Graph;
+import org.enso.compiler.pass.analyse.alias.graph.GraphBuilder;
+import org.enso.compiler.pass.analyse.alias.graph.GraphOccurrence;
 import org.enso.persist.Persistance;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.Option;
 
 public class PassPersistanceTest {
   @BeforeClass
   public static void initializePersistables() {
     org.enso.compiler.core.ir.Persistables.initialize();
     org.enso.compiler.pass.analyse.Persistables.initialize();
+    org.enso.compiler.pass.analyse.alias.graph.Persistables.initialize();
   }
 
   @Test
@@ -31,6 +37,42 @@ public class PassPersistanceTest {
     assertEquals("Two elements", 2, out.preferences().size());
     assertEquals("They are structurally equal", pref, out);
     assertNotSame("But not ==", pref, out);
+  }
+
+  @Test
+  public void graphScopePersistance() throws Exception {
+    var b = GraphBuilder.create();
+    var x = b.newDef("x", null, Option.empty());
+    var b2 = b.addChild();
+    var y = b2.newDef("y", null, Option.empty());
+    var ux = b2.newUse("x", null, Option.empty(), true);
+    var uy = b2.newUse("y", null, Option.empty(), true);
+
+    assertGraphScopePersistance("Before serialization", b.toGraph(), y.id());
+
+    var g = serde(Graph.class, b.toGraph(), -1);
+
+    assertGraphScopePersistance("After deserialization", g, y.id());
+  }
+
+  private static void assertGraphScopePersistance(String prefix, Graph g, int yId) {
+    var found = new ArrayList<GraphOccurrence.Def>();
+    g.rootScope()
+        .forEachOccurenceDefinition(
+            (d) -> {
+              found.add(d);
+              return null;
+            });
+
+    assertEquals(prefix + ". One definition: " + found, 1, found.size());
+
+    var childScope = g.scopeFor(yId).get();
+    childScope.forEachOccurenceDefinition(
+        (d) -> {
+          found.add(d);
+          return null;
+        });
+    assertEquals(prefix + ". One more definition", 2, found.size());
   }
 
   private static <T> T serde(Class<T> clazz, T l, int expectedSize) throws IOException {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
@@ -81,8 +81,10 @@ public class DebugLocalScope extends EnsoObject {
 
   @TruffleBoundary
   public static DebugLocalScope createFromFrame(EnsoRootNode rootNode, MaterializedFrame frame) {
-    return new DebugLocalScope(
-        rootNode, frame, gatherBindingsByLevels(rootNode.getLocalScope().flattenBindings()), 0);
+    var scope = rootNode.getLocalScope();
+    var flatten = scope.flattenBindings();
+    var byLevels = gatherBindingsByLevels(flatten);
+    return new DebugLocalScope(rootNode, frame, byLevels, 0);
   }
 
   @TruffleBoundary

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -3,7 +3,6 @@ package org.enso.persist.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -74,43 +73,51 @@ public class PersistableProcessor extends AbstractProcessor {
           var propsPkg = entry.getKey();
           var propsName = "Persistables.properties";
           var cn = entry.getKey() + ".Persistables";
-          var res = processingEnv.getFiler().getResource(propsWhere, propsPkg, propsName);
-          if (res != null) {
-            try (var is = res.openInputStream()) {
-              props.load(is);
-            } catch (IOException ex) {
-              // ignore and go on
+          try {
+            var res = processingEnv.getFiler().getResource(propsWhere, propsPkg, propsName);
+            if (res != null) {
+              try (var is = res.openInputStream()) {
+                props.load(is);
+              }
             }
+          } catch (IOException notReallyImportant) {
+            processingEnv
+                .getMessager()
+                .printMessage(
+                    Kind.OTHER,
+                    "Cannot read "
+                        + propsPkg
+                        + "."
+                        + propsName
+                        + ": "
+                        + notReallyImportant.getMessage());
           }
           var src = processingEnv.getFiler().createSourceFile(cn);
-          try (java.io.Writer w = src.openWriter()) {
+          try (var w = src.openWriter()) {
             w.append("package " + entry.getKey() + ";\n");
             w.append("public final class Persistables {\n");
             w.append("  private Persistables() {}\n");
             w.append("  public static void initialize() {\n");
             w.append("  }\n");
 
-            var merged = new HashMap<Integer, String>();
-            for (var newEntry : props.entrySet()) {
-              var key = Integer.parseInt(newEntry.getKey().toString());
-              merged.put(key, newEntry.getValue().toString());
-            }
             // values from processor take preceedence
-            merged.putAll(entry.getValue());
+            for (var idName : entry.getValue().entrySet()) {
+              props.setProperty("" + idName.getKey(), idName.getValue());
+            }
 
-            for (var idName : merged.entrySet()) {
+            for (var idName : props.entrySet()) {
               w.append(
                   "  private static final org.enso.persist.Persistance PERSIST_"
                       + idName.getKey()
                       + " = new "
                       + idName.getValue()
                       + "();\n");
-              props.setProperty("" + idName.getKey(), idName.getValue());
             }
             w.append("}\n");
           }
           var out = processingEnv.getFiler().createResource(propsWhere, propsPkg, propsName);
-          try (java.io.OutputStream os = out.openOutputStream()) {
+          try (var os = out.openOutputStream()) {
+            // store accumulated key/value pairs for subsequent (incremental) update
             props.store(os, "");
           }
         } catch (IOException ex) {

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -3,8 +3,10 @@ package org.enso.persist.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -25,6 +27,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleAnnotationValueVisitor9;
 import javax.tools.Diagnostic.Kind;
+import javax.tools.StandardLocation;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -66,7 +69,19 @@ public class PersistableProcessor extends AbstractProcessor {
     if (roundEnv.processingOver()) {
       for (var entry : registeredClasses.entrySet()) {
         try {
+          var props = new Properties();
+          var propsWhere = StandardLocation.SOURCE_OUTPUT;
+          var propsPkg = entry.getKey();
+          var propsName = "Persistables.properties";
           var cn = entry.getKey() + ".Persistables";
+          var res = processingEnv.getFiler().getResource(propsWhere, propsPkg, propsName);
+          if (res != null) {
+            try (var is = res.openInputStream()) {
+              props.load(is);
+            } catch (IOException ex) {
+              // ignore and go on
+            }
+          }
           var src = processingEnv.getFiler().createSourceFile(cn);
           try (java.io.Writer w = src.openWriter()) {
             w.append("package " + entry.getKey() + ";\n");
@@ -74,15 +89,29 @@ public class PersistableProcessor extends AbstractProcessor {
             w.append("  private Persistables() {}\n");
             w.append("  public static void initialize() {\n");
             w.append("  }\n");
-            for (var idName : entry.getValue().entrySet()) {
+
+            var merged = new HashMap<Integer, String>();
+            for (var newEntry : props.entrySet()) {
+              var key = Integer.parseInt(newEntry.getKey().toString());
+              merged.put(key, newEntry.getValue().toString());
+            }
+            // values from processor take preceedence
+            merged.putAll(entry.getValue());
+
+            for (var idName : merged.entrySet()) {
               w.append(
                   "  private static final org.enso.persist.Persistance PERSIST_"
                       + idName.getKey()
                       + " = new "
                       + idName.getValue()
                       + "();\n");
+              props.setProperty("" + idName.getKey(), idName.getValue());
             }
             w.append("}\n");
+          }
+          var out = processingEnv.getFiler().createResource(propsWhere, propsPkg, propsName);
+          try (java.io.OutputStream os = out.openOutputStream()) {
+            props.store(os, "");
           }
         } catch (IOException ex) {
           processingEnv.getMessager().printMessage(Kind.ERROR, ex.getMessage());


### PR DESCRIPTION
### Pull Request Description

Makes _local variables_ visible when debugging sources loaded from caches. The problem was in serde of `ScopeImpl`. It didn't properly fill `occurrencesById`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
