### PR TITLE
Module index invalidation triggers analysis

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
@@ -2,7 +2,9 @@ package org.enso.interpreter.instrument.command;
 
 import java.util.UUID;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
+import org.enso.interpreter.instrument.job.AnalyzeModuleInScopeJob;
 import org.enso.interpreter.instrument.job.DeserializeLibrarySuggestionsJob;
+import org.enso.interpreter.instrument.job.EnsureCompiledJob;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.polyglot.runtime.Runtime$Api$InvalidateModulesIndexResponse;
 import org.slf4j.LoggerFactory;
@@ -14,6 +16,8 @@ import scala.runtime.BoxedUnit;
 /** A command that invalidates the modules index. */
 public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
 
+  private final Option<UUID> maybeRequestId;
+
   /**
    * Create a command that invalidates the modules index.
    *
@@ -21,6 +25,7 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
    */
   public InvalidateModulesIndexCommand(Option<UUID> maybeRequestId) {
     super(maybeRequestId);
+    this.maybeRequestId = maybeRequestId;
   }
 
   @Override
@@ -34,13 +39,22 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
             ctx.jobControlPlane().stopBackgroundJobs();
             ctx.jobControlPlane()
                 .abortBackgroundJobs(
-                    "invalidate modules index", DeserializeLibrarySuggestionsJob.class);
+                    "invalidate modules index",
+                    DeserializeLibrarySuggestionsJob.class,
+                    AnalyzeModuleInScopeJob.class);
 
             EnsoContext context = ctx.executionService().getContext();
             context
                 .getTopScope()
                 .getModules()
                 .forEach(module -> ctx.state().suggestions().markIndexAsDirty(module));
+
+            maybeRequestId.foreach(
+                uuid -> {
+                  var stack = ctx.contextManager().getStack(uuid);
+                  ctx.jobProcessor().run(EnsureCompiledJob.apply(stack, ctx));
+                  return BoxedUnit.UNIT;
+                });
 
             context
                 .getPackageRepository()

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -648,14 +648,6 @@ object EnsureCompiledJob {
       }
   }
 
-  /** Create [[EnsureCompiledJob]] for a single file.
-    *
-    * @param file the file to compile
-    * @return new instance of [[EnsureCompiledJob]]
-    */
-  def apply(file: File): EnsureCompiledJob =
-    new EnsureCompiledJob(Seq(file))
-
   /** Create [[EnsureCompiledJob]] for a stack.
     *
     * @param stack the call stack to compile


### PR DESCRIPTION
### Pull Request Description

[Previous](#12907) fix for #12859 was helpful, but not sufficient. It revealed an inherent race-condition between
`InvalidateModulesIndexJob` and `AnalyzeModuleInScopeJob`, which could lead to silent discarding of suggestions info for non-Main modules. It was entirely time-related and could result in no widgets on startup.

This change ensures that any invalidation of modules' indexes always triggers necessary compilation. The latter in turn would trigger analysis of cancelled modules.

### Important Notes

Another attempt to close #12859. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
