### PR TITLE
Adjust RuntimeAsyncCommandsTest program start timeouts

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -456,7 +456,7 @@ class RuntimeAsyncCommandsTest
         |
         |main =
         |    IO.println "started"
-        |    v = loop 50
+        |    v = loop 80
         |    v
         |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
@@ -548,7 +548,7 @@ class RuntimeAsyncCommandsTest
         |
         |main =
         |    IO.println "started"
-        |    operator1 = loop 10
+        |    operator1 = loop 20
         |    operator2 = operator1 + 1
         |    operator2
         |
@@ -639,7 +639,7 @@ class RuntimeAsyncCommandsTest
 
     val response1 = context.receiveNIgnoreExpressionUpdates(
       6,
-      timeoutSeconds = 20
+      timeoutSeconds = 30
     )
     response1 should contain allOf (
       Api.Response(requestId, Api.PushContextResponse(contextId)),
@@ -675,7 +675,7 @@ class RuntimeAsyncCommandsTest
     )
     val response2 = context.receiveNIgnoreExpressionUpdates(
       5,
-      timeoutSeconds = 20
+      timeoutSeconds = 30
     )
     response2 should contain allOf (
       Api.Response(requestId, Api.RecomputeContextResponse(contextId)),


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

RuntimeAsyncCommandsTest suite can still fail with timeouts sometimes https://github.com/enso-org/enso/actions/runs/14808986873/job/41581697344#step:13:3641

```
INFO ide_ci::program::command: sbt ℹ️ [info] - should interrupt running execution context without sending Panic in expression updates *** FAILED *** (4 seconds, 32 milliseconds)
 INFO ide_ci::program::command: sbt ℹ️ [info]   Program start timed out (RuntimeAsyncCommandsTest.scala:497)
```


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
