### PR TITLE
Dump stacktraces when tests fail to close context

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -755,6 +755,7 @@ lazy val componentModulesPaths =
     (`runtime-instrument-runtime-server` / Compile / exportedModuleBin).value,
     (`runtime-language-arrow` / Compile / exportedModuleBin).value,
     (`runtime-language-epb` / Compile / exportedModuleBin).value,
+    (`runtime-utils` / Compile / exportedModuleBin).value,
     (`runtime-version-manager` / Compile / exportedModuleBin).value,
     (`persistance` / Compile / exportedModuleBin).value,
     (`cli` / Compile / exportedModuleBin).value,

--- a/build.sbt
+++ b/build.sbt
@@ -3189,6 +3189,7 @@ lazy val `runtime-benchmarks` =
       },
       Compile / internalModuleDependencies := Seq(
         (`runtime` / Compile / exportedModule).value,
+        (`runtime-utils` / Compile / exportedModule).value,
         (`runtime-instrument-common` / Compile / exportedModule).value,
         (`runtime-instrument-runtime-server` / Compile / exportedModule).value,
         (`runtime-instrument-repl-debugger` / Compile / exportedModule).value,

--- a/build.sbt
+++ b/build.sbt
@@ -2447,6 +2447,7 @@ lazy val `language-server` = (project in file("engine/language-server"))
       (`runtime-instrument-repl-debugger` / Compile / exportedModule).value,
       (`runtime-instrument-id-execution` / Compile / exportedModule).value,
       (`runtime-language-epb` / Compile / exportedModule).value,
+      (`runtime-utils` / Compile / exportedModule).value,
       (`ydoc-polyfill` / Compile / exportedModule).value,
       (`syntax-rust-definition` / Compile / exportedModule).value,
       (`profiling-utils` / Compile / exportedModule).value,

--- a/build.sbt
+++ b/build.sbt
@@ -1402,6 +1402,15 @@ lazy val `jna-wrapper` = project
     }
   )
 
+lazy val `runtime-utils` = project
+  .in(file("lib/java/runtime-utils"))
+  .enablePlugins(JPMSPlugin)
+  .settings(
+    frgaalJavaCompilerSetting,
+    scalaModuleDependencySetting,
+    javaModuleName := "org.enso.runtime.utils"
+  )
+
 lazy val `directory-watcher-wrapper` = project
   .in(file("lib/java/directory-watcher-wrapper"))
   .enablePlugins(JPMSPlugin)
@@ -1885,6 +1894,7 @@ lazy val `json-rpc-server` = project
       (`akka-wrapper` / Compile / exportedModule).value
     )
   )
+  .dependsOn(`runtime-utils` % "test->compile")
 
 // An automatic JPMS module
 lazy val testkit = project
@@ -2725,7 +2735,8 @@ lazy val `runtime-language-epb` =
         "org.graalvm.sdk"      % "nativeimage" % graalMavenPackagesVersion
       ),
       Compile / internalModuleDependencies := Seq(
-        (`ydoc-polyfill` / Compile / exportedModule).value
+        (`ydoc-polyfill` / Compile / exportedModule).value,
+        (`runtime-utils` / Compile / exportedModule).value
       )
     )
 
@@ -3003,6 +3014,7 @@ lazy val `runtime-integration-tests` =
         (`runtime-compiler` / Compile / exportedModule).value,
         (`runtime-compiler-dump` / Compile / exportedModule).value,
         (`runtime-compiler-dump-igv` / Compile / exportedModule).value,
+        (`runtime-utils` / Compile / exportedModule).value,
         (`polyglot-api` / Compile / exportedModule).value,
         (`polyglot-api-macros` / Compile / exportedModule).value,
         (`pkg` / Compile / exportedModule).value,
@@ -3054,6 +3066,7 @@ lazy val `runtime-integration-tests` =
         (`runtime-test-instruments` / javaModuleName).value,
         (`ydoc-polyfill` / javaModuleName).value,
         (`runtime-instrument-common` / javaModuleName).value,
+        (`runtime-utils` / javaModuleName).value,
         (`text-buffer` / javaModuleName).value,
         (`logging-service-logback` / Test / javaModuleName).value,
         (`logging-service-telemetry` / Compile / javaModuleName).value,
@@ -3114,6 +3127,7 @@ lazy val `runtime-integration-tests` =
     )
     .dependsOn(`runtime`)
     .dependsOn(`runtime-test-instruments`)
