### PR TITLE
Update default audit log endpoint

### DIFF
--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/CloudAPI.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/CloudAPI.java
@@ -11,8 +11,7 @@ public final class CloudAPI {
    */
   public static String getAPIRootURI() {
     var envUri = Environment_Utils.get_environment_variable("ENSO_CLOUD_API_URI");
-    var effectiveUri =
-        envUri == null ? "https://7aqkn3tnbc.execute-api.eu-west-1.amazonaws.com/" : envUri;
+    var effectiveUri = envUri == null ? "https://api.cloud.enso.org/" : envUri;
     var uriWithSlash = effectiveUri.endsWith("/") ? effectiveUri : effectiveUri + "/";
     return uriWithSlash;
   }


### PR DESCRIPTION
### Pull Request Description

This is a minor consistency update. Similarly to #13049 audit log now uses a human-readable default endpoint.

This doesn't change the fact that logic of audit/telemetry/remote logs should be merged but that's a topic for #12564.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
