### PR TITLE
Callback to native executable from HotSpot JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2666,9 +2666,13 @@ def customFrgaalJavaCompilerSettings(targetJdk: String) = {
     // Ensure that our tooling uses the right Java version for checking the code.
     Compile / javacOptions ++= Seq(
       "-source",
-      frgaalSourceLevel,
-      "--enable-preview"
-    )
+      frgaalSourceLevel
+    ) ++
+    (if (Integer.parseInt(targetJdk) <= 21) {
+       Seq("--enable-preview")
+     } else {
+       Seq("-target", "21")
+     })
   )
 }
 
@@ -4274,7 +4278,7 @@ lazy val `os-environment` =
     .in(file("lib/java/os-environment"))
     .enablePlugins(JPMSPlugin)
     .settings(
-      // frgaalJavaCompilerSetting,
+      customFrgaalJavaCompilerSettings("24"),
       scalaModuleDependencySetting,
       libraryDependencies ++= slf4jApi ++ Seq(
         "org.graalvm.sdk" % "nativeimage"     % graalMavenPackagesVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -4274,7 +4274,7 @@ lazy val `os-environment` =
     .in(file("lib/java/os-environment"))
     .enablePlugins(JPMSPlugin)
     .settings(
-      frgaalJavaCompilerSetting,
+      // frgaalJavaCompilerSetting,
       scalaModuleDependencySetting,
       libraryDependencies ++= slf4jApi ++ Seq(
         "org.graalvm.sdk" % "nativeimage"     % graalMavenPackagesVersion % "provided",

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
@@ -1,5 +1,6 @@
 package org.enso.os.environment.jni;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
@@ -10,16 +11,19 @@ import java.math.BigInteger;
 final class TestMain {
   private TestMain() {}
 
-  public static void main(String... args) throws Throwable {
+  static void main(String... args) throws Throwable {
     var jvmIsolate = Long.parseLong(args[0]);
     var fnCallbackAddress = MemorySegment.ofAddress(Long.parseLong(args[1]));
     var fnDescriptor =
-        FunctionDescriptor.ofVoid(
-            ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG);
+        FunctionDescriptor.of(
+            ValueLayout.JAVA_BOOLEAN,
+            ValueLayout.JAVA_LONG,
+            ValueLayout.JAVA_LONG,
+            ValueLayout.ADDRESS);
     var fnHandle = Linker.nativeLinker().downcallHandle(fnCallbackAddress, fnDescriptor);
     var n = Integer.parseInt(args[2]);
 
-    var res = factorial(n).longValue();
+    var res = factorial(n).toString();
     reportResultToSvmIsolate(jvmIsolate, fnHandle, n, res);
   }
 
@@ -35,7 +39,17 @@ final class TestMain {
   }
 
   private static void reportResultToSvmIsolate(
-      long jvmIsolate, MethodHandle fn, long key, long value) throws Throwable {
-    fn.invokeExact(jvmIsolate, key, value);
+      long jvmIsolate, MethodHandle fn, long key, String value) throws Throwable {
+    try (var arena = Arena.ofConfined()) {
+      var valueStr = arena.allocateFrom(value);
+      Object result = fn.invoke(jvmIsolate, key, valueStr);
+      if (!Boolean.TRUE.equals(result)) {
+        var ex =
+            new IllegalStateException(
+                "Not correct result for " + key + " and value " + value + " result " + result);
+        ex.printStackTrace();
+        throw ex;
+      }
+    }
   }
 }

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
@@ -1,21 +1,29 @@
 package org.enso.os.environment.jni;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
 import java.math.BigInteger;
 
-public final class TestMain {
+final class TestMain {
   private TestMain() {}
 
-  public static void main(String... args) throws Exception {
-    var out = new File(args[0]);
-    var n = Integer.parseInt(args[1]);
-    try (java.io.FileWriter os = new FileWriter(out)) {
-      os.write(factorial(n).toString());
-    }
+  public static void main(String... args) throws Throwable {
+    var jvmIsolate = Long.parseLong(args[0]);
+    var fnCallbackAddress = MemorySegment.ofAddress(Long.parseLong(args[1]));
+    var fnDescriptor =
+        FunctionDescriptor.ofVoid(
+            ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG);
+    var fnHandle = Linker.nativeLinker().downcallHandle(fnCallbackAddress, fnDescriptor);
+    var n = Integer.parseInt(args[2]);
+
+    var res = factorial(n).longValue();
+    reportResultToSvmIsolate(jvmIsolate, fnHandle, n, res);
   }
 
-  static BigInteger factorial(int n) {
+  static BigInteger factorial(long n) {
     var acc = BigInteger.valueOf(1);
     for (; ; ) {
       acc = acc.multiply(BigInteger.valueOf(n));
@@ -24,5 +32,10 @@ public final class TestMain {
       }
     }
     return acc;
+  }
+
+  private static void reportResultToSvmIsolate(
+      long jvmIsolate, MethodHandle fn, long key, long value) throws Throwable {
+    fn.invokeExact(jvmIsolate, key, value);
   }
 }

--- a/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
+++ b/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
@@ -14,6 +14,7 @@ import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.function.CEntryPointLiteral;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
+import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.junit.Test;
 
@@ -115,25 +116,28 @@ public class LoadClassTest {
 
   @Test
   public void executeMainClass() throws Exception {
-    var callbackFn = CALLBACK_FN.getFunctionPointer().rawValue();
     var jvmIsolate = CurrentIsolate.getCurrentThread().rawValue();
+    var callbackFn = CALLBACK_FN.getFunctionPointer().rawValue();
     var gen = new Random();
+    var n = 0L;
     for (var i = 0; i < 5; i++) {
-      var n = gen.nextLong(1, 15);
-      jvm()
-          .executeMain(
-              "org/enso/os/environment/jni/TestMain", "" + jvmIsolate, "" + callbackFn, "" + n);
-      long content = COLLECTED_RESULTS.get(n);
-      assertEquals(
-          "Factorial of " + n + " is the same", TestMain.factorial(n).longValue(), content);
+      n += gen.nextLong(1000, 5000);
+      var mainClass = "org/enso/os/environment/jni/TestMain";
+      jvm().executeMain(mainClass, "" + jvmIsolate, "" + callbackFn, "" + n);
     }
+    assertEquals("Five results found: " + CORRECT_RESULTS, 5, CORRECT_RESULTS.size());
   }
 
-  private static final Map<Long, Long> COLLECTED_RESULTS = new HashMap<>();
+  private static final Map<Long, String> CORRECT_RESULTS = new HashMap<>();
 
   @CEntryPoint
-  private static void acceptResultFromHotSpotJvm(IsolateThread threadId, long key, long value) {
-    COLLECTED_RESULTS.put(key, value);
+  private static boolean acceptResultFromHotSpotJvm(
+      IsolateThread threadId, long n, CCharPointer resultStr) {
+    var result = CTypeConversion.toJavaString(resultStr);
+    var ownResult = TestMain.factorial(n).toString();
+    assertEquals("fac(" + n + ") is correct in both JVMs", ownResult, result);
+    CORRECT_RESULTS.put(n, result);
+    return ownResult.equals(result);
   }
 
   private static final CEntryPointLiteral<CFunctionPointer> CALLBACK_FN =
@@ -142,5 +146,5 @@ public class LoadClassTest {
           "acceptResultFromHotSpotJvm",
           IsolateThread.class,
           long.class,
-          long.class);
+          CCharPointer.class);
 }

--- a/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
+++ b/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
@@ -4,10 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import org.enso.os.environment.jni.JNI.JValue;
+import org.graalvm.nativeimage.CurrentIsolate;
+import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.function.CEntryPoint;
+import org.graalvm.nativeimage.c.function.CEntryPointLiteral;
+import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.junit.Test;
 
@@ -27,6 +33,7 @@ public class LoadClassTest {
           JVM.create(
               path,
               "--module-path=" + MODULE_PATH,
+              "--enable-native-access=org.enso.os.environment",
               "-Djdk.module.main=org.enso.os.environment",
               "-Dsay=Ahoj");
     }
@@ -108,14 +115,32 @@ public class LoadClassTest {
 
   @Test
   public void executeMainClass() throws Exception {
-    var out = File.createTempFile("check-main", ".log");
+    var callbackFn = CALLBACK_FN.getFunctionPointer().rawValue();
+    var jvmIsolate = CurrentIsolate.getCurrentThread().rawValue();
     var gen = new Random();
     for (var i = 0; i < 5; i++) {
-      var n = gen.nextInt(10000, 20000);
-      jvm().executeMain("org/enso/os/environment/jni/TestMain", out.getPath(), "" + n);
-      var content = Files.readString(out.toPath());
-      assertEquals("Factorial of " + n + " is the same", TestMain.factorial(n).toString(), content);
-      out.delete();
+      var n = gen.nextLong(1, 15);
+      jvm()
+          .executeMain(
+              "org/enso/os/environment/jni/TestMain", "" + jvmIsolate, "" + callbackFn, "" + n);
+      long content = COLLECTED_RESULTS.get(n);
+      assertEquals(
+          "Factorial of " + n + " is the same", TestMain.factorial(n).longValue(), content);
     }
   }
+
+  private static final Map<Long, Long> COLLECTED_RESULTS = new HashMap<>();
+
+  @CEntryPoint
+  private static void acceptResultFromHotSpotJvm(IsolateThread threadId, long key, long value) {
+    COLLECTED_RESULTS.put(key, value);
+  }
+
+  private static final CEntryPointLiteral<CFunctionPointer> CALLBACK_FN =
+      CEntryPointLiteral.create(
+          LoadClassTest.class,
+          "acceptResultFromHotSpotJvm",
+          IsolateThread.class,
+          long.class,
+          long.class);
 }

--- a/project/FrgaalJavaCompiler.scala
+++ b/project/FrgaalJavaCompiler.scala
@@ -85,10 +85,13 @@ object FrgaalJavaCompiler {
       shouldNotLimitModules   = shouldNotLimitModules
     )
 
-    // do you know what to change here to invoke standard compiler?
-    // e.g. [LocalJavaCompiler](https://github.com/sbt/zinc/blob/57a2df7104b3ce27b46404bb09a0126bd4013427/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala#L280)
-    val javaTools = sbt.internal.inc.javac
-      .JavaTools(frgaalJavac, sbtCompilers.javaTools.javadoc())
+    var javac = if (Integer.parseInt(javaVersion) <= 21) {
+      frgaalJavac
+    } else {
+      sbtCompilers.javaTools.javac()
+    }
+    val javadoc   = sbtCompilers.javaTools.javadoc()
+    val javaTools = sbt.internal.inc.javac.JavaTools(javac, javadoc)
     xsbti.compile.Compilers.of(sbtCompilers.scalac, javaTools)
   }
 

--- a/project/FrgaalJavaCompiler.scala
+++ b/project/FrgaalJavaCompiler.scala
@@ -84,6 +84,9 @@ object FrgaalJavaCompiler {
       shouldCompileModuleInfo = shouldCompileModuleInfo,
       shouldNotLimitModules   = shouldNotLimitModules
     )
+
+    // do you know what to change here to invoke standard compiler?
+    // e.g. [LocalJavaCompiler](https://github.com/sbt/zinc/blob/57a2df7104b3ce27b46404bb09a0126bd4013427/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/LocalJava.scala#L280)
     val javaTools = sbt.internal.inc.javac
       .JavaTools(frgaalJavac, sbtCompilers.javaTools.javadoc())
     xsbti.compile.Compilers.of(sbtCompilers.scalac, javaTools)


### PR DESCRIPTION
### Pull Request Description

The `LoadClassTest.executeMainClass` no longer writes output to a file, but performs a callback from the HotSpot JVM to the _native image_ JVM. This is an essential step in exchanging data and making calls between two JVMs participating in the mixed `--jvm` mode.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
