### PR TITLE
Native libraries from packages are not copied

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4008,7 +4008,6 @@ lazy val `engine-runner` = project
               // Workaround a problem with build-/runtime-initialization conflict
               // by disabling this service provider
               "-H:ServiceLoaderFeatureExcludeServiceProviders=net.snowflake.client.core.FileTypeDetector",
-              "-Dorg.enso.feature.native.lib.output=" + (engineDistributionRoot.value / "bin"),
               "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin"),
               // Snowflake uses Apache Arrow (equivalent of #9664 in native-image setup)
               "--add-opens=java.base/java.nio=ALL-UNNAMED"

--- a/build.sbt
+++ b/build.sbt
@@ -4009,6 +4009,9 @@ lazy val `engine-runner` = project
               // by disabling this service provider
               "-H:ServiceLoaderFeatureExcludeServiceProviders=net.snowflake.client.core.FileTypeDetector",
               "-Dorg.sqlite.lib.exportPath=" + (engineDistributionRoot.value / "bin"),
+              "--features=org.enso.interpreter.runtime.nativeimage.NativeLibraryFeature",
+              // Needed for the NativeLibraryFeature
+              "--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
               // Snowflake uses Apache Arrow (equivalent of #9664 in native-image setup)
               "--add-opens=java.base/java.nio=ALL-UNNAMED"
             ) ++ (if (GraalVM.EnsoLauncher.debug) {
@@ -4064,7 +4067,8 @@ lazy val `engine-runner` = project
             initializeAtBuildtime = NativeImage.defaultBuildTimeInitClasses ++
               Seq(
                 "org.bouncycastle",
-                "org.enso.snowflake.BouncyCastleInitializer"
+                "org.enso.snowflake.BouncyCastleInitializer",
+                "org.enso.interpreter.runtime.nativeimage"
               )
           )
       }

--- a/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
+++ b/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java
@@ -2,39 +2,18 @@ package org.enso.runner;
 
 import static scala.jdk.javaapi.CollectionConverters.asJava;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.LinkedHashSet;
 import java.util.TreeSet;
 import org.enso.compiler.core.EnsoParser;
 import org.enso.compiler.core.ir.module.scope.imports.Polyglot;
-import org.enso.filesystem.FileSystem$;
-import org.enso.pkg.NativeLibraryFinder;
 import org.enso.pkg.PackageManager$;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 public final class EnsoLibraryFeature implements Feature {
-  private static final String LIB_OUTPUT = "org.enso.feature.native.lib.output";
-  private final File nativeLibDir;
-
-  public EnsoLibraryFeature() {
-    var nativeLibOut = System.getProperty(LIB_OUTPUT);
-    if (nativeLibOut == null) {
-      throw new IllegalStateException("Missing system property: " + LIB_OUTPUT);
-    }
-    nativeLibDir = new File(nativeLibOut);
-    if (!nativeLibDir.exists() || !nativeLibDir.isDirectory()) {
-      var created = nativeLibDir.mkdirs();
-      if (!created) {
-        throw new IllegalStateException("Cannot create directory: " + nativeLibDir);
-      }
-    }
-  }
-
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
 
@@ -68,7 +47,6 @@ public final class EnsoLibraryFeature implements Feature {
     */
 
     var classes = new TreeSet<String>();
-    var nativeLibPaths = new TreeSet<String>();
     try {
       for (var p : libs) {
         var result = PackageManager$.MODULE$.Default().loadPackage(p.toFile());
@@ -106,15 +84,6 @@ public final class EnsoLibraryFeature implements Feature {
               }
             }
           }
-          if (pkg.nativeLibraryDir().exists()) {
-            var nativeLibs =
-                NativeLibraryFinder.listAllNativeLibraries(pkg, FileSystem$.MODULE$.defaultFs());
-            for (var nativeLib : nativeLibs) {
-              var out = new File(nativeLibDir, nativeLib.getName());
-              Files.copy(nativeLib.toPath(), out.toPath(), StandardCopyOption.REPLACE_EXISTING);
-              nativeLibPaths.add(out.getAbsolutePath());
-            }
-          }
           pkg.markAotReady();
         }
       }
