### PR TITLE
Remove *_NODE_TYPE constants from TableVisualization.vue

### DIFF
--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -43,7 +43,7 @@ test('Column size can be set and is retained', async ({ page }) => {
   await page.waitForTimeout(1000)
   const tableVisualization = locate.tableVisualization(page)
   await expect(tableVisualization).toExist()
-  await expect(tableVisualization).toContainText('Total Row Count: 10')
+  await expect(tableVisualization).toContainText('10 rows.')
 
   const col = tableVisualization.getByRole('columnheader', { name: /^0/ })
   const colManualSize = await resizeCol(col)

--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -27,7 +27,7 @@ test('Load Table Visualisation', async ({ page }) => {
   await page.waitForTimeout(1000)
   const tableVisualization = locate.tableVisualization(page)
   await expect(tableVisualization).toExist()
-  await expect(tableVisualization).toContainText('Total Row Count: 10')
+  await expect(tableVisualization).toContainText('10 rows.')
   await expect(tableVisualization).toContainText('0,0')
   await expect(tableVisualization).toContainText('1,0')
   await expect(tableVisualization).toContainText('2,0')

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -142,6 +142,7 @@ const page = ref(0)
 const pageLimit = ref(0)
 const rowCount = ref(0)
 const filteredRowCount = ref(null)
+const showRowCount = ref(true)
 const isTruncated = ref(false)
 const filterModel = ref<GridFilterModel[]>([])
 const sortModel = ref<SortModel[]>([])
@@ -882,6 +883,7 @@ watchEffect(() => {
 
   // Update paging
   const newRowCount = data_.all_rows_count == null ? 1 : data_.all_rows_count
+  showRowCount.value = !(data_.all_rows_count == null)
   rowCount.value = newRowCount
   const newPageLimit = Math.ceil(newRowCount / rowLimit.value)
   pageLimit.value = newPageLimit
@@ -1043,7 +1045,7 @@ config.setToolbar(
 
 <template>
   <div ref="rootNode" class="TableVisualization" @wheel.stop @pointerdown.stop>
-    <template v-if="!isSSRM && isRowCountSelectorVisible">
+    <template v-if="!showStatusBar">
       <div class="table-visualization-status-bar">
         <select
           v-if="isRowCountSelectorVisible"
@@ -1056,7 +1058,7 @@ config.setToolbar(
             v-text="limit"
           ></option>
         </select>
-
+        <template v-if="showRowCount">
           <span
             v-if="isRowCountSelectorVisible && isTruncated"
             v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
@@ -1064,7 +1066,7 @@ config.setToolbar(
           <span v-else-if="isRowCountSelectorVisible" v-text="' rows.'"></span>
           <span v-else-if="rowCount === 1" v-text="'1 row.'"></span>
           <span v-else v-text="`${rowCount} rows.`"></span>
-
+        </template>
       </div>
     </template>
     <!-- TODO[ao]: Suspence in theory is not needed here (the entire visualization is inside

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -114,7 +114,7 @@ interface EnsoTableOrColumn {
   visualization_header: string
   data_quality_metrics?: DataQualityMetric[]
   is_using_server_sort_and_filter: boolean
-  show_status_bar: boolean
+  use_bottom_status_bar: boolean
   enable_create_node: boolean
   requires_number_format: boolean[]
   table_version_hash?: string
@@ -183,11 +183,11 @@ const isSSRM = computed(
     props.data.is_using_server_sort_and_filter,
 )
 
-const showStatusBar = computed(
+const useBottomStatusBar = computed(
   () =>
     typeof props.data === 'object' &&
-    'show_status_bar' in props.data &&
-    props.data.show_status_bar,
+    'use_bottom_status_bar' in props.data &&
+    props.data.use_bottom_status_bar,
 )
 
 const isCreateNewNodeEnabled = computed(
@@ -207,24 +207,19 @@ const ssrmDatasource = computed(() => {
   return isSSRM.value && createServerSideDatasource()
 })
 
-const statusBar = computed(() =>
-  allRowCount.value ?
-    {
-      statusPanels:
-      showStatusBar.value ?
-          [
-            {
-              statusPanel: TableVizStatusBar,
-              statusPanelParams: {
-                total: allRowCount.value,
-                filtered: isSSRM.value ? filteredRowCount.value : null,
-              },
-            },
-          ]
-        : [],
-    }
-  : null,
-)
+const statusBar = computed(() => ({
+  statusPanels: useBottomStatusBar.value
+    ? [
+        {
+          statusPanel: TableVizStatusBar,
+          statusPanelParams: {
+            total: allRowCount.value,
+            filtered: isSSRM.value ? filteredRowCount.value : null,
+          },
+        },
+      ]
+    : [],
+}));
 
 const isCreateNodeButtonEnabled = computed(
   () =>
@@ -1043,7 +1038,7 @@ config.setToolbar(
 
 <template>
   <div ref="rootNode" class="TableVisualization" @wheel.stop @pointerdown.stop>
-    <template v-if="!showStatusBar">
+    <template v-if="!useBottomStatusBar">
       <div class="table-visualization-status-bar">
         <select
           v-if="isRowCountSelectorVisible"

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -208,8 +208,9 @@ const ssrmDatasource = computed(() => {
 })
 
 const statusBar = computed(() => ({
-  statusPanels: useBottomStatusBar.value
-    ? [
+  statusPanels:
+    useBottomStatusBar.value ?
+      [
         {
           statusPanel: TableVizStatusBar,
           statusPanelParams: {
@@ -219,7 +220,7 @@ const statusBar = computed(() => ({
         },
       ]
     : [],
-}));
+}))
 
 const isCreateNodeButtonEnabled = computed(
   () =>
@@ -824,10 +825,7 @@ watchEffect(() => {
 
     if (!data_.is_using_server_sort_and_filter) {
       const shift = data_.type === 'EnsoTableOrColumn' ? 1 : 0
-      rowData.value =
-        data_.data ?
-          createRowsForTable(data_.data, shift, false)
-        : []
+      rowData.value = data_.data ? createRowsForTable(data_.data, shift, false) : []
     }
   }
   const headerGroupingMap = new Map()

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -137,7 +137,6 @@ const INDEX_FIELD_NAME = '#'
 const TABLE_NODE_TYPE = 'Standard.Table.Table.Table'
 const DB_TABLE_NODE_TYPE = 'Standard.Database.DB_Table.DB_Table'
 const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
-const ROW_NODE_TYPE = 'Standard.Table.Row.Row'
 
 const rowLimit = ref(0)
 const page = ref(0)
@@ -652,9 +651,7 @@ function createNode(
   const selectorKey = params.data[selector]
   const castSelector =
     castValueTypes === 'number' && !isNaN(Number(selectorKey)) ? Number(selectorKey) : selectorKey
-  const identifierAction =
-    config.nodeType === (COLUMN_NODE_TYPE) ? 'at' : action
-  const pattern = getAstPattern(castSelector, identifierAction)
+  const pattern = getAstPattern(castSelector, action)
   if (pattern) {
     config.createNodes({
       content: pattern,
@@ -816,9 +813,6 @@ watchEffect(() => {
             castValueTypes: data_.link_value_type,
           })
         }
-        if (config.nodeType === ROW_NODE_TYPE) {
-          return toRowField(v, i, valueType)
-        }
         return toField(v, { index: i, valueType })
       }) ?? []
 
@@ -835,14 +829,9 @@ watchEffect(() => {
       : dataHeader
 
     if (!data_.is_using_server_sort_and_filter) {
-      const hasIndexRow =
-        config.nodeType === TABLE_NODE_TYPE ||
-        config.nodeType === COLUMN_NODE_TYPE ||
-        config.nodeType === DB_TABLE_NODE_TYPE
-      const shift = hasIndexRow ? 1 : 0
       rowData.value =
         data_.data ?
-          createRowsForTable(data_.data, shift, data_.is_using_server_sort_and_filter)
+          createRowsForTable(data_.data, 1, false)
         : []
     }
   }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -117,6 +117,8 @@ interface UnknownTable {
   visualization_header: string
   data_quality_metrics?: DataQualityMetric[]
   is_using_server_sort_and_filter: boolean
+  show_status_bar: boolean
+  enable_create_node: boolean
   requires_number_format: boolean[]
   table_version_hash?: string
 }
@@ -134,16 +136,12 @@ const props = defineProps<{ data: Data }>()
 const config = useVisualizationConfig()
 
 const INDEX_FIELD_NAME = '#'
-const TABLE_NODE_TYPE = 'Standard.Table.Table.Table'
-const DB_TABLE_NODE_TYPE = 'Standard.Database.DB_Table.DB_Table'
-const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
 
 const rowLimit = ref(0)
 const page = ref(0)
 const pageLimit = ref(0)
 const rowCount = ref(0)
 const filteredRowCount = ref(null)
-const showRowCount = ref(true)
 const isTruncated = ref(false)
 const filterModel = ref<GridFilterModel[]>([])
 const sortModel = ref<SortModel[]>([])
@@ -187,6 +185,20 @@ const isSSRM = computed(
     props.data.is_using_server_sort_and_filter,
 )
 
+const showStatusBar = computed(
+  () =>
+    typeof props.data === 'object' &&
+    'show_status_bar' in props.data &&
+    props.data.show_status_bar,
+)
+
+const isCreateNewNodeEnabled = computed(
+  () =>
+    typeof props.data === 'object' &&
+    'enable_create_node' in props.data &&
+    props.data.enable_create_node,
+)
+
 const ssrmServer = computed(() => {
   return isSSRM.value && createServer()
 })
@@ -201,7 +213,7 @@ const statusBar = computed(() =>
   allRowCount.value ?
     {
       statusPanels:
-        config.nodeType === TABLE_NODE_TYPE || config.nodeType === COLUMN_NODE_TYPE ?
+      showStatusBar.value ?
           [
             {
               statusPanel: TableVizStatusBar,
@@ -239,7 +251,7 @@ watchEffect(() => {
 
 const textFormatterSelected = ref<TextFormatOptions>('partial')
 
-const isRowCountSelectorVisible = computed(() => rowCount.value >= 1000)
+const isRowCountSelectorVisible = computed(() => rowCount.value > 1000)
 const dataGroupingMap = shallowRef<Map<string, boolean>>()
 
 const selectableRowLimits = computed(() => {
@@ -267,10 +279,6 @@ watchEffect(() =>
     'prepare_visualization',
     rowLimit.value.toString(),
   ),
-)
-
-const isCreateNewNodeEnabled = computed(
-  () => config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE,
 )
 
 const numberFormatGroupped = new Intl.NumberFormat(undefined, {
@@ -874,7 +882,6 @@ watchEffect(() => {
 
   // Update paging
   const newRowCount = data_.all_rows_count == null ? 1 : data_.all_rows_count
-  showRowCount.value = !(data_.all_rows_count == null) && config.nodeType != TABLE_NODE_TYPE
   rowCount.value = newRowCount
   const newPageLimit = Math.ceil(newRowCount / rowLimit.value)
   pageLimit.value = newPageLimit
@@ -1036,7 +1043,7 @@ config.setToolbar(
 
 <template>
   <div ref="rootNode" class="TableVisualization" @wheel.stop @pointerdown.stop>
-    <template v-if="!isSSRM">
+    <template v-if="!isSSRM && isRowCountSelectorVisible">
       <div class="table-visualization-status-bar">
         <select
           v-if="isRowCountSelectorVisible"
@@ -1049,7 +1056,7 @@ config.setToolbar(
             v-text="limit"
           ></option>
         </select>
-        <template v-if="showRowCount">
+
           <span
             v-if="isRowCountSelectorVisible && isTruncated"
             v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
@@ -1057,7 +1064,7 @@ config.setToolbar(
           <span v-else-if="isRowCountSelectorVisible" v-text="' rows.'"></span>
           <span v-else-if="rowCount === 1" v-text="'1 row.'"></span>
           <span v-else v-text="`${rowCount} rows.`"></span>
-        </template>
+
       </div>
     </template>
     <!-- TODO[ao]: Suspence in theory is not needed here (the entire visualization is inside

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -623,13 +623,6 @@ function toField(
   }
 }
 
-function toRowField(name: string, index: number, valueType?: ValueType | null | undefined) {
-  return {
-    ...toField(name, { index, valueType }),
-    cellDataType: false,
-  }
-}
-
 function getAstPattern(selector?: string | number, action?: string) {
   if (action && selector != null) {
     return Pattern.new<Ast.Expression>((ast) =>

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -52,7 +52,7 @@ export const defaultPreprocessor = [
   '1000',
 ] as const
 
-type Data = number | string | Error | Matrix | ObjectMatrix | UnknownTable | Excel_Workbook
+type Data = number | string | Error | Matrix | ObjectMatrix | EnsoTableOrColumn | Excel_Workbook
 
 interface Error {
   type: undefined
@@ -98,11 +98,8 @@ interface ObjectMatrix {
   visualization_header: string
 }
 
-interface UnknownTable {
-  // This is INCORRECT. It is actually a string, however we do not need to access this.
-  // Setting it to `string` breaks the discriminated union detection that is being used to
-  // distinguish `Matrix` and `ObjectMatrix`.
-  type: undefined
+interface EnsoTableOrColumn {
+  type: 'EnsoTableOrColumn'
   json: unknown
   all_rows_count?: number
   header: string[] | undefined
@@ -838,9 +835,10 @@ watchEffect(() => {
       : dataHeader
 
     if (!data_.is_using_server_sort_and_filter) {
+      const shift = data_.type === 'EnsoTableOrColumn' ? 1 : 0
       rowData.value =
         data_.data ?
-          createRowsForTable(data_.data, 1, false)
+          createRowsForTable(data_.data, shift, false)
         : []
     }
   }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -136,7 +136,6 @@ const config = useVisualizationConfig()
 const INDEX_FIELD_NAME = '#'
 const TABLE_NODE_TYPE = 'Standard.Table.Table.Table'
 const DB_TABLE_NODE_TYPE = 'Standard.Database.DB_Table.DB_Table'
-const VECTOR_NODE_TYPE = 'Standard.Base.Data.Vector.Vector'
 const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
 const ROW_NODE_TYPE = 'Standard.Table.Row.Row'
 
@@ -654,7 +653,7 @@ function createNode(
   const castSelector =
     castValueTypes === 'number' && !isNaN(Number(selectorKey)) ? Number(selectorKey) : selectorKey
   const identifierAction =
-    config.nodeType === (COLUMN_NODE_TYPE || VECTOR_NODE_TYPE) ? 'at' : action
+    config.nodeType === (COLUMN_NODE_TYPE) ? 'at' : action
   const pattern = getAstPattern(castSelector, identifierAction)
   if (pattern) {
     config.createNodes({

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/docs/api/Table/Visualization.md
@@ -11,7 +11,7 @@
 - make_json_for_object_matrix current:Standard.Base.Any.Any vector:Standard.Base.Any.Any idx:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_json_for_other x:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_row row:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- make_json_for_table dataframe:Standard.Base.Any.Any max_rows:Standard.Base.Any.Any all_rows_count:Standard.Base.Any.Any is_db_table:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- make_json_for_table dataframe:Standard.Base.Any.Any max_rows:Standard.Base.Any.Any all_rows_count:Standard.Base.Any.Any is_db_table:Standard.Base.Any.Any is_column:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_value val:Standard.Base.Any.Any level:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_json_for_vector vector:Standard.Base.Any.Any max_rows:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_json_for_xml_element xml_element:Standard.Base.Any.Any max_items:Standard.Base.Any.Any type:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -30,17 +30,10 @@ prepare_visualization y max_rows=1000 = if y.is_error then (make_json_for_error 
         v : Row -> make_json_for_row v
         t : Table ->
             all_rows_count = t.row_count
-            make_json_for_table t max_rows all_rows_count False
-        c : Column -> make_json_for_table c.to_table max_rows c.length False child_node_action="at"
-        t : DB_Table ->
-            dataframe = t.read (..First max_rows)
-            case dataframe.is_error of
-                False ->
-                    all_rows_count = t.row_count
-                    make_json_for_table dataframe max_rows all_rows_count True
-                True ->
-                    JS_Object.from_pairs [["error", 'Error querying the database:\n' + dataframe.catch.to_display_text]] . to_text
-        c : DB_Column -> prepare_visualization c.to_table max_rows
+            make_json_for_table t max_rows all_rows_count False False
+        c : Column -> make_json_for_table c.to_table max_rows c.length False True
+        t : DB_Table -> _make_json_for_db_table t max_rows is_column=False
+        c : DB_Column -> _make_json_for_db_table c.to_table max_rows is_column=True
         f : Function ->
             pairs = [['_display_text_', '[Function '+f.to_text+']']]
             value = JS_Object.from_pairs pairs
@@ -185,6 +178,16 @@ make_json_for_xml_element xml_element max_items type:Text="XML_Element" =
     get_child_node_fields = if type == "XML_Element" then [["get_child_node_action", "get"], ["get_child_node_link_name", "key"], ["link_value_type", "number"]] else [["get_child_node_action", "get_child_element"], ["get_child_node_link_name", "key"], ["link_value_type", "number"]]
     JS_Object.from_pairs <| [header, data, all_rows, ["type", type]] + get_child_node_fields
 
+
+private _make_json_for_db_table t max_rows is_column =
+    dataframe = t.read (..First max_rows)
+    case dataframe.is_error of
+        False ->
+            all_rows_count = t.row_count
+            make_json_for_table dataframe max_rows all_rows_count True is_column
+        True ->
+            JS_Object.from_pairs [["error", 'Error querying the database:\n' + dataframe.catch.to_display_text]] . to_text
+
 ## PRIVATE
    Creates a JSON representation for the visualizations.
 
@@ -193,8 +196,8 @@ make_json_for_xml_element xml_element max_items type:Text="XML_Element" =
      to display.
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
-make_json_for_table : Table -> Integer -> Integer -> Boolean -> Text -> JS_Object
-make_json_for_table dataframe max_rows all_rows_count is_db_table child_node_action="get_row" =
+make_json_for_table : Table -> Integer -> Integer -> Boolean -> Boolean -> JS_Object
+make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
     act_max = if max_rows < all_rows_count then max_rows else all_rows_count
     get_vector c         = Warning.set (Vector.new act_max i-> make_json_for_value (c.get i)) []
     columns              = dataframe.columns
@@ -202,7 +205,9 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table child_node_act
     value_type           = ["value_type", columns.map .value_type]
     all_rows             = ["all_rows_count", all_rows_count]
     has_index_col        = ["has_index_col", True]
-    links                = ["get_child_node_action", child_node_action]
+    links                = ["get_child_node_action", if is_column then "at" else "get_row"]
+    show_status_bar      = ["show_status_bar", if is_db_table then False else True]
+    enable_create_node   = ["enable_create_node", if is_column then False else True]
     child_label          = ["child_label", "row"]
     is_using_server_model = if is_db_table then False else all_rows_count > 1000
     data                 = if is_using_server_model.not then columns.map get_vector else Nothing
@@ -216,7 +221,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table child_node_act
         number_non_triv = JS_Object.from_pairs [["name", "Count non trivial whitespace" + sampled_label], ["percentage_value", columns.map .count_non_trivial_whitespace]]
         JS_Object.from_pairs
         [number_nothing, number_untrimmed, number_non_triv]
-    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, ["data_quality_metrics", data_quality_metrics] ,["type", "Table"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
+    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, show_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "Table"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -31,7 +31,7 @@ prepare_visualization y max_rows=1000 = if y.is_error then (make_json_for_error 
         t : Table ->
             all_rows_count = t.row_count
             make_json_for_table t max_rows all_rows_count False
-        c : Column -> prepare_visualization c.to_table max_rows
+        c : Column -> make_json_for_table c.to_table max_rows c.length False child_node_action="at"
         t : DB_Table ->
             dataframe = t.read (..First max_rows)
             case dataframe.is_error of
@@ -193,8 +193,8 @@ make_json_for_xml_element xml_element max_items type:Text="XML_Element" =
      to display.
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
-make_json_for_table : Table -> Integer -> Integer -> Boolean -> JS_Object
-make_json_for_table dataframe max_rows all_rows_count is_db_table =
+make_json_for_table : Table -> Integer -> Integer -> Boolean -> Text -> JS_Object
+make_json_for_table dataframe max_rows all_rows_count is_db_table child_node_action="get_row" =
     act_max = if max_rows < all_rows_count then max_rows else all_rows_count
     get_vector c         = Warning.set (Vector.new act_max i-> make_json_for_value (c.get i)) []
     columns              = dataframe.columns
@@ -202,7 +202,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table =
     value_type           = ["value_type", columns.map .value_type]
     all_rows             = ["all_rows_count", all_rows_count]
     has_index_col        = ["has_index_col", True]
-    links                = ["get_child_node_action", "get_row"]
+    links                = ["get_child_node_action", child_node_action]
     child_label          = ["child_label", "row"]
     is_using_server_model = if is_db_table then False else all_rows_count > 1000
     data                 = if is_using_server_model.not then columns.map get_vector else Nothing

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -221,7 +221,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
         number_non_triv = JS_Object.from_pairs [["name", "Count non trivial whitespace" + sampled_label], ["percentage_value", columns.map .count_non_trivial_whitespace]]
         JS_Object.from_pairs
         [number_nothing, number_untrimmed, number_non_triv]
-    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, show_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "Table"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
+    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, show_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "EnsoTableOrColumn"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -199,16 +199,16 @@ private _make_json_for_db_table t max_rows is_column =
 make_json_for_table : Table -> Integer -> Integer -> Boolean -> Boolean -> JS_Object
 make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
     act_max = if max_rows < all_rows_count then max_rows else all_rows_count
-    get_vector c         = Warning.set (Vector.new act_max i-> make_json_for_value (c.get i)) []
-    columns              = dataframe.columns
-    header               = ["header", columns.map .name]
-    value_type           = ["value_type", columns.map .value_type]
-    all_rows             = ["all_rows_count", all_rows_count]
-    has_index_col        = ["has_index_col", True]
-    links                = ["get_child_node_action", if is_column then "at" else "get_row"]
-    show_status_bar      = ["show_status_bar", if is_db_table then False else True]
-    enable_create_node   = ["enable_create_node", if is_column then False else True]
-    child_label          = ["child_label", "row"]
+    get_vector c          = Warning.set (Vector.new act_max i-> make_json_for_value (c.get i)) []
+    columns               = dataframe.columns
+    header                = ["header", columns.map .name]
+    value_type            = ["value_type", columns.map .value_type]
+    all_rows              = ["all_rows_count", all_rows_count]
+    has_index_col         = ["has_index_col", True]
+    links                 = ["get_child_node_action", if is_column then "at" else "get_row"]
+    use_bottom_status_bar = ["use_bottom_status_bar", if is_db_table then False else True]
+    enable_create_node    = ["enable_create_node", if is_column then False else True]
+    child_label           = ["child_label", "row"]
     is_using_server_model = if is_db_table then False else all_rows_count > 1000
     data                 = if is_using_server_model.not then columns.map get_vector else Nothing
     requires_number_formatting = ["requires_number_format", columns.map .requires_numeric_formatter_check]
@@ -221,7 +221,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
         number_non_triv = JS_Object.from_pairs [["name", "Count non trivial whitespace" + sampled_label], ["percentage_value", columns.map .count_non_trivial_whitespace]]
         JS_Object.from_pairs
         [number_nothing, number_untrimmed, number_non_triv]
-    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, show_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "EnsoTableOrColumn"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
+    pairs                = [header, value_type, ["data", data], all_rows, has_index_col, links, use_bottom_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "EnsoTableOrColumn"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -49,13 +49,15 @@ type Foo_Link
     to_js_object self = JS_Object.from_pairs [["x", self.x], ["links", ["a", "b", "c"]]]
 
 add_specs suite_builder =
-    make_json header data all_rows value_type has_index_col get_child_node is_ssrm number_of_nothing=Nothing number_of_untrimmed_whitespace=Nothing number_of_untrimmed_whitespace_sampled=Nothing number_non_trivial_ws=Nothing number_non_trivial_ws_sampled=Nothing requires_number_format table_version_hash=Nothing =
+    make_json header data all_rows value_type has_index_col get_child_node is_ssrm number_of_nothing=Nothing number_of_untrimmed_whitespace=Nothing number_of_untrimmed_whitespace_sampled=Nothing number_non_trivial_ws=Nothing number_non_trivial_ws_sampled=Nothing requires_number_format table_version_hash=Nothing use_bottom_status_bar=True enable_create_node=True =
         p_header      = ["header", header]
         p_data        = ["data",   data]
         p_all_rows    = ["all_rows_count", all_rows]
         p_value_type  = ["value_type", value_type]
         p_has_index_col = ["has_index_col", has_index_col]
         p_get_child_node = ["get_child_node_action", get_child_node]
+        p_use_bottom_status_bar = ["use_bottom_status_bar", use_bottom_status_bar]
+        p_enable_create_node    = ["enable_create_node", enable_create_node]
         p_is_ssrm       = ["is_using_server_sort_and_filter", is_ssrm]
         p_requires_number_format = ["requires_number_format", requires_number_format]
         p_table_version_hash = ["table_version_hash", table_version_hash]
@@ -65,7 +67,7 @@ add_specs suite_builder =
         p_number_of_untrimmed_whitespace_sampled = if number_of_untrimmed_whitespace_sampled.is_nothing then [] else [JS_Object.from_pairs [["name", "Count untrimmed whitespace (sampled)"], ["percentage_value", number_of_untrimmed_whitespace_sampled]]]
         p_number_non_trivial_ws_sampled = if number_non_trivial_ws_sampled.is_nothing then [] else [JS_Object.from_pairs [["name", "Count non trivial whitespace (sampled)"], ["percentage_value", number_non_trivial_ws_sampled]]]
         data_quality_metrics = p_number_of_nothing + p_number_of_untrimmed_whitespace + p_number_of_untrimmed_whitespace_sampled + p_number_non_trivial_ws + p_number_non_trivial_ws_sampled
-        pairs    = [p_header, p_value_type, p_data, p_all_rows, p_has_index_col, p_get_child_node, ["data_quality_metrics", data_quality_metrics], ["type", "Table"], ["child_label", "row"], p_is_ssrm, p_requires_number_format, p_table_version_hash]
+        pairs    = [p_header, p_value_type, p_data, p_all_rows, p_has_index_col, p_get_child_node, p_use_bottom_status_bar, p_enable_create_node, ["data_quality_metrics", data_quality_metrics], ["type", "EnsoTableOrColumn"], ["child_label", "row"], p_is_ssrm, p_requires_number_format, p_table_version_hash]
         JS_Object.from_pairs pairs . to_text
     
     suite_builder.group "Table Visualization" group_builder->
@@ -75,31 +77,31 @@ add_specs suite_builder =
             vis = Visualization.prepare_visualization data.t 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False requires_number_format=[False, False, False] use_bottom_status_bar=False enable_create_node=True
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["display_text", "Float (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char] has_index_col=True get_child_node="get_row" is_ssrm=False requires_number_format=[False]
+            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char] has_index_col=True get_child_node="at" is_ssrm=False requires_number_format=[False] use_bottom_status_bar=False enable_create_node=False
             vis . should_equal json
 
             g = data.t.aggregate ["A", "B"] [Aggregate_Column.Average "C"] . at "Average C"
             vis2 = Visualization.prepare_visualization g 1
-            json2 = make_json header=["Average C"] data=[[4.0]]  all_rows=2 value_type=[value_type_float] has_index_col=True get_child_node="get_row" is_ssrm=False requires_number_format=[False]
+            json2 = make_json header=["Average C"] data=[[4.0]]  all_rows=2 value_type=[value_type_float] has_index_col=True get_child_node="at" is_ssrm=False requires_number_format=[False] use_bottom_status_bar=False enable_create_node=False
             vis2 . should_equal json2
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False]
+            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0,0,0] number_of_untrimmed_whitespace=[Nothing, Nothing, Nothing] number_non_trivial_ws=[Nothing, Nothing, Nothing] requires_number_format=[False, False, False] use_bottom_status_bar=True enable_create_node=True
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False number_of_nothing=[0] number_of_untrimmed_whitespace=[Nothing] number_non_trivial_ws=[Nothing] requires_number_format=[False]
+            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int] has_index_col=True get_child_node="at" is_ssrm=False number_of_nothing=[0] number_of_untrimmed_whitespace=[Nothing] number_non_trivial_ws=[Nothing] requires_number_format=[False] use_bottom_status_bar=True enable_create_node=False
             vis . should_equal json
 
         group_builder.specify "should handle Vectors" <|


### PR DESCRIPTION
### Pull Request Description

Removes one way in which we specialise the Table Visualisations (namely checking and special casing the underlying Enso type). Moves a lot of that specialisation into the enso libraries code.

Fixes a few minor visual defects as a side effect.

Table before

![image](https://github.com/user-attachments/assets/ba503821-8dc9-4a51-b1ef-f62b6041244f)

Table after

![image](https://github.com/user-attachments/assets/aee44454-9a4c-4e4c-9ced-e799f12e5470)

Column before

![image](https://github.com/user-attachments/assets/fad48464-ee63-455b-8fd1-69170c12c3bf)

Column after

![image](https://github.com/user-attachments/assets/fb039fac-0e2e-4671-9480-62955f90f2c3)

DB_Table before

![image](https://github.com/user-attachments/assets/86081fcd-d001-4510-a5c8-f89ee23b6331)

DB_Table after

![image](https://github.com/user-attachments/assets/d2636bcf-b979-4821-92df-50fbdfec7c07)

DB_Column before

![image](https://github.com/user-attachments/assets/e0dc0f3f-01f4-40d2-a6f0-379e910a3399)

DB_Column after

![image](https://github.com/user-attachments/assets/b6702a9d-4d27-4e25-8062-423cd35e8283)

Row before

![image](https://github.com/user-attachments/assets/1c58de36-3b44-4f10-9090-bfa97ea3d8ba)

Row after

![image](https://github.com/user-attachments/assets/44d23b87-cf6f-48cc-9400-c8311513daf7)

Row Defect Before

![image](https://github.com/user-attachments/assets/af1b8334-3fc7-45b8-a4c2-3c9247072b21)

Row Defect After

![image](https://github.com/user-attachments/assets/63f076cb-ef36-4e08-a1ee-094abe2788c6)



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
