### PR TITLE
Making `ENSO_LAUNCHER=native,fast` fast

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3848,34 +3848,55 @@ lazy val `engine-runner` = project
           langServer ++
           epbLang
       ).distinct
-      val stdLibsJars =
-        `base-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `database-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `google-api-polyglot-root`
-          .listFiles("*.jar")
-          .map(_.getAbsolutePath()) ++
-        `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
-        `std-microsoft-polyglot-root`
-          .listFiles("*.jar")
-          .map(_.getAbsolutePath()) ++
-        `std-snowflake-polyglot-root`
-          .listFiles("*.jar")
-          .map(_.getAbsolutePath()) ++
-        `std-tableau-polyglot-root`
-          .listFiles("*.jar")
-          .map(_.getAbsolutePath())
+      def stdLibsJars = {
+        val log = streams.value.log
+        val base =
+          `base-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath())
+        if (GraalVM.EnsoLauncher.fast) {
+          log.info(
+            s"Skipping support for non-Standard.Base libraries in the image build as ${GraalVM.EnsoLauncher.VAR_NAME} env variable is ${GraalVM.EnsoLauncher.toString}"
+          )
+          base
+        } else {
+          base ++
+          `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+          `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+          `database-polyglot-root`
+            .listFiles("*.jar")
+            .map(_.getAbsolutePath()) ++
+          `google-api-polyglot-root`
+            .listFiles("*.jar")
+            .map(_.getAbsolutePath()) ++
+          `std-aws-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
+          `std-microsoft-polyglot-root`
+            .listFiles("*.jar")
+            .map(_.getAbsolutePath()) ++
+          `std-snowflake-polyglot-root`
+            .listFiles("*.jar")
+            .map(_.getAbsolutePath()) ++
+          `std-tableau-polyglot-root`
+            .listFiles("*.jar")
+            .map(_.getAbsolutePath())
+        }
+      }
       core ++ stdLibsJars ++ extraNITestLibs.value
     },
     extraNITestLibs := Def.taskDyn {
       if (GraalVM.EnsoLauncher.test) Def.task {
-        Seq(
+        val baseHelpers =
           (`enso-test-java-helpers` / Compile / packageBin).value
-            .getAbsolutePath(),
+            .getAbsolutePath()
+        val snowHelpers =
           (`snowflake-test-java-helpers` / Compile / packageBin).value
             .getAbsolutePath()
-        )
+        if (GraalVM.EnsoLauncher.fast) {
+          Seq(baseHelpers)
+        } else {
+          Seq(
+            baseHelpers,
+            snowHelpers
+          )
+        }
       }
       else {
         Def.task {

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -213,8 +213,8 @@ following:
 - There are additional variants of `native` useful for _development_. They are
   specified as comma separated attributes following `native`:
   - using `native,fast` turns on _native image_ build, but disables
-    optimizations and support for libraries other than `Standard.Base` -
-    e.g. produces build similar to _release mode_, but more quickly
+    optimizations and support for libraries other than `Standard.Base` - e.g.
+    produces build similar to _release mode_, but more quickly
   - using `native,test` _enables assertions_ - e.g. it instructs
     `buildEngineDistribution` command to build native image with assertions
     enabled (`-ea`). Useful for running Enso tests in the _native mode_. Also

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -213,8 +213,8 @@ following:
 - There are additional variants of `native` useful for _development_. They are
   specified as comma separated attributes following `native`:
   - using `native,fast` turns on _native image_ build, but disables
-    optimizations - e.g. produces build similar to _release mode_, but more
-    quickly
+    optimizations and support for libraries other than `Standard.Base` -
+    e.g. produces build similar to _release mode_, but more quickly
   - using `native,test` _enables assertions_ - e.g. it instructs
     `buildEngineDistribution` command to build native image with assertions
     enabled (`-ea`). Useful for running Enso tests in the _native mode_. Also


### PR DESCRIPTION
### Pull Request Description

- waiting for NI build is tedious
- in most of the cases a `Standard.Base` only support is enough
- use `ENSO_LAUNCHER=native,fast` to make `sbt buildEngineDistribution` _"fast"_
- such a build finishes in 3 min 30 s and takes at most 7 GB of memory


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Verified that `ENSO_LAUNCHER=native,fast,test sbt runEngineDistribution '--run test/Base_Tests'` succeeds without any errors
