### PR TITLE
Add grid reset button and apply button to date filters 

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -1013,7 +1013,7 @@ config.setToolbar(
     isFilterSortNodeEnabled,
     createNodes: config.createNodes,
     getColumnValueToEnso,
-    refreshGrid: () => refreshGrid(),
+    refreshGrid,
   }),
 )
 </script>

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -555,7 +555,7 @@ function toField(
   const icon = valueType ? getValueTypeIcon(valueType.constructor) : null
   const filterType = valueType ? getFilterType(valueType.constructor) : null
   const filterOptions = valueType ? getFilterOptions(valueType.constructor) : null
-  const filterButtons = valueType ? getFilterButtons(valueType.constructor)  : null
+  const filterButtons = valueType ? getFilterButtons(valueType.constructor) : null
   const cellValueType = valueType ? getCellDataType(valueType.constructor) : false
 
   const dataQualityMetrics =
@@ -989,8 +989,8 @@ function checkSortAndFilter(e: SortChangedEvent) {
 }
 
 const refreshGrid = () => {
-  grid.value?.gridApi?.setFilterModel(null);
-  grid.value?.gridApi?.resetColumnState();
+  grid.value?.gridApi?.setFilterModel(null)
+  grid.value?.gridApi?.resetColumnState()
 }
 
 // ===============
@@ -1013,7 +1013,7 @@ config.setToolbar(
     isFilterSortNodeEnabled,
     createNodes: config.createNodes,
     getColumnValueToEnso,
-    refreshGrid: () => refreshGrid()
+    refreshGrid: () => refreshGrid(),
   }),
 )
 </script>

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -513,6 +513,13 @@ function getFilterOptions(valueType: string) {
     return null
   }
 }
+function getFilterButtons(valueType: string) {
+  if (valueType === 'Date') {
+    return ['apply', 'clear']
+  } else {
+    return ['clear']
+  }
+}
 
 function getCellDataType(valueType: string) {
   if (valueType === 'Date') {
@@ -548,6 +555,7 @@ function toField(
   const icon = valueType ? getValueTypeIcon(valueType.constructor) : null
   const filterType = valueType ? getFilterType(valueType.constructor) : null
   const filterOptions = valueType ? getFilterOptions(valueType.constructor) : null
+  const filterButtons = valueType ? getFilterButtons(valueType.constructor)  : null
   const cellValueType = valueType ? getCellDataType(valueType.constructor) : false
 
   const dataQualityMetrics =
@@ -587,7 +595,7 @@ function toField(
       maxNumConditions: 1,
       values: getFilterValues,
       filterOptions: filterOptions,
-      buttons: ['clear'],
+      buttons: filterButtons,
     },
     headerComponentParams: {
       template,

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -988,6 +988,11 @@ function checkSortAndFilter(e: SortChangedEvent) {
   }
 }
 
+const refreshGrid = () => {
+  grid.value?.gridApi?.setFilterModel(null);
+  grid.value?.gridApi?.resetColumnState();
+}
+
 // ===============
 // === Updates ===
 // ===============
@@ -1008,6 +1013,7 @@ config.setToolbar(
     isFilterSortNodeEnabled,
     createNodes: config.createNodes,
     getColumnValueToEnso,
+    refreshGrid: () => refreshGrid()
   }),
 )
 </script>

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
@@ -311,7 +311,7 @@ function createFormatMenu({ textFormatterSelected }: FormatMenuOptions): Toolbar
 
 function createRefreshMenu({ refreshGrid }: RefreshButtonOptions): ToolbarItem {
   return {
-    title: 'Refresh Grid',
+    title: 'Reset any sort, filter or columns changes made to the table',
     icon: 'refresh',
     onClick: refreshGrid,
   }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
@@ -38,7 +38,14 @@ export interface FormatMenuOptions {
   textFormatterSelected: Ref<TextFormatOptions>
 }
 
-export interface Options extends SortFilterNodesButtonOptions, FormatMenuOptions {}
+export interface RefreshButtonOptions {
+  refreshGrid: () => void
+}
+
+export interface Options
+  extends SortFilterNodesButtonOptions,
+    FormatMenuOptions,
+    RefreshButtonOptions {}
 
 function useSortFilterNodesButton({
   filterModel,
@@ -302,9 +309,18 @@ function createFormatMenu({ textFormatterSelected }: FormatMenuOptions): Toolbar
   }
 }
 
+function createRefreshMenu({ refreshGrid }: RefreshButtonOptions): ToolbarItem {
+  return {
+    title: 'Refresh Grid',
+    icon: 'refresh',
+    onClick: refreshGrid,
+  }
+}
+
 /** TODO: Add docs */
 export function useTableVizToolbar(options: Options): ComputedRef<ToolbarItem[]> {
   const createNodesButton = useSortFilterNodesButton(options)
   const formatMenu = createFormatMenu(options)
-  return computed(() => [formatMenu, ...(createNodesButton.value ? [createNodesButton.value] : [])])
+  const refreshButton = createRefreshMenu(options)
+  return computed(() => [formatMenu, ...(createNodesButton.value ? [createNodesButton.value] : []), refreshButton])
 }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/tableVizToolbar.ts
@@ -311,7 +311,7 @@ function createFormatMenu({ textFormatterSelected }: FormatMenuOptions): Toolbar
 
 function createRefreshMenu({ refreshGrid }: RefreshButtonOptions): ToolbarItem {
   return {
-    title: 'Reset any sort, filter or columns changes made to the table',
+    title: 'Reset any sort, filter or column changes made to the table',
     icon: 'refresh',
     onClick: refreshGrid,
   }
@@ -322,5 +322,9 @@ export function useTableVizToolbar(options: Options): ComputedRef<ToolbarItem[]>
   const createNodesButton = useSortFilterNodesButton(options)
   const formatMenu = createFormatMenu(options)
   const refreshButton = createRefreshMenu(options)
-  return computed(() => [formatMenu, ...(createNodesButton.value ? [createNodesButton.value] : []), refreshButton])
+  return computed(() => [
+    formatMenu,
+    ...(createNodesButton.value ? [createNodesButton.value] : []),
+    refreshButton,
+  ])
 }


### PR DESCRIPTION
- closes #12887 
- closes #12884 

The Date filter required the user to chose the date with the date picker and then chose an action (equals, before...) from the dropdown which is not that intuitive, adding an 'apply' button will make this clearer for users. 
![date-col-apply](https://github.com/user-attachments/assets/abe20eed-ea66-4238-8fb3-cdd33841321e)

The refresh button resets any sorting, filtering, column ordering or hiding to the original state.  
![reset-button](https://github.com/user-attachments/assets/cd33b3d9-654f-4192-b464-3629a28e2a1f)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
