### PR TITLE
Remove warnings before calling into AbstractTypeCheckNode

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/typecheck/TypeCheckValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/typecheck/TypeCheckValueTest.java
@@ -7,6 +7,9 @@ import com.oracle.truffle.api.CallTarget;
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.warning.Warning;
+import org.enso.interpreter.runtime.warning.WarningsLibrary;
+import org.enso.interpreter.runtime.warning.WithWarnings;
 import org.enso.test.utils.ContextUtils;
 import org.enso.test.utils.TestRootNode;
 import org.junit.ClassRule;
@@ -49,5 +52,31 @@ public class TypeCheckValueTest {
     root.insertChildren(bothNode);
     call[0] = root.getCallTarget();
     return call[0];
+  }
+
+  @Test
+  public void checkWithWarnings() throws Exception {
+    var ctx = ctxRule.ensoContext();
+    var builtins = ctx.getBuiltins();
+
+    var convert = allOfIntegerAndText();
+    var hi = Text.create("Hi");
+    var m1 =
+        EnsoMultiValue.NewNode.getUncached()
+            .newValue(new Type[] {builtins.text(), builtins.number().getInteger()}, 2, 0, hi, 42);
+    var warning = Warning.create(ctx, Text.create("Problem"), builtins.nothing());
+    var w1 = WithWarnings.create(m1, 100, false, warning);
+
+    assertEquals("'Hi'", w1.toDisplayString(true).toString());
+
+    var with = convert.call(w1);
+    assertTrue("Converted value has warnings", WarningsLibrary.getUncached().hasWarnings(with));
+
+    var res = WarningsLibrary.getUncached().removeWarnings(with);
+
+    assertTrue("Got multivalue again", res instanceof EnsoMultiValue);
+    var emv = (EnsoMultiValue) res;
+
+    assertEquals("42", emv.toDisplayString(true));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.typecheck;
 
-import java.util.Arrays;
 
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.EnsoRootNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -1,6 +1,8 @@
 package org.enso.interpreter.node.typecheck;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
 import java.util.Arrays;
 import java.util.List;
@@ -14,16 +16,21 @@ import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.util.CachingSupplier;
+import org.enso.interpreter.runtime.warning.AppendWarningNode;
+import org.enso.interpreter.runtime.warning.WarningsLibrary;
 
 /** A node and a factory for nodes performing type checks (including necessary conversions). */
 public final class TypeCheckValueNode extends Node {
   private @Child AbstractTypeCheckNode check;
+  private @Child WarningsLibrary warnings;
+  private @Child AppendWarningNode append;
   private final boolean allTypes;
 
   TypeCheckValueNode(AbstractTypeCheckNode check, boolean allTypes) {
     assert check != null;
     this.check = check;
     this.allTypes = allTypes;
+    this.warnings = WarningsLibrary.getFactory().createDispatched(3);
   }
 
   /**
@@ -52,6 +59,27 @@ public final class TypeCheckValueNode extends Node {
    *     null} value that can be used as a result
    */
   public final Object handleCheckOrConversion(
+      VirtualFrame frame, Object value, ExpressionNode expr) {
+    if (warnings.hasWarnings(value)) {
+      if (append == null) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        append = insert(AppendWarningNode.build());
+      }
+      try {
+        var plainValue = warnings.removeWarnings(value);
+        var result = handleCheckOrConversionImpl(frame, plainValue, expr);
+        var warnMap = warnings.getWarnings(value, false);
+        return append.executeAppend(frame, result, warnMap);
+      } catch (UnsupportedMessageException ex) {
+        var ctx = EnsoContext.get(this);
+        throw ctx.raiseAssertionPanic(this, null, ex);
+      }
+    } else {
+      return handleCheckOrConversionImpl(frame, value, expr);
+    }
+  }
+
+  private final Object handleCheckOrConversionImpl(
       VirtualFrame frame, Object value, ExpressionNode expr) {
     var result = check.executeCheckOrConversion(frame, value, expr);
     if (result == null) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -68,8 +68,12 @@ public final class TypeCheckValueNode extends Node {
       try {
         var plainValue = warnings.removeWarnings(value);
         var result = handleCheckOrConversionImpl(frame, plainValue, expr);
-        var warnMap = warnings.getWarnings(value, false);
-        return append.executeAppend(frame, result, warnMap);
+        if (result == plainValue) {
+          return value;
+        } else {
+          var warnMap = warnings.getWarnings(value, false);
+          return append.executeAppend(frame, result, warnMap);
+        }
       } catch (UnsupportedMessageException ex) {
         var ctx = EnsoContext.get(this);
         throw ctx.raiseAssertionPanic(this, null, ex);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/WithWarnings.java
@@ -102,7 +102,7 @@ public final class WithWarnings extends EnsoObject {
    * @param warnings array of warnings to be attached to the {@code value}
    */
   public static WithWarnings create(
-      Object value, int maxWarnings, boolean limitReached, Warning[] warnings) {
+      Object value, int maxWarnings, boolean limitReached, Warning... warnings) {
     assert warnings.length <= maxWarnings;
     if (limitReached) {
       assert warnings.length == maxWarnings;

--- a/test/Base_Tests/src/Data/Round_Spec.enso
+++ b/test/Base_Tests/src/Data/Round_Spec.enso
@@ -24,7 +24,8 @@ type Batch_Runner
         epsilon_vec  = configs.map c-> c.at 3
         warning_vec  = configs.map c-> c.at 4
         got_vec = self.run_batch values_vec dps_vec rounding_mode
-        got_vec.each_with_index ix-> got->
+        0.up_to got_vec.length . each \ix ->
+            got = got_vec.at ix
             expected = expected_vec.at ix
             value = values_vec.at ix
             dp = dps_vec.at ix

--- a/test/Base_Tests/src/Data/Round_Spec.enso
+++ b/test/Base_Tests/src/Data/Round_Spec.enso
@@ -24,8 +24,7 @@ type Batch_Runner
         epsilon_vec  = configs.map c-> c.at 3
         warning_vec  = configs.map c-> c.at 4
         got_vec = self.run_batch values_vec dps_vec rounding_mode
-        0.up_to got_vec.length . each \ix ->
-            got = got_vec.at ix
+        got_vec.each_with_index ix-> got->
             expected = expected_vec.at ix
             value = values_vec.at ix
             dp = dps_vec.at ix

--- a/test/Base_Tests/src/Semantic/Multi_On_Any_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_On_Any_Spec.enso
@@ -41,6 +41,9 @@ add_specs suite_builder =
         group_builder.specify "hide the refinement" <|
             ((x : My_Atom|Nothing).is_nothing) . should_be_false
 
+        group_builder.specify "access field of My_Atom" <|
+            x.a . should_equal 42
+
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -306,7 +306,7 @@ add_specs suite_builder =
             y.a_method . should_equal "A method"
             y.b_method . should_equal "B method"
 
-        group_builder.specify "attaching warnings to an intersection type should not lose even the hidden refinements" pending="Warnings not yet supported #12180" <|
+        group_builder.specify "attaching warnings to an intersection type should not lose even the hidden refinements" <|
             ab = make_a_and_b
             x = ab:A
             x_with_warning = Warning.attach (Illegal_State.Error "my warning") x

--- a/test/Base_Tests/src/Semantic/Multi_Value_Column_Like_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_Column_Like_Spec.enso
@@ -1,0 +1,36 @@
+from Standard.Base import all
+from Standard.Test import all
+import Standard.Base.Errors.Illegal_State.Illegal_State
+
+type Base_Column
+    Value underlying
+
+type In_Memory_Column
+    Value vec
+
+type My_Warning
+    Warning msg
+
+Base_Column.from (that:In_Memory_Column) =
+    Base_Column.Value that
+
+In_Memory_Column.from (that:Base_Column) =
+    if that.underlying.is_a In_Memory_Column then that.underlying else
+        Error.throw (Illegal_State.Error "In_Memory_Column.from: that is not an In_Memory_Column")
+
+refine base:Base_Column =
+    (base : Base_Column & In_Memory_Column)
+
+new_column vec:Vector -> Base_Column =
+    refine (In_Memory_Column.Value vec)
+
+add_specs suite_builder =
+    suite_builder.group "Multi Value Like Column" group_builder->
+        group_builder.specify "With warnings" <|
+            col = new_column [1,2,3]
+            col_warn = Warning.attach (My_Warning.Warning "My warning") col
+            col_as_in_mem = col_warn:In_Memory_Column
+            col_as_base = col_as_in_mem:Base_Column
+            col_as_both = col_as_base:(Base_Column & In_Memory_Column)
+            col_back = col_as_both:In_Memory_Column
+            col_back.to_text . should_equal "(In_Memory_Column.Value [1, 2, 3])"

--- a/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Common.No_Such_Method
 
 import project.Data.Complex.Complex
+import project.Semantic.Multi_Value_Column_Like_Spec
 
 type A
     a = "a"
@@ -182,4 +183,5 @@ Any.confuse_me self = self
 main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
+        Multi_Value_Column_Like_Spec.add_specs suite_builder
     suite.run_with_filter filter


### PR DESCRIPTION
### Pull Request Description

- Fixes #13108 by `WarningsLibrary.removeWarnings` before processing type checks
- If the check returns the same value (without warnings), returns the same value (prior warnings being removed)
- If the check converts to different value, the [original warnings are re-attached](https://github.com/enso-org/enso/pull/13118#discussion_r2099972524) to the new value

### Important Notes

Such a removal however has deep consequences. The attempt to address them outgrew the scope of the original change magnificently. Thus starting from scratch and leaving the following for later:

- however turns out that `Array.removeWarnings` actually removes warnings from all its values as well!
   - that's very likely wrong
   - but without it we [have trouble](https://github.com/enso-org/enso/pull/13118#issuecomment-2895098807) when passing `Array` with elements with warnings to _host interop_
- also `Vector.Builder` isn't behaving properly 
   - [long & double fixes](https://github.com/enso-org/enso/pull/13118/files#r2097037793) needed - not anymore that fix was reverted as converting from `long` to `double` changes the _type of the number_ behind the scene
- adds `runEngineDistribution --env` support in e8ba79e340 - separated into #13131 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [ ] Benchmarks are fine
   - [ ] [engine run](https://github.com/enso-org/enso/actions/runs/15158954505) and [run after latest fix](https://github.com/enso-org/enso/actions/runs/15163565475)
   - [ ] [stdlibs run](https://github.com/enso-org/enso/actions/runs/15158961404) and [run after latest fix](https://github.com/enso-org/enso/actions/runs/15163603627)