### PR TITLE
Do not inherit types when resetting scopes

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -1644,4 +1644,312 @@ class RuntimeSuggestionUpdatesTest
       context.executionComplete(contextId)
     )
   }
+
+  it should "send suggestions for non-Main module" in {
+    val contextId   = UUID.randomUUID()
+    val requestId   = UUID.randomUUID()
+    val moduleName  = "Enso_Test.Test.Main"
+    val aModuleName = "Enso_Test.Test.A"
+
+    val mainCode =
+      """import Standard.Base.IO
+        |
+        |import project.A
+        |
+        |main =
+        |    t = A.newType 10
+        |    v = t.foo
+        |    IO.println v.to_text
+        |    IO.println "Hello World!"
+        |""".stripMargin.linesIterator.mkString("\n")
+    val aCode =
+      """|
+         |type MyType
+         |    MkA a
+         |
+         |    foo self = self.a
+         |
+         |newType a = MyType.MkA a
+         |""".stripMargin.linesIterator.mkString("\n")
+
+    val mainFile = context.writeMain(mainCode)
+    val aFile    = context.writeInSrcDir("A", aCode)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // open files
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, mainCode))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(aFile, aCode))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Enso_Test.Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receiveNIgnoreExpressionUpdates(
+      5
+    ) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.SuggestionsDatabaseModuleUpdateNotification(
+          module = "Enso_Test.Test.Main",
+          actions =
+            Vector(Api.SuggestionsDatabaseAction.Clean("Enso_Test.Test.Main")),
+          exports = Vector(
+            Api.ExportsUpdate(
+              ModuleExports(
+                "Enso_Test.Test.Main",
+                ListSet(
+                  ExportedSymbol.Method("Enso_Test.Test.Main", "main")
+                )
+              ),
+              Api.ExportsAction.Add()
+            )
+          ),
+          updates = Tree.Root(
+            Vector(
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Module(
+                    "Enso_Test.Test.Main",
+                    None
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.DefinedMethod(
+                    None,
+                    moduleName,
+                    "main",
+                    List(),
+                    moduleName,
+                    ConstantsGen.ANY,
+                    true,
+                    None,
+                    Seq()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector(
+                  Tree.Node(
+                    Api.SuggestionUpdate(
+                      Suggestion.Local(
+                        None,
+                        moduleName,
+                        "t",
+                        ConstantsGen.ANY,
+                        Suggestion.Scope(
+                          Suggestion.Position(4, 6),
+                          Suggestion.Position(8, 29)
+                        ),
+                        None
+                      ),
+                      Api.SuggestionAction.Add()
+                    ),
+                    Vector()
+                  ),
+                  Tree.Node(
+                    Api.SuggestionUpdate(
+                      Suggestion.Local(
+                        None,
+                        moduleName,
+                        "v",
+                        ConstantsGen.ANY,
+                        Suggestion.Scope(
+                          Suggestion.Position(4, 6),
+                          Suggestion.Position(8, 29)
+                        ),
+                        None
+                      ),
+                      Api.SuggestionAction.Add()
+                    ),
+                    Vector()
+                  )
+                )
+              )
+            )
+          )
+        )
+      ),
+      Api.Response(
+        Api.SuggestionsDatabaseModuleUpdateNotification(
+          module  = aModuleName,
+          actions = Vector(Api.SuggestionsDatabaseAction.Clean(aModuleName)),
+          exports = Vector(
+            Api.ExportsUpdate(
+              ModuleExports(
+                aModuleName,
+                Set(
+                  ExportedSymbol.Type(aModuleName, "MyType"),
+                  ExportedSymbol.Method(aModuleName, "newType")
+                )
+              ),
+              Api.ExportsAction.Add()
+            )
+          ),
+          updates = Tree.Root(
+            Vector(
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Module(aModuleName, None, ListSet()),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Type(
+                    None,
+                    aModuleName,
+                    "MyType",
+                    List(),
+                    "Enso_Test.Test.A.MyType",
+                    Some(ConstantsGen.ANY),
+                    None,
+                    ListSet()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Constructor(
+                    None,
+                    aModuleName,
+                    "MkA",
+                    List(
+                      Suggestion.Argument(
+                        "a",
+                        ConstantsGen.ANY,
+                        false,
+                        false,
+                        None,
+                        None
+                      )
+                    ),
+                    "Enso_Test.Test.A.MyType",
+                    None,
+                    List(),
+                    ListSet()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Getter(
+                    None,
+                    aModuleName,
+                    "a",
+                    List(
+                      Suggestion.Argument(
+                        "self",
+                        "Enso_Test.Test.A.MyType",
+                        false,
+                        false,
+                        None,
+                        None
+                      )
+                    ),
+                    "Enso_Test.Test.A.MyType",
+                    ConstantsGen.ANY,
+                    None,
+                    List(),
+                    ListSet()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.DefinedMethod(
+                    None,
+                    aModuleName,
+                    "foo",
+                    List(
+                      Suggestion.Argument(
+                        "self",
+                        "Enso_Test.Test.A.MyType",
+                        false,
+                        false,
+                        None,
+                        None
+                      )
+                    ),
+                    "Enso_Test.Test.A.MyType",
+                    ConstantsGen.ANY,
+                    false,
+                    None,
+                    List(),
+                    ListSet()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.DefinedMethod(
+                    None,
+                    "Enso_Test.Test.A",
+                    "newType",
+                    List(
+                      Suggestion.Argument(
+                        "a",
+                        ConstantsGen.ANY,
+                        false,
+                        false,
+                        None,
+                        None
+                      )
+                    ),
+                    "Enso_Test.Test.A",
+                    ConstantsGen.ANY,
+                    true,
+                    None,
+                    List(),
+                    ListSet()
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              )
+            )
+          )
+        )
+      ),
+      Api.Response(Api.AnalyzeModuleInScopeJobFinished()),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("10", "Hello World!")
+  }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -1695,6 +1695,13 @@ class RuntimeSuggestionUpdatesTest
       Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
+    context.send(
+      Api.Request(
+        requestId,
+        Api.InvalidateModulesIndexRequest()
+      )
+    )
+
     // push main
     context.send(
       Api.Request(
@@ -1709,9 +1716,11 @@ class RuntimeSuggestionUpdatesTest
         )
       )
     )
+
     context.receiveNIgnoreExpressionUpdates(
-      5
+      4
     ) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.InvalidateModulesIndexResponse()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
         Api.SuggestionsDatabaseModuleUpdateNotification(
@@ -1797,6 +1806,32 @@ class RuntimeSuggestionUpdatesTest
           )
         )
       ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("10", "Hello World!")
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          aFile,
+          Seq(
+          ),
+          execute = true,
+          idMap = Some(
+            model.IdMap(
+              Vector(
+                (model.Span(59, 71), UUID.randomUUID())
+              )
+            )
+          )
+        )
+      )
+    )
+
+    context.receiveNIgnoreExpressionUpdates(
+      2
+    ) should contain theSameElementsAs Seq(
       Api.Response(
         Api.SuggestionsDatabaseModuleUpdateNotification(
           module  = aModuleName,
@@ -1947,9 +1982,7 @@ class RuntimeSuggestionUpdatesTest
           )
         )
       ),
