### PR TITLE
Ydoc server: Do not require ls query param when using env.

### DIFF
--- a/app/ydoc-server/src/index.ts
+++ b/app/ydoc-server/src/index.ts
@@ -42,23 +42,28 @@ export async function createGatewayServer(
   const wss = new WebSocketServer({ noServer: true })
   wss.on('connection', (ws: WS, _request: IncomingMessage, data: ConnectionData) => {
     ws.on('error', onWebSocketError)
-    setupGatewayClient(ws, overrideLanguageServerUrl ?? data.lsUrl, data.doc)
+    try {
+      setupGatewayClient(ws, data.lsUrl, data.doc)
+    } catch (e) {
+      if (e instanceof Error) {
+        onWebSocketError(e)
+        ws.close(1003, e.message)
+      } else throw e
+    }
   })
 
   httpServer.on('upgrade', (request, socket, head) => {
     socket.on('error', onHttpSocketError)
     authenticate(request, function next(err, data) {
-      if (err != null) {
+      if (err != null || data == null) {
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
         socket.destroy()
         return
       }
       socket.removeListener('error', onHttpSocketError)
-      if (data != null) {
-        wss.handleUpgrade(request, socket, head, function done(ws: WS) {
-          wss.emit('connection', ws, request, data)
-        })
-      }
+      wss.handleUpgrade(request, socket, head, function done(ws: WS) {
+        wss.emit('connection', ws, request, data)
+      })
     })
   })
 
@@ -82,7 +87,7 @@ export async function createGatewayServer(
     const { pathname, query } = parse(request.url, true)
     if (pathname == null) return callback(null, null)
     const doc = docName(pathname)
-    const lsUrl = query.ls
+    const lsUrl = overrideLanguageServerUrl ?? query.ls
     const data = doc != null && typeof lsUrl === 'string' ? { lsUrl, doc, user } : null
     callback(null, data)
   }


### PR DESCRIPTION
Now language server will properly initialize connection without `ls` GET request parameter present when it is running with predefined URL set during startup.

Example command to start the ydoc server with correct ENV:
```
LANGUAGE_SERVER_URL=ws://127.0.0.1:56751 pnpm run --filter ydoc-server-nodejs dev:watch
```

Then, `wscat` can be used to connect to it:
```
❯ wscat --connect ws://localhost:5976/project/index
Connected (press CTRL+C to quit)
<
< D��)modules   Main.enso$954afe36-1a1e-4f77-8f19-03d2975f7211v
```