### PR TITLE
Types (and their constructors) in private modules are considered private

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Internal/Decomposed_S3_Path.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Internal/Decomposed_S3_Path.enso
@@ -22,21 +22,21 @@ type Decomposed_S3_Path
     key self -> Text =
         add_directory_suffix = self.parts.not_empty && self.parts.last.is_directory
         suffix = if add_directory_suffix then S3_Path.delimiter else ""
-        self.parts.map .name . join separator=S3_Path.delimiter suffix=suffix
+        self.parts.map (\x -> x.name) . join separator=S3_Path.delimiter suffix=suffix
 
     parse (key : Text) -> Decomposed_S3_Path =
         has_directory_suffix = key.ends_with S3_Path.delimiter
         parts = key.split S3_Path.delimiter . filter (p-> p.is_empty.not)
         entries = case has_directory_suffix of
-            True -> parts.map Path_Entry.Directory
+            True -> parts.map \x -> Path_Entry.Directory x
             False ->
                 if parts.is_empty then [] else
-                    (parts.drop (..Last 1) . map Path_Entry.Directory) + [Path_Entry.File parts.last]
+                    (parts.drop (..Last 1) . map \x -> Path_Entry.Directory x) + [Path_Entry.File parts.last]
         Decomposed_S3_Path.Value entries
 
     join (paths : Vector Decomposed_S3_Path) -> Decomposed_S3_Path =
         if paths.is_empty then Error.throw (Illegal_Argument.Error "Cannot join an empty list of paths.") else
-            flattened = paths.flat_map .parts
+            flattened = paths.flat_map \x -> x.parts
             # Any `File` parts from the middle are now transformed to `Directory`:
             aligned = flattened.map_with_index ix-> part-> case part of
                 Path_Entry.Directory _ -> part
@@ -46,7 +46,7 @@ type Decomposed_S3_Path
             Decomposed_S3_Path.Value aligned
 
     normalize self -> Decomposed_S3_Path =
-        new_parts = Path_Helpers.normalize_segments self.parts .name
+        new_parts = Path_Helpers.normalize_segments self.parts \x -> x.name
         Decomposed_S3_Path.Value new_parts
 
     parent self -> Decomposed_S3_Path | Nothing =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
@@ -63,9 +63,7 @@ credentials_file = case Environment.get "ENSO_CLOUD_CREDENTIALS_FILE" of
 
 ## PRIVATE
 type Authentication_Service
-    ## PRIVATE
-       TODO: We cannot mark this constructor as `private` until we change token tests in `Enso_Cloud_Spec` to run with `--disable-private-check`.
-    Instance (_auth_data : Ref Authentication_Data)
+    private Instance (_auth_data : Ref Authentication_Data)
 
     ## PRIVATE
        The authentication data, which is a mutable reference to the current
@@ -106,7 +104,9 @@ instantiate_authentication_service =
 ## PRIVATE
 type Authentication_Data
     ## PRIVATE
-    Value access_token:Text expire_at:Date_Time
+    private Value _access_token:Text expire_at:Date_Time
+
+    access_token self -> Text = self._access_token
 
     ## PRIVATE
     read_from_credentials -> Authentication_Data =
@@ -121,7 +121,7 @@ type Authentication_Data
         expiration_date_string = get_field "expire_at"
         expiration_date = Date_Time.parse expiration_date_string format=Date_Time_Formatter.iso_zoned_date_time . catch Time_Error error->
             Panic.throw (Illegal_State.Error invalid_format_prefix+"invalid date format in `expire_at` field: "+error.to_display_text cause=error)
-        Authentication_Data.Value access_token=token expire_at=expiration_date
+        Authentication_Data.Value token expiration_date
 
 ## PRIVATE
 type Refresh_Token_Data
@@ -174,7 +174,7 @@ type Refresh_Token_Data
 
         if token_type != "Bearer" then
             Panic.throw (Enso_Cloud_Error.Invalid_Response_Payload "Invalid `TokenType` field in response: expected `Bearer`, got `"+token_type+"`.")
-        Authentication_Data.Value access_token=access_token expire_at=expire_at
+        Authentication_Data.Value access_token expire_at
 
 ## PRIVATE
    The amount of time before the token expiration that we pro-actively refresh

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
@@ -65,7 +65,12 @@ credentials_file = case Environment.get "ENSO_CLOUD_CREDENTIALS_FILE" of
 type Authentication_Service
     ## PRIVATE
        TODO: We cannot mark this constructor as `private` until we change token tests in `Enso_Cloud_Spec` to run with `--disable-private-check`.
-    Instance (auth_data : Ref Authentication_Data)
+    Instance (_auth_data : Ref Authentication_Data)
+
+    ## PRIVATE
+       The authentication data, which is a mutable reference to the current
+       authentication data.
+    auth_data self -> Ref Authentication_Data = self._auth_data
 
     ## PRIVATE
     get_access_token self -> Text =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -357,7 +357,7 @@ type Private_Access
        Convert the Private_Access error to a human-readable format.
     to_display_text : Text
     to_display_text self =