+    .dependsOn(`runtime-utils` % "test->compile")
     .dependsOn(`logging-service-logback` % "test->test")
     .dependsOn(`logging-service-telemetry` % "test->compile")
     .dependsOn(`logging-utils` % Test)
@@ -3616,6 +3630,7 @@ lazy val `runtime-instrument-common` =
         (`runtime-compiler-dump` / Compile / exportedModule).value,
         (`runtime-parser` / Compile / exportedModule).value,
         (`runtime-suggestions` / Compile / exportedModule).value,
+        (`runtime-utils` / Compile / exportedModule).value,
         (`text-buffer` / Compile / exportedModule).value,
         (`pkg` / Compile / exportedModule).value,
         (`polyglot-api` / Compile / exportedModule).value,
@@ -3623,6 +3638,7 @@ lazy val `runtime-instrument-common` =
       )
     )
     .dependsOn(`refactoring-utils`)
+    .dependsOn(`runtime-utils`)
     .dependsOn(`runtime` % "compile->compile;runtime->runtime")
 
 lazy val `runtime-instrument-id-execution` =
@@ -4826,6 +4842,7 @@ lazy val `process-utils` = project
     scalaModuleDependencySetting,
     compileOrder := CompileOrder.ScalaThenJava
   )
+  .dependsOn(`runtime-utils`)
 
 lazy val `locking-test-helper` = project
   .in(file("lib/scala/locking-test-helper"))

