### PR TITLE
Fix z-index of drop-down panels

### DIFF
--- a/app/gui/src/project-view/components/DropdownMenu.vue
+++ b/app/gui/src/project-view/components/DropdownMenu.vue
@@ -63,7 +63,9 @@ const { floatingStyles } = useFloating(rootElement, floatElement, {
       class="arrow"
     />
     <SizeTransition height :duration="100">
-      <div v-if="open" ref="floatElement" :style="floatingStyles"><slot name="menu" /></div>
+      <div v-if="open" ref="floatElement" class="DropDownPanel" :style="floatingStyles">
+        <slot name="menu" />
+      </div>
     </SizeTransition>
   </div>
 </template>
@@ -88,5 +90,9 @@ const { floatingStyles } = useFloating(rootElement, floatElement, {
   pointer-events: none;
   --icon-transform: translateX(-50%) rotate(90deg) scale(0.7);
   --icon-transform-origin: center;
+}
+
+.DropDownPanel {
+  z-index: var(--drop-down-panel-z-index, 10);
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

The implementation of #12882 

The panel in all drop-downs got a default z-index > 0, which is configurable with CSS variable.

Integration test will arrive in next PR. Now I want to push fix to release branch ASAP.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual chages, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
~~- [ ] Unit tests have been written where possible.~~
~~- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
