### PR TITLE
Sort `~` out properly this time

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -899,20 +899,24 @@ list_descendants file =
    the parts, allowing the data link logic to kick in.
 resolve_local_file (path : Text) = handle_invalid_path path <|
     local_file = get_file path
+    is_home = path.match "^~([\\/].*|$)"
+    is_absolute = local_file.is_absolute
+
     resolved_local_file =
         parts = Path_Helpers.split_path path
+
         # Special case - if there are no parts, it means path was "", so we use that as base.
         base_part = parts.get 0 if_missing=""
 
         # Handle special case when starts with ~
-        base = if base_part != '~' then get_file base_part else
+        base = if is_home.not then get_file base_part else
             if Enso_File.cloud_project_parent_directory == Nothing then File.home else Enso_File.home
 
         rest = parts.drop 1
         rest.fold base acc-> part-> acc.resolve_single_part part
 
     # Absolute files always resolve to themselves.
-    if local_file.is_absolute then resolved_local_file else
+    if is_absolute || is_home then resolved_local_file else
         case Enso_File.cloud_project_parent_directory of
             Nothing -> resolved_local_file
             base_cloud_directory -> base_cloud_directory / path


### PR DESCRIPTION
### Pull Request Description

- `~` wasn't being handled correctly in `File.new` especially in cloud.
![image](https://github.com/user-attachments/assets/95d7d1da-a809-4194-9396-d70949ac0268)

![image](https://github.com/user-attachments/assets/8d0386dd-80cd-452d-ae2d-160541237d24)

Tested in both local and hybrid with windows and linux separators.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
