### PR TITLE
Add engine distribution check before unpacking

### DIFF
--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -357,7 +357,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -420,7 +422,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -495,7 +499,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -568,7 +574,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -642,7 +650,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -716,7 +726,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -790,7 +802,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -851,7 +865,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -929,7 +945,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1005,7 +1023,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1082,7 +1102,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1159,7 +1181,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1237,7 +1261,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1313,7 +1339,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1390,7 +1418,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1467,7 +1497,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1544,7 +1576,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -357,9 +357,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -422,9 +420,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -499,9 +495,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -574,9 +568,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -650,9 +642,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -726,9 +716,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -802,9 +790,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -865,9 +851,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -945,9 +929,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1023,9 +1005,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1102,9 +1082,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1181,9 +1159,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1261,9 +1237,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1339,9 +1313,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1418,9 +1390,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1497,9 +1467,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1576,9 +1544,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -357,7 +357,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -420,7 +422,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -495,7 +499,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -568,7 +574,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -642,7 +650,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -716,7 +726,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -790,7 +802,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -851,7 +865,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -929,7 +945,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1005,7 +1023,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1082,7 +1102,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1159,7 +1181,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1237,7 +1261,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1313,7 +1339,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1390,7 +1418,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1467,7 +1497,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -1544,7 +1576,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -357,6 +357,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -418,6 +420,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -491,6 +495,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -562,6 +568,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -634,6 +642,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -706,6 +716,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -778,6 +790,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -837,6 +851,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -913,6 +929,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -987,6 +1005,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1062,6 +1082,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1137,6 +1159,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1213,6 +1237,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1287,6 +1313,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1362,6 +1390,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1437,6 +1467,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -1512,6 +1544,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -358,10 +358,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run libraries lint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -420,10 +419,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -494,10 +492,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -566,10 +563,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -639,10 +635,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -712,10 +707,9 @@ jobs:
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -785,10 +779,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend stdlib-api-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -845,10 +838,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -922,10 +914,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -997,10 +988,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1073,10 +1063,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1149,10 +1138,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1226,10 +1214,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, aarch64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1301,10 +1288,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1377,10 +1363,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1453,10 +1438,9 @@ jobs:
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -1529,10 +1513,9 @@ jobs:
         with:
           name: Engine Distribution (Oracle GraalVM) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -120,9 +120,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -196,9 +194,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -275,9 +271,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -120,7 +120,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -194,7 +196,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -271,7 +275,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -120,6 +120,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -192,6 +194,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -267,6 +271,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -120,7 +120,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -194,7 +196,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -271,7 +275,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -121,10 +121,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -194,10 +193,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -270,10 +268,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (macos, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -182,7 +182,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -245,7 +247,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -319,7 +323,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -393,7 +399,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -454,7 +462,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -531,7 +541,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -608,7 +620,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -685,7 +699,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -182,6 +182,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -243,6 +245,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -315,6 +319,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -387,6 +393,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -446,6 +454,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -521,6 +531,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -596,6 +608,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -671,6 +685,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -182,9 +182,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -247,9 +245,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -323,9 +319,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -399,9 +393,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -462,9 +454,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -541,9 +531,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -620,9 +608,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -699,9 +685,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -182,7 +182,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -245,7 +247,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -319,7 +323,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -393,7 +399,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -454,7 +462,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -531,7 +541,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -608,7 +620,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -685,7 +699,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -183,10 +183,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run libraries lint
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -245,10 +244,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -318,10 +316,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -391,10 +388,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend stdlib-api-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -451,10 +447,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -527,10 +522,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -603,10 +597,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
@@ -679,10 +672,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (windows, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test standard-library-in-native
         env:
           ENSO_LIB_S3_AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -118,6 +118,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .
@@ -201,6 +203,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: file built-distribution.tar
+        shell: bash
       - name: Unpack Engine Distribution
         run: |-
           tar -xvf built-distribution.tar -C .

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -118,9 +118,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -205,9 +203,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: |-
-          file built-distribution.tar
-          sha256sum built-distribution.tar
+      - run: sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -119,10 +119,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test std-snowflake
         env:
           ENSO_CLOUD_COGNITO_REGION: ${{ vars.ENSO_CLOUD_COGNITO_REGION }}
@@ -203,10 +202,9 @@ jobs:
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
       - name: Unpack Engine Distribution
-        run: |
-          tar -xvf built-distribution.tar || tar -xvf built-distribution.tar;
+        run: |-
+          tar -xvf built-distribution.tar -C .
           rm built-distribution.tar
-        shell: bash
       - run: ./run backend test std-cloud-related
         env:
           ENSO_CLOUD_COGNITO_REGION: ${{ vars.ENSO_CLOUD_COGNITO_REGION }}

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -118,7 +118,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -203,7 +205,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: file built-distribution.tar
+      - run: |-
+          file built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -118,7 +118,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-
@@ -203,7 +205,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
-      - run: sha256sum built-distribution.tar
+      - run: |-
+          ls -l built-distribution.tar
+          sha256sum built-distribution.tar
         shell: bash
       - name: Unpack Engine Distribution
         run: |-

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -244,6 +244,7 @@ impl JobArchetype for JvmTests {
                 vec![
                     cleanup_engine_distribution,
                     download_engine_distribution,
+                    step::check_engine_distribution(),
                     step::unpack_engine_distribution(),
                     step,
                     step::engine_test_reporter(target, graal_edition),
@@ -352,6 +353,7 @@ impl JobArchetype for StandardLibraryTests {
             vec![
                 cleanup_engine_distribution,
                 download_engine_distribution,
+                step::check_engine_distribution(),
                 step::unpack_engine_distribution(),
                 updated_main_step,
                 step::stdlib_test_reporter(target, graal_edition),
@@ -421,6 +423,7 @@ impl JobArchetype for EnsoCodeLintCheck {
                     check_syntax,
                     cleanup_engine_distribution,
                     download_engine_distribution,
+                    step::check_engine_distribution(),
                     step::unpack_engine_distribution(),
                     step,
                 ]
@@ -457,6 +460,7 @@ impl JobArchetype for StandardLibraryApiCheck {
                 vec![
                     cleanup_engine_distribution,
                     download_engine_distribution,
+                    step::check_engine_distribution(),
                     step::unpack_engine_distribution(),
                     step,
                 ]
@@ -635,6 +639,7 @@ impl JobArchetype for SnowflakeTests {
                 vec![
                     cleanup_engine_distribution,
                     download_engine_distribution,
+                    step::check_engine_distribution(),
                     step::unpack_engine_distribution(),
                     updated_main_step,
                     step::extra_stdlib_test_reporter(target, GRAAL_EDITION_FOR_EXTRA_TESTS),

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -84,11 +84,7 @@ pub fn download_engine_distribution(
 
 pub fn check_engine_distribution() -> Step {
     Step {
-        run: Some(
-            "file built-distribution.tar
-sha256sum built-distribution.tar"
-                .into(),
-        ),
+        run: Some("sha256sum built-distribution.tar".into()),
         shell: Some(Shell::Bash),
         ..Default::default()
     }

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -83,15 +83,13 @@ pub fn download_engine_distribution(
 }
 
 pub fn unpack_engine_distribution() -> Step {
-    let extract_archive = retry_shell_command("tar -xvf built-distribution.tar");
     Step {
         name: Some("Unpack Engine Distribution".into()),
-        run: Some(format!(
-            "{extract_archive};
-rm built-distribution.tar
-"
-        )),
-        shell: Some(Shell::Bash),
+        run: Some(
+            "tar -xvf built-distribution.tar -C .
+rm built-distribution.tar"
+                .into(),
+        ),
         ..Default::default()
     }
 }
@@ -122,11 +120,6 @@ fn built_distribution_directories(engine_launcher: engine::EngineLauncher) -> St
         engine::EngineLauncher::TestDebugNative => " test",
         _ => "",
     })
-}
-
-fn retry_shell_command(command: impl Into<String>) -> String {
-    let cmd = command.into();
-    format!("{cmd} || {cmd}")
 }
 
 pub fn upload_artifact(step_name: impl Into<String>) -> Step {

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -84,7 +84,11 @@ pub fn download_engine_distribution(
 
 pub fn check_engine_distribution() -> Step {
     Step {
-        run: Some("sha256sum built-distribution.tar".into()),
+        run: Some(
+            "ls -l built-distribution.tar
+sha256sum built-distribution.tar"
+                .into(),
+        ),
         shell: Some(Shell::Bash),
         ..Default::default()
     }

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -82,6 +82,14 @@ pub fn download_engine_distribution(
     )
 }
 
+pub fn check_engine_distribution() -> Step {
+    Step {
+        run: Some("file built-distribution.tar".into()),
+        shell: Some(Shell::Bash),
+        ..Default::default()
+    }
+}
+
 pub fn unpack_engine_distribution() -> Step {
     Step {
         name: Some("Unpack Engine Distribution".into()),

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -84,7 +84,11 @@ pub fn download_engine_distribution(
 
 pub fn check_engine_distribution() -> Step {
     Step {
-        run: Some("file built-distribution.tar".into()),
+        run: Some(
+            "file built-distribution.tar
+sha256sum built-distribution.tar"
+                .into(),
+        ),
         shell: Some(Shell::Bash),
         ..Default::default()
     }


### PR DESCRIPTION
### Pull Request Description

- followup #12948 
- followup #13045

Debugging issues during the unpacking engine distribution step:
```
tar: Unexpected EOF in archive
tar: rmtlseek not stopped at a record boundary
tar: Error is not recoverable: exiting now
```

Changelog:
- remove: retry unpacking the engine distribution
- update: check the engine distribution file before unpacking

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
