### PR TITLE
Grid resize on load bug

### DIFF
--- a/app/gui/src/project-view/components/shared/AgGridTableView.vue
+++ b/app/gui/src/project-view/components/shared/AgGridTableView.vue
@@ -89,8 +89,11 @@ import type {
   RowDataUpdatedEvent,
   RowEditingStartedEvent,
   RowEditingStoppedEvent,
+  RowHeightParams,
   SortChangedEvent,
 } from 'ag-grid-enterprise'
+import * as iter from 'enso-common/src/utilities/data/iter'
+import { LINE_BOUNDARIES } from 'enso-common/src/utilities/data/string'
 import {
   Component,
   type ComponentInstance,
@@ -320,6 +323,22 @@ const mappedComponents = computed(() => {
   }
   return retval
 })
+const DEFAULT_ROW_HEIGHT = 22
+function getRowHeight(params: RowHeightParams): number {
+  if (props.textFormatOption === 'off') {
+    return DEFAULT_ROW_HEIGHT
+  }
+  const rowData = Object.values(params.data)
+  const textValues = rowData.filter((r): r is string => typeof r === 'string')
+  if (!textValues.length) {
+    return DEFAULT_ROW_HEIGHT
+  }
+  const returnCharsCount = iter.map(textValues, (text) =>
+    iter.count(text.matchAll(LINE_BOUNDARIES)),
+  )
+  const maxReturnCharsCount = iter.reduce(returnCharsCount, Math.max, 0)
+  return (maxReturnCharsCount + 1) * DEFAULT_ROW_HEIGHT
+}
 
 const { AgGridVue } = await import('./AgGridTableView/AgGridVue')
 </script>
@@ -352,6 +371,7 @@ const { AgGridVue } = await import('./AgGridTableView/AgGridVue')
       :processDataFromClipboard="processDataFromClipboard"
       :allowContextMenuWithControlKey="true"
       :cacheBlockSize="rowModelType === 'clientSide' ? undefined : 1000"
+      :getRowHeight="rowModelType === 'clientSide' ? getRowHeight : null"
       @gridReady="onGridReady"
       @firstDataRendered="updateColumnWidths"
       @rowDataUpdated="(updateColumnWidths($event), emit('rowDataUpdated', $event))"

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -610,7 +610,7 @@ function toField(
       showDataQuality,
     },
     cellDataType: cellValueType,
-    autoHeight: (cellValueType === 'text' && isSSRM.value)
+    autoHeight: cellValueType === 'text' && isSSRM.value,
   }
 }
 

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -163,7 +163,6 @@ const defaultColDef: Ref<ColDef> = ref({
     'separator',
     'export',
   ],
-  autoHeight: true,
 } satisfies ColDef)
 const rowData = ref<Record<string, any>[]>([])
 const columnDefs: Ref<ColDef[]> = ref([])
@@ -611,6 +610,7 @@ function toField(
       showDataQuality,
     },
     cellDataType: cellValueType,
+    autoHeight: (cellValueType === 'text' && isSSRM.value)
   }
 }
 


### PR DESCRIPTION
- closes #12868 

This bug is caused by the behaviour from setting column autoHeight to true. When using the server side row model (tables >1000 rows) this is required to have variable row height.  see: https://www.ag-grid.com/javascript-data-grid/server-side-model-row-height/

This PR reverts the autoHeight where possible (if the table is not SSRM, or there are no text columns). This should hopefully reduce the amount of times the grid grows and shrinks on load.

Table not using server row model (less than 1000 rows) row height calculated 
![smalll-table-no-AH](https://github.com/user-attachments/assets/7e566cc6-ba50-4c46-bbb5-0dfec955a7f3)

Table using server row model (more than 1000 rows) but with no Text columns so auto height is turned off
![large-table-no-AH](https://github.com/user-attachments/assets/b343dabb-1d68-4ba7-8aac-8bd8ced5c017)

Table using server row model (more than 1000 rows) with text columns so auto height is on, therefore still experiencing resizing. 
![large-table-with-AH](https://github.com/user-attachments/assets/baadf6b4-b466-44fc-810d-0eaba4540f70)

Table using server row model (more than 1000 rows) with text columns that require variable row height 
![large-table-with-AH-needed](https://github.com/user-attachments/assets/b65ef6a1-2319-4755-b789-7d30d721d52d)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
