### PR TITLE
Always show toast when exporting to local

### DIFF
--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -48,6 +48,7 @@
   "asyncHookError": "Error while fetching data",
   "fetchLatestVersionError": "Could not get the latest version of the asset",
   "uploadProjectToCloudSuccess": "Successfully exported local project to the cloud!",
+  "downloadingProjectToLocal": "Exporting cloud project to your computer...",
   "downloadProjectToLocalSuccess": "Successfully exported cloud project to your computer!",
   "changeUserGroupsError": "Could not set user groups",
   "deleteUserGroupError": "Could not delete user group '$0'",

--- a/app/gui/src/dashboard/hooks/backendUploadFilesHooks.tsx
+++ b/app/gui/src/dashboard/hooks/backendUploadFilesHooks.tsx
@@ -1,5 +1,4 @@
 /** @file Hooks for uploading files. */
-
 import {
   backendMutationOptions,
   listDirectoryQueryOptions,
@@ -733,7 +732,6 @@ export function useUploadFileMutation(
  * Does not work in environments that do not have a local backend.
  */
 export function useUploadFileToLocal(category: Category) {
-  const { getText } = useText()
   const transferBetweenCategories = useTransferBetweenCategories(category)
 
   const { localCategories } = useCategories()
@@ -743,6 +741,5 @@ export function useUploadFileToLocal(category: Category) {
   return useEventCallback(async (assets: readonly AnyAsset[]) => {
     invariant(localHomeCategory, 'Local home category must exist to download to local')
     await transferBetweenCategories(category, localHomeCategory, assets)
-    toast.success(getText('downloadProjectToLocalSuccess'))
   })
 }

--- a/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
@@ -127,11 +127,18 @@ export function useTransferBetweenCategories(currentCategory: Category) {
               return
             }
 
+            const toastId = toast.loading(getText('downloadingProjectToLocal'))
             await downloadAssetsMutation({
               ids: assetsArray,
               targetDirectoryId,
             })
-            toast.success(getText('downloadProjectToLocalSuccess'))
+            toast.update(toastId, {
+              type: 'success',
+              isLoading: null,
+              closeButton: null,
+              autoClose: null,
+              render: getText('downloadProjectToLocalSuccess'),
+            })
             return
           }
 

--- a/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
@@ -19,6 +19,7 @@ import { AssetType, type AssetId, type DirectoryId } from '#/services/Backend'
 import { parseDirectoriesPath } from '#/services/utilities'
 import { useMutationCallback } from '#/utilities/tanstackQuery'
 import type { DropOperation } from '@react-types/shared'
+import { toast } from 'react-toastify'
 import { z } from 'zod'
 import {
   CATEGORY_SCHEMA,
@@ -112,23 +113,29 @@ export function useTransferBetweenCategories(currentCategory: Category) {
       const targetDirectoryId = newParentId ?? to.homeDirectoryId
 
       switch (from.type) {
-        case 'team': {
+        case 'team':
+        case 'cloud':
+        case 'user': {
           if (to.type === 'trash') {
-            return deleteAssetsMutation([keysArray, false])
+            await deleteAssetsMutation([keysArray, false])
+            return
           }
 
           if (isLocalCategory(to)) {
-            if (method === 'move') {
-              return askToCopyInstead(getText, getText('copyInsteadOfMoving', from.label))
+            if (from.type === 'team' && method === 'move') {
+              await askToCopyInstead(getText, getText('copyInsteadOfMoving', from.label))
+              return
             }
 
-            return downloadAssetsMutation({
+            await downloadAssetsMutation({
               ids: assetsArray,
               targetDirectoryId,
             })
+            toast.success(getText('downloadProjectToLocalSuccess'))
+            return
           }
 
-          if (to.type === 'cloud' || to.type === 'user') {
+          if (from.type === 'team' && (to.type === 'cloud' || to.type === 'user')) {
             let resolution: Resolution = 'confirm'
 
             if (method === 'move') {
@@ -139,23 +146,9 @@ export function useTransferBetweenCategories(currentCategory: Category) {
             }
 
             if (resolution === 'confirm') {
-              return copyAssetsMutation([keysArray, targetDirectoryId])
+              await copyAssetsMutation([keysArray, targetDirectoryId])
+              return
             }
-          }
-
-          return mutationByOperation[method](keysArray, targetDirectoryId)
-        }
-        case 'cloud':
-        case 'user': {
-          if (to.type === 'trash') {
-            return deleteAssetsMutation([keysArray, false])
-          }
-
-          if (isLocalCategory(to)) {
-            return downloadAssetsMutation({
-              ids: assetsArray,
-              targetDirectoryId: newParentId ?? to.homeDirectoryId,
-            })
           }
 
           return mutationByOperation[method](keysArray, targetDirectoryId)
@@ -164,7 +157,6 @@ export function useTransferBetweenCategories(currentCategory: Category) {
           if (to.type === 'trash') {
             return
           }
-
           if (isLocalCategory(to)) {
             return
           }


### PR DESCRIPTION
### Pull Request Description
- Show toast when exporting to local, even if it is from drag-n-drop

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
