### PR TITLE
Disable NI tests on nightly checks

### DIFF
--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -597,7 +597,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run backend test standard-library-in-native
+      - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
           ENSO_LIB_S3_AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}
@@ -661,7 +661,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run backend test standard-library-in-native
+      - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
           ENSO_LIB_S3_AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}
@@ -723,7 +723,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run backend test standard-library-in-native
+      - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
           ENSO_LIB_S3_AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}
@@ -786,7 +786,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run backend test standard-library-in-native
+      - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
           ENSO_LIB_S3_AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}
@@ -849,7 +849,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run backend test standard-library-in-native
+      - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
           ENSO_LIB_S3_AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}

--- a/build_tools/build/src/ci_gen.rs
+++ b/build_tools/build/src/ci_gen.rs
@@ -845,17 +845,17 @@ pub fn engine_checks_nightly() -> Result<Workflow> {
     let mut workflow = Workflow { name: "Engine Nightly Checks".into(), on, ..default() };
 
     // Oracle GraalVM jobs run only on Linux
-    add_backend_checks(&mut workflow, PRIMARY_TARGET, graalvm::Edition::Enterprise, true);
+    add_backend_checks(&mut workflow, PRIMARY_TARGET, graalvm::Edition::Enterprise, false);
 
     // Run macOS AArch64 tests only once a day, as we have only one self-hosted runner for this.
     for target in PR_CHECKED_TARGETS {
-        add_backend_checks(&mut workflow, target, graalvm::Edition::Community, true);
+        add_backend_checks(&mut workflow, target, graalvm::Edition::Community, false);
     }
     add_backend_checks(
         &mut workflow,
         (OS::MacOS, Arch::AArch64),
         graalvm::Edition::Community,
-        true,
+        false,
     );
     Ok(workflow)
 }
@@ -877,7 +877,7 @@ pub fn extra_nightly_tests() -> Result<Workflow> {
     workflow.add(target, job::StandardLibraryTests {
         graal_edition:       graalvm::Edition::Community,
         cloud_tests_enabled: true,
-        native_image_mode:   true,
+        native_image_mode:   false,
     });
     Ok(workflow)
 }

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -379,7 +379,7 @@ impl Processor {
                                     "Snowflake_Tests".to_string()
                                 ]),
                             );
-                            config.build_native_runner = true;
+                            config.build_native_runner = false;
                         }
                         Tests::StdCloudRelated => {
                             config.add_standard_library_test_selection(
@@ -397,7 +397,7 @@ impl Processor {
                                     "Image_Tests".to_string(),
                                 ]),
                             );
-                            config.build_native_runner = true;
+                            config.build_native_runner = false;
                         }
                     }
                 }


### PR DESCRIPTION
### Pull Request Description

Until we are able to run them on workers.

### Important Notes

NI builds are rather expensive. Disabling until we are able to reliably run them on the provided workers.
