### PR TITLE
Check NI size after it is built

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -305,6 +305,8 @@ lazy val Benchmark = config("bench") extend sbt.Test
 lazy val rebuildNativeImage = taskKey[Unit]("Force to rebuild native image")
 lazy val buildNativeImage =
   taskKey[Unit]("Ensure that the Native Image is built.")
+lazy val checkNativeImageSize =
+  taskKey[Unit]("Ensures the generated Native Image has reasonable size")
 
 // ============================================================================
 // === Global Project =========================================================
@@ -4064,7 +4066,16 @@ lazy val `engine-runner` = project
           "enso",
           targetDir = engineDistributionRoot.value / "bin"
         )
-    }.value
+    }.value,
+    checkNativeImageSize := Def
+      .taskDyn {
+        NativeImage.checkNativeImageSize(
+          name      = "enso",
+          targetDir = engineDistributionRoot.value / "bin"
+        )
+      }
+      .dependsOn(buildNativeImage)
+      .value
   )
   .dependsOn(`version-output`)
   .dependsOn(pkg)
@@ -5671,6 +5682,7 @@ buildEngineDistributionNoIndex := Def.taskIf {
   createEnginePackageNoIndex.value
   if (shouldBuildNativeImage.value) {
     (`engine-runner` / buildNativeImage).value
+    (`engine-runner` / checkNativeImageSize).value
   }
 }.value
 

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -72,6 +72,40 @@ object GraalVM {
     def release               = native && !test && !debug && !fast && !disableLanguageServer
   }
 
+  case class NativeImageSize(
+    minMb: Int,
+    maxMb: Int
+  )
+
+  object NativeImageSize {
+    def expectedSizeForCurrentPlatform(): NativeImageSize = {
+      if (EnsoLauncher.release) {
+        if (Platform.isWindows) {
+          windowsX64Release
+        } else if (Platform.isLinux) {
+          linuxX64Release
+        } else if (Platform.isMacOS && Platform.isAmd64) {
+          macX64Release
+        } else if (Platform.isMacOS && Platform.isArm64) {
+          macARM64Release
+        } else {
+          throw new IllegalArgumentException("Unexpected platform")
+        }
+      } else {
+        testNISize
+      }
+    }
+
+    // Expected production NI sizes deduced from sizes on latest
+    // nightly builds: https://github.com/enso-org/enso/pull/12996#discussion_r2073742680
+    // With maximal size relaxed by 30 MB.
+    private val windowsX64Release = NativeImageSize(200, 420)
+    private val linuxX64Release   = NativeImageSize(200, 463)
+    private val macX64Release     = NativeImageSize(200, 408)
+    private val macARM64Release   = NativeImageSize(200, 423)
+    private val testNISize        = NativeImageSize(100, 550)
+  }
+
   /** Has the user requested to use Espresso for Java interop? */
   private def isEspressoMode(): Boolean =
     "espresso".equals(System.getenv("ENSO_JAVA"))

--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -332,27 +332,21 @@ object NativeImage {
         "Ensure that the dependency on `buildNativeImage` is properly set."
       )
     }
-    val bytes              = generatedBin.attributes.size()
-    val productionNIBounds = (150, 450)
-    val testNIBounds       = (110, 550)
-    val mb                 = bytes / (1024 * 1024)
-    val bounds = if (GraalVM.EnsoLauncher.release) {
-      productionNIBounds
-    } else {
-      testNIBounds
-    }
+    val bytes        = generatedBin.attributes.size()
+    val mb           = bytes / (1024 * 1024)
+    val expectedSize = GraalVM.NativeImageSize.expectedSizeForCurrentPlatform()
     val isInBounds =
-      bounds._1 <= mb && mb <= bounds._2
+      expectedSize.minMb <= mb && mb <= expectedSize.maxMb
     if (!isInBounds) {
       logger.error(
         s"Generated binary $generatedBin has unexpected size: $mb MB. " +
-        s"Expected size is between ${bounds._1} and ${bounds._2} MB."
+        s"Expected size is between ${expectedSize.minMb} and ${expectedSize.maxMb} MB."
       )
       throw new RuntimeException(s"Generated binary $generatedBin is too large")
     } else {
       logger.info(
         s"Generated binary $generatedBin size ($mb MB) " +
-        s"is within the expected size: [${bounds._1}, ${bounds._2}] MB."
+        s"is within the expected size: [${expectedSize.minMb}, ${expectedSize.maxMb}] MB."
       )
     }
   }

