### PR TITLE
Reduce the stack trace output in tests

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -14,7 +14,7 @@ import org.enso.polyglot.runtime.Runtime.Api.{
 import org.enso.runtime.utils.ThreadUtils
 import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
 import org.enso.text.editing.model
-import org.enso.testkit.FlakySpec
+import org.enso.testkit.{DebugSpec, FlakySpec}
 import org.graalvm.polyglot.Context
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
@@ -30,6 +30,7 @@ class RuntimeAsyncCommandsTest
     extends AnyFlatSpec
     with Matchers
     with BeforeAndAfterEach
+    with DebugSpec
     with FlakySpec {
 
   // === Test Utilities =======================================================

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/DebugSpec.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/DebugSpec.scala
@@ -1,0 +1,21 @@
+package org.enso.testkit
+
+import org.enso.runtime.utils.ThreadUtils
+import org.scalatest._
+
+/** Trait provides debug information when a test fails in the suite. */
+trait DebugSpec extends TestSuite {
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    val result = super.withFixture(test)
+
+    if (result.isFailed || result.isCanceled) {
+      val msg = ThreadUtils.dumpAllStacktraces(
+        s"Thread dump of the failed test `${test.name}`"
+      )
+      println(msg)
+    }
+
+    result
+  }
+}

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/FlakySpec.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/FlakySpec.scala
@@ -1,6 +1,5 @@
 package org.enso.testkit
 
-import org.enso.runtime.utils.ThreadUtils
 import org.scalatest._
 
 /** Trait is used to mark the tests in the suite as _flaky_ and make them
@@ -21,16 +20,7 @@ trait FlakySpec extends TestSuite {
   object SkipOnFailure extends Tag("org.enso.test.skiponfailure")
 
   override def withFixture(test: NoArgTest): Outcome = {
-    val result = super.withFixture(test)
-
-    if (result.isFailed || result.isCanceled) {
-      val msg = ThreadUtils.dumpAllStacktraces(
-        s"Thread dump of the failed flaky test `${test.name}`"
-      )
-      println(msg)
-    }
-
-    result match {
+    super.withFixture(test) match {
       case Failed(_) | Canceled(_)
           if Flaky.isEnabled && test.tags.contains(Flaky.name) =>
         Pending


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- followup #13044

Changelog:
- update: move the logic that prints stack traces to a separate `DebugSuite` to reduce the test output

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