-        if self.msg.is_nothing then self.default_to_text else self.msg
+        self.msg.if_nothing self.default_to_text
 
     private default_to_text self =
         this_proj = if self.this_project_name.is_nothing then "unknown project" else "project '"+self.this_project_name+"'"

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
@@ -138,7 +138,7 @@ aggregate table:DB_Table group_by:(Vector | Text | Integer | Regex) columns:Vect
 
             new_columns = partitioned.second
             problem_builder.attach_problems_before on_problems <|
-                problems = partitioned.first.map .value
+                problems = partitioned.first.map \x->x.value
                 on_problems.attach_problems_before problems <|
                     handle_no_output_columns =
                         first_problem = if problems.is_empty then Nothing else problems.first

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -64,7 +64,10 @@ sqlserver =
 type SQLServer_Dialect
     ## PRIVATE
        The dialect of SQL Server databases.
-    Value dialect_operations
+    Value _dialect_operations
+
+    ## PRIVATE
+    dialect_operations self = self._dialect_operations
 
     ## PRIVATE
        Name of the dialect.

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Group.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Group.enso
@@ -15,7 +15,10 @@ type Group_Builder
        - name: The name of the group.
        - builder: Vector builder used for storing specs.
        - teardown_ref: A reference to a teardown method.
-    Impl (name : Text) (builder = Builder.new) (teardown_ref = Ref.new (_ -> Nothing))
+    private Impl (_name : Text) (builder = Builder.new) (teardown_ref = Ref.new (_ -> Nothing))
+
+    ## PRIVATE
+    name self = self._name
 
     ## Specifies a single test.
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -724,11 +724,13 @@ object BindingsMap {
 
   case class Argument(name: String, hasDefaultValue: Boolean)
 
-  /** A representation of a sum type
+  /** A representation of a type with constructors.
     *
     * @param name the type name
     * @param members the member names
     * @param builtinType true if constructor is annotated with @Builtin_Type, false otherwise.
+    * @param isPrivate if a type is considered private (for example because it is defined in a private module) -
+    *        constructors and fields of a private type are not accessible outside the defining project
     */
   case class Type(
     override val name: String,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -734,13 +734,18 @@ object BindingsMap {
     override val name: String,
     params: Seq[String],
     members: Seq[Cons],
-    builtinType: Boolean
+    builtinType: Boolean,
+    isPrivate: Boolean
   ) extends DefinedEntity {
     override def canExport: Boolean = true
   }
 
   object Type {
-    def fromIr(ir: Definition.Type, isBuiltinType: Boolean): Type =
+    def fromIr(
+      ir: Definition.Type,
+      isBuiltinType: Boolean,
+      isPrivate: Boolean
+    ): Type =
       BindingsMap.Type(
         ir.name.name,
         ir.params.map(_.name.name),
@@ -756,7 +761,8 @@ object BindingsMap {
             m.isPrivate
           )
         ),
-        isBuiltinType
+        isBuiltinType,
+        isPrivate
       )
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -60,7 +60,7 @@ case object BindingAnalysis extends IRPass {
       val isBuiltinType = sumType
         .getMetadata(ModuleAnnotations)
         .exists(_.annotations.exists(_.name == "@Builtin_Type"))
-      BindingsMap.Type.fromIr(sumType, isBuiltinType)
+      BindingsMap.Type.fromIr(sumType, isBuiltinType, ir.isPrivate)
     }
     val importedPolyglot = ir.imports.collect { case poly: imports.Polyglot =>
       BindingsMap.PolyglotSymbol(poly.getVisibleName)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
@@ -66,7 +66,7 @@ class BindingAnalysisTest extends CompilerTest {
       val metadata = ir.unsafeGetMetadata(BindingAnalysis, "Should exist.")
 
       metadata.definedEntities should contain theSameElementsAs List(
-        Type("My_Type", List(), List(), false),
+        Type("My_Type", List(), List(), false, false),
         ExtensionMethod("extension_method", "My_Type")
       )
 
@@ -92,8 +92,8 @@ class BindingAnalysisTest extends CompilerTest {
       val metadata = ir.unsafeGetMetadata(BindingAnalysis, "Should exist.")
 
       metadata.definedEntities should contain theSameElementsAs List(
-        Type("My_Type", List(), List(), false),
-        Type("Other_Type", List(), List(), false),
+        Type("My_Type", List(), List(), false, false),
+        Type("Other_Type", List(), List(), false, false),
         ExtensionMethod("extension_method", "My_Type"),
         ExtensionMethod("extension_method", "Other_Type")
       )
@@ -123,8 +123,8 @@ class BindingAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessModule.analyse
       val metadata = ir.unsafeGetMetadata(BindingAnalysis, "Should exist.")
       metadata.definedEntities should contain theSameElementsAs List(
-        Type("Source", List(), List(), false),
-        Type("Target", List(), List(), false),
+        Type("Source", List(), List(), false, false),
+        Type("Target", List(), List(), false, false),
         ConversionMethod("from", "Source", "Target"),
         ConversionMethod("from", "Target", "Source")
       )
@@ -181,10 +181,11 @@ class BindingAnalysisTest extends CompilerTest {
               isProjectPrivate = false
             )
           ),
-          builtinType = false
+          builtinType = false,
+          false
         ),
-        Type("Bar", List(), List(), builtinType         = false),
-        Type("Baz", List("x", "y"), List(), builtinType = false),
+        Type("Bar", List(), List(), builtinType         = false, false),
+        Type("Baz", List("x", "y"), List(), builtinType = false, false),
         ExtensionMethod("foo", "Baz"),
         ExtensionMethod("baz", "Bar"),
         ConversionMethod("from", "Bar", "Foo"),

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
@@ -92,7 +92,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List("a", "b", "c"), List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false, false)
           )
         )
       )