@@ -127,6 +96,5 @@ public final class EnsoLibraryFeature implements Feature {
       System.err.println("  " + className);
     }
     System.err.println("Registered " + classes.size() + " classes for reflection");
-    System.err.println("Copied native libraries: " + nativeLibPaths + " into " + nativeLibDir);
   }
 }

--- a/engine/runtime/src/main/java/module-info.java
+++ b/engine/runtime/src/main/java/module-info.java
@@ -28,6 +28,7 @@ open module org.enso.runtime {
   requires org.apache.tika.core;
   requires org.slf4j;
   requires org.graalvm.collections;
+  requires org.graalvm.nativeimage;
   requires org.graalvm.polyglot;
   requires org.graalvm.truffle;
   requires com.ibm.icu;

--- a/engine/runtime/src/main/java/module-info.java
+++ b/engine/runtime/src/main/java/module-info.java
@@ -29,7 +29,6 @@ open module org.enso.runtime {
   requires org.slf4j;
   requires org.graalvm.collections;
   requires org.graalvm.polyglot;
-  requires org.graalvm.nativeimage;
   requires org.graalvm.truffle;
   requires com.ibm.icu;
 

--- a/engine/runtime/src/main/java/module-info.java
+++ b/engine/runtime/src/main/java/module-info.java
@@ -29,6 +29,7 @@ open module org.enso.runtime {
   requires org.slf4j;
   requires org.graalvm.collections;
   requires org.graalvm.polyglot;
+  requires org.graalvm.nativeimage;
   requires org.graalvm.truffle;
   requires com.ibm.icu;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibraryFeature.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibraryFeature.java
@@ -1,0 +1,56 @@
+package org.enso.interpreter.runtime.nativeimage;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+
+/** This feature sets the static fields of {@link NativeLibrarySearchPath} during NI build time. */
+final class NativeLibraryFeature implements Feature {
+  private static final String NATIVE_LIBS_CLASS_NAME = "com.oracle.svm.core.jdk.NativeLibraries";
+  private static final String NATIVE_LIBS_SUPPORT_CLASS_NAME =
+      "com.oracle.svm.core.jdk.NativeLibrarySupport";
+  private static final String LIB_LOADER_CLASS_NAME =
+      "org.enso.interpreter.runtime.nativeimage.NativeLibrarySearchPath";
+  private static final String USR_PATH_GETTER_FIELD_NAME = "usrPathsGetter";
+  private static final String USR_PATH_SETTER_FIELD_NAME = "usrPathsSetter";
+  private static final String NATIVE_LIBS_INSTANCE_FIELD_NAME = "nativeLibsInstance";
+  private static final String USR_PATHS_FIELD_NAME = "usrPaths";
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    var nativeLibsClass = access.findClassByName(NATIVE_LIBS_CLASS_NAME);
+    var nativeLibSupportClass = access.findClassByName(NATIVE_LIBS_SUPPORT_CLASS_NAME);
+    assert nativeLibSupportClass != null;
+    var lookup = MethodHandles.lookup();
+    MethodHandle getterMethodHandle;
+    MethodHandle setterMethodHandle;
+    try {
+      var privateLookup = MethodHandles.privateLookupIn(nativeLibsClass, lookup);
+      getterMethodHandle =
+          privateLookup.findGetter(nativeLibSupportClass, USR_PATHS_FIELD_NAME, String[].class);
+      setterMethodHandle =
+          privateLookup.findSetter(nativeLibSupportClass, USR_PATHS_FIELD_NAME, String[].class);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new AssertionError(e);
+    }
+    var libLoaderClass = access.findClassByName(LIB_LOADER_CLASS_NAME);
+    Field usrPathsGetterField;
+    Field usrPathsSetterField;
+    Field nativeLibsInstanceField;
+    try {
+      usrPathsGetterField = libLoaderClass.getDeclaredField(USR_PATH_GETTER_FIELD_NAME);
+      usrPathsSetterField = libLoaderClass.getDeclaredField(USR_PATH_SETTER_FIELD_NAME);
+      nativeLibsInstanceField = libLoaderClass.getDeclaredField(NATIVE_LIBS_INSTANCE_FIELD_NAME);
+    } catch (NoSuchFieldException e) {
+      throw new AssertionError(e);
+    }
+    var singleton = ImageSingletons.lookup(nativeLibSupportClass);
+    access.registerFieldValueTransformer(nativeLibsInstanceField, (receiver, origVal) -> singleton);
+    access.registerFieldValueTransformer(
+        usrPathsGetterField, (receiver, origVal) -> getterMethodHandle);
+    access.registerFieldValueTransformer(
+        usrPathsSetterField, (receiver, origVal) -> setterMethodHandle);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibrarySearchPath.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibrarySearchPath.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.runtime.nativeimage;
 
-import java.io.File;
 import java.lang.invoke.MethodHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,15 +44,6 @@ public final class NativeLibrarySearchPath {
     if (ImageInfo.inImageRuntimeCode()) {
       assert Files.isDirectory(Path.of(path));
       addPath(path);
-    }
-  }
-
-  public static String[] getSearchPath() {
-    if (ImageInfo.inImageRuntimeCode()) {
-      return getFieldValue();
-    } else {
-      var prop = System.getProperty("java.library.path");
-      return prop.split(File.pathSeparator);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibrarySearchPath.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibrarySearchPath.java
@@ -1,0 +1,83 @@
+package org.enso.interpreter.runtime.nativeimage;
+
+import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.ImageSingletons;
+
+/**
+ * Utility class for handling <emph>native library search path</emph> changes at runtime. Changing
+ * the search path works only in NI.
+ *
+ * <p>Semantically the same as changing the {@code java.library.path} system property, and ensuring
+ * the property change is reflected by the JVM.
+ *
+ * <p>Inspired by <a
+ * href="https://github.com/Akirathan/native-lib-loader">Akirathan/native-lib-loader</a>
+ */
+public final class NativeLibrarySearchPath {
+  private NativeLibrarySearchPath() {}
+
+  /** Getter for field {@code com.oracle.svm.core.jdk.NativeLibraries#usrPaths}. */
+  static MethodHandle usrPathsGetter;
+
+  /** Setter for field {@code com.oracle.svm.core.jdk.NativeLibraries#usrPaths}. */
+  static MethodHandle usrPathsSetter;
+
+  /**
+   * {@link ImageSingletons singleton} instance of {@code
+   * com.oracle.svm.core.jdk.NativeLibrarySupport}. This instance has {@code usrPaths} field that we
+   * want to change at runtime. Note that this field needs to be {@code final}, otherwise, NI build
+   * fails.
+   */
+  static final Object nativeLibsInstance = null;
+
+  /**
+   * Adds the given {@code path} directory to the search path for native libraries. Semantically, it
+   * is equivalent to changing the {@code java.library.path} system property. Only works in Native
+   * Image.
+   *
+   * @param path Directory to add to the search path.
+   */
+  public static void addToSearchPath(String path) {
+    if (ImageInfo.inImageRuntimeCode()) {
+      assert Files.isDirectory(Path.of(path));
+      addPath(path);
+    }
+  }
+
+  public static String[] getSearchPath() {
+    if (ImageInfo.inImageRuntimeCode()) {
+      return getFieldValue();
+    } else {
+      var prop = System.getProperty("java.library.path");
+      return prop.split(File.pathSeparator);
+    }
+  }
+
+  private static String[] getFieldValue() {
+    try {
+      return (String[]) usrPathsGetter.invoke(nativeLibsInstance);
+    } catch (Throwable e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static void addPath(String path) {
+    var oldValue = getFieldValue();
+    var newValue = new String[oldValue.length + 1];
+    System.arraycopy(oldValue, 0, newValue, 0, oldValue.length);
+    newValue[newValue.length - 1] = path;
+    setFieldValue(newValue);
+  }
+
+  private static void setFieldValue(String[] newValue) {
+    try {
+      usrPathsSetter.invoke(nativeLibsInstance, newValue);
+    } catch (Throwable e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -263,10 +263,6 @@ private class DefaultPackageRepository(
       distinctParentDirs.foreach { dir =>
         logger.debug("Adding '{}' to native lib search path", dir.getPath)
         NativeLibrarySearchPath.addToSearchPath(dir.getPath)
-        logger.trace(
-          "Current value of native lib search path: {}",
-          NativeLibrarySearchPath.getSearchPath
-        )
       }
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -43,11 +43,10 @@ import org.enso.editions.updater.EditionManager
 import org.enso.editions.{DefaultEdition, Editions, LibraryName}
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.instrument.NotificationHandler
+import org.enso.interpreter.runtime.nativeimage.NativeLibrarySearchPath
 import org.enso.librarymanager.DefaultLibraryProvider
 import org.graalvm.nativeimage.ImageInfo
 import org.slf4j.LoggerFactory
-
-import java.io.File
 
 /** The default [[PackageRepository]] implementation.
   *
@@ -259,16 +258,15 @@ private class DefaultPackageRepository(
         pkg,
         TruffleFileSystem.INSTANCE
       )
-      val propName = "java.library.path"
       val distinctParentDirs = nativeLibs.asScala
         .map(_.getParent)
         .toSet
       distinctParentDirs.foreach { dir =>
-        logger.debug("Adding '{}' to {} system prop", dir.getPath, propName)
-        val oldPropValue = System.getProperty(propName)
-        System.setProperty(
-          propName,
-          oldPropValue + File.pathSeparator + dir.getPath
+        logger.debug("Adding '{}' to native lib search path", dir.getPath)
+        NativeLibrarySearchPath.addToSearchPath(dir.getPath)
+        logger.trace(
+          "Current value of native lib search path: {}",
+          NativeLibrarySearchPath.getSearchPath
         )
       }
     }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -246,8 +246,7 @@ private class DefaultPackageRepository(
   }
 
   /** If the package contains any native libraries, their parent directories are added to the
-    * `java.library.path` system prop. This only works in native image - in JVM, changes
-    * to `java.library.path` system prop are ignored.
+    * native library search path. This only works in native image.
     * @param pkg the package to check for native libraries
     */
   private def addNativeLibPath(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -1,7 +1,6 @@
 package org.enso.interpreter.runtime
 
 import scala.jdk.OptionConverters.RichOption
-
 import org.enso.common.HostEnsoUtils
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.context.CompilerContext
@@ -19,7 +18,10 @@ import org.enso.logger.masking.MaskedPath
 import org.enso.pkg.{
   Component,
   ComponentGroup,
+  ComponentGroups,
   ExtendedComponentGroup,
+  NativeLibraryFinder,
+  Package,
   PackageManager,
   QualifiedName,
   SourceFile
@@ -29,7 +31,11 @@ import org.enso.common.CompilationStage
 
 import java.nio.file.Path
 import scala.collection.immutable.ListSet
-import scala.jdk.CollectionConverters.{IterableHasAsJava, SeqHasAsJava}
+import scala.jdk.CollectionConverters.{
+  CollectionHasAsScala,
+  IterableHasAsJava,
+  SeqHasAsJava
+}
 import scala.util.{Failure, Success, Try, Using}
 import org.enso.distribution.locking.ResourceManager
 import org.enso.distribution.{DistributionManager, LanguageHome}
@@ -38,8 +44,10 @@ import org.enso.editions.{DefaultEdition, Editions, LibraryName}
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.instrument.NotificationHandler
 import org.enso.librarymanager.DefaultLibraryProvider
-import org.enso.pkg.{ComponentGroups, Package}
+import org.graalvm.nativeimage.ImageInfo
 import org.slf4j.LoggerFactory
+
+import java.io.File
 
 /** The default [[PackageRepository]] implementation.
   *
@@ -232,9 +240,38 @@ private class DefaultPackageRepository(
     if (isLibrary) {
       val root = Path.of(pkg.root.toString)
       notificationHandler.addedLibrary(libraryName, libraryVersion, root)
+      addNativeLibPath(pkg)
     }
 
     loadedPackages.put(libraryName, Some(pkg))
+  }
+
+  /** If the package contains any native libraries, their parent directories are added to the
+    * `java.library.path` system prop. This only works in native image - in JVM, changes
+    * to `java.library.path` system prop are ignored.
+    * @param pkg the package to check for native libraries
+    */
+  private def addNativeLibPath(
+    pkg: Package[TruffleFile]
+  ): Unit = {
+    if (ImageInfo.inImageRuntimeCode()) {
+      val nativeLibs = NativeLibraryFinder.listAllNativeLibraries(
+        pkg,
+        TruffleFileSystem.INSTANCE
+      )
+      val propName = "java.library.path"
+      val distinctParentDirs = nativeLibs.asScala
+        .map(_.getParent)
+        .toSet
+      distinctParentDirs.foreach { dir =>
+        logger.debug("Adding '{}' to {} system prop", dir.getPath, propName)
+        val oldPropValue = System.getProperty(propName)
+        System.setProperty(
+          propName,
+          oldPropValue + File.pathSeparator + dir.getPath
+        )
+      }
+    }
   }
 
   /** For any given source file, infer data necessary to generate synthetic modules as well as their contents.


### PR DESCRIPTION
Closes #12557

### Pull Request Description

Removes the copying of native libraries next to the generated NI binary. Native libraries of packages are loaded from the same location in both JVM and AOT modes.

**Old behavior:** [EnsoLibraryFeature](https://github.com/enso-org/enso/blob/7106fdd1cc32902554e7318e811d66e66cc6f3e4/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java) copies all the native libraries within `**/polyglot/lib/**` next to the generated NI binary. The motivation for that is mentioned in the description of #11874.

**New behavior:** [EnsoLibraryFeature](https://github.com/enso-org/enso/blob/7106fdd1cc32902554e7318e811d66e66cc6f3e4/engine/runner/src/main/java/org/enso/runner/EnsoLibraryFeature.java) no longer copies native libraries. Instead, once a package is loaded in [DefaultPackageRepository.registerPackageInternal](https://github.com/enso-org/enso/blob/d369fcbe69f3eb1baa5fe7a5b8d24354b74067ad/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala#L203-L247), paths to its native libraries are added to the native library search path via [NativeLibrarySearchPath](https://github.com/enso-org/enso/blob/9d8866944b145add67bbb944328ded1e3c4a3bba/engine/runtime/src/main/java/org/enso/interpreter/runtime/nativeimage/NativeLibrarySearchPath.java). Inspired by https://github.com/Akirathan/native-lib-loader.

### Important Notes

- In JVM mode, native libraries of packages are still loaded by [HostClassLoader.findLibrary](https://github.com/enso-org/enso/blob/7658faf64563ef25e8f04003892cfb074fd907c5/engine/runtime/src/main/java/org/enso/interpreter/runtime/HostClassLoader.java#L86-L109).
- In AOT mode, [com.oracle.svm.core.jdk.NativeLibraries#usrPaths](https://github.com/oracle/graal/blob/91061cb6a151ffaa83e05f6852384537c2c85e6b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibraries.java#L67) field is changed at runtime.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
