### PR TITLE
VSCode verifies `rootFolder` exists before using it

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -146,7 +146,7 @@ jobs:
           mvn versions:set -DnewVersion="$POM_VERSION.$MICRO_VERSION"
 
       - name: Build with Maven
-        run: mvn -B -Pvsix package --file tools/enso4igv/pom.xml -Denso.parser.lib=`pwd`/enso_parser/
+        run: mvn -B -Pvsix package --file tools/enso4igv/pom.xml -Denso.parser.lib=`pwd`/enso_parser/ -DskipTests
 
       - name: Archive NBM file
         uses: actions/upload-artifact@v4
@@ -168,3 +168,10 @@ jobs:
         with:
           name: VSCode Extension
           path: tools/enso4igv/*.vsix
+
+      - name: Generate .enso-sources Meta Data
+        run: |
+          ./run backend sbt -- compile
+
+      - name: Run Tests with Maven
+        run: mvn -B test --file tools/enso4igv/pom.xml -Denso.parser.lib=`pwd`/enso_parser/

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -169,9 +169,5 @@ jobs:
           name: VSCode Extension
           path: tools/enso4igv/*.vsix
 
-      - name: Generate .enso-sources Meta Data
-        run: |
-          ./run backend sbt -- compile
-
       - name: Run Tests with Maven
         run: mvn -B test --file tools/enso4igv/pom.xml -Denso.parser.lib=`pwd`/enso_parser/

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
 import javax.swing.Action;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.project.Project;
@@ -88,6 +89,9 @@ final class EnsoRootProject implements Project {
     }
 
     private static void searchForProjects(FileObject fo, Collection<Project> found, int depth) {
+      if (fo.getName().startsWith("bazel")) {
+          return;
+      }
       if (fo.isFolder() && depth > 0) {
         if (EnsoProjectFactory.isProjectCheck(fo) == 1) {
           try {
@@ -96,6 +100,7 @@ final class EnsoRootProject implements Project {
               found.add(p);
             }
           } catch (IllegalArgumentException | IOException ex) {
+            Installer.LOG.log(Level.WARNING, "error processing " + fo, ex);
           }
         } else {
           for (var ch : fo.getChildren()) {

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -220,10 +221,14 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
                 var moduleCp = ClassPathSupport.createClassPath(modulePath.toArray(new FileObject[0]));
                 var srcCp = ClassPathSupport.createClassPath(srcRoots.toArray(new FileObject[0]));
                 var s = new EnsoSources(cp, moduleCp, srcCp, platform, outputDir, source, options);
-                if ("main".equals(s.getName())) {
-                  sources.add(0, s);
+                if (s.getRootFolder() == null) {
+                    LOG.log(Level.WARNING, "Cannot find root folder for " + prj);
                 } else {
-                  sources.add(s);
+                    if ("main".equals(s.getName())) {
+                      sources.add(0, s);
+                    } else {
+                      sources.add(s);
+                    }
                 }
             }
         }
@@ -334,8 +339,8 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
     @Override
     public URL[] computeRoots(EnsoSources result) {
-        if (result.output() != null) {
-            return new URL[] { result.output().toURL() };
+        if (result.output != null) {
+            return new URL[] { result.output.toURL() };
         } else {
             return new URL[0];
         }
@@ -387,14 +392,33 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
       return findSourceRoots2(binaryRoot);
     }
 
-    record EnsoSources(
-        ClassPath cp,
-        ClassPath moduleCp,
-        ClassPath srcCp,
-        JavaPlatform platform,
-        FileObject output,
-        String source, List<String> options
-    ) implements SourceGroup {
+    static final class EnsoSources implements SourceGroup {
+        private final ClassPath cp;
+        private final ClassPath moduleCp;
+        private final ClassPath srcCp;
+        private final JavaPlatform platform;
+        private final FileObject output;
+        private final String source;
+        private final List<String> options;
+
+        private EnsoSources(
+            ClassPath cp,
+            ClassPath moduleCp,
+            ClassPath srcCp,
+            JavaPlatform platform,
+            FileObject output,
+            String source,
+            List<String> options
+        ) {
+            this.cp = cp;
+            this.moduleCp = moduleCp;
+            this.srcCp = srcCp;
+            this.platform = platform;
+            this.output = output;
+            this.source = source;
+            this.options = options;
+        }
+
         @Override
         public FileObject getRootFolder() {
             var arr = srcCp.getRoots();
@@ -445,17 +469,17 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
         }
 
         private boolean outputsTo(FileObject fo) {
-            if (fo == null || output() == null) {
+            if (fo == null || output == null) {
                 return false;
             }
-            if (fo.equals(output())) {
+            if (fo.equals(output)) {
                 return true;
             }
-            return FileUtil.isParentOf(output(), fo);
+            return FileUtil.isParentOf(output, fo);
         }
 
         public String toString() {
-            return "EnsoSources[name=" + getName() + ",root=" + getRootFolder() + ",output=" + output() + "]";
+            return "EnsoSources[name=" + getName() + ",root=" + getRootFolder() + ",output=" + output + "]";
         }
     }
 

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -1,12 +1,15 @@
 package org.enso.tools.enso4igv;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.Sources;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.project.SubprojectProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -19,6 +22,37 @@ public class EnsoSbtProjectTest extends NbTestCase {
   @Override
   protected void setUp() throws Exception {
     clearWorkDir();
+  }
+
+  public void testAllProjectsWillBeFound() throws Exception {
+      var root = new File(EnsoSbtProjectTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+      for (;;) {
+          assertNotNull("Root isn't a dir", root);
+          var sbt = new File(root, "build.sbt");
+          if (sbt.exists()) {
+              break;
+          }
+          root = root.getParentFile();
+      }
+      var sbt = new File(root, "build.sbt");
+      assertTrue("build script found", sbt.exists());
+      var text = Files.readAllLines(sbt.toPath());
+      var aggregateAndRest = text.stream().dropWhile(l -> !l.contains(".aggregate(")).toList();
+      var aggregate = aggregateAndRest.stream().skip(1).takeWhile(l -> !l.contains(")")).toList();
+
+      assertSimilar("Aggregates are we searching for: " + aggregate, 96, aggregate.size(), 10);
+
+      var inFiles = text.stream().filter(l -> l.contains(".in(file(") || l.contains("project in file(")).toList();
+      assertSimilar("Same amount of in(file( as aggregates", aggregate.size(), inFiles.size(), 10);
+
+      var rootFO = FileUtil.toFileObject(root);
+      var prj = ProjectManager.getDefault().findProject(rootFO);
+
+      var spp = prj.getLookup().lookup(SubprojectProvider.class);
+      assertNotNull("subprojects are supported", spp);
+      var projects = spp.getSubprojects();
+
+      assertSimilar("Found exactly the same amount of projects: " + projects, aggregate.size(), projects.size(), 10);
   }
 
   public void testLanguageServerProject() throws Exception {
@@ -95,5 +129,12 @@ public class EnsoSbtProjectTest extends NbTestCase {
       os.write(txt.getBytes(StandardCharsets.UTF_8));
     }
     return root;
+  }
+
+  private static void assertSimilar(String msg, int expected, int actual, int allowedDifference) {
+      if (Math.abs(expected - actual) <= allowedDifference) {
+          return;
+      }
+      assertEquals(msg, expected, actual);
   }
 }

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -2,9 +2,12 @@ package org.enso.tools.enso4igv;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.AssumptionViolatedException;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.Sources;
@@ -12,6 +15,7 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.spi.project.SubprojectProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.Utilities;
 
 public class EnsoSbtProjectTest extends NbTestCase {
 
@@ -24,35 +28,48 @@ public class EnsoSbtProjectTest extends NbTestCase {
     clearWorkDir();
   }
 
+  public void testRuntimeParserProjectFound() throws Exception {
+    var root = findRepoRoot();
+
+    var rootFO = FileUtil.toFileObject(root);
+    var prj = ProjectManager.getDefault().findProject(rootFO);
+
+    var spp = prj.getLookup().lookup(SubprojectProvider.class);
+    assertNotNull("subprojects are supported", spp);
+    var projects = spp.getSubprojects();
+
+    assertTrue("At least few projects found: " + projects, projects.size() >= 5);
+
+    var set = projects.stream().map(p -> p.getProjectDirectory()).collect(Collectors.toSet());
+
+    assertTrue("runtime-parser found: " + set, set.contains(rootFO.getFileObject("engine/runtime-parser")));
+  }
+
   public void testAllProjectsWillBeFound() throws Exception {
-      var root = new File(EnsoSbtProjectTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-      for (;;) {
-          assertNotNull("Root isn't a dir", root);
-          var sbt = new File(root, "build.sbt");
-          if (sbt.exists()) {
-              break;
-          }
-          root = root.getParentFile();
-      }
-      var sbt = new File(root, "build.sbt");
-      assertTrue("build script found", sbt.exists());
-      var text = Files.readAllLines(sbt.toPath());
-      var aggregateAndRest = text.stream().dropWhile(l -> !l.contains(".aggregate(")).toList();
-      var aggregate = aggregateAndRest.stream().skip(1).takeWhile(l -> !l.contains(")")).toList();
+    var root = findRepoRoot();
+    var sbt = new File(root, "build.sbt");
+    if (!assumeEssentialsAreCompiled(root)) {
+      return;
+    }
 
-      assertSimilar("Aggregates are we searching for: " + aggregate, 96, aggregate.size(), 10);
+    assertTrue("build script found", sbt.exists());
+    var text = Files.readAllLines(sbt.toPath());
+    var aggregateAndRest = text.stream().dropWhile(l -> !l.contains(".aggregate(")).toList();
+    var aggregate = aggregateAndRest.stream().skip(1).takeWhile(l -> !l.contains(")")).toList();
 
-      var inFiles = text.stream().filter(l -> l.contains(".in(file(") || l.contains("project in file(")).toList();
-      assertSimilar("Same amount of in(file( as aggregates", aggregate.size(), inFiles.size(), 10);
+    assertSimilar("Aggregates are we searching for: " + aggregate, 96, aggregate.size(), 10);
 
-      var rootFO = FileUtil.toFileObject(root);
-      var prj = ProjectManager.getDefault().findProject(rootFO);
+    var inFiles = text.stream().filter(l -> l.contains(".in(file(") || l.contains("project in file(")).toList();
+    assertSimilar("Same amount of in(file( as aggregates", aggregate.size(), inFiles.size(), 10);
 
-      var spp = prj.getLookup().lookup(SubprojectProvider.class);
-      assertNotNull("subprojects are supported", spp);
-      var projects = spp.getSubprojects();
+    var rootFO = FileUtil.toFileObject(root);
+    var prj = ProjectManager.getDefault().findProject(rootFO);
 
-      assertSimilar("Found exactly the same amount of projects: " + projects, aggregate.size(), projects.size(), 10);
+    var spp = prj.getLookup().lookup(SubprojectProvider.class);
+    assertNotNull("subprojects are supported", spp);
+    var projects = spp.getSubprojects();
+
+    assertSimilar("Found exactly the same amount of projects: " + projects, aggregate.size(), projects.size(), 15);
   }
 
   public void testLanguageServerProject() throws Exception {
@@ -132,9 +149,39 @@ public class EnsoSbtProjectTest extends NbTestCase {
   }
 
   private static void assertSimilar(String msg, int expected, int actual, int allowedDifference) {
-      if (Math.abs(expected - actual) <= allowedDifference) {
-          return;
-      }
-      assertEquals(msg, expected, actual);
+    if (Math.abs(expected - actual) <= allowedDifference) {
+      return;
+    }
+    assertEquals(msg, expected, actual);
   }
+
+  private static File findRepoRoot() throws URISyntaxException, IllegalArgumentException {
+    var root = Utilities.toFile(EnsoSbtProjectTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+    for (;;) {
+      assertNotNull("Root isn't a dir", root);
+      var sbt = new File(root, "build.sbt");
+      if (sbt.exists()) {
+        break;
+      }
+      root = root.getParentFile();
+    }
+    return root;
+  }
+
+  private static boolean assumeEssentialsAreCompiled(File root) {
+    var engineRuntimeCheck = new File(new File(new File(root, "engine"), "runtime"), ".enso-sources");
+    if (!engineRuntimeCheck.exists()) {
+      var msg = """
+      This test requires `sbt compile` to be executed first.
+      Such command generates `.enso-sources` meta data.
+      Without them running "check all" test makes little sense.
+      Not found: """ + engineRuntimeCheck;
+      var ex = new AssumptionViolatedException(msg);
+      ex.printStackTrace();
+      return false;
+    } else {
+      return true;
+    }
+  }
+
 }


### PR DESCRIPTION
### Pull Request Description

Recently a change in `sbt` project structure (done as part of #12618) renamed a project and left a debris behind. One can remove it as
```
enso$ rm -r lib/java/desktop-environment/
```
and that fixes the problem as well. However this PR makes the Enso VSCode extension code more robust to "survive" such debris and not break other projects in the Git repository. Also it fixes the scan for _"all"_ projects.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
