### PR TITLE
std-base classes should not make Enso calls during initialization

### DIFF
--- a/std-bits/base/src/main/java/org/enso/base/cache/ReloadDetector.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/ReloadDetector.java
@@ -67,12 +67,21 @@ public class ReloadDetector {
    */
   private static class ReloadSentinel {
     private Value ensoReloadSentinel;
+    private boolean initialized;
 
     public ReloadSentinel() {
-      resetEnsoReloadSentinel();
+      initialized = false;
+    }
+
+    private void ensureInitialized() {
+      if (!initialized) {
+        resetEnsoReloadSentinel();
+      }
+      initialized = true;
     }
 
     public boolean hasReloadOccurred() {
+      ensureInitialized();
       var reloadHasOccurred = ensoReloadSentinel.invokeMember("has_reload_occurred").asBoolean();
       if (reloadHasOccurred) {
         resetEnsoReloadSentinel();
@@ -87,6 +96,7 @@ public class ReloadDetector {
     }
 
     public void simulateReloadTestOnly() {
+      ensureInitialized();
       EnsoMeta.callStaticModuleMethod(
           "Standard.Base.Network.Reload_Sentinel", "simulate_reload_test_only", ensoReloadSentinel);
     }

--- a/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/reflect-config.json
+++ b/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/reflect-config.json
@@ -160,6 +160,21 @@
         "name": "org.enso.base.enso_cloud.audit.AuditLog"
     },
     {
+        "name": "org.enso.base.enso_cloud.audit.AuditLog$AuditLogError"
+    },
+    {
+        "name": "org.enso.base.enso_cloud.audit.AuditLog.AuditLogError"
+    },
+    {
+        "name": "org.enso.base.enso_cloud.audit.AuditLogApiAccess",
+        "fields": [
+            {
+                "name": "INSTANCE"
+            }
+        ],
+        "allPublicMethods": true
+    },
+    {
         "name": "org.enso.base.file_format.FileFormatSPI"
     },
     {
@@ -491,6 +506,15 @@
             {
                 "name": "init",
                 "parameterTypes": ["javax.net.ssl.KeyManager[]", "javax.net.ssl.TrustManager[]", "java.security.SecureRandom"]
+            }
+        ]
+    },
+    {
+        "name": "java.io.Console",
+        "methods": [
+            {
+                "name": "isTerminal",
+                "parameterTypes": []
             }
         ]
     }

--- a/test/Base_Tests/src/Native_Image_Imports.enso
+++ b/test/Base_Tests/src/Native_Image_Imports.enso
@@ -2,5 +2,3 @@
 # `env ENSO_LAUNCHER=test sbt buildEngineDistribution`.
 # This module is not actually used - it is scanned by `EnsoLibraryFeature` when NI is built.
 private
-
-polyglot java import java.io.Console as Java_Console


### PR DESCRIPTION
### Pull Request Description

When Java code is calling Enso methods via `invokeMember` in the static initializer and `ThreadManager` happens to interrupt it, we may end up with a broken initialization of the class (manifested as `NoClassDefFoundError`).

This change delays initilization of `ReloadDetector` until it is really needed.
Closes #12955.

Also rewrote #12930 - we really don't need all methods of `java.io.Console` in Native Image.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
