### PR TITLE
Fix test failures on nightly Snowflake tests

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1128,6 +1128,10 @@ type DB_Column
              import Standard.Examples
 
              example_min = Examples.decimal_column.min Examples.integer_column
+
+       ? SQLite NULL handling
+         In SQLite, if any of the values is NULL, the result is NULL.
+         In all other backends the NULL values are ignored.
     min self (values : Any | Vector Any) -> DB_Column =
         Value_Type_Helpers.check_multi_argument_comparable_op self values <|
             args = Vector.unify_vector_or_element values
@@ -1148,6 +1152,10 @@ type DB_Column
              import Standard.Examples
 
              example_max = Examples.decimal_column.max Examples.integer_column
+
+       ? SQLite NULL handling
+         In SQLite, if any of the values is NULL, the result is NULL.
+         In all other backends the NULL values are ignored.
     max self (values : Any | Vector Any) -> DB_Column =
         Value_Type_Helpers.check_multi_argument_comparable_op self values <|
             args = Vector.unify_vector_or_element values

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -197,7 +197,7 @@ type Snowflake_Dialect
         query_text = case statement of
             text : Text -> text
             _ : SQL_Statement -> statement.prepare.first
-        keywords_that_need_execute = ["VALUES", "DECODE"]
+        keywords_that_need_execute = ["VALUES", "DECODE", "LEAST", "GREATEST", "COALESCE"]
         regex = keywords_that_need_execute.join "|"
         needs_execute = query_text.find regex . is_nothing . not
         needs_execute
@@ -418,7 +418,7 @@ make_dialect_operations =
     cases = [["LOWER", Base_Generator.make_function "LOWER"], ["UPPER", Base_Generator.make_function "UPPER"]]
     text = [starts_with, contains, ends_with, agg_shortest, agg_longest, make_case_sensitive, ["REPLACE", replace], left, right, regex_match]+concat_ops+cases+trim_ops
     counts = [agg_count_is_null, agg_count_empty, agg_count_not_empty, ["COUNT_DISTINCT", agg_count_distinct], ["COUNT_DISTINCT_INCLUDE_NULL", agg_count_distinct_include_null]]
-    arith_extensions = [is_nan, is_inf, is_finite, floating_point_div, mod_op, decimal_div, decimal_mod, ["ROW_MIN", Base_Generator.make_function "LEAST"], ["ROW_MAX", Base_Generator.make_function "GREATEST"]]
+    arith_extensions = [is_nan, is_inf, is_finite, floating_point_div, mod_op, decimal_div, decimal_mod, ["ROW_MIN", Base_Generator.make_function "LEAST_IGNORE_NULLS"], ["ROW_MAX", Base_Generator.make_function "GREATEST_IGNORE_NULLS"]]
     bool = [bool_or]
 
     stddev_pop = ["STDDEV_POP", Base_Generator.make_function "stddev_pop"]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1426,8 +1426,12 @@ add_column_operation_specs suite_builder setup =
             c2.to_vector . should_equal [2, 2, 3]
             setup.expect_integer_type c2
 
-            c3 = data.a.min [2.5, 2]
-            c3.to_vector . should_equal [1, 2, 2]
+            c3 = data.a.min [2.5, 1.2]
+            c3.to_vector . should_equal [1, 1.2, 1.2]
+            IO.println c3.to_vector
+            c3.print
+            c3.read.print
+            IO.println c3.read.value_type
             c3.value_type.should_be_a (Value_Type.Float ...)
 
             c4 = data.a.max [2.5, 2]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -47,7 +47,7 @@ type Min_Max_Data
     t self = self.data.at 3
 
     setup table_builder = Min_Max_Data.Value <|
