### PR TITLE
Remove duplicate method call

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -331,7 +331,6 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .projectRoot(serverConfig.contentRootPath)
     .logLevel(logLevel)
     .strictErrors(false)
-    .disableLinting(false)
     .enableIrCaches(true)
     .out(stdOut)
     .err(stdErr)


### PR DESCRIPTION
### Pull Request Description

This PR just removes an unnecessary `disableLinting(false)` method call, which is a leftover. `disableLinting(true)` is called in https://github.com/enso-org/enso/blob/9a324ea6773bbbf65bc04aab37f0d9ead2322051/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala#L339.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