--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -320,6 +320,43 @@ object NativeImage {
       }
     }
 
+  def checkNativeImageSize(
+    name: String,
+    targetDir: File
+  ): Def.Initialize[Task[Unit]] = Def.task {
+    val generatedBin = artifactFile(targetDir, name)
+    val logger       = streams.value.log
+    if (!generatedBin.exists) {
+      logger.error(s"Generated binary $generatedBin does not exist.")
+      logger.error(
+        "Ensure that the dependency on `buildNativeImage` is properly set."
+      )
+    }
+    val bytes              = generatedBin.attributes.size()
+    val productionNIBounds = (150, 450)
+    val testNIBounds       = (110, 550)
+    val mb                 = bytes / (1024 * 1024)
+    val bounds = if (GraalVM.EnsoLauncher.release) {
+      productionNIBounds
+    } else {
+      testNIBounds
+    }
+    val isInBounds =
+      bounds._1 <= mb && mb <= bounds._2
+    if (!isInBounds) {
+      logger.error(
+        s"Generated binary $generatedBin has unexpected size: $mb MB. " +
+        s"Expected size is between ${bounds._1} and ${bounds._2} MB."
+      )
+      throw new RuntimeException(s"Generated binary $generatedBin is too large")
+    } else {
+      logger.info(
+        s"Generated binary $generatedBin size ($mb MB) " +
+        s"is within the expected size: [${bounds._1}, ${bounds._2}] MB."
+      )
+    }
+  }
+
   /** [[File]] representing the artifact called `name` built with the Native
     * Image.
     */

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -42,8 +42,8 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
         max_size_mb = 450
         exec = File.new enso_bin
         exec.exists . should_be_true
-        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB]") <|
-            actual_size_mb = exec.size / (1024 * 1024)
+        actual_size_mb = exec.size / (1024 * 1024)
+        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB], but was: " + actual_size_mb.to_text + "MB.") <|
             (min_size_mb < actual_size_mb) . should_be_true
             (actual_size_mb < max_size_mb) . should_be_true
 

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -42,8 +42,8 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
         max_size_mb = 450
         exec = File.new enso_bin
         exec.exists . should_be_true
-        actual_size_mb = exec.size / (1024 * 1024)
-        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB], but was: " + actual_size_mb.to_text + "MB.") <|
+        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB]") <|
+            actual_size_mb = exec.size / (1024 * 1024)
             (min_size_mb < actual_size_mb) . should_be_true
             (actual_size_mb < max_size_mb) . should_be_true
 

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -36,6 +36,17 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             Test.with_clue clue <|
                 retcode . should_equal 0
 
+    ni_size_pending = if runs_in_aot then Nothing else "Only runs in AOT"
+    group_builder.specify "Size of the Native Image executable should be kept reasonably small" pending=ni_size_pending <|
+        min_size_mb = 150
+        max_size_mb = 450
+        exec = File.new enso_bin
+        exec.exists . should_be_true
+        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB]") <|
+            actual_size_mb = exec.size / (1024 * 1024)
+            (min_size_mb < actual_size_mb) . should_be_true
+            (actual_size_mb < max_size_mb) . should_be_true
+
 
 runs_in_aot =
     prop = J_System.getProperty "org.graalvm.nativeimage.imagecode"

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -36,17 +36,6 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             Test.with_clue clue <|
                 retcode . should_equal 0
 
-    ni_size_pending = if runs_in_aot then Nothing else "Only runs in AOT"
-    group_builder.specify "Size of the Native Image executable should be kept reasonably small" pending=ni_size_pending <|
-        min_size_mb = 150
-        max_size_mb = 450
-        exec = File.new enso_bin
-        exec.exists . should_be_true
-        Test.with_clue ("Size of the NI executable should be between [" + min_size_mb.to_text + "MB, " + max_size_mb.to_text + "MB]") <|
-            actual_size_mb = exec.size / (1024 * 1024)
-            (min_size_mb < actual_size_mb) . should_be_true
-            (actual_size_mb < max_size_mb) . should_be_true
-
 
 runs_in_aot =
     prop = J_System.getProperty "org.graalvm.nativeimage.imagecode"


### PR DESCRIPTION
### Pull Request Description

Size of the generated `enso` NI executable is checked right after it was built. The size bounds for the production NI are set to `150 MB <= x <= 450 MB`, explained in https://github.com/enso-org/enso/pull/12996#discussion_r2073742680.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