-        t = table_builder [["a", [1, 2, 3]], ["b", [4.5, 5.5, 6.5]], ["c", ['a', 'b', 'c']], ["d", [True, False, True]]] . sort "a"
+        t = table_builder [["a", [1, 2, 3]], ["b", [4.5, 5.5, 6.5]], ["c", ['a', 'b', 'c']], ["d", [True, False, True]], ["e", [1, Nothing, 10]]] . sort "a"
         a = t.at "a"
         b = t.at "b"
         c = t.at "c"
@@ -1457,6 +1457,13 @@ add_column_operation_specs suite_builder setup =
             c10 = (data.t.at "d").max False
             c10.to_vector . should_equal [True, False, True]
             c10.value_type.should_equal Value_Type.Boolean
+
+        group_builder.specify "should ignore null values" <|
+            data.t.at "e" . min 5 . to_vector . should_equal [1, 5, 5]
+            data.t.at "e" . max [3, Nothing, Nothing, 4] . to_vector . should_equal [4, 4, 10]
+
+            # Will still return Nothing if all were Nothing
+            data.t.at "e" . max Nothing . to_vector . should_equal [1, Nothing, 10]
 
         group_builder.specify "should allow Date/Time columns" pending=pending_datetime <|
             dt_data = Min_Max_Datetime_Data.setup setup.table_builder

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1426,12 +1426,8 @@ add_column_operation_specs suite_builder setup =
             c2.to_vector . should_equal [2, 2, 3]
             setup.expect_integer_type c2
 
-            c3 = data.a.min [2.5, 1.2]
-            c3.to_vector . should_equal [1, 1.2, 1.2]
-            IO.println c3.to_vector
-            c3.print
-            c3.read.print
-            IO.println c3.read.value_type
+            c3 = data.a.min [2.5, 2]
+            c3.to_vector . should_equal [1, 2, 2]
             c3.value_type.should_be_a (Value_Type.Float ...)
 
             c4 = data.a.max [2.5, 2]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1458,7 +1458,7 @@ add_column_operation_specs suite_builder setup =
             c10.to_vector . should_equal [True, False, True]
             c10.value_type.should_equal Value_Type.Boolean
 
-        group_builder.specify "should ignore null values" <|
+        group_builder.specify "should ignore null values" pending=(if setup.prefix.contains "SQLite" then "SQLite does not support ignoring NULL values in inputs to functions, so if any input value is NULL then the result will also be NULL.") <|
             data.t.at "e" . min 5 . to_vector . should_equal [1, 5, 5]
             data.t.at "e" . max [3, Nothing, Nothing, 4] . to_vector . should_equal [4, 4, 10]
 

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -24,7 +24,7 @@ add_derived_columns_specs suite_builder setup =
     table_builder = setup.light_table_builder
     pending_datetime = if (setup.flagged ..Date_Time).not then "Date/Time operations are not supported by this backend."
     suite_builder.group prefix+"(Derived_Columns_Spec) Table.set with Simple_Expression" group_builder->
-        group_builder.specify "arithmetics" pending=(if prefix.contains "Snowflake" then "TODO: re-enable these once https://github.com/enso-org/enso/pull/10583 is merged") <|
+        group_builder.specify "arithmetics" <|
             t = table_builder [["A", [1, 2]], ["B", [10, 40]]]
             t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Copy) "C" . at "C" . to_vector . should_equal [1, 2]
             t.set (..Simple_Expr (..Name "A") ..Copy) "C" . at "C" . to_vector . should_equal [1, 2]

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -700,7 +700,6 @@ postgres_specific_spec suite_builder create_connection_fn db_name setup =
 
         ## column expressions
         group_builder.specify "round returns the correct type" <|
-            # TODO https://github.com/enso-org/enso/issues/10345
             do_round data 231 1 . should_be_a Decimal
             do_round data 231 0 . should_be_a Float
             do_round data 231 . should_be_a Float


### PR DESCRIPTION
### Pull Request Description

- Fixes 2 failing tests for Snowflake
- Adds tests for `min`/`max` handling of `Nothing`/`NULL`
- Re-enables tests that should have been enabled when #10583 was merged.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