-      Api.Response(Api.AnalyzeModuleInScopeJobFinished()),
       context.executionComplete(contextId)
     )
-    context.consumeOut shouldEqual List("10", "Hello World!")
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -415,7 +415,7 @@ public final class Module extends EnsoObject {
   private void compile(EnsoContext context) throws IOException {
     Source source = getSource();
     if (source == null) return;
-    scopeBuilder = newScopeBuilder(false);
+    scopeBuilder = newScopeBuilder();
     compilationStage = CompilationStage.INITIAL;
     context.getCompiler().run(asCompilerModule());
   }
@@ -500,12 +500,8 @@ public final class Module extends EnsoObject {
     return scopeBuilder;
   }
 
-  public ModuleScope.Builder newScopeBuilder(boolean inheritTypes) {
-    if (inheritTypes) {
-      this.scopeBuilder = this.scopeBuilder.newBuilderInheritingTypes();
-    } else {
-      this.scopeBuilder = new ModuleScope.Builder(this);
-    }
+  public ModuleScope.Builder newScopeBuilder() {
+    this.scopeBuilder = new ModuleScope.Builder(this);
     return this.scopeBuilder;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -760,7 +760,7 @@ final class TruffleCompilerContext implements CompilerContext {
         module.module.setLoadedFromCache(loadedFromCache);
       }
       if (resetScope) {
-        module.module.newScopeBuilder(true);
+        module.module.newScopeBuilder();
       }
       if (invalidateCache) {
         module.module.getCache().invalidate(context);
@@ -870,7 +870,7 @@ final class TruffleCompilerContext implements CompilerContext {
     @Override
     public ModuleScopeBuilder newScopeBuilder() {
       return new org.enso.interpreter.runtime.scope.TruffleCompilerModuleScopeBuilder(
-          module.newScopeBuilder(false));
+          module.newScopeBuilder());
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -135,7 +135,7 @@ public final class Builtins {
     EnsoLanguage language = context.getLanguage();
     module = Module.empty(QualifiedName.fromString(MODULE_NAME), null);
     module.compileScope(context); // Dummy compilation for an empty module
-    ModuleScope.Builder scopeBuilder = module.newScopeBuilder(false);
+    ModuleScope.Builder scopeBuilder = module.newScopeBuilder();
 
     builtins = initializeBuiltinTypes(loadedBuiltinConstructors, language, scopeBuilder);
     builtinsByName =


### PR DESCRIPTION
### Pull Request Description

Seems like a relic from the past, when `Scope`s were mutable. By inheriting types (and their methods) from previous compilations we were getting silent `RedefinedMethodException` for projects with modules other than `Main`. As compilation would fail for such modules, analysis would not kick in and suggestions (and widgets) were not inferred.

### Important Notes

We probably should
-  load local modules from caches (currently failing)
- package local caches in packages

But that's something to consider for later.

Closes #12859 .

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
