### PR TITLE
Update NI size check - smaller Linux NI.

### DIFF
--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -97,10 +97,10 @@ object GraalVM {
     }
 
     // Expected production NI sizes deduced from sizes on latest
-    // nightly builds: https://github.com/enso-org/enso/pull/12996#discussion_r2073742680
+    // nightly builds: https://github.com/enso-org/enso/pull/12843#issuecomment-2869897463
     // With maximal size relaxed by 30 MB.
     private val windowsX64Release = NativeImageSize(200, 420)
-    private val linuxX64Release   = NativeImageSize(200, 463)
+    private val linuxX64Release   = NativeImageSize(200, 434)
     private val macX64Release     = NativeImageSize(200, 408)
     private val macARM64Release   = NativeImageSize(200, 423)
     private val testNISize        = NativeImageSize(100, 550)


### PR DESCRIPTION
Created from this comment: https://github.com/enso-org/enso/pull/12843#issuecomment-2869897463

### Pull Request Description

Decreasing the maximum expected NI size of Linux by 30 MB.

The new sizes (as reported in https://github.com/enso-org/enso/pull/12843#issuecomment-2869897463):
- [Linux](https://github.com/enso-org/enso/actions/runs/14951454883/job/42001442578#step:10:3067) **404MB**
- [MacOSX Arm](https://github.com/enso-org/enso/actions/runs/14951454883/job/42001442393#step:10:3076) **392MB**
- [MacOSX Intel](https://github.com/enso-org/enso/actions/runs/14951454883/job/42001442260#step:10:2883) **377MB**
- [Windows](https://github.com/enso-org/enso/actions/runs/14951454883/job/42001442715#step:10:3129) **390MB**

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
