### PR TITLE
Fix for Widgets on values with Warnings

### DIFF
--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -28,20 +28,22 @@ get_widget_json value call_name argument_names uuids="{}" =
         Widget.log_message "Failed for "+argument+": "+err.payload.to_display_text ..Warning
         Nothing
 
+    # We need to clear the warnings, otherwise the Not_Invokable panic will not have the cause
+    no_warnings = Warning.clear value
     read_annotation argument = Panic.catch Any handler=(log_panic argument) <|
-        annotation = Warning.clear <| Meta.get_annotation value call_name argument
+        annotation = Meta.get_annotation no_warnings call_name argument
         case annotation of
             # The annotation is a function that is taking the 'self' value and _maybe_ a cache parameter.
             f : Function ->
                 # We pass the self value and the cache to the function.
-                Panic.catch Not_Invokable (f value cache=cache) caught_panic->
+                Panic.catch Not_Invokable (f no_warnings cache=cache) caught_panic->
                     ## If the cache argument was not expected, we ignore the problem
                        and return just the result of `f value` - held by
                        the target of the Not_Invokable error.
                     was_not_expecting_cache_argument = caught_panic.payload.cause == (No_Such_Argument.Error "cache")
                     if was_not_expecting_cache_argument then caught_panic.payload.target else
                         # If this is some other error, we want to rethrow it.
-                        Panic.throw caught_panic
+                        log_panic argument caught_panic
 
             # The annotation is a constant, so we just return it.
             _ -> annotation


### PR DESCRIPTION
### Pull Request Description

Quick fix for dynamic widgets not showing if the value has a warning.
The `Not_Invokable` cause is not populated properly if the value has a warning. This should be looked at later.

https://github.com/user-attachments/assets/96b093ed-c233-47e1-b1a7-8728ad04079b

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
