### PR TITLE
Default starting time of Project Schedule to start of current hour

### DIFF
--- a/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectExecutionsCalendar.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectExecutionsCalendar.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import {
   CalendarDate,
   getLocalTimeZone,
+  now,
   startOfMonth,
   toCalendarDate,
   today,
@@ -222,7 +223,7 @@ function ProjectExecutionsCalendarInternal(props: ProjectExecutionsCalendarInter
         <NewProjectExecutionModal
           backend={backend}
           item={item}
-          defaultDate={toZoned(selectedDate, timeZone)}
+          defaultDate={toZoned(selectedDate, timeZone).set({ hour: now(timeZone).hour })}
         />
       </DialogTrigger>
       <Text>{getText('projectSessionsOnX', selectedDate.toString())}</Text>

--- a/app/gui/src/dashboard/layouts/NewProjectExecutionModal.tsx
+++ b/app/gui/src/dashboard/layouts/NewProjectExecutionModal.tsx
@@ -211,7 +211,10 @@ export function NewProjectExecutionForm(props: NewProjectExecutionFormProps) {
   const valueJson = useRef('')
 
   // Only initialize `minFirstOccurrence` once.
-  const [minFirstOccurrence] = useState(() => now(timeZone))
+  // Initialize to the start of today.
+  const [minFirstOccurrence] = useState(() =>
+    now(timeZone).set({ hour: 0, minute: 0, second: 0, millisecond: 0 }),
+  )
   const defaultStartDate = defaultDate ?? minFirstOccurrence
   const form = Form.useForm({
     method: 'dialog',


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/1956
  - Set the hour of the pre-filled "first occurrence" to the start of the current hour
    - The date stays unchanged.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