@@ -131,7 +131,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List("a", "b", "c"), List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false, false)
           )
         )
       )
@@ -142,7 +142,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Bar", List(), List(), false)
+            Type("Bar", List(), List(), false, false)
           )
         )
       )
@@ -157,7 +157,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Bar", List(), List(), false)
+            Type("Bar", List(), List(), false, false)
           )
         )
       )
@@ -174,7 +174,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List("a", "b", "c"), List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false, false)
           )
         )
       )

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -196,7 +196,6 @@ public final class ImportExportCache
   @Persistable(
       clazz = org.enso.compiler.data.BindingsMap$ModuleReference$Abstract.class,
       id = 33007)
-  @Persistable(clazz = BindingsMap.Type.class, id = 33009)
   @Persistable(clazz = BindingsMap.ResolvedImport.class, id = 33010)
   @Persistable(clazz = BindingsMap.Cons.class, id = 33011)
   @Persistable(clazz = BindingsMap.ResolvedModule.class, id = 33012)
@@ -213,10 +212,11 @@ public final class ImportExportCache
   @Persistable(clazz = BindingsMap.ExtensionMethod.class, id = 33023)
   @Persistable(clazz = BindingsMap.ConversionMethod.class, id = 33024)
   @Persistable(clazz = BindingsMap.Argument.class, id = 33025)
+  @Persistable(clazz = BindingsMap.Type.class, id = 33026)
   @Persistable(id = 33055)
   public static final class PersistBindingsMap extends Persistance<BindingsMap> {
     public PersistBindingsMap() {
-      super(BindingsMap.class, false, 33005);
+      super(BindingsMap.class, false, 33055);
     }
 
     @Override

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
@@ -50,7 +50,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
           true
         )
       } else {
-        val hasAllConstructorsPrivate =
+        val hasAllConstructorsPrivate = tp.isPrivate ||
           tp.members.nonEmpty && tp.members.forall(_.isProjectPrivate)
         val createdType =
           if (tp.members.nonEmpty || tp.builtinType) {

--- a/test/Base_Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Meta_Spec.enso
@@ -98,6 +98,28 @@ add_specs suite_builder =
             Meta.meta (List.Cons 1 List.Nil) . constructor . fields . should_equal ["x", "xs"]
 
         group_builder.specify "prevent getting value from private constructor" <|
+            # constructor of a type defined in
+            cons = Public_Type.cons
+
+            # obtaining meta for constructor fails
+            meta = Meta.meta cons
+            meta . should_fail_with Private_Access
+
+            # the constructor call fails too
+            Panic.recover Any (cons 42) . should_fail_with Private_Access
+
+        group_builder.specify "prevent getting value from constructor in private module" <|
+            # constructor of a type defined in
+            cons = Public_Type.implicit_cons
+
+            # obtaining meta for constructor fails
+            meta = Meta.meta cons
+            meta . should_fail_with Private_Access
+
+            # the constructor call fails too
+            Panic.recover Any (cons 42) . should_fail_with Private_Access
+
+        group_builder.specify "prevent getting value from private constructor" <|
             atom = Public_Type.new 6*7
             meta = Meta.meta atom
 

--- a/test/Helpers/src/Internal.enso
+++ b/test/Helpers/src/Internal.enso
@@ -18,3 +18,5 @@ type Priv_Type
 
     private priv_method self = self.data
 
+type Implicitly_Private
+    Cons data

--- a/test/Helpers/src/Main.enso
+++ b/test/Helpers/src/Main.enso
@@ -1,4 +1,5 @@
 import project.Internal.Priv_Type
+import project.Internal.Implicitly_Private
 
 ## Provides access to the methods of the Priv_Type
 type Public_Type
@@ -7,6 +8,8 @@ type Public_Type
     new d = Public_Type.Hidden_Cons d
 
     cons = Priv_Type.Cons
+    implicit_cons = Implicitly_Private.Cons
+
     create data = Priv_Type.create data
     in_ctx ~action = Priv_Type.in_ctx action...
     private priv_method self = Priv_Type.priv_method


### PR DESCRIPTION
### Pull Request Description

- additional fix to #12967
- to tighten up #12976
- making a module `private` should imply everything in the module is also `private`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
