### PR TITLE
Refactor in preparation for folder browsing and new cloud browser behaviour

### DIFF
--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -11,11 +11,19 @@ import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
 import SvgButton from '@/components/SvgButton.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import FileBrowserEntry from '@/components/widgets/FileBrowserWidget/FileBrowserEntry.vue'
-import { Directory, useFileBrowserStack } from '@/components/widgets/FileBrowserWidget/paths'
+import {
+  CannotEnterDir,
+  pathToSegments,
+  usePathBrowsing,
+  useUserFiles,
+  type Directory,
+} from '@/components/widgets/FileBrowserWidget/paths'
 import { useBackend } from '@/composables/backend'
 import { Action } from '@/providers/action'
 import { injectProjectBackend } from '@/providers/backend'
 import { assert } from '@/util/assert'
+import { findDifferenceIndex } from '@/util/data/array'
+import { Err, unwrapOr, unwrapOrWithLog } from '@/util/data/result'
 import type { ToValue } from '@/util/reactivity'
 import { useToast } from '@/util/toast'
 import type { AnyAsset, DirectoryAsset, DirectoryId } from 'enso-common/src/services/Backend'
@@ -26,7 +34,7 @@ import Backend, {
   assetIsSecret,
   AssetType,
 } from 'enso-common/src/services/Backend'
-import { computed, onMounted, reactive, ref, toRef, toValue, watch } from 'vue'
+import { computed, reactive, ref, toValue, watch, watchEffect } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -36,6 +44,17 @@ const props = withDefaults(
   }>(),
   { writeMode: false, choosenPath: '', type: 'file' },
 )
+
+const rootSegments = computed(() => pathToSegments(toValue(userFiles.value?.rootPath) ?? 'enso://'))
+function segmentsExcludingRoot(segments: string[]) {
+  const rootSegs = unwrapOrWithLog(rootSegments.value ?? Err('cannot load root directory'), [])
+  const afterRootIndex = findDifferenceIndex(segments, rootSegs)
+  if (afterRootIndex < rootSegs.length) {
+    return []
+  } else {
+    return segments.slice(afterRootIndex)
+  }
+}
 
 const emit = defineEmits<{
   pathAccepted: [path: string]
@@ -57,25 +76,44 @@ let nextKeyForNewDir = 0
  */
 const keyOverride: Map<DirectoryId | symbol, number> = reactive(new Map())
 
-const currentUser = query('usersMe', [])
-const currentOrganization = query('getOrganization', [])
+const { userFiles, userFilesError } = useUserFiles({
+  backend,
+  user: query('usersMe', []),
+  organization: query('getOrganization', []),
+})
+
+const rootDirectory = computed(() => {
+  const id = toValue(userFiles.value?.rootDirectoryId)
+  if (!id) return
+  return { id, title: 'Cloud' }
+})
+
+const listDirectory = (dir: Directory | undefined) => fetch('listDirectory', listDirectoryArgs(dir))
 
 const {
-  filenameInputContents,
-  directoryStack,
+  setBrowsingPath,
+  enteredPath,
+  unenteredPath,
   currentDirectory,
-  currentFilePath,
-  highlightedName,
-  initializeStack,
-  enterSubdirectories,
-  isDirectoryStackInitializing,
-  assetExists,
-} = useFileBrowserStack(
-  backend,
-  toRef(props, 'choosenPath'),
-  currentUser.data,
-  toRef(props, 'writeMode'),
-  (dir) => fetch('listDirectory', listDirectoryArgs(dir)),
+  isPending: isBrowsingPending,
+} = usePathBrowsing({
+  listDirectory,
+})
+
+const chosenPath = ref<string[]>([])
+watchEffect(() => {
+  const chosenPathSegments = pathToSegments(props.choosenPath)
+  const defaultPathSegments = toValue(userFiles.value?.home ?? [])
+  chosenPath.value = segmentsExcludingRoot(unwrapOr(chosenPathSegments, defaultPathSegments))
+})
+watchEffect(() => rootDirectory.value && setBrowsingPath(chosenPath.value, rootDirectory.value))
+
+const filenameInputContents = ref('')
+
+watch(unenteredPath, (unenteredPath) => (filenameInputContents.value = unenteredPath))
+
+const highlightedName = computed(() =>
+  props.writeMode ? filenameInputContents.value : unenteredPath.value,
 )
 
 // === Directory Contents ===
@@ -97,10 +135,7 @@ function listDirectoryArgs(params: ToValue<Directory | undefined>) {
   })
 }
 
