### PR TITLE
Compute the binding coverage of the type inference

### DIFF
--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
@@ -46,6 +46,7 @@ class TopScope(private val value: Value) {
     val docsArg = generateDocs.map {
       case "api" => "api"
       case "md"  => "md"
+      case "type-coverage" => "type-coverage"
       case other =>
         throw new IllegalStateException("Invalid docs format: " + other)
     }

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -839,6 +839,7 @@ public class Main {
    */
   private void generateDocsFrom(
       String docsFormat, String path, Level logLevel, boolean logMasking, boolean enableIrCaches) {
+    boolean enableStaticAnalysis = docsFormat.equals("type-coverage");
     var executionContext =
         new PolyglotContext(
             ContextFactory.create()
@@ -848,6 +849,7 @@ public class Main {
                 .logLevel(logLevel)
                 .logMasking(logMasking)
                 .enableIrCaches(enableIrCaches)
+                .enableStaticAnalysis(enableStaticAnalysis)
                 .build());
 
     var file = new File(path);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/TypesCoverageVisit.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/TypesCoverageVisit.java
@@ -1,0 +1,102 @@
+package org.enso.compiler.docs;
+
+import static org.enso.compiler.MetadataInteropHelpers.getMetadataOrNull;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Module;
+import org.enso.compiler.core.ir.module.scope.Definition;
+import org.enso.compiler.core.ir.module.scope.definition.Method;
+import org.enso.compiler.pass.analyse.types.InferredType;
+import org.enso.compiler.pass.analyse.types.TypeInferencePropagation;
+import org.enso.compiler.pass.analyse.types.TypeRepresentation;
+import org.enso.pkg.QualifiedName;
+
+public class TypesCoverageVisit implements DocsVisit {
+  @Override
+  public boolean visitModule(QualifiedName name, Module ir, PrintWriter writer) throws IOException {
+    writer.println("method,bindings,checked bindings");
+    return true;
+  }
+
+  @Override
+  public boolean visitUnknown(IR ir, PrintWriter w) throws IOException {
+    return true;
+  }
+
+  @Override
+  public void visitMethod(Definition.Type t, Method.Explicit m, PrintWriter writer)
+      throws IOException {
+    if (t != null) {
+      writer.print(t.name().name());
+      writer.print(".");
+    }
+    writer.print(m.methodName().name());
+    writer.print(",");
+
+    count(m.body()).print(writer);
+    writer.println();
+  }
+
+  @Override
+  public void visitConversion(Method.Conversion c, PrintWriter w) throws IOException {
+    if (c.typeName().isDefined()) {
+      w.print(c.typeName().get().name());
+      w.print(".");
+    }
+    w.print(c.methodName().name());
+    w.print(",");
+
+    count(c.body()).print(w);
+    w.println();
+  }
+
+  private record BindingsCount(int all, int checked) {
+    void print(PrintWriter w) {
+      w.print(all);
+      w.print(",");
+      w.print(checked);
+    }
+  }
+
+  private static class BindingsCounter {
+    private int all = 0;
+    private int checked = 0;
+
+    void count(IR b) {
+      IR.preorder(
+          b,
+          (expr) -> {
+            if (expr instanceof Expression.Binding binding) {
+              all++;
+              var inferredType =
+                  getMetadataOrNull(binding, TypeInferencePropagation.INSTANCE, InferredType.class);
+              if (inferredType != null && !inferredType.type().equals(TypeRepresentation.UNKNOWN)) {
+                checked++;
+              }
+            }
+          });
+    }
+
+    BindingsCount finish() {
+      return new BindingsCount(all, checked);
+    }
+  }
+
+  private BindingsCount count(IR b) {
+    var counter = new BindingsCounter();
+    counter.count(b);
+    return counter.finish();
+  }
+
+  @Override
+  public boolean visitType(Definition.Type t, PrintWriter w) throws IOException {
+    return true;
+  }
+
+  @Override
+  public void visitConstructor(Definition.Type t, Definition.Data d, PrintWriter w)
+      throws IOException {}
+}

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -1,22 +1,11 @@
 package org.enso.compiler
 
 import scala.jdk.CollectionConverters.IterableHasAsJava
-import org.enso.compiler.context.{
-  CompilerContext,
-  FreshNameSupply,
-  InlineContext,
-  ModuleContext
-}
+import org.enso.compiler.context.{CompilerContext, FreshNameSupply, InlineContext, ModuleContext}
 import org.enso.compiler.context.CompilerContext.Module
 import org.enso.compiler.core.CompilerError
 import org.enso.compiler.core.Implicits.AsMetadata
-import org.enso.compiler.core.ir.{
-  Diagnostic,
-  Expression,
-  Name,
-  Warning,
-  Module => IRModule
-}
+import org.enso.compiler.core.ir.{Diagnostic, Expression, Name, Warning, Module => IRModule}
 import org.enso.compiler.core.ir.MetadataStorage.MetadataPair
 import org.enso.compiler.core.ir.expression.Error
 import org.enso.compiler.core.ir.module.scope.Export
@@ -30,23 +19,14 @@ import org.enso.compiler.phase.{ImportResolver, ImportResolverAlgorithm}
 import org.enso.editions.LibraryName
 import org.enso.pkg.QualifiedName
 import org.enso.common.CompilationStage
-import org.enso.compiler.docs.{DocsGenerate, DocsVisit}
+import org.enso.compiler.docs.{DocsGenerate, DocsVisit, TypesCoverageVisit}
 import org.enso.compiler.dump.service.{IRDumpFactoryService, IRDumper}
-import org.enso.compiler.phase.exports.{
-  ExportCycleException,
-  ExportSymbolAnalysis,
-  ExportsResolution
-}
+import org.enso.compiler.phase.exports.{ExportCycleException, ExportSymbolAnalysis, ExportsResolution}
 import org.enso.syntax2.Tree
 import org.enso.syntax2.Parser
 
 import java.io.PrintStream
-import java.util.concurrent.{
-  CompletableFuture,
-  ExecutorService,
-  Future,
-  TimeUnit
-}
+import java.util.concurrent.{CompletableFuture, ExecutorService, Future, TimeUnit}
 import java.util.logging.Level
 import scala.collection.immutable.HashMap
 
@@ -181,14 +161,19 @@ class Compiler(
               shouldCompileDependencies
             )
 
-            if (generateDocs.isDefined) {
-              val v = if (generateDocs.get == "api") {
-                DocsVisit.createSignatures()
-              } else {
-                DocsVisit.createMarkdown();
-              }
-              val outDir = DocsGenerate.write(v, pkg, packageModules.asJava)
-              printDiagnostic(s"Documentation generated to ${outDir}")
+            generateDocs match {
+              case Some(generateDocsOption) =>
+                val visitor = generateDocsOption match {
+                  case "api" =>
+                    DocsVisit.createSignatures()
+                  case "type-coverage" =>
+                    new TypesCoverageVisit()
+                  case _ =>
+                    DocsVisit.createMarkdown()
+                }
+                val outDir = DocsGenerate.write(visitor, pkg, packageModules.asJava)
+                printDiagnostic(s"Documentation generated to ${outDir}")
+              case None =>
             }
 
             if (shouldWriteCache) {


### PR DESCRIPTION
### Pull Request Description

Prototype of a tool that allows us to compute what % of bindings inside of methods have some inferred type (other than 'Any').

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
