### PR TITLE
Revert a small change that was in the Fixed Width PR.

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Fixed_Width/Fixed_Width_Format.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Fixed_Width/Fixed_Width_Format.md
@@ -16,5 +16,6 @@
     - entries self -> Standard.Base.Data.Vector.Vector
     - from_descriptions descs:(Standard.Base.Data.Vector.Vector Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Column_Description) -> Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Layout
 - Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Layout.from that:Standard.Table.Table.Table -> Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Layout
+- Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Layout.from that:Standard.Base.Function.Function -> Standard.Table.Fixed_Width.Fixed_Width_Format.Fixed_Width_Layout
 - type Fixed_Width_Layout_Entry
     - Value start:Standard.Base.Data.Numbers.Integer width:Standard.Base.Data.Numbers.Integer name:Standard.Base.Data.Text.Text

--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Table.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Table.md
@@ -38,7 +38,7 @@
     - get self selector:(Standard.Base.Data.Numbers.Integer|Standard.Base.Data.Text.Text)= ~if_missing:Standard.Base.Any.Any= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - get_row self index:Standard.Base.Data.Numbers.Integer= ~if_missing:Standard.Base.Any.Any= -> (Standard.Table.Row.Row|Standard.Base.Any.Any)
     - get_value self selector:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= index:Standard.Base.Data.Numbers.Integer= ~if_missing:Standard.Base.Any.Any= -> Standard.Base.Any.Any
-    - input columns:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any)= -> Standard.Table.Table.Table
+    - input columns:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any) -> Standard.Table.Table.Table
     - join self right:Standard.Table.Table.Table= join_kind:Standard.Table.Join_Kind.Join_Kind= on:(Standard.Base.Any.Any|Standard.Base.Data.Text.Text|Standard.Table.Join_Condition.Join_Condition)= right_prefix:Standard.Base.Data.Text.Text= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Table.Table.Table
     - last_column self -> Standard.Table.Column.Column!Standard.Base.Errors.Common.Index_Out_Of_Bounds
     - last_row self -> Standard.Table.Row.Row!Standard.Base.Errors.Common.Index_Out_Of_Bounds

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Fixed_Width/Fixed_Width_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Fixed_Width/Fixed_Width_Format.enso
@@ -184,10 +184,16 @@ Fixed_Width_Layout.from (that:Table) =
     names = if has_names then that.columns.at 0 . to_vector else Nothing
     starts = if has_names then that.columns.at 1 . to_vector else that.columns.at 0 . to_vector
     widths = if has_names then that.columns.at 2 . to_vector else that.columns.at 1 . to_vector
-    descs = 0.up_to that.row_count . map i->
+    descriptions = 0.up_to that.row_count . map i->
         name = if names.is_nothing then Nothing else names.at i
         start = starts.at i
         width = widths.at i
         if start.is_nothing then Fixed_Width_Column_Description.Width width name else
             Fixed_Width_Column_Description.Start_And_Width start width name
-    Fixed_Width_Layout.from_descriptions descs
+    Fixed_Width_Layout.from_descriptions descriptions
+
+Fixed_Width_Layout.from (that : Function) =
+    is_unapplied_table_input = (that.to_text.starts_with "Table.type.new") || (that.to_text.starts_with "Table.type.input")
+    if is_unapplied_table_input then
+        Error.throw (Illegal_Argument.Error "Table has not been populated. A fixed-width column specification must have two or three columns (optional column name; start; width).")
+    Panic.throw (Type_Error.Error Fixed_Width_Layout that "Expected to get a Fixed_Width_Layout or a Table describing it.")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -226,7 +226,7 @@ type Table
         ? Consistent Row Count
         All columns must have the same number of rows. If a column has a
         different number of entries, an error is thrown.
-    input (columns : Vector (Vector | Column) = [['Column 1', []]]) -> Table =
+    input (columns : Vector (Vector | Column)) -> Table =
         throw_bad_column = Error.throw (Illegal_Argument.Error "Each column must be represented as a Vector of column name (Text), data (vector like elements) and optionally a type (Value_Type), or an existing column.")
         resolved_columns = columns.map c-> case c of
             _ : Column -> c

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -247,6 +247,7 @@ type Table
        Arguments:
        - internal_java_table: The internal java representation of the table.
     private Value internal_java_table
+
     ## PRIVATE
        A getter that is a workaround for bug https://github.com/enso-org/enso/issues/12180
     private java_table self = self.internal_java_table

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -41,7 +41,6 @@ type My_Comparator
 
 Comparable.from (that:My) = Comparable.new that My_Comparator
 
-
 type Data
     Value ~varied_type_table
 

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -132,11 +132,6 @@ add_specs suite_builder =
             r_5.column_names . should_equal ["foo"]
             r_5.columns.map .value_type . should_equal [Value_Type.Integer]
 
-        group_builder.specify "Table.input should default to a single empty column" <|
-            r = Table.input
-            r.column_names . should_equal ["Column 1"]
-            r.at "Column 1" . to_vector . should_equal []
-
         group_builder.specify "Table.new should allow inputting a table with types" <|
             r = Table.new [["foo", [1, 2, 3], Value_Type.Float], ["bar", [False, True, False]]]
             r.column_names . should_equal ["foo", "bar"]


### PR DESCRIPTION
### Pull Request Description

The Fixed Width PR added a default value to the `Table.input` function.
This PR reverts that change.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
