### PR TITLE
Resolve the URI of suggestions correctly

### DIFF
--- a/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
@@ -199,6 +199,8 @@ export function suggestionDocumentationUrl(entry: SuggestionEntry): string | und
   if (!functionPath) return
   const postPath = functionPath.replace(`${path}.`, '')
 
+  // The path should be split into qualified name segments as the definition file.
+  // The function Path (e.g. Table.filter) is kept as a single part of the URL.
   return [DOCUMENTATION_ROOT, project, ...qnSegments(path), postPath].join('/')
 }
 

--- a/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
@@ -191,11 +191,15 @@ const DOCUMENTATION_ROOT = 'https://help.enso.org/docs/api'
 /** TODO: Add docs */
 export function suggestionDocumentationUrl(entry: SuggestionEntry): string | undefined {
   if (entry.kind !== SuggestionKind.Method && entry.kind !== SuggestionKind.Function) return
-  const { project, path } = entry.definitionPath
-  const definedPath = entry.definedIn.path + '.'
-  const usedPath = definedPath ? path?.replace(definedPath, definedPath?.replaceAll('.', '/')) : path
-  const concatenatedPath = `${DOCUMENTATION_ROOT}/${project}/${usedPath}`
-  return concatenatedPath
+
+  const { project, path } = entry.definedIn
+  if (!project?.startsWith('Standard.') || !path) return
+
+  const functionPath = entry.definitionPath.path
+  if (!functionPath) return
+  const postPath = functionPath.replace(`${path}.`, '')
+
+  return [DOCUMENTATION_ROOT, project, ...qnSegments(path), postPath].join('/')
 }
 
 /** `true` if calling the function without providing a value for this argument will result in an error. */

--- a/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
@@ -192,8 +192,10 @@ const DOCUMENTATION_ROOT = 'https://help.enso.org/docs/api'
 export function suggestionDocumentationUrl(entry: SuggestionEntry): string | undefined {
   if (entry.kind !== SuggestionKind.Method && entry.kind !== SuggestionKind.Function) return
   const { project, path } = entry.definitionPath
-  if (!project?.startsWith('Standard.') || !path) return
-  return [DOCUMENTATION_ROOT, project, ...qnSegments(path)].join('/')
+  const definedPath = entry.definedIn.path + '.'
+  const usedPath = definedPath ? path?.replace(definedPath, definedPath?.replaceAll('.', '/')) : path
+  const concatenatedPath = `${DOCUMENTATION_ROOT}/${project}/${usedPath}`
+  return concatenatedPath
 }
 
 /** `true` if calling the function without providing a value for this argument will result in an error. */


### PR DESCRIPTION
### Pull Request Description

Currently, the resolved URIs for the help pages were incorrect. Adjusted the process to produce the correct form of the address.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