-const { isPending, isError, data, error } = query(
-  'listDirectory',
-  listDirectoryArgs(currentDirectory),
-)
+const { isPending, data, error } = query('listDirectory', listDirectoryArgs(currentDirectory))
 const compareTitle = (a: { title: string }, b: { title: string }) => a.title.localeCompare(b.title)
 const directories = computed(
   () => data.value && data.value.filter((asset) => assetIsDirectory(asset)).sort(compareTitle),
@@ -133,20 +168,18 @@ watch(directories, (directories) => {
 // === Interactivity ===
 
 function enterDir(dir: DirectoryAsset) {
-  directoryStack.value.push(dir)
+  chosenPath.value = [...enteredPath.value.slice(1), dir.title]
 }
 
 function popTo(index: number) {
-  directoryStack.value.splice(index + 1)
+  chosenPath.value.splice(index)
 }
 
 function popDirectory() {
-  if (directoryStack.value.length > 1) {
-    directoryStack.value.pop()
-  }
+  chosenPath.value.pop()
 }
 
-const canPop = computed(() => directoryStack.value.length > 1)
+const canPop = computed(() => chosenPath.value.length > 0)
 
 type TargetType = AnyAsset & { [brandTargetType]: never }
 function chooseFile(file: TargetType) {
@@ -159,12 +192,29 @@ function chooseFile(file: TargetType) {
 const askForOverwrite = ref(false)
 const warningText = ref<string | null>(null)
 
+type AssetExists = { exists: true; type: AssetType } | { exists: false }
+
+async function assetExists(name: string): Promise<AssetExists> {
+  const currentDir = currentDirectory.value
+  if (currentDir == null) return { exists: false }
+  const content = await listDirectory(currentDir)
+  const asset = content.find((asset) => asset.title === name)
+  if (!asset) return { exists: false }
+  return { exists: true, type: asset.type }
+}
+
 async function tryAcceptCurrentFile() {
-  const enteringResult = await enterSubdirectories()
+  const path = [...enteredPath.value.slice(1), ...filenameInputContents.value.split('/')]
+  const enteringResult =
+    rootDirectory.value ?
+      await setBrowsingPath(path, rootDirectory.value)
+    : Err(new CannotEnterDir('emptyStack', path.join('/')))
+  chosenPath.value = path
   if (!enteringResult.ok) {
     warningText.value = `${enteringResult.error.payload.toString()}`
     return
   }
+  filenameInputContents.value = unenteredPath.value
   const assetInfo = await assetExists(filenameInputContents.value)
   if (assetInfo.exists && assetInfo.type === AssetType.file && props.writeMode) {
     askForOverwrite.value = true
@@ -172,13 +222,18 @@ async function tryAcceptCurrentFile() {
     warningText.value = `'${filenameInputContents.value}' is a directory, not a file`
   } else {
     acceptCurrentFile()
+    return
   }
 }
 
 function acceptCurrentFile() {
-  if (currentFilePath.value) {
-    emit('pathAccepted', currentFilePath.value)
-  }
+  const rootPath = toValue(userFiles.value?.rootPath ?? 'enso:/')
+  const currentFilePath = [
+    rootPath,
+    ...enteredPath.value.slice(1),
+    filenameInputContents.value,
+  ].join('/')
+  emit('pathAccepted', currentFilePath)
 }
 
 function overwriteConfirmed() {
@@ -194,14 +249,9 @@ function warningDismissed() {
   warningText.value = null
 }
 
-const isBusy = computed(() => isDirectoryStackInitializing.value || isPending.value)
+const isBusy = computed(() => isBrowsingPending.value || isPending.value)
 
-const anyError = computed(() =>
-  isError.value ? error
-  : currentUser.isError.value ? currentUser.error
-  : currentOrganization.isError.value ? currentOrganization.error
-  : undefined,
-)
+const anyError = computed<boolean>(() => !!error.value || !!userFilesError.value)
 
 // === Creating and Renaming Directories ===
 
@@ -288,16 +338,6 @@ const renameAction: Action = {
   disabled: computed(() => focusedDirectory.value == null || editedAsset.value != null),
   action: () => focusedDirectory.value && renameDirectory(focusedDirectory.value),
 }
-
-// === Initialization ===
-
-onMounted(() => {
-  Promise.all([currentUser.promise.value, currentOrganization.promise.value]).then(
-    ([user, organization]) => {
-      initializeStack(user, organization)
-    },
-  )
-})
 </script>
 
 <template>
@@ -320,13 +360,13 @@ onMounted(() => {
         <SvgButton name="navigate_up" title="Up" :disabled="!canPop" @click.stop="popDirectory" />
         <div class="breadcrumbs">
           <TransitionGroup>
-            <template v-for="(directory, index) in directoryStack" :key="directory.id ?? 'root'">
+            <template v-for="(directory, index) in enteredPath" :key="`${index}:${directory}`">
               <SvgIcon v-if="index > 0" name="navigate_breadcrumb" />
               <div
                 class="clickable"
-                :class="{ nonInteractive: index === directoryStack.length - 1 }"
+                :class="{ nonInteractive: index === enteredPath.length - 1 }"
                 @click.stop="popTo(index)"
-                v-text="directory.title"
+                v-text="directory"
               ></div>
             </template>
           </TransitionGroup>

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/paths.ts
@@ -1,25 +1,23 @@
-import { findDifferenceIndex } from '@/util/data/array'
-import { Opt } from '@/util/data/opt'
-import { Err, Ok, Result, unwrapOr, unwrapOrWithLog, withContext } from '@/util/data/result'
-import { arrayEquals } from '@/util/equals'
+import { type Opt } from '@/util/data/opt'
+import { Err, Ok, Result } from '@/util/data/result'
 import { type ToValue } from '@/util/reactivity'
 import type {
   AnyAsset,
-  AssetType,
+  DirectoryAsset,
   DirectoryId,
   OrganizationInfo,
   User,
 } from 'enso-common/src/services/Backend'
 import { assetIsDirectory } from 'enso-common/src/services/Backend'
-import { computed, ref, toValue } from 'vue'
+import { computed, reactive, ref, toRaw, toValue, type ComputedRef, type Ref } from 'vue'
 
-function pathToSegments(path: string) {
+export function pathToSegments(path: string) {
   const withProtocol = path.split('/')
   if (withProtocol[0] !== 'enso:') return Err(`"${path}" is not an enso path`)
   return Ok(withProtocol.slice(1).filter((segment) => segment))
 }
 
-class CannotEnterDir {
+export class CannotEnterDir {
   constructor(
     public reason: 'emptyStack' | 'notFound' | 'notDir',
     public name: string,
@@ -43,168 +41,140 @@ export interface Directory {
   title: string
 }
 
-/**
- * A part of FileBrowserWidget: extracted logic for managing directory stack and current
- * highlight/selection.
- */
-export function useFileBrowserStack(
-  backend: ToValue<
-    Opt<{
-      rootPath(user: User): string
-      rootDirectoryId(
-        user: User,
-        organization: OrganizationInfo | null,
-        localRootDirectory: null,
-      ): DirectoryId | null
-    }>
-  >,
-  choosenPath: ToValue<string>,
-  currentUser: ToValue<Opt<User>>,
-  writeMode: ToValue<boolean>,
-  listDirectory: (dir: Directory) => Promise<readonly AnyAsset<AssetType>[]>,
-) {
-  const filenameInputContents = ref<string>('')
-  const directoryStack = ref<Directory[]>([])
-  const isDirectoryStackInitializing = computed(() => directoryStack.value.length === 0)
-  const currentDirectory = computed(() => directoryStack.value[directoryStack.value.length - 1])
-  const choosenPathSegments = computed(() => pathToSegments(toValue(choosenPath)))
-
-  const rootSegments = computed(() => {
-    const user = toValue(currentUser)
-    if (!user) return
-    const root = toValue(backend)?.rootPath(user) ?? 'enso://'
-    return pathToSegments(root)
-  })
-  const currentDirSegments = computed(() => {
-    if (!rootSegments.value?.ok) return
-    return [...rootSegments.value.value, ...directoryStack.value.slice(1).map((dir) => dir.title)]
-  })
-
-  const currentPath = computed(() => {
-    if (currentDirSegments.value == null) return
-    return `enso://${currentDirSegments.value.map((dir) => `${dir}/`).join('')}`
-  })
-
-  const highlightedName = computed(() => {
-    if (toValue(writeMode)) return filenameInputContents.value
-    else {
-      if (
-        currentDirSegments.value != null &&
-        choosenPathSegments.value?.ok &&
-        choosenPathSegments.value.value.length === currentDirSegments.value.length + 1 &&
-        arrayEquals(currentDirSegments.value, choosenPathSegments.value.value.slice(0, -1))
-      ) {
-        return choosenPathSegments.value.value[choosenPathSegments.value.value.length - 1]
-      } else {
-        return undefined
-      }
-    }
-  })
-
-  const currentFilePath = computed(
-    () =>
-      filenameInputContents.value &&
-      currentPath.value &&
-      `${currentPath.value}${filenameInputContents.value}`,
-  )
-
-  type AssetExists = { exists: true; type: AssetType } | { exists: false }
-
-  async function assetExists(name: string): Promise<AssetExists> {
-    const currentDir = directoryStack.value[directoryStack.value.length - 1]
-    if (currentDir == null) return { exists: false }
-    const content = await listDirectory(currentDir)
-    const asset = content.find((asset) => asset.title === name)
-    if (!asset) return { exists: false }
-    return { exists: true, type: asset.type }
-  }
-
-  async function enterDirByName(
-    name: string,
-    stack: Directory[],
-  ): Promise<Result<void, CannotEnterDir>> {
-    const currentDir = stack[stack.length - 1]
-    if (currentDir == null) return Err(new CannotEnterDir('emptyStack', name))
-    const content = await listDirectory(currentDir)
-    const nextAsset = content.find((asset) => asset.title === name)
-    if (!nextAsset) return Err(new CannotEnterDir('notFound', name))
-    if (!assetIsDirectory(nextAsset)) return Err(new CannotEnterDir('notDir', name))
-    stack.push(nextAsset)
-    return Ok()
-  }
-
-  /** Split `filenameInputContents` into subdirectories by `/` and enter them, up to last existing directory. */
-  async function enterSubdirectories(): Promise<Result<void, CannotEnterDir>> {
-    let nextSlash = filenameInputContents.value.indexOf('/')
-    while (nextSlash !== -1) {
-      const directoryName = filenameInputContents.value.slice(0, nextSlash)
-      const result = await enterDirByName(directoryName, directoryStack.value)
-      if (result.ok) {
-        filenameInputContents.value = filenameInputContents.value.slice(nextSlash + 1)
-        nextSlash = filenameInputContents.value.indexOf('/')
-      } else {
-        return result
-      }
-    }
-    return Ok()
-  }
-
-  function dirsToEnterOnInit(user: User) {
-    const initialSegments = unwrapOr(choosenPathSegments.value, ['Users', user.name])
-    const rootSegs = unwrapOrWithLog(rootSegments.value ?? Err('cannot load root directory'), [])
-    const afterRootIndex = findDifferenceIndex(initialSegments, rootSegs)
-    if (afterRootIndex < rootSegs.length) {
-      return []
-    } else {
-      return initialSegments.slice(afterRootIndex)
-    }
-  }
-
-  async function initializeStack(
-    user: User | null,
+interface UserFilesBackend {
+  rootPath: (user: User) => string
+  rootDirectoryId: (
+    user: User,
     organization: OrganizationInfo | null,
-  ): Promise<Result> {
-    return withContext(
-      () => 'Cannot enter initial directory',
-      async (): Promise<Result<undefined, unknown>> => {
-        if (!user) {
-          return Err('Cannot load file list: not logged in.')
-        }
-        const rootDirectoryId =
-          toValue(backend)?.rootDirectoryId(user, organization, null) ?? user.rootDirectoryId
+    localRootDirectory: null,
+  ) => DirectoryId | null
+}
 
-        const stack = [{ id: rootDirectoryId, title: 'Cloud' }]
-        const toEnter = dirsToEnterOnInit(user)
-        for (const [index, name] of toEnter.entries()) {
-          const result = await enterDirByName(name, stack)
-          if (result.ok) continue
-          const breakReason = result.error.payload.reason
-          if (
-            breakReason === 'notDir' ||
-            (breakReason === 'notFound' && index == toEnter.length - 1)
-          ) {
-            filenameInputContents.value = name
-          } else if (breakReason != 'notFound') {
-            return result
-          }
-          break
-        }
-        directoryStack.value = stack
-        return Ok()
-      },
-    )
+interface QueryResult<T> {
+  data: ToValue<T>
+  isFetched: ToValue<boolean>
+  error: ToValue<Error | null>
+}
+
+export type PathSegment = string
+
+export interface UserFiles {
+  rootPath: ToValue<string>
+  home: ToValue<PathSegment[]>
+  rootDirectoryId: ToValue<DirectoryId>
+}
+
+/** @returns An API for getting information about the logged-in user's files. */
+export function useUserFiles({
+  backend,
+  user,
+  organization,
+}: {
+  backend: ToValue<UserFilesBackend | null>
+  user: QueryResult<Opt<User>>
+  organization: QueryResult<Opt<OrganizationInfo>>
+}): { userFiles: ComputedRef<UserFiles | null>; userFilesError: ComputedRef<Error | null> } {
+  function userFiles(backend: UserFilesBackend, user: User): UserFiles {
+    return {
+      rootPath: computed<string>(() => backend.rootPath(user)),
+      rootDirectoryId: computed<DirectoryId>(() => {
+        const currentOrganization = toValue(organization.data)
+        return (
+          (currentOrganization && backend.rootDirectoryId(user, currentOrganization, null)) ??
+          user.rootDirectoryId
+        )
+      }),
+      /** The user's home directory. */
+      home: computed<PathSegment[]>(() => ['Users', user.name]),
+    }
   }
 
   return {
-    filenameInputContents,
-    directoryStack,
-    currentDirectory,
-    currentPath,
-    currentFilePath,
-    highlightedName,
-    assetExists,
-    initializeStack,
-    enterSubdirectories,
-    isDirectoryStackInitializing,
+    userFiles: computed<UserFiles | null>(() => {
+      if (!toValue(user.isFetched) || !toValue(organization.isFetched)) return null
+      const currentBackend = toValue(backend)
+      if (!currentBackend) return null
+      const currentUser = toValue(user.data)
+      if (!currentUser) return null
+      return userFiles(currentBackend, currentUser)
+    }),
+    userFilesError: computed<Error | null>(
+      () => toValue(user.error) ?? toValue(organization.error),
+    ),
+  }
+}
+
+export interface PathBrowsing {
+  setBrowsingPath: (path: PathSegment[], root: Directory) => Promise<Result<void, CannotEnterDir>>
+  /** The entered directories, from after the root through the current directory. */
+  enteredPath: Readonly<Ref<PathSegment[]>>
+  /**
+   * Any unentered trailing portion of the path; this starts with any referenced directories that
+   * were not found to exist, and ends with any non-directory element present.
+   */
+  unenteredPath: Readonly<Ref<string>>
+  currentDirectory: Readonly<Ref<Directory | undefined>>
+  isPending: Readonly<Ref<boolean>>
+}
+
+export function usePathBrowsing({
+  listDirectory,
+}: {
+  listDirectory: (dir: Directory) => Promise<readonly AnyAsset[]>
+}): PathBrowsing {
+  const enteredDirectories = reactive<Directory[]>([])
+  const unenteredPath = ref('')
+  const isPending = ref(true)
+
+  async function getChildDirectory(
+    name: string,
+    parent: Directory,
+  ): Promise<Result<DirectoryAsset, CannotEnterDir>> {
+    const content = await listDirectory(parent)
+    const nextAsset = content.find((asset) => asset.title === name)
+    if (!nextAsset) return Err(new CannotEnterDir('notFound', name))
+    if (!assetIsDirectory(nextAsset)) return Err(new CannotEnterDir('notDir', name))
+    return Ok(nextAsset)
+  }
+
+  async function setBrowsingPath(
+    path: PathSegment[],
+    root: Directory,
+  ): Promise<Result<void, CannotEnterDir>> {
+    const oldDirectories = toRaw(enteredDirectories)
+    if (root.id !== oldDirectories[0]?.id) enteredDirectories.length = 0
+    enteredDirectories[0] = root
+    let i = 1
+    isPending.value = true
+    let result: Result<void, CannotEnterDir> = Ok()
+    for (const title of path) {
+      if (oldDirectories[i]?.title !== title) {
+        enteredDirectories.length = i
+        const thisResult = await getChildDirectory(title, oldDirectories[i - 1]!)
+        if (!thisResult.ok) {
+          result = thisResult
+          const breakReason = thisResult.error.payload.reason
+          if (breakReason === 'notDir' || (breakReason === 'notFound' && i === path.length - 1))
+            unenteredPath.value = title
+          break
+        }
+        enteredDirectories.push({
+          id: thisResult.value.id,
+          title,
+        })
+      }
+      i += 1
+    }
+    enteredDirectories.length = i
+    isPending.value = false
+    return result
+  }
+
+  return {
+    setBrowsingPath,
+    enteredPath: computed(() => enteredDirectories.map(({ title }) => title)),
+    unenteredPath,
+    currentDirectory: computed(() => enteredDirectories[enteredDirectories.length - 1]),
+    isPending,
   }
 }


### PR DESCRIPTION
### Pull Request Description

Refactor WidgetCloudBrowser in preparation for folder browsing and new cloud browser behaviour.

Part of #12799.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
