### PR TITLE
Adjust RuntimeAsyncCommandsTest program start timeouts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1889,6 +1889,7 @@ lazy val testkit = project
     Compile / exportedModuleBin := (Compile / packageBin).value
   )
   .dependsOn(`logging-service-logback`)
+  .dependsOn(`runtime-utils`)
 
 lazy val searcher = project
   .in(file("lib/scala/searcher"))

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -74,7 +74,7 @@ class RuntimeAsyncCommandsTest
       var out: List[String] = Nil
       val expectedList      = expected.toList
       monitor.synchronized {
-        while (!receivedExpected && iteration < 20) {
+        while (!receivedExpected && iteration < 50) {
           out = readOutAsList()
           receivedExpected =
             if (exact) out == expectedList

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -11,6 +11,7 @@ import org.enso.polyglot.runtime.Runtime.Api.{
   MethodCall,
   MethodPointer
 }
+import org.enso.runtime.utils.ThreadUtils
 import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
 import org.enso.text.editing.model
 import org.enso.testkit.FlakySpec
@@ -159,7 +160,16 @@ class RuntimeAsyncCommandsTest
   }
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.close()
+      try {
+        context.close()
+      } catch {
+        case e: IllegalStateException =>
+          val msg = ThreadUtils.dumpAllStacktraces(
+            "Thread dump on failure to close test Instrument Context:"
+          )
+          println(msg)
+          throw e
+      }
       context.out.reset()
       context = null
     }

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/FlakySpec.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/FlakySpec.scala
@@ -1,5 +1,6 @@
 package org.enso.testkit
 
+import org.enso.runtime.utils.ThreadUtils
 import org.scalatest._
 
 /** Trait is used to mark the tests in the suite as _flaky_ and make them
@@ -19,8 +20,17 @@ trait FlakySpec extends TestSuite {
   /** Tags test as pending on failure */
   object SkipOnFailure extends Tag("org.enso.test.skiponfailure")
 
-  override def withFixture(test: NoArgTest): Outcome =
-    super.withFixture(test) match {
+  override def withFixture(test: NoArgTest): Outcome = {
+    val result = super.withFixture(test)
+
+    if (result.isFailed || result.isCanceled) {
+      val msg = ThreadUtils.dumpAllStacktraces(
+        s"Thread dump of the failed flaky test `${test.name}`"
+      )
+      println(msg)
+    }
+
+    result match {
       case Failed(_) | Canceled(_)
           if Flaky.isEnabled && test.tags.contains(Flaky.name) =>
         Pending
@@ -29,4 +39,5 @@ trait FlakySpec extends TestSuite {
       case outcome =>
         outcome
     }
+  }
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

I can still see the failures due to slow program start time https://github.com/enso-org/enso/actions/runs/14865804823/job/41744507564?pr=13043#step:13:3759

```
INFO ide_ci::program::command: sbt ℹ️ [info] - should interrupt running execution context without sending Panic in visualization updates *** FAILED *** (3 seconds, 912 milliseconds)
 INFO ide_ci::program::command: sbt ℹ️ [info]   Program start timed out (RuntimeAsyncCommandsTest.scala:599)
```

Changelog:
- update: `RuntimeAsyncCommandsTest` increase the time while the test is waiting for the program to start

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
