### PR TITLE
engine-runner log-to-file level is DEBUG, not TRACE

### DIFF
--- a/engine/runner/src/main/resources/application.conf
+++ b/engine/runner/src/main/resources/application.conf
@@ -28,7 +28,7 @@ logging-service {
   log-to-file {
     enable = true
     enable = ${?ENSO_LOG_TO_FILE}
-    log-level = trace
+    log-level = debug
     log-level = ${?ENSO_LOG_TO_FILE_LOG_LEVEL}
   }
 }


### PR DESCRIPTION
### Pull Request Description

The default `log-to-file.level` in `engine-runner` used to be TRACE. This PR changes it to DEBUG. This is consistent with the setting of [project-manager](https://github.com/enso-org/enso/blob/da6a6ae9dde9c0cef02c1d07be5e03660b40d086/lib/scala/project-manager/src/main/resources/application.conf#L51), which logs DEBUG level to file as well. Note that the TRACE level of `engine-runner.log-to-file` caused `~/.local/share/enso/log/*cli*` to be huge. With https://github.com/enso-org/enso/pull/13017/commits/051bdcdb7e6bcc970c66bbf499b07eb98b1818a5, I have accidentally generated 7 GB of logs in less than a minute.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
