### PR TITLE
getEventListeners returns JavaScript like array

### DIFF
--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.enso.ydoc.polyfill.Arguments;
 import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyArray;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,8 +87,24 @@ final class EventTarget implements ProxyExecutable {
       this.listeners = listeners;
     }
 
-    public Value[] getEventListeners(String type) {
-      return listeners.getOrDefault(type, Set.of()).toArray(new Value[0]);
+    public ProxyArray getEventListeners(String type) {
+      var arr = listeners.getOrDefault(type, Set.of()).toArray(new Value[0]);
+      return new ProxyArray() {
+        @Override
+        public Object get(long index) {
+          return arr[(int) index];
+        }
+
+        @Override
+        public void set(long index, Value value) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getSize() {
+          return arr.length;
+        }
+      };
     }
 
     public void addEventListener(String type, Value listener) {

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/EventTarget.java
@@ -89,22 +89,7 @@ final class EventTarget implements ProxyExecutable {
 
     public ProxyArray getEventListeners(String type) {
       var arr = listeners.getOrDefault(type, Set.of()).toArray(new Value[0]);
-      return new ProxyArray() {
-        @Override
-        public Object get(long index) {
-          return arr[(int) index];
-        }
-
-        @Override
-        public void set(long index, Value value) {
-          throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getSize() {
-          return arr.length;
-        }
-      };
+      return ProxyArray.fromArray((Object[]) arr);
     }
 
     public void addEventListener(String type, Value listener) {

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebEnvironment.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebEnvironment.java
@@ -11,7 +11,7 @@ import org.graalvm.polyglot.Value;
 public final class WebEnvironment {
 
   public static final HostAccess.Builder defaultHostAccess =
-      HostAccess.newBuilder(HostAccess.EXPLICIT).allowArrayAccess(true).allowBufferAccess(true);
+      HostAccess.newBuilder(HostAccess.EXPLICIT).allowBufferAccess(true);
 
   private WebEnvironment() {}
 

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventTargetTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/EventTargetTest.java
@@ -43,7 +43,15 @@ public class EventTargetTest extends ExecutorSetup {
         """
         var count = 0;
         var et = new EventTarget();
-        et.addEventListener('inc', () => count += 1);
+        var l = () => count += 1;
+        et.addEventListener('inc', l);
+        var arr = et.getEventListeners('inc');
+        if (arr.length != 1) {
+            throw 'Expecting one listener';
+        }
+        if (arr[0] != l) {
+            throw 'Expecting the one listener!';
+        }
         et.dispatchEvent({type: 'inc'});
         count;
         """;


### PR DESCRIPTION
### Pull Request Description

- fixes #11965 related problem
- cannot return `Value[]` as that's not a `Value` itself
- returning `ProxyArray` instead


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
- [x] Unit tests have been written where possible.
