### PR TITLE
Compiler (without any Truffle) test

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -85,8 +85,6 @@ public interface CompilerContext extends CompilerStub {
   void initializeBuiltinsIr(
       Compiler compiler, boolean irCachingEnabled, FreshNameSupply freshNameSupply, Passes passes);
 
-  QualifiedName getModuleName(Module module);
-
   IdMap getIdMap(Module module);
 
   void updateModule(Module module, Consumer<Updater> callback);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -97,8 +97,6 @@ public interface CompilerContext extends CompilerStub {
 
   boolean wasLoadedFromCache(Module module);
 
-  org.enso.compiler.core.ir.Module getIr(Module module);
-
   Future<Boolean> serializeLibrary(
       Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations);
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -87,8 +87,6 @@ public interface CompilerContext extends CompilerStub {
 
   QualifiedName getModuleName(Module module);
 
-  CharSequence getCharacters(Module module) throws IOException;
-
   IdMap getIdMap(Module module);
 
   void updateModule(Module module, Consumer<Updater> callback);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -101,8 +101,6 @@ public interface CompilerContext extends CompilerStub {
 
   org.enso.compiler.core.ir.Module getIr(Module module);
 
-  CompilationStage getCompilationStage(Module module);
-
   Future<Boolean> serializeLibrary(
       Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations);
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -93,8 +93,6 @@ public interface CompilerContext extends CompilerStub {
 
   void updateModule(Module module, Consumer<Updater> callback);
 
-  boolean isSynthetic(Module module);
-
   boolean isInteractive(Module module);
 
   boolean isModuleInRootPackage(Module module);

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -318,12 +318,12 @@ class Compiler(
       ) {
         val importedModulesLoadedFromSource = importedModules
           .filter(isLoadedFromSource)
-          .map(context.getModuleName)
+          .map(_.getName)
         context.log(
           Compiler.defaultLogLevel,
           "{} imported module caches were invalided, forcing invalidation of {}. [{}]",
           importedModulesLoadedFromSource.length,
-          context.getModuleName(module).toString,
+          module.getName().toString,
           importedModulesLoadedFromSource.take(10).mkString("", ",", "...")
         )
         context.updateModule(module, _.invalidateCache())
@@ -490,7 +490,7 @@ class Compiler(
             context.log(
               Compiler.defaultLogLevel,
               "Generating code for module [{0}].",
-              context.getModuleName(module)
+              module.getName()
             )
 
             context.truffleRunCodegen(module, moduleScopeBuilder, config)
@@ -515,7 +515,7 @@ class Compiler(
               !context.isInteractive(module) && !module.isSynthetic()
             ) {
               if (isInteractiveMode) {
-                context.notifySerializeModule(context.getModuleName(module))
+                context.notifySerializeModule(module.getName())
               } else {
                 context.serializeModule(
                   this,
@@ -529,7 +529,7 @@ class Compiler(
             context.log(
               Compiler.defaultLogLevel,
               "Skipping serialization for [{0}].",
-              context.getModuleName(module)
+              module.getName()
             )
           }
         }
@@ -645,8 +645,7 @@ class Compiler(
         Nil
       case other =>
         throw new CompilerError(
-          s"Unexpected import type after processing ${context
-            .getModuleName(module)}: [$other]."
+          s"Unexpected import type after processing ${module.getName()}: [$other]."
         )
     }
     importedModules.distinct.map(_.qualifiedName).toArray
@@ -661,7 +660,7 @@ class Compiler(
     context.log(
       Compiler.defaultLogLevel,
       "Parsing module [{0}].",
-      context.getModuleName(module)
+      module.getName()
     )
     context.updateModule(module, _.resetScope())
 
@@ -697,7 +696,7 @@ class Compiler(
     context.log(
       Compiler.defaultLogLevel,
       "Loading module [{0}] from source.",
-      context.getModuleName(module)
+      module.getName()
     )
     context.updateModule(module, _.resetScope())
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -373,7 +373,7 @@ class Compiler(
         )
         val compilerOutput =
           runGlobalTypingPasses(
-            context.getIr(module),
+            module.getIr(),
             moduleContext,
             irDumper = getOrCreateDumper(module)
           )
@@ -407,7 +407,7 @@ class Compiler(
           )
           val compilerOutput =
             runMethodBodyPasses(
-              context.getIr(module),
+              module.getIr(),
               moduleContext,
               irDumper = getOrCreateDumper(module)
             )
@@ -439,7 +439,7 @@ class Compiler(
           )
           val compilerOutput =
             runFinalTypeInferencePasses(
-              context.getIr(module),
+              module.getIr(),
               moduleContext,
               irDumper = getOrCreateDumper(module)
             )
@@ -632,7 +632,7 @@ class Compiler(
       irCachingEnabled && !context.isInteractive(module),
       false
     )
-    val importedModules = context.getIr(module).imports.flatMap {
+    val importedModules = module.getIr().imports.flatMap {
       case imp: Import.Module =>
         imp.name.parts.take(2).map(_.name) match {
           case List(namespace, name) => List(LibraryName(namespace, name))
@@ -1021,7 +1021,7 @@ class Compiler(
   private def gatherDiagnostics(module: Module): List[Diagnostic] = {
     GatherDiagnostics
       .runModule(
-        context.getIr(module),
+        module.getIr(),
         ModuleContext(module, compilerConfig = config)
       )
       .unsafeGetMetadata(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -708,7 +708,7 @@ class Compiler(
       isGeneratingDocs = generateDocs
     )
 
-    val src   = context.getCharacters(module)
+    val src   = module.getCharacters()
     val idMap = Option(context.getIdMap(module))
     val expr  = EnsoParser.compile(src, idMap.map(_.values).orNull)
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -306,7 +306,7 @@ class Compiler(
 
     val requiredModules = modules.flatMap { module =>
       val isLoadedFromSource =
-        (m: Module) => !context.wasLoadedFromCache(m) && !context.isSynthetic(m)
+        (m: Module) => !context.wasLoadedFromCache(m) && !m.isSynthetic()
       val importedModules = runImportsAndExportsResolution(
         module,
         generateCode && context.wasLoadedFromCache(module)
@@ -512,7 +512,7 @@ class Compiler(
               irCachingEnabled && !context.wasLoadedFromCache(module)
             if (
               shouldStoreCache && !hasErrors(module) &&
-              !context.isInteractive(module) && !context.isSynthetic(module)
+              !context.isInteractive(module) && !module.isSynthetic()
             ) {
               if (isInteractiveMode) {
                 context.notifySerializeModule(context.getModuleName(module))
@@ -599,7 +599,7 @@ class Compiler(
         false
       )
     }
-    if (context.isSynthetic(module)) {
+    if (module.isSynthetic()) {
       // Synthetic modules need to be import-analyzed
       // i.e. we need to fill in resolved{Imports/Exports} and exportedSymbols in bindings
       // because we do not generate (and deserialize) IR for them
@@ -713,7 +713,7 @@ class Compiler(
     val expr  = EnsoParser.compile(src, idMap.map(_.values).orNull)
 
     val exprWithModuleExports =
-      if (context.isSynthetic(module))
+      if (module.isSynthetic())
         expr
       else
         injectSyntheticModuleExports(expr, module.getDirectModulesRefs)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -358,8 +358,8 @@ class Compiler(
     }
     requiredModules.foreach { module =>
       if (
-        !context
-          .getCompilationStage(module)
+        !module
+          .getCompilationStage()
           .isAtLeast(
             CompilationStage.AFTER_GLOBAL_TYPES
           )
@@ -391,8 +391,8 @@ class Compiler(
 
       requiredModules.foreach { module =>
         if (
-          !context
-            .getCompilationStage(module)
+          !module
+            .getCompilationStage()
             .isAtLeast(
               CompilationStage.AFTER_STATIC_PASSES
             )
@@ -423,8 +423,8 @@ class Compiler(
 
       requiredModules.foreach { module =>
         if (
-          !context
-            .getCompilationStage(module)
+          !module
+            .getCompilationStage()
             .isAtLeast(
               CompilationStage.AFTER_TYPE_INFERENCE_PASSES
             )
@@ -457,8 +457,8 @@ class Compiler(
 
       val requiredModulesWithScope = requiredModules.map { module =>
         if (
-          !context
-            .getCompilationStage(module)
+          !module
+            .getCompilationStage()
             .isAtLeast(
               CompilationStage.AFTER_RUNTIME_STUBS
             )
@@ -479,8 +479,8 @@ class Compiler(
 
       requiredModulesWithScope.foreach { case (module, moduleScopeBuilder) =>
         if (
-          !context
-            .getCompilationStage(module)
+          !module
+            .getCompilationStage()
             .isAtLeast(
               CompilationStage.AFTER_CODEGEN
             )
@@ -775,8 +775,8 @@ class Compiler(
     generateDocs: Boolean
   ): Unit = {
     if (
-      !context
-        .getCompilationStage(module)
+      !module
+        .getCompilationStage()
         .isAtLeast(
           CompilationStage.AFTER_PARSING
         )

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -40,7 +40,7 @@ final class ImportResolver(compiler: Compiler) extends ImportResolverForIR {
       val context = compiler.context
       val (ir, currentLocal) =
         try {
-          val ir = context.getIr(current)
+          val ir = current.getIr()
           val currentLocal = ir.unsafeGetMetadata(
             BindingAnalysis,
             "Non-parsed module used in ImportResolver"

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -66,8 +66,8 @@ final class ImportResolver(compiler: Compiler) extends ImportResolverForIR {
         }
       // put the list of resolved imports in the module metadata
       if (
-        context
-          .getCompilationStage(current)
+        current
+          .getCompilationStage()
           .isBefore(
             CompilationStage.AFTER_IMPORT_RESOLUTION
           )

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -61,7 +61,7 @@ public final class CompilerErrorTest {
     var out = new ByteArrayOutputStream();
     var ps = new PrintStream(out);
     var repo = new MockPackageRepository();
-    var ctx = new MockCompilerContext(repo, ps, qName);
+    var ctx = new MockCompilerContext(repo, ps);
     var cfg =
         new CompilerConfig(
             true, true, true, true, scala.Option.empty(), true, true, scala.Option.apply(ps));
@@ -194,15 +194,13 @@ public final class CompilerErrorTest {
     }
   }
 
-  private class MockPackageRepository implements PackageRepository {
+  private static class MockPackageRepository implements PackageRepository {
 
-    public MockPackageRepository() {}
-
-    CompilerContext.Module MODULE_ANY;
+    MockPackageRepository() {}
 
     @Override
     public Either<PackageRepository.Error, BoxedUnit> initialize() {
-      return new Right<PackageRepository.Error, BoxedUnit>(null);
+      return new Right<>(null);
     }
 
     @Override
@@ -249,7 +247,7 @@ public final class CompilerErrorTest {
     @Override
     public Option<CompilerContext.Module> getLoadedModule(String qualifiedName) {
       return switch (qualifiedName) {
-        case "Standard.Base.Any" -> Option.apply(MODULE_ANY);
+        case "Standard.Base.Any" -> Option.apply(null);
         default -> throw new UnsupportedOperationException("no module: " + qualifiedName);
       };
     }
@@ -260,6 +258,7 @@ public final class CompilerErrorTest {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Option<Package<Object>> getMainProjectPackage() {
       try {
         var pm = new PackageManager<File>(FileSystem.Default$.MODULE$);
@@ -318,16 +317,14 @@ public final class CompilerErrorTest {
     }
   }
 
-  private static class MockCompilerContext implements CompilerContext {
+  private static final class MockCompilerContext implements CompilerContext {
 
     private final MockPackageRepository repo;
-    private final PrintStream ps;
-    private final QualifiedName qName;
+    private final PrintStream outErr;
 
-    public MockCompilerContext(MockPackageRepository repo, PrintStream ps, QualifiedName qName) {
+    MockCompilerContext(MockPackageRepository repo, PrintStream ps) {
       this.repo = repo;
-      this.ps = ps;
-      this.qName = qName;
+      this.outErr = ps;
     }
 
     @Override
@@ -357,24 +354,24 @@ public final class CompilerErrorTest {
 
     @Override
     public PrintStream getErr() {
-      return ps;
+      return outErr;
     }
 
     @Override
     public PrintStream getOut() {
-      return ps;
+      return outErr;
     }
 
     @Override
     public void log(Level level, String msg, Object... args) {
-      ps.println(msg + " " + Arrays.toString(args));
+      outErr.println(msg + " " + Arrays.toString(args));
     }
 
     @Override
     public void log(Level level, String msg, Throwable ex) {
-      ps.println("" + msg);
+      outErr.println("" + msg);
       if (ex != null) {
-        ex.printStackTrace(ps);
+        ex.printStackTrace(outErr);
       }
     }
 
@@ -437,23 +434,19 @@ public final class CompilerErrorTest {
         Passes passes) {}
 
     @Override
-    public QualifiedName getModuleName(CompilerContext.Module module) {
-      return qName;
-    }
-
-    @Override
     public IdMap getIdMap(CompilerContext.Module module) {
       return null;
     }
 
     @Override
     public void updateModule(
-        CompilerContext.Module module, Consumer<CompilerContext.Updater> callback) {
+        CompilerContext.Module raw, Consumer<CompilerContext.Updater> callback) {
+      var module = (MockModule) raw;
       callback.accept(
           new Updater() {
             @Override
             public void bindingsMap(BindingsMap map) {
-              ((MockModule) module).bm = map;
+              module.bm = map;
             }
 
             @Override
@@ -463,12 +456,12 @@ public final class CompilerErrorTest {
 
             @Override
             public void ir(org.enso.compiler.core.ir.Module ir) {
-              ((MockModule) module).ir = ir;
+              module.ir = ir;
             }
 
             @Override
             public void compilationStage(CompilationStage stage) {
-              ((MockModule) module).stage = stage;
+              module.stage = stage;
             }
 
             @Override

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -105,9 +105,7 @@ public final class CompilerErrorTest {
 
     @Override
     public int findLine(IdentifiedLocation loc) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -117,9 +115,7 @@ public final class CompilerErrorTest {
 
     @Override
     public URI getUri() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -147,9 +143,7 @@ public final class CompilerErrorTest {
 
     @Override
     public IdMap getIdMap() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -174,23 +168,17 @@ public final class CompilerErrorTest {
 
     @Override
     public boolean isPrivate() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public CompilerContext.ModuleScopeBuilder getScopeBuilder() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public CompilerContext.ModuleScopeBuilder newScopeBuilder() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
   }
 
@@ -220,58 +208,42 @@ public final class CompilerErrorTest {
     @Override
     public Either<PackageRepository.Error, BoxedUnit> ensurePackageIsLoaded(
         LibraryName libraryName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isPackageLoaded(LibraryName libraryName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Seq<Package<Object>> getLoadedPackages() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Seq<CompilerContext.Module> getLoadedModules() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Map<String, CompilerContext.Module> getModuleMap() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public scala.collection.immutable.Map<String, CompilerContext.Module> freezeModuleMap() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public scala.collection.immutable.Map<LibraryName, ComponentGroups> getComponents() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public ListSet<CompilerContext.Module> getPendingModules() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -284,9 +256,7 @@ public final class CompilerErrorTest {
 
     @Override
     public void registerMainProjectPackage(LibraryName libraryName, Package<Object> pkg) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -303,66 +273,48 @@ public final class CompilerErrorTest {
 
     @Override
     public void registerModuleCreatedInRuntime(CompilerContext.Module module) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void registerSyntheticPackage(String namespace, String name) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void deregisterModule(String qualifiedName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void renameProject(String namespace, String oldName, String newName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isNamespaceRegistered(String namespace) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Option<Package<Object>> getPackageForLibrary(LibraryName lib) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public List<CompilerContext.Module> getModulesForLibrary(LibraryName libraryName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Option<Module> getLibraryBindings(
         LibraryName libraryName, QualifiedName moduleName, CompilerContext context) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void shutdown() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
   }
 
@@ -385,9 +337,7 @@ public final class CompilerErrorTest {
 
     @Override
     public boolean isPrivateCheckDisabled() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -430,23 +380,17 @@ public final class CompilerErrorTest {
 
     @Override
     public void logSerializationManager(Level level, String msg, Object... args) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void notifySerializeModule(QualifiedName moduleName) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public CompilerContext.Module findTopScopeModule(String name) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -457,16 +401,12 @@ public final class CompilerErrorTest {
 
     @Override
     public boolean isCreateThreadAllowed() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public ExecutorService newParsingPool() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -475,24 +415,18 @@ public final class CompilerErrorTest {
         CompilerContext.ModuleScopeBuilder scopeBuilder,
         CompilerConfig config)
         throws IOException {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void runStubsGenerator(
         CompilerContext.Module module, CompilerContext.ModuleScopeBuilder scopeBuilder) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean typeContainsValues(String name) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -530,9 +464,7 @@ public final class CompilerErrorTest {
 
             @Override
             public void idMap(IdMap idMap) {
-              throw new UnsupportedOperationException(
-                  "Not supported yet."); // Generated from
-                                         // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+              throw new UnsupportedOperationException();
             }
 
             @Override
@@ -564,16 +496,12 @@ public final class CompilerErrorTest {
 
     @Override
     public boolean isInteractive(CompilerContext.Module module) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isModuleInRootPackage(CompilerContext.Module module) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -596,17 +524,13 @@ public final class CompilerErrorTest {
     @Override
     public Future<Boolean> serializeLibrary(
         Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public Option<Object> deserializeSuggestions(LibraryName libraryName)
         throws InterruptedException {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -615,30 +539,22 @@ public final class CompilerErrorTest {
         CompilerContext.Module module,
         boolean useGlobalCacheLocations,
         boolean usePool) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean deserializeModule(Compiler compiler, CompilerContext.Module module) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void shutdown(boolean waitForPendingJobCompletion) {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public RuntimeException throwAbortedException() {
-      throw new UnsupportedOperationException(
-          "Not supported yet."); // Generated from
-                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -489,12 +489,6 @@ public final class CompilerErrorTest {
     }
 
     @Override
-    public boolean isSynthetic(CompilerContext.Module module) {
-      // XXX duplicated
-      return module.isSynthetic();
-    }
-
-    @Override
     public boolean isInteractive(CompilerContext.Module module) {
       throw new UnsupportedOperationException();
     }

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -1,0 +1,644 @@
+package org.enso.compiler.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import org.enso.common.CompilationStage;
+import org.enso.compiler.Compiler;
+import org.enso.compiler.PackageRepository;
+import org.enso.compiler.Passes;
+import org.enso.compiler.context.CompilerContext;
+import org.enso.compiler.context.FreshNameSupply;
+import org.enso.compiler.core.ir.Diagnostic;
+import org.enso.compiler.core.ir.IdentifiedLocation;
+import org.enso.compiler.core.ir.Module;
+import org.enso.compiler.core.ir.expression.errors.Redefined;
+import org.enso.compiler.data.BindingsMap;
+import org.enso.compiler.data.CompilerConfig;
+import org.enso.compiler.data.IdMap;
+import org.enso.compiler.pass.analyse.BindingAnalysis$;
+import org.enso.editions.LibraryName;
+import org.enso.filesystem.FileSystem;
+import org.enso.pkg.ComponentGroups;
+import org.enso.pkg.Package;
+import org.enso.pkg.PackageManager;
+import org.enso.pkg.QualifiedName;
+import org.junit.Test;
+import scala.Option;
+import scala.collection.concurrent.Map;
+import scala.collection.immutable.List;
+import scala.collection.immutable.ListSet;
+import scala.collection.immutable.Seq;
+import scala.runtime.BoxedUnit;
+import scala.util.Either;
+import scala.util.Right;
+
+public final class CompilerErrorTest {
+  @Test
+  public void varialesIsRedefinedInIfBranch() {
+    var path = "check.enso";
+    var qName = QualifiedName.fromString("local.check");
+    var code = """
+    check x =
+        x = 'No'
+        x == 'False'
+    """;
+
+    var out = new ByteArrayOutputStream();
+    var ps = new PrintStream(out);
+    var repo = new MockPackageRepository();
+    var ctx = new MockCompilerContext(repo, ps, qName);
+    var cfg =
+        new CompilerConfig(
+            true, true, true, true, scala.Option.empty(), true, true, scala.Option.apply(ps));
+    var c = new Compiler(ctx, repo, cfg);
+    var optPkg = c.getPackageRepository().getMainProjectPackage();
+    var m = new MockModule(optPkg.get(), qName, path, code);
+    try {
+      var res = c.run(m);
+      fail("Compilation shall fail, but got: " + res);
+    } catch (DiagnosticException t) {
+      assertSame(m, t.module);
+      assertNotNull(t.diagnostic);
+      assertTrue(t.diagnostic instanceof Redefined.Binding);
+      var invalid = ((Redefined.Binding) t.diagnostic).invalidBinding();
+      assertEquals("x", invalid.name().name());
+    }
+  }
+
+  private static final class MockModule extends CompilerContext.Module {
+    private final QualifiedName qName;
+    private final String code;
+    private final String path;
+    private final Package<? extends Object> pkg;
+
+    private org.enso.compiler.core.ir.Module ir;
+    private BindingsMap bm;
+    private CompilationStage stage;
+
+    MockModule(Package<?> pkg, QualifiedName qName, String path, String code) {
+      this.pkg = pkg;
+      this.qName = qName;
+      this.path = path;
+      this.code = code;
+      this.stage = CompilationStage.INITIAL;
+    }
+
+    @Override
+    public CharSequence getCharacters() throws IOException {
+      return code;
+    }
+
+    @Override
+    public int findLine(IdentifiedLocation loc) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public String getPath() {
+      return path;
+    }
+
+    @Override
+    public URI getUri() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Package<? extends Object> getPackage() {
+      return pkg;
+    }
+
+    @Override
+    public QualifiedName getName() {
+      return qName;
+    }
+
+    @Override
+    public BindingsMap getBindingsMap() {
+      if (this.getIr() != null) {
+        // move to better location than the context
+        var meta = this.getIr().passData();
+        var pass = meta.get(BindingAnalysis$.MODULE$);
+        if (pass.isDefined()) {
+          return (BindingsMap) pass.get();
+        }
+      }
+      return bm;
+    }
+
+    @Override
+    public IdMap getIdMap() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public java.util.List<QualifiedName> getDirectModulesRefs() {
+      return java.util.List.of();
+    }
+
+    @Override
+    public CompilationStage getCompilationStage() {
+      return stage;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+      return false;
+    }
+
+    @Override
+    public Module getIr() {
+      return ir;
+    }
+
+    @Override
+    public boolean isPrivate() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public CompilerContext.ModuleScopeBuilder getScopeBuilder() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public CompilerContext.ModuleScopeBuilder newScopeBuilder() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+  }
+
+  private static final class DiagnosticException extends RuntimeException {
+    final MockModule module;
+    final Diagnostic diagnostic;
+    final boolean isOutputRedirected;
+
+    DiagnosticException(MockModule module, Diagnostic diagnostic, boolean isOutputRedirected) {
+      this.module = module;
+      this.diagnostic = diagnostic;
+      this.isOutputRedirected = isOutputRedirected;
+    }
+  }
+
+  private class MockPackageRepository implements PackageRepository {
+
+    public MockPackageRepository() {}
+
+    CompilerContext.Module MODULE_ANY;
+
+    @Override
+    public Either<PackageRepository.Error, BoxedUnit> initialize() {
+      return new Right<PackageRepository.Error, BoxedUnit>(null);
+    }
+
+    @Override
+    public Either<PackageRepository.Error, BoxedUnit> ensurePackageIsLoaded(
+        LibraryName libraryName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean isPackageLoaded(LibraryName libraryName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Seq<Package<Object>> getLoadedPackages() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Seq<CompilerContext.Module> getLoadedModules() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Map<String, CompilerContext.Module> getModuleMap() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public scala.collection.immutable.Map<String, CompilerContext.Module> freezeModuleMap() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public scala.collection.immutable.Map<LibraryName, ComponentGroups> getComponents() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public ListSet<CompilerContext.Module> getPendingModules() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Option<CompilerContext.Module> getLoadedModule(String qualifiedName) {
+      return switch (qualifiedName) {
+        case "Standard.Base.Any" -> Option.apply(MODULE_ANY);
+        default -> throw new UnsupportedOperationException("no module: " + qualifiedName);
+      };
+    }
+
+    @Override
+    public void registerMainProjectPackage(LibraryName libraryName, Package<Object> pkg) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Option<Package<Object>> getMainProjectPackage() {
+      try {
+        var pm = new PackageManager<File>(FileSystem.Default$.MODULE$);
+        var tmp = Files.createTempDirectory("mockdir");
+        var dir = pm.getOrCreate(tmp.toFile());
+        return Option.apply((Package) dir);
+      } catch (IOException ex) {
+        throw new IllegalStateException(ex);
+      }
+    }
+
+    @Override
+    public void registerModuleCreatedInRuntime(CompilerContext.Module module) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void registerSyntheticPackage(String namespace, String name) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void deregisterModule(String qualifiedName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void renameProject(String namespace, String oldName, String newName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean isNamespaceRegistered(String namespace) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Option<Package<Object>> getPackageForLibrary(LibraryName lib) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public List<CompilerContext.Module> getModulesForLibrary(LibraryName libraryName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Option<Module> getLibraryBindings(
+        LibraryName libraryName, QualifiedName moduleName, CompilerContext context) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void shutdown() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+  }
+
+  private static class MockCompilerContext implements CompilerContext {
+
+    private final MockPackageRepository repo;
+    private final PrintStream ps;
+    private final QualifiedName qName;
+
+    public MockCompilerContext(MockPackageRepository repo, PrintStream ps, QualifiedName qName) {
+      this.repo = repo;
+      this.ps = ps;
+      this.qName = qName;
+    }
+
+    @Override
+    public boolean isIrCachingDisabled() {
+      return true;
+    }
+
+    @Override
+    public boolean isPrivateCheckDisabled() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean isUseGlobalCacheLocations() {
+      return false;
+    }
+
+    @Override
+    public boolean isInteractiveMode() {
+      return false;
+    }
+
+    @Override
+    public PackageRepository getPackageRepository() {
+      return repo;
+    }
+
+    @Override
+    public PrintStream getErr() {
+      return ps;
+    }
+
+    @Override
+    public PrintStream getOut() {
+      return ps;
+    }
+
+    @Override
+    public void log(Level level, String msg, Object... args) {
+      ps.println(msg + " " + Arrays.toString(args));
+    }
+
+    @Override
+    public void log(Level level, String msg, Throwable ex) {
+      ps.println("" + msg);
+      if (ex != null) {
+        ex.printStackTrace(ps);
+      }
+    }
+
+    @Override
+    public void logSerializationManager(Level level, String msg, Object... args) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void notifySerializeModule(QualifiedName moduleName) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public CompilerContext.Module findTopScopeModule(String name) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public RuntimeException formatDiagnostic(
+        CompilerContext.Module module, Diagnostic diagnostic, boolean isOutputRedirected) {
+      return new DiagnosticException((MockModule) module, diagnostic, isOutputRedirected);
+    }
+
+    @Override
+    public boolean isCreateThreadAllowed() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public ExecutorService newParsingPool() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void truffleRunCodegen(
+        CompilerContext.Module module,
+        CompilerContext.ModuleScopeBuilder scopeBuilder,
+        CompilerConfig config)
+        throws IOException {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void runStubsGenerator(
+        CompilerContext.Module module, CompilerContext.ModuleScopeBuilder scopeBuilder) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean typeContainsValues(String name) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void initializeBuiltinsIr(
+        Compiler compiler,
+        boolean irCachingEnabled,
+        FreshNameSupply freshNameSupply,
+        Passes passes) {}
+
+    @Override
+    public QualifiedName getModuleName(CompilerContext.Module module) {
+      return qName;
+    }
+
+    @Override
+    public CharSequence getCharacters(CompilerContext.Module module) throws IOException {
+      // XXX duplicated method
+      return module.getCharacters();
+    }
+
+    @Override
+    public IdMap getIdMap(CompilerContext.Module module) {
+      return null;
+    }
+
+    @Override
+    public void updateModule(
+        CompilerContext.Module module, Consumer<CompilerContext.Updater> callback) {
+      callback.accept(
+          new Updater() {
+            @Override
+            public void bindingsMap(BindingsMap map) {
+              ((MockModule) module).bm = map;
+            }
+
+            @Override
+            public void idMap(IdMap idMap) {
+              throw new UnsupportedOperationException(
+                  "Not supported yet."); // Generated from
+                                         // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+            }
+
+            @Override
+            public void ir(org.enso.compiler.core.ir.Module ir) {
+              ((MockModule) module).ir = ir;
+            }
+
+            @Override
+            public void compilationStage(CompilationStage stage) {
+              ((MockModule) module).stage = stage;
+            }
+
+            @Override
+            public void loadedFromCache(boolean b) {}
+
+            @Override
+            public void resetScope() {}
+
+            @Override
+            public void invalidateCache() {}
+          });
+    }
+
+    @Override
+    public boolean isSynthetic(CompilerContext.Module module) {
+      // XXX duplicated
+      return module.isSynthetic();
+    }
+
+    @Override
+    public boolean isInteractive(CompilerContext.Module module) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean isModuleInRootPackage(CompilerContext.Module module) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean wasLoadedFromCache(CompilerContext.Module module) {
+      return false;
+    }
+
+    @Override
+    public org.enso.compiler.core.ir.Module getIr(CompilerContext.Module module) {
+      // XXX duplicated
+      return module.getIr();
+    }
+
+    @Override
+    public CompilationStage getCompilationStage(CompilerContext.Module module) {
+      // XXX duplicated
+      return module.getCompilationStage();
+    }
+
+    @Override
+    public Future<Boolean> serializeLibrary(
+        Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Option<Object> deserializeSuggestions(LibraryName libraryName)
+        throws InterruptedException {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public Future<Boolean> serializeModule(
+        Compiler compiler,
+        CompilerContext.Module module,
+        boolean useGlobalCacheLocations,
+        boolean usePool) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public boolean deserializeModule(Compiler compiler, CompilerContext.Module module) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public void shutdown(boolean waitForPendingJobCompletion) {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+
+    @Override
+    public RuntimeException throwAbortedException() {
+      throw new UnsupportedOperationException(
+          "Not supported yet."); // Generated from
+                                 // nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+    }
+  }
+}

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -510,12 +510,6 @@ public final class CompilerErrorTest {
     }
 
     @Override
-    public CompilationStage getCompilationStage(CompilerContext.Module module) {
-      // XXX duplicated
-      return module.getCompilationStage();
-    }
-
-    @Override
     public Future<Boolean> serializeLibrary(
         Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
       throw new UnsupportedOperationException();

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -442,12 +442,6 @@ public final class CompilerErrorTest {
     }
 
     @Override
-    public CharSequence getCharacters(CompilerContext.Module module) throws IOException {
-      // XXX duplicated method
-      return module.getCharacters();
-    }
-
-    @Override
     public IdMap getIdMap(CompilerContext.Module module) {
       return null;
     }

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/CompilerErrorTest.java
@@ -498,12 +498,6 @@ public final class CompilerErrorTest {
     }
 
     @Override
-    public org.enso.compiler.core.ir.Module getIr(CompilerContext.Module module) {
-      // XXX duplicated
-      return module.getIr();
-    }
-
-    @Override
     public Future<Boolean> serializeLibrary(
         Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
       throw new UnsupportedOperationException();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -190,11 +190,6 @@ final class TruffleCompilerContext implements CompilerContext {
     return ((Module) module).unsafeModule().wasLoadedFromCache();
   }
 
-  @Override
-  public org.enso.compiler.core.ir.Module getIr(CompilerContext.Module module) {
-    return module.getIr();
-  }
-
   final TypeGraph getTypeHierarchy() {
     return Types.getTypeHierarchy();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -200,11 +200,6 @@ final class TruffleCompilerContext implements CompilerContext {
     return module.getIr();
   }
 
-  @Override
-  public CompilationStage getCompilationStage(CompilerContext.Module module) {
-    return module.getCompilationStage();
-  }
-
   final TypeGraph getTypeHierarchy() {
     return Types.getTypeHierarchy();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -169,11 +169,6 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
-  public CharSequence getCharacters(CompilerContext.Module module) throws IOException {
-    return module.getCharacters();
-  }
-
-  @Override
   public IdMap getIdMap(CompilerContext.Module module) {
     return module.getIdMap();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -179,11 +179,6 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
-  public boolean isSynthetic(CompilerContext.Module module) {
-    return module.isSynthetic();
-  }
-
-  @Override
   public boolean isInteractive(CompilerContext.Module module) {
     return ((Module) module).unsafeModule().isInteractive();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -163,10 +163,6 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   // module related
-  @Override
-  public QualifiedName getModuleName(CompilerContext.Module module) {
-    return module.getName();
-  }
 
   @Override
   public IdMap getIdMap(CompilerContext.Module module) {


### PR DESCRIPTION
### Pull Request Description

Designs new kind of compiler tests. Those that build IR by calling parser, process the IR thru compiler passes and if there is an unexpected failure, they fail. No Truffle library is loaded when executing these tests. Various `CompilerContext` methods were de-duplicated in the process of writing the `MockCompilerContext` & co. helper classes.

As a side effect: the `CompilerContext` used during these tests could be useful in VSCode extension to report advanced errors to the users.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