--- a/engine/runtime-instrument-common/src/main/java/module-info.java
+++ b/engine/runtime-instrument-common/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module org.enso.runtime.instrument.common {
   requires org.enso.runtime.compiler;
   requires org.enso.runtime.parser;
   requires org.enso.runtime.suggestions;
+  requires org.enso.runtime.utils;
   requires org.enso.text.buffer;
   requires org.enso.pkg;
   requires org.enso.polyglot.api;

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -4,6 +4,7 @@ import org.enso.common.Asserts.assertInJvm
 import org.enso.interpreter.instrument.InterpreterContext
 import org.enso.interpreter.instrument.job.{BackgroundJob, Job, UniqueJob}
 import org.enso.text.Sha3_224VersionCalculator
+import org.enso.runtime.utils.ThreadUtils
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -113,25 +114,11 @@ final class JobExecutionEngine(
             )
           } catch {
             case _: TimeoutException =>
-              val sb = new StringBuilder(
+              val msg = ThreadUtils.dumpAllStacktraces(
                 "Threaddump when timeout is reached while waiting for the job " + runningJob.id + " running in thread " + runningJob.job
-                  .threadNameExecutingJob() + " to cancel:\n"
+                  .threadNameExecutingJob() + " to cancel:"
               )
-              Thread.getAllStackTraces.entrySet.forEach { entry =>
-                sb.append(entry.getKey.getName).append("\n")
-                entry.getValue.foreach { e =>
-                  sb.append("    ")
-                    .append(e.getClassName)
-                    .append(".")
-                    .append(e.getMethodName)
-                    .append("(")
-                    .append(e.getFileName)
-                    .append(":")
-                    .append(e.getLineNumber)
-                    .append(")\n")
-                }
-              }
-              logger.warn(sb.toString())
+              logger.warn(msg)
               runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
             case _: CancellationException =>
               logger.debug(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -115,7 +115,7 @@ final class JobExecutionEngine(
           } catch {
             case _: TimeoutException =>
               val msg = ThreadUtils.dumpAllStacktraces(
-                "Threaddump when timeout is reached while waiting for the job " + runningJob.id + " running in thread " + runningJob.job
+                "Thread dump when timeout is reached while waiting for the job " + runningJob.id + " running in thread " + runningJob.job
                   .threadNameExecutingJob() + " to cancel:"
               )
               logger.warn(msg)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
@@ -6,6 +6,7 @@ import org.enso.pkg.{Package, PackageManager}
 import org.enso.common.LanguageInfo
 import org.enso.polyglot.PolyglotContext
 import org.enso.polyglot.runtime.Runtime.Api
+import org.enso.runtime.utils.ThreadUtils
 import org.graalvm.polyglot.Context
 
 import java.io.File
@@ -155,7 +156,16 @@ abstract class InstrumentTestContext(packageName: String) {
 
   def close(): Unit = {
     if (context() != null) {
-      context().close()
+      try {
+        context().close()
+      } catch {
+        case e: IllegalStateException =>
+          val msg = ThreadUtils.dumpAllStacktraces(
+            "Threadump on failure to close test Instrument Context:"
+          )
+          println(msg)
+          throw e
+      }
     }
     Await.ready(runtimeServerEmulator.terminate(), 5.seconds)
     lockManager.reset()

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
@@ -161,7 +161,7 @@ abstract class InstrumentTestContext(packageName: String) {
       } catch {
         case e: IllegalStateException =>
           val msg = ThreadUtils.dumpAllStacktraces(
-            "Threadump on failure to close test Instrument Context:"
+            "Thread dump on failure to close test Instrument Context:"
           )
           println(msg)
           throw e

--- a/engine/runtime-language-epb/src/main/java/module-info.java
+++ b/engine/runtime-language-epb/src/main/java/module-info.java
@@ -2,6 +2,7 @@ open module org.enso.runtime.language.epb {
   requires java.logging;
   requires org.graalvm.polyglot;
   requires org.graalvm.truffle;
+  requires org.enso.runtime.utils;
   requires org.enso.ydoc.polyfill;
 
   provides com.oracle.truffle.api.provider.TruffleLanguageProvider with

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -12,6 +12,7 @@ import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.logging.Level;
+import org.enso.runtime.utils.ThreadUtils;
 import org.enso.ydoc.polyfill.web.WebEnvironment;
 import org.graalvm.polyglot.Value;
 
@@ -119,30 +120,10 @@ final class EpbContext {
   }
 
   private boolean dumpStack(int ms) {
-    var sb = new StringBuilder("Polyglot access failed. Waiting " + ms + " ms. Threaddump:\n");
-    var traces = Thread.getAllStackTraces();
-    for (var entry : traces.entrySet()) {
-      var thread = new StringBuilder();
-      thread.append(entry.getKey().getName()).append("\n");
-      var keep = false;
-      for (var e : entry.getValue()) {
-        keep |= e.getClassName().contains("com.oracle.truffle");
-        thread
-            .append("    ")
-            .append(e.getClassName())
-            .append(".")
-            .append(e.getMethodName())
-            .append("(")
-            .append(e.getFileName())
-            .append(":")
-            .append(e.getLineNumber())
-            .append(")\n");
-      }
-      if (keep) {
-        sb.append(thread.toString());
-      }
-    }
-    log(Level.WARNING, sb.toString());
+    var msg =
+        ThreadUtils.dumpAllStacktraces(
+            "Polyglot access failed. Waiting " + ms + " ms. Threaddump:");
+    log(Level.WARNING, msg);
     return true;
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -122,7 +122,7 @@ final class EpbContext {
   private boolean dumpStack(int ms) {
     var msg =
         ThreadUtils.dumpAllStacktraces(
-            "Polyglot access failed. Waiting " + ms + " ms. Threaddump:");
+            "Polyglot access failed. Waiting " + ms + " ms. Thread dump:");
     log(Level.WARNING, msg);
     return true;
   }

--- a/lib/java/runtime-utils/src/main/java/module-info.java
+++ b/lib/java/runtime-utils/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.enso.runtime.utils {
+    exports org.enso.runtime.utils;
+}

--- a/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
+++ b/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
@@ -1,0 +1,30 @@
+package org.enso.runtime.utils;
+
+import java.util.Arrays;
+
+public class ThreadUtils {
+
+    private ThreadUtils() {}
+
+    public static String dumpAllStacktraces(String prefix) {
+        var sb = new StringBuilder(prefix);
+        sb.append(System.lineSeparator());
+        Thread.getAllStackTraces().entrySet().forEach(entry -> {
+            sb.append(entry.getKey().getName()).append(System.lineSeparator());
+            Arrays.stream(entry.getValue()).forEach(e ->
+                sb.append("    ")
+                        .append(e.getClassName())
+                        .append(".")
+                        .append(e.getMethodName())
+                        .append("(")
+                        .append(e.getFileName())
+                        .append(":")
+                        .append(e.getLineNumber())
+                        .append(")")
+                        .append(System.lineSeparator())
+            );
+        });
+        return sb.toString();
+    }
+
+}

--- a/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
+++ b/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
@@ -14,6 +14,7 @@ import org.enso.jsonrpc.{
   JsonRpcServer,
   ProtocolFactory
 }
+import org.enso.runtime.utils.ThreadUtils
 import org.scalactic.source.Position
 import org.scalatest.matchers.{MatchResult, Matcher}
 import org.scalatest.matchers.should.Matchers
@@ -131,24 +132,10 @@ abstract class JsonRpcServerTestKit
               if e.getMessage.contains(
                 "timeout"
               ) && printStackTracesOnFailure =>
-            val sb = new StringBuilder(
-              "Thread dump when timeout is reached while waiting for the message:\n"
-            )
-            Thread.getAllStackTraces.entrySet.forEach { entry =>
-              sb.append(entry.getKey.getName).append("\n")
-              entry.getValue.foreach { e =>
-                sb.append("    ")
-                  .append(e.getClassName)
-                  .append(".")
-                  .append(e.getMethodName)
-                  .append("(")
-                  .append(e.getFileName)
-                  .append(":")
-                  .append(e.getLineNumber)
-                  .append(")\n")
-              }
-            }
-            println(sb.toString())
+            val msg = ThreadUtils.dumpAllStacktraces(
+              "Thread dump when timeout is reached while waiting for the message:"
+            );
+            println(msg)
             throw e
         }
       if (debugMessages) println(message)

--- a/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
+++ b/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
@@ -2,6 +2,7 @@ package org.enso.process
 
 import java.io._
 import java.util.concurrent.{Semaphore, TimeUnit}
+import org.enso.runtime.utils.ThreadUtils
 import scala.collection.Factory
 import scala.concurrent.TimeoutException
 import scala.jdk.CollectionConverters._
@@ -205,24 +206,10 @@ class WrappedProcess(command: Seq[String], process: Process) {
       case e @ (_: InterruptedException | _: TimeoutException) =>
         if (process.isAlive) {
           println(s"Killing the timed-out process: ${command.mkString(" ")}")
-          val sb = new StringBuilder(
-            "Thread dump before forcefully killing the process:\n"
+          val msg = ThreadUtils.dumpAllStacktraces(
+            "Thread dump before forcefully killing the process:"
           )
-          Thread.getAllStackTraces.entrySet.forEach { entry =>
-            sb.append(entry.getKey.getName).append("\n")
-            entry.getValue.foreach { e =>
-              sb.append("    ")
-                .append(e.getClassName)
-                .append(".")
-                .append(e.getMethodName)
-                .append("(")
-                .append(e.getFileName)
-                .append(":")
-                .append(e.getLineNumber)
-                .append(")\n")
-            }
-          }
-          println(sb.toString())
+          println(msg)
           process.destroyForcibly()
         }
         for (processHandle <- descendants) {


### PR DESCRIPTION

### Pull Request Description

We are starting to experience flaky `runtime-integration-test` that fail to cleanup:
```
[info] org.enso.interpreter.test.instrument.RuntimeServerTest *** ABORTED *** (31 seconds, 896 milliseconds)
[info]   java.lang.IllegalStateException: The context is currently executing on another thread. Set cancelIfExecuting to true to stop the execution on this thread.
[info]   at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineException.illegalState(PolyglotEngineException.java:133)
[info]   at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.closeAndMaybeWait(PolyglotContextImpl.java:2037)
...
[info]   at org.enso.runtime/org.enso.interpreter.test.instrument.InstrumentTestContext.close(InstrumentTestContext.scala:158)
[info]   at org.enso.runtime/org.enso.interpreter.test.instrument.RuntimeServerTest$TestContext.close(RuntimeServerTest.scala:120)
[info]   at org.enso.runtime/org.enso.interpreter.test.instrument.RuntimeServerTest.afterEach(RuntimeServerTest.scala:136)
[info]   at org.scalatest.BeforeAndAfterEach.$anonfun$runTest$1(BeforeAndAfterEach.scala:247)
[info]   ...
```
This change catches the exception and dumps all stacktraces in an attempt to debug the problem in CI (not reproducible otherwise). Since the logic is already repeated in numerous places, refactored it to a single `runtime-utils` project and re-used.


### Important Notes

Recent examples of failures:
- https://github.com/enso-org/enso/actions/runs/14780427449/job/41497962037#step:10:3830
- https://github.com/enso-org/enso/actions/runs/14775739759/job/41483592236?pr=12987#step:10:3574

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
