### PR TITLE
Redesign the ManageLabels modal

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -852,6 +852,13 @@ export const COLORS = [
 
 export const FALLBACK_COLOR = COLORS[0]
 
+/** Returns true if the two colors are equal. */
+export function colorsAreEqual(a: LChColor, b: LChColor) {
+  return (
+    a.lightness === b.lightness && a.chroma === b.chroma && a.hue === b.hue && a.alpha === b.alpha
+  )
+}
+
 /** Converts a {@link LChColor} to a CSS color string. */
 export function lChColorToCssColor(color: LChColor): string {
   const alpha = 'alpha' in color ? ` / ${color.alpha}` : ''

--- a/app/common/src/text.ts
+++ b/app/common/src/text.ts
@@ -174,6 +174,8 @@ interface PlaceholderOverrides {
     destinationCategoryName: string,
   ]
 
+  readonly 'manageLabelsModal.createLabelWithTitle': [labelName: string]
+
   readonly planOverriddenToX: [planName: string]
 }
 

--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -873,7 +873,7 @@
   "copyAllShortcut": "Copy All",
   "cutAllShortcut": "Cut All",
   "pasteAllShortcut": "Paste All",
-  "deleteLabelShortcut": "Delete Label",
+  "removeLabelShortcut": "Remove Label",
   "openInFileBrowserShortcut": "Open in File Browser",
   "openInFileBrowserShortcutWindows": "Open in Explorer",
   "openInFileBrowserShortcutMacOs": "Open in Finder",

--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -195,10 +195,8 @@
   "specialLoadingAssetType": "special loading asset",
   "specialEmptyAssetType": "special empty asset",
   "specialErrorAssetType": "special error asset",
-
   "uploadingXFilesWithProgressNotification": "Uploading $0/$1 file(s)... ($2/$3MB)",
   "uploadedXFilesNotification": "Uploaded $0 file(s).",
-
   "couldNotConnectToPM": "Could not connect to the Project Manager. Please try restarting Enso, or manually launching the Project Manager.",
   "upgradeToUseCloud": "Upgrade your plan to use Enso Cloud.",
   "me": "Me",
@@ -313,6 +311,8 @@
   "more": "More",
   "close": "Close",
   "notifications": "Notifications",
+  "search": "Search",
+  "search.placeholder": "Search...",
   "snowflakeCredentialType": "Snowflake",
   "snowflakeCredentialAccount": "Account",
   "snowflakeCredentialClientId": "Client ID",
@@ -579,7 +579,6 @@
   "anUploadIsInProgress": "An upload is in progress.",
   "youAreAllCaughtUp": "You're all caught up!",
   "clearCacheAndReload": "Clear cache and reload",
-
   "deleteLabelActionText": "delete the label '$0'",
   "deleteSelectedAssetActionText": "delete '$0'",
   "deleteSelectedAssetsActionText": "delete $0 selected items",
@@ -1207,5 +1206,14 @@
   "createConfigurationLogEvent": "Create Configuration",
   "listConfigurationsLogEvent": "List Configurations",
   "getConfigurationLogEvent": "Get Configuration",
-  "resolvePathLogEvent": "Resolve Path"
+  "resolvePathLogEvent": "Resolve Path",
+  "manageLabelsModal.createLabel": "Create Label",
+  "manageLabelsModal.createLabelWithTitle": "Create $0",
+  "manageLabelsModal.editLabel": "Edit Label",
+  "manageLabelsModal.allLabels": "Select a label or create a new one",
+  "manageLabelsModal.noLabels": "No labels found",
+  "manageLabelsModal.nextColor": "Next color",
+  "manageLabelsModal.chooseColor": "Choose a color",
+  "manageLabelsModal.labelAlreadyExists": "Label already exists",
+  "manageLabelsModal.selectedLabels": "Selected labels"
 }

--- a/app/gui/src/dashboard/components/AriaComponents/Dialog/DialogTrigger.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Dialog/DialogTrigger.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import * as aria from '#/components/aria'
 
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
+import { createHideableComponent } from '@react-aria/collections'
 import { useOverlayTriggerState } from 'react-stately'
 
 /** Props passed to the render function of a {@link DialogTrigger}. */
@@ -30,7 +31,9 @@ export interface DialogTriggerProps {
 }
 
 /** A DialogTrigger opens a dialog when a trigger element is pressed. */
-export function DialogTrigger(props: DialogTriggerProps) {
+export const DialogTrigger = createHideableComponent(function DialogTrigger(
+  props: DialogTriggerProps,
+) {
   const { children, onOpenChange, onOpen = () => {}, onClose = () => {} } = props
 
   // @ts-expect-error Typescript requires to explicitly add `undefined` to the props
@@ -72,4 +75,4 @@ export function DialogTrigger(props: DialogTriggerProps) {
       {typeof dialog === 'function' ? dialog(renderProps) : dialog}
     </aria.DialogTrigger>
   )
-}
+})

--- a/app/gui/src/dashboard/components/AriaComponents/Form/Form.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/Form.tsx
@@ -24,19 +24,20 @@ export const Form = Object.assign(
       formOptions,
       className,
       style,
-      onSubmit,
-      onSubmitted = () => {},
-      onSubmitSuccess = () => {},
-      onSubmitFailed = () => {},
-      id = formId,
-      schema,
-      defaultValues,
-      gap,
-      method,
-      canSubmitOffline = false,
-      testId = props['data-testid'],
-      ...formProps
-    } = props
+      onChange,
+    onSubmit,
+    onSubmitted = () => {},
+    onSubmitSuccess = () => {},
+    onSubmitFailed = () => {},
+    id = formId,
+    schema,
+    defaultValues,
+    gap,
+    method,
+    canSubmitOffline = false,
+    testId = props['data-testid'],
+    ...formProps
+  } = props
 
     const dialogContext = dialog.useDialogContext()
 
@@ -44,22 +45,23 @@ export const Form = Object.assign(
       form ?? {
         ...formOptions,
         ...(defaultValues ? { defaultValues } : {}),
-        method,
-        schema,
-        canSubmitOffline,
-        onSubmit,
-        onSubmitFailed,
-        onSubmitSuccess: async (...args) => {
-          if (method === 'dialog') {
-            dialogContext?.close()
-          }
-          await onSubmitSuccess(...args)
-        },
-        onSubmitted,
-        shouldFocusError: true,
-        debugName: `Form ${testId} id: ${id}`,
+        ...(onChange ? { onChange } : {}),
+      method,
+      schema,
+      canSubmitOffline,
+      onSubmit,
+      onSubmitFailed,
+      onSubmitSuccess: async (...args) => {
+        if (method === 'dialog') {
+          dialogContext?.close()
+        }
+        await onSubmitSuccess(...args)
       },
-    )
+      onSubmitted,
+      shouldFocusError: true,
+      debugName: `Form ${testId} id: ${id}`,
+    },
+  )
 
     React.useImperativeHandle(formRef, () => innerForm, [innerForm])
     React.useImperativeHandle(form?.closeRef, () => dialogContext?.close ?? (() => {}), [

--- a/app/gui/src/dashboard/components/AriaComponents/Form/Form.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/Form.tsx
@@ -25,19 +25,19 @@ export const Form = Object.assign(
       className,
       style,
       onChange,
-    onSubmit,
-    onSubmitted = () => {},
-    onSubmitSuccess = () => {},
-    onSubmitFailed = () => {},
-    id = formId,
-    schema,
-    defaultValues,
-    gap,
-    method,
-    canSubmitOffline = false,
-    testId = props['data-testid'],
-    ...formProps
-  } = props
+      onSubmit,
+      onSubmitted = () => {},
+      onSubmitSuccess = () => {},
+      onSubmitFailed = () => {},
+      id = formId,
+      schema,
+      defaultValues,
+      gap,
+      method,
+      canSubmitOffline = false,
+      testId = props['data-testid'],
+      ...formProps
+    } = props
 
     const dialogContext = dialog.useDialogContext()
 
@@ -46,22 +46,22 @@ export const Form = Object.assign(
         ...formOptions,
         ...(defaultValues ? { defaultValues } : {}),
         ...(onChange ? { onChange } : {}),
-      method,
-      schema,
-      canSubmitOffline,
-      onSubmit,
-      onSubmitFailed,
-      onSubmitSuccess: async (...args) => {
-        if (method === 'dialog') {
-          dialogContext?.close()
-        }
-        await onSubmitSuccess(...args)
+        method,
+        schema,
+        canSubmitOffline,
+        onSubmit,
+        onSubmitFailed,
+        onSubmitSuccess: async (...args) => {
+          if (method === 'dialog') {
+            dialogContext?.close()
+          }
+          await onSubmitSuccess(...args)
+        },
+        onSubmitted,
+        shouldFocusError: true,
+        debugName: `Form ${testId} id: ${id}`,
       },
-      onSubmitted,
-      shouldFocusError: true,
-      debugName: `Form ${testId} id: ${id}`,
-    },
-  )
+    )
 
     React.useImperativeHandle(formRef, () => innerForm, [innerForm])
     React.useImperativeHandle(form?.closeRef, () => dialogContext?.close ?? (() => {}), [

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/FormProvider.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/FormProvider.tsx
@@ -4,6 +4,7 @@
  * Context that injects form instance into the component tree.
  */
 import { createContext, useContext } from 'react'
+import { FormProvider as ReactHookFormProvider } from 'react-hook-form'
 import invariant from 'tiny-invariant'
 import type * as types from './types'
 import type { FormInstance, FormInstanceValidated } from './types'
@@ -19,15 +20,21 @@ const FormContext = createContext<FormContextType<any> | null>(null)
 
 /** Provides the form instance to the component tree. */
 export function FormProvider<Schema extends types.TSchema>(
-  props: FormContextType<Schema> & { children: React.ReactNode },
+  props: FormContextType<Schema> & {
+    children: React.ReactNode | ((form: types.UseFormReturn<Schema>) => React.ReactNode)
+  },
 ) {
   const { children, form } = props
 
+  // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/no-explicit-any
+  const narrowedForm = form as types.UseFormReturn<any>
+
   return (
-    // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/no-explicit-any
-    <FormContext.Provider value={{ form: form as types.UseFormReturn<any> }}>
-      {children}
-    </FormContext.Provider>
+    <ReactHookFormProvider {...narrowedForm}>
+      <FormContext.Provider value={{ form: narrowedForm }}>
+        {typeof children === 'function' ? children(form) : children}
+      </FormContext.Provider>
+    </ReactHookFormProvider>
   )
 }
 

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/Submit.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/Submit.tsx
@@ -72,7 +72,7 @@ export function Submit<
 
   return (
     <Button
-      type="submit"
+      type="button"
       variant={variant}
       size={size}
       isLoading={loading || formState.isSubmitting}
@@ -80,6 +80,8 @@ export function Submit<
         if (value != null && name != null) {
           form.setValue(name, value)
         }
+
+        void form.submit()
 
         return onPress?.(event)
       }}

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/types.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/types.ts
@@ -93,6 +93,15 @@ export interface UseFormOptions<Schema extends TSchema, SubmitResult = void>
   /** When set to `dialog`, form submission will close the parent dialog on successful submission. */
   readonly method?: 'dialog' | (string & {}) | undefined
   readonly resetOnSubmit?: boolean
+  /**
+   * A callback that is called when the form values change.
+   * This is useful for updating the UI when the form values change.
+   */
+  readonly onChange?: <TFieldName extends FieldPath<Schema>>(
+    field: TFieldName,
+    value: FieldValues<Schema>[TFieldName],
+    form: UseFormReturn<Schema>,
+  ) => void
 }
 
 /** Register function for a form field. */

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
@@ -271,8 +271,17 @@ export function useForm<Schema extends types.TSchema, SubmitResult = void>(
       formInstance.reset(options.defaultValues as types.FieldValues<Schema>)
     })
 
+    const setValue = useEventCallback<reactHookForm.UseFormSetValue<types.FieldValues<Schema>>>(
+      (name, value, setValueOptions) => {
+        formInstance.setValue(name, value, setValueOptions)
+        // eslint-disable-next-line no-restricted-syntax
+        onChangeStableProp(name as never, value as never, form)
+      },
+    )
+
     const form: types.UseFormReturn<Schema> = {
       ...formInstance,
+      setValue,
       reset,
       submit,
       // @ts-expect-error Our `UseFormRegister<Schema>` is the same as `react-hook-form`'s,

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
@@ -252,13 +252,13 @@ export function useForm<Schema extends types.TSchema, SubmitResult = void>(
         if (isOffline && !canSubmitOffline) {
           formInstance.setError('root.offline', { message: getText('unavailableOffline') })
           return Promise.resolve()
-        } else {
-          if (event) {
-            return formOnSubmit(event)
-          } else {
-            return formOnSubmit()
-          }
         }
+
+        if (event != null) {
+          return formOnSubmit(event)
+        }
+
+        return formOnSubmit()
       },
     )
 

--- a/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/components/useForm.ts
@@ -79,10 +79,13 @@ export function useForm<Schema extends types.TSchema, SubmitResult = void>(
       onSubmitSuccess,
       debugName,
       resetOnSubmit = true,
+      onChange: onChangeProp,
       ...options
     } = optionsOrFormInstance
 
     const computedSchema = typeof schema === 'function' ? schema(schemaModule.schema) : schema
+
+    const onChangeStableProp = useEventCallback(onChangeProp)
 
     const formInstance = reactHookForm.useForm({
       ...options,
@@ -140,32 +143,33 @@ export function useForm<Schema extends types.TSchema, SubmitResult = void>(
       ),
     })
 
-    const register: types.UseFormRegister<Schema> = React.useCallback(
-      (name, opts) => {
-        const registered = formInstance.register(name, opts)
+    const register: types.UseFormRegister<Schema> = useEventCallback((name, opts) => {
+      const registered = formInstance.register(name, opts)
 
-        const onChange: types.UseFormRegisterReturn<Schema>['onChange'] = (value) =>
-          registered.onChange(mapValueOnEvent(value))
-
-        const onBlur: types.UseFormRegisterReturn<Schema>['onBlur'] = (value) =>
-          registered.onBlur(mapValueOnEvent(value))
-
-        const result: types.UseFormRegisterReturn<Schema, typeof name> = {
-          ...registered,
-          disabled: registered.disabled ?? false,
-          isDisabled: registered.disabled ?? false,
-          invalid: !!formInstance.formState.errors[name],
-          isInvalid: !!formInstance.formState.errors[name],
-          required: registered.required ?? false,
-          isRequired: registered.required ?? false,
-          onChange,
-          onBlur,
-        }
-
+      const onChange: types.UseFormRegisterReturn<Schema>['onChange'] = async (value) => {
+        const result = await registered.onChange(mapValueOnEvent(value))
+        const values = formInstance.getValues()
+        onChangeStableProp(name, values[name], form)
         return result
-      },
-      [formInstance],
-    )
+      }
+
+      const onBlur: types.UseFormRegisterReturn<Schema>['onBlur'] = (value) =>
+        registered.onBlur(mapValueOnEvent(value))
+
+      const result: types.UseFormRegisterReturn<Schema, typeof name> = {
+        ...registered,
+        disabled: registered.disabled ?? false,
+        isDisabled: registered.disabled ?? false,
+        invalid: !!formInstance.formState.errors[name],
+        isInvalid: !!formInstance.formState.errors[name],
+        required: registered.required ?? false,
+        isRequired: registered.required ?? false,
+        onChange,
+        onBlur,
+      }
+
+      return result
+    })
 
     // We need to disable the eslint rules here, because we call hooks conditionally
     // but it's safe to do so, because we don't switch between the two types of arguments

--- a/app/gui/src/dashboard/components/AriaComponents/Form/types.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/Form/types.ts
@@ -22,7 +22,14 @@ export type FormProps<Schema extends components.TSchema, SubmitResult = void> =
 interface BaseFormProps<Schema extends components.TSchema>
   extends Omit<
       React.HTMLProps<HTMLFormElement>,
-      'children' | 'className' | 'form' | 'onSubmit' | 'onSubmitCapture' | 'style'
+      | 'children'
+      | 'className'
+      | 'form'
+      | 'onChange'
+      | 'onChangeCapture'
+      | 'onSubmit'
+      | 'onSubmitCapture'
+      | 'style'
     >,
     Omit<styles.FormStyleProps, 'class' | 'className'>,
     TestIdProps {
@@ -42,7 +49,6 @@ interface BaseFormProps<Schema extends components.TSchema>
 
   /** When set to `dialog`, form submission will close the parent dialog on successful submission. */
   readonly method?: 'dialog' | (NonNullable<unknown> & string)
-
   readonly canSubmitOffline?: boolean
 }
 
@@ -60,6 +66,7 @@ export interface FormPropsWithParentForm<Schema extends components.TSchema>
   readonly onSubmitSuccess?: never
   readonly onSubmitFailed?: never
   readonly onSubmitted?: never
+  readonly onChange?: never
 }
 
 /**
@@ -83,6 +90,15 @@ export interface FormPropsWithOptions<Schema extends components.TSchema, SubmitR
    */
   readonly defaultValues?: components.UseFormOptions<Schema>['defaultValues']
   readonly form?: never
+  /**
+   * A callback that is called when the form values change.
+   * This is useful for updating the UI when the form values change.
+   */
+  readonly onChange?: (
+    field: components.FieldPath<Schema>,
+    value: components.FieldValues<Schema>[components.FieldPath<Schema>],
+    form: components.UseFormReturn<Schema>,
+  ) => void
 }
 
 /** Register function for a form field. */

--- a/app/gui/src/dashboard/components/AriaComponents/Inputs/Input/Input.tsx
+++ b/app/gui/src/dashboard/components/AriaComponents/Inputs/Input/Input.tsx
@@ -57,6 +57,7 @@ export interface InputProps<
   readonly icon?: ReactElement | string | null
   readonly variants?: ExtractFunction<typeof INPUT_STYLES> | undefined
   readonly fieldVariants?: FieldComponentProps<Schema>['variants']
+  readonly fieldClassName?: string | undefined
 }
 
 /** Basic input component. Input component is a component that is used to get user input in a text field. */
@@ -74,6 +75,7 @@ export const Input = forwardRef(function Input<
     variant,
     variants = INPUT_STYLES,
     fieldVariants,
+    fieldClassName,
     form: formRaw,
     className,
     contextualHelp,
@@ -137,6 +139,7 @@ export const Input = forwardRef(function Input<
         fullWidth: true,
         variants: fieldVariants,
         form: formInstance,
+        className: fieldClassName,
       })}
       ref={ref}
       name={name}

--- a/app/gui/src/dashboard/components/AriaComponents/index.ts
+++ b/app/gui/src/dashboard/components/AriaComponents/index.ts
@@ -2,6 +2,7 @@
 export * from './Alert'
 export * from './AlertDialog'
 export * from './Button'
+export * from './Check'
 export * from './Checkbox'
 export * from './CopyBlock'
 export * from './Dialog'

--- a/app/gui/src/dashboard/components/ColorPicker.tsx
+++ b/app/gui/src/dashboard/components/ColorPicker.tsx
@@ -23,10 +23,10 @@ function ColorPickerItem(props: InternalColorPickerItemProps) {
     <FocusRing within>
       <aria.Radio
         value={cssColor}
-        className="group flex size-radio-button cursor-pointer rounded-full p-radio-button-dot"
+        className="group flex h-6 w-6 cursor-pointer items-center justify-center rounded-full"
         style={{ backgroundColor: cssColor }}
       >
-        <div className="hidden size-radio-button-dot rounded-full bg-selected-frame group-selected:block" />
+        <div className="hidden aspect-square h-3 w-3 rounded-full bg-selected-frame group-selected:block" />
       </aria.Radio>
     </FocusRing>
   )

--- a/app/gui/src/dashboard/components/Scroller/Scroller.tsx
+++ b/app/gui/src/dashboard/components/Scroller/Scroller.tsx
@@ -28,6 +28,16 @@ export const SCROLLER_STYLES = tv({
         content: 'no-scrollbar',
       },
     },
+    background: {
+      primary: {
+        shadowStart: 'from-dashboard',
+        shadowEnd: 'from-dashboard',
+      },
+      secondary: {
+        shadowStart: 'from-background/80',
+        shadowEnd: 'from-background/80',
+      },
+    },
     orientation: {
       horizontal: {
         content: '',
@@ -74,8 +84,8 @@ export const SCROLLER_STYLES = tv({
 
   slots: {
     content: '',
-    shadowStart: 'pointer-events-none absolute from-dashboard transition-opacity',
-    shadowEnd: 'pointer-events-none absolute from-dashboard transition-opacity',
+    shadowStart: 'pointer-events-none absolute transition-opacity',
+    shadowEnd: 'pointer-events-none absolute transition-opacity',
   },
 
   compoundVariants: [
@@ -126,6 +136,7 @@ export const SCROLLER_STYLES = tv({
     showShadows: true,
     startHidden: true,
     endHidden: true,
+    background: 'primary',
   },
 })
 
@@ -154,6 +165,7 @@ export function Scroller(props: ScrollerProps) {
     showShadows = true,
     testId = 'scroller',
     onScroll,
+    background = 'primary',
     ...rest
   } = props
 
@@ -234,6 +246,7 @@ export function Scroller(props: ScrollerProps) {
     startHidden,
     endHidden,
     showShadows,
+    background,
   })
 
   return (

--- a/app/gui/src/dashboard/components/SelectionBrush.tsx
+++ b/app/gui/src/dashboard/components/SelectionBrush.tsx
@@ -89,7 +89,7 @@ const enum DIRECTION {
 /**
  * A selection brush to indicate the area being selected by the mouse drag action.
  */
-export const SelectionBrush = React.memo(function SelectionBrush(props: SelectionBrushV2Props) {
+export function SelectionBrush(props: SelectionBrushV2Props) {
   const {
     targetRef,
     preventDrag = () => false,
@@ -136,6 +136,7 @@ export const SelectionBrush = React.memo(function SelectionBrush(props: Selectio
   const startDragging = useEventCallback(() => {
     setIsDragging(true)
     hasPassedDeadZoneRef.current = true
+    document.documentElement.style.userSelect = 'none'
   })
 
   const applyBrushPosition = useEventCallback((rectangle: geometry.DetailedRectangle) => {
@@ -158,6 +159,7 @@ export const SelectionBrush = React.memo(function SelectionBrush(props: Selectio
     top.set(null)
     width.set(null)
     height.set(null)
+    document.documentElement.style.userSelect = ''
   })
 
   const updateBrush = useEventCallback((rectangle: geometry.DetailedRectangle) => {
@@ -376,7 +378,7 @@ export const SelectionBrush = React.memo(function SelectionBrush(props: Selectio
       />
     </Portal>
   )
-})
+}
 
 /**
  * Whether the current position is in the dead zone.

--- a/app/gui/src/dashboard/components/dashboard/Label.tsx
+++ b/app/gui/src/dashboard/components/dashboard/Label.tsx
@@ -2,11 +2,12 @@
 import type { DragEvent, MouseEvent, PropsWithChildren } from 'react'
 
 import type { PressEvent } from '#/components/aria'
-import { Text } from '#/components/AriaComponents'
+import { Button, Text } from '#/components/AriaComponents'
 import FocusRing from '#/components/styled/FocusRing'
+import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import type { Label as BackendLabel } from '#/services/Backend'
 import { lChColorToCssColor, type LChColor } from '#/services/Backend'
-import { twMerge } from '#/utilities/tailwindMerge'
+import { twJoin, twMerge } from '#/utilities/tailwindMerge'
 
 /** Props for a {@link Label}. */
 interface InternalLabelProps extends Readonly<PropsWithChildren> {
@@ -28,6 +29,7 @@ interface InternalLabelProps extends Readonly<PropsWithChildren> {
     event: MouseEvent<HTMLButtonElement> | PressEvent,
     label?: BackendLabel,
   ) => void
+  readonly onDelete?: () => Promise<void> | void
   readonly onContextMenu?: (event: MouseEvent<HTMLElement>) => void
   readonly onDragStart?: (event: DragEvent<HTMLElement>) => void
 }
@@ -35,10 +37,21 @@ interface InternalLabelProps extends Readonly<PropsWithChildren> {
 /** An label that can be applied to an asset. */
 export default function Label(props: InternalLabelProps) {
   const { active = false, isDisabled = false, color, negated = false, draggable, title } = props
-  const { onPress, onDragStart, onContextMenu, label } = props
+  const { onPress, onDragStart, onContextMenu, label, onDelete } = props
   const { children: childrenRaw } = props
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const isLight = color.lightness > 50
+
+  const handleDelete = useEventCallback(onDelete)
+  const onClick = useEventCallback((e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onPress?.(e, label)
+  })
+
+  const onDragStartStableCallback = useEventCallback((e: DragEvent<HTMLElement>) => {
+    e.stopPropagation()
+    onDragStart?.(e)
+  })
 
   return (
     <FocusRing within placement="after">
@@ -58,17 +71,13 @@ export default function Label(props: InternalLabelProps) {
           disabled={isDisabled}
           className={twMerge(
             'relative flex h-6 items-center whitespace-nowrap rounded-inherit px-[7px] opacity-50 transition-all after:pointer-events-none after:absolute after:inset after:rounded-full hover:opacity-100 focus:opacity-100',
+            onPress == null && 'cursor-default',
             active && 'active',
             negated && 'after:border-2 after:border-delete',
           )}
           style={{ backgroundColor: lChColorToCssColor(color) }}
-          onClick={(event) => {
-            event.stopPropagation()
-            onPress?.(event, label)
-          }}
-          onDragStart={(e) => {
-            onDragStart?.(e)
-          }}
+          onClick={onClick}
+          onDragStart={onDragStartStableCallback}
           onContextMenu={onContextMenu}
         >
           {typeof childrenRaw !== 'string' ?
@@ -82,6 +91,16 @@ export default function Label(props: InternalLabelProps) {
               {childrenRaw}
             </Text>
           }
+
+          {onDelete && (
+            <Button
+              icon="tab_close"
+              variant="icon"
+              size="small"
+              onPress={handleDelete}
+              className={twJoin('ml-2', !isLight && 'text-white')}
+            />
+          )}
         </button>
       </div>
     </FocusRing>

--- a/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
+++ b/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
@@ -93,48 +93,56 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
           <div className="pointer-events-none absolute bottom-0 right-10 top-0 w-10 bg-gradient-to-l from-dashboard-row opacity-100" />
         )}
       </div>
-      {managesThisAsset && (
-        <DialogTrigger>
-          <Button
-            variant="icon"
-            showIconOnHover
-            tooltip={getText('manageLabels')}
-            tooltipPlacement="left"
-            icon="edit"
-          />
-          <ManageLabelsModal backend={backend} item={item} />
-        </DialogTrigger>
-      )}
-      {isOverflowing && (
-        <Popover.Trigger>
-          <Button
-            variant="icon"
-            showIconOnHover
-            icon={DotsIcon}
-            tooltip={getText('showAllLabels')}
-          />
-          <Popover
-            triggerRef={rootRef}
-            size="auto"
-            style={() => ({ width: rootRef.current?.clientWidth })}
-          >
-            <div className="flex flex-wrap items-center gap-1">
-              {labelsList}
-              {managesThisAsset && (
-                <DialogTrigger>
-                  <Button
-                    variant="icon"
-                    tooltip={getText('manageLabels')}
-                    tooltipPlacement="left"
-                    icon="edit"
-                  />
-                  <ManageLabelsModal backend={backend} item={item} />
-                </DialogTrigger>
-              )}
-            </div>
-          </Popover>
-        </Popover.Trigger>
-      )}
+      <div
+        className="contents"
+        onClick={(event) => {
+          // Prevent the click from being propagated to the parent and trigger the row selection.
+          event.stopPropagation()
+        }}
+      >
+        {managesThisAsset && (
+          <DialogTrigger>
+            <Button
+              variant="icon"
+              showIconOnHover
+              tooltip={getText('manageLabels')}
+              tooltipPlacement="left"
+              icon="edit"
+            />
+            <ManageLabelsModal backend={backend} item={item} />
+          </DialogTrigger>
+        )}
+        {isOverflowing && (
+          <Popover.Trigger>
+            <Button
+              variant="icon"
+              showIconOnHover
+              icon={DotsIcon}
+              tooltip={getText('showAllLabels')}
+            />
+            <Popover
+              triggerRef={rootRef}
+              size="auto"
+              style={() => ({ width: rootRef.current?.clientWidth })}
+            >
+              <div className="flex flex-wrap items-center gap-1">
+                {labelsList}
+                {managesThisAsset && (
+                  <DialogTrigger>
+                    <Button
+                      variant="icon"
+                      tooltip={getText('manageLabels')}
+                      tooltipPlacement="left"
+                      icon="edit"
+                    />
+                    <ManageLabelsModal backend={backend} item={item} />
+                  </DialogTrigger>
+                )}
+              </div>
+            </Popover>
+          </Popover.Trigger>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
+++ b/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
@@ -1,5 +1,4 @@
 /** @file A column listing the labels on this asset. */
-import * as authProvider from '#/providers/AuthProvider'
 import { useText } from '$/providers/react'
 
 import DotsIcon from '#/assets/dots.svg'
@@ -10,28 +9,23 @@ import Label from '#/components/dashboard/Label'
 import { Button, DialogTrigger, Popover } from '#/components/AriaComponents'
 import ContextMenuEntry from '#/components/ContextMenuEntry'
 import { backendMutationOptions } from '#/hooks/backendHooks'
+import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useMeasureCallback } from '#/hooks/measureHooks'
 import ManageLabelsModal from '#/modals/ManageLabelsModal'
 import { setModal, unsetModal } from '#/providers/ModalProvider'
 import { FALLBACK_COLOR } from '#/services/Backend'
 import { mergeRefs } from '#/utilities/mergeRefs'
-import * as permissions from '#/utilities/permissions'
 import { useMutationCallback } from '#/utilities/tanstackQuery'
 import { useRef, useState } from 'react'
-import { useEventCallback } from '../../../hooks/eventCallbackHooks'
 
 /** A column listing the labels on this asset. */
 export default function LabelsColumn(props: column.AssetColumnProps) {
   const { item, state, labels } = props
-  const { backend, category } = state
-  const { user } = authProvider.useFullUserSession()
+
+  const { backend } = state
+
   const { getText } = useText()
   const labelsByName = new Map(labels.map((label) => [label.value, label]))
-  const self = permissions.tryFindSelfPermission(user, item.permissions)
-  const managesThisAsset =
-    category.type !== 'trash' &&
-    (self?.permission === permissions.PermissionAction.own ||
-      self?.permission === permissions.PermissionAction.admin)
 
   const rootRef = useRef<HTMLDivElement>(null)
   const labelsListRef = useRef<HTMLDivElement>(null)
@@ -105,18 +99,6 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
           event.stopPropagation()
         }}
       >
-        {managesThisAsset && (
-          <DialogTrigger>
-            <Button
-              variant="icon"
-              showIconOnHover
-              tooltip={getText('manageLabels')}
-              tooltipPlacement="left"
-              icon="edit"
-            />
-            <ManageLabelsModal backend={backend} item={item} />
-          </DialogTrigger>
-        )}
         {isOverflowing && (
           <Popover.Trigger>
             <Button
@@ -132,21 +114,31 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
             >
               <div className="flex flex-wrap items-center gap-1">
                 {labelsList}
-                {managesThisAsset && (
-                  <DialogTrigger>
-                    <Button
-                      variant="icon"
-                      tooltip={getText('manageLabels')}
-                      tooltipPlacement="left"
-                      icon="edit"
-                    />
-                    <ManageLabelsModal backend={backend} item={item} />
-                  </DialogTrigger>
-                )}
+
+                <DialogTrigger>
+                  <Button
+                    variant="icon"
+                    tooltip={getText('manageLabels')}
+                    tooltipPlacement="top"
+                    icon="edit"
+                  />
+                  <ManageLabelsModal backend={backend} item={item} />
+                </DialogTrigger>
               </div>
             </Popover>
           </Popover.Trigger>
         )}
+
+        <DialogTrigger>
+          <Button
+            variant="icon"
+            showIconOnHover
+            tooltip={getText('manageLabels')}
+            tooltipPlacement="top"
+            icon="edit"
+          />
+          <ManageLabelsModal backend={backend} item={item} />
+        </DialogTrigger>
       </div>
     </div>
   )

--- a/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
+++ b/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
@@ -11,6 +11,7 @@ import ContextMenuEntry from '#/components/ContextMenuEntry'
 import { backendMutationOptions } from '#/hooks/backendHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useMeasureCallback } from '#/hooks/measureHooks'
+import { useToastAndLog } from '#/hooks/toastAndLogHooks'
 import ManageLabelsModal from '#/modals/ManageLabelsModal'
 import { setModal, unsetModal } from '#/providers/ModalProvider'
 import { FALLBACK_COLOR } from '#/services/Backend'
@@ -25,6 +26,7 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
   const { backend } = state
 
   const { getText } = useText()
+  const toastAndLog = useToastAndLog()
   const labelsByName = new Map(labels.map((label) => [label.value, label]))
 
   const rootRef = useRef<HTMLDivElement>(null)
@@ -45,7 +47,10 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
   const doDelete = useEventCallback(async (label: string) => {
     unsetModal()
     const newLabels = item.labels?.filter((oldLabel) => oldLabel !== label) ?? []
-    return associateTag([item.id, newLabels, item.title])
+
+    return associateTag([item.id, newLabels, item.title]).catch((error) => {
+      toastAndLog('deleteLabelBackendError', error, label)
+    })
   })
 
   const labelsList = (item.labels ?? [])

--- a/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
+++ b/app/gui/src/dashboard/components/dashboard/column/LabelsColumn.tsx
@@ -9,18 +9,21 @@ import Label from '#/components/dashboard/Label'
 
 import { Button, DialogTrigger, Popover } from '#/components/AriaComponents'
 import ContextMenuEntry from '#/components/ContextMenuEntry'
+import { backendMutationOptions } from '#/hooks/backendHooks'
 import { useMeasureCallback } from '#/hooks/measureHooks'
 import ManageLabelsModal from '#/modals/ManageLabelsModal'
 import { setModal, unsetModal } from '#/providers/ModalProvider'
 import { FALLBACK_COLOR } from '#/services/Backend'
 import { mergeRefs } from '#/utilities/mergeRefs'
 import * as permissions from '#/utilities/permissions'
+import { useMutationCallback } from '#/utilities/tanstackQuery'
 import { useRef, useState } from 'react'
+import { useEventCallback } from '../../../hooks/eventCallbackHooks'
 
 /** A column listing the labels on this asset. */
 export default function LabelsColumn(props: column.AssetColumnProps) {
   const { item, state, labels } = props
-  const { backend, category, setQuery } = state
+  const { backend, category } = state
   const { user } = authProvider.useFullUserSession()
   const { getText } = useText()
   const labelsByName = new Map(labels.map((label) => [label.value, label]))
@@ -43,6 +46,14 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
     },
   })
 
+  const associateTag = useMutationCallback(backendMutationOptions(backend, 'associateTag'))
+
+  const doDelete = useEventCallback(async (label: string) => {
+    unsetModal()
+    const newLabels = item.labels?.filter((oldLabel) => oldLabel !== label) ?? []
+    return associateTag([item.id, newLabels, item.title])
+  })
+
   const labelsList = (item.labels ?? [])
     .filter((label) => labelsByName.has(label))
     .map((label) => (
@@ -52,27 +63,21 @@ export default function LabelsColumn(props: column.AssetColumnProps) {
         title={getText('rightClickToRemoveLabel')}
         color={labelsByName.get(label)?.color ?? FALLBACK_COLOR}
         active
+        onDelete={() => doDelete(label)}
         onContextMenu={(event) => {
           event.preventDefault()
           event.stopPropagation()
-          const doDelete = () => {
-            unsetModal()
-            const newLabels = item.labels?.filter((oldLabel) => oldLabel !== label) ?? []
-            void backend.associateTag(item.id, newLabels, item.title)
-          }
           setModal(
             <ContextMenu aria-label={getText('labelContextMenuLabel')} event={event}>
               <ContextMenuEntry
                 action="delete"
-                label={getText('deleteLabelShortcut')}
-                doAction={doDelete}
+                label={getText('removeLabelShortcut')}
+                doAction={() => {
+                  unsetModal()
+                  void doDelete(label)
+                }}
               />
             </ContextMenu>,
-          )
-        }}
-        onPress={(event) => {
-          setQuery((oldQuery) =>
-            oldQuery.withToggled('labels', 'negativeLabels', label, event.shiftKey),
           )
         }}
       >

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -451,9 +451,9 @@ function NotFoundLabel(props: NotFoundLabelProps) {
   const { getText } = useText()
 
   const form = Form.useForm({
-    schema: (z) => z.object({ name: z.string(), color: z.custom<LChColor>() }),
-    defaultValues: { name: query, color: leastUsedColor },
-    onSubmit: ({ name, color }) => onCreateLabel(name, color),
+    schema: (z) => z.object({ color: z.custom<LChColor>() }),
+    defaultValues: { color: leastUsedColor },
+    onSubmit: ({ color }) => onCreateLabel(query, color),
   })
 
   return (

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -223,8 +223,6 @@ function ManageLabelsForm(props: ManageLabelsModalProps) {
       </div>
 
       <div className="flex w-full flex-col gap-2 px-2 py-2">
-        <Form.FormError />
-
         <Button.Group width="full" align="between" gap="small">
           <Popover.Trigger>
             <Button variant="icon" size="small" fullWidth icon="add">
@@ -278,6 +276,8 @@ function ManageLabelsForm(props: ManageLabelsModalProps) {
             </Popover>
           </Popover.Trigger>
         </Button.Group>
+
+        <Form.FormError />
       </div>
     </Form>
   )

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -330,32 +330,14 @@ function AllLabels(props: AllLabelsProps) {
         selectedKeys={selectedLabels}
         defaultSelectedKeys={defaultSelectedKeys}
         onSelectionChange={onSelectionChange}
+        dependencies={[query]}
         renderEmptyState={() => (
-          <Form
-            className="my-4"
-            schema={(z) => z.object({ name: z.string(), color: z.custom<LChColor>() })}
-            defaultValues={{ name: query, color: leastUsedColor }}
-            onSubmit={({ name, color }) => onCreateLabel(name, color)}
-          >
-            <Button.Group verticalAlign="center" gap="xxsmall" align="center">
-              <Form.FieldValue name="color">
-                {(color) => (
-                  <ColorSwitcher
-                    name="color"
-                    // This is safe because the form schema ensures that the color is a valid LChColor.
-                    // eslint-disable-next-line no-restricted-syntax
-                    color={color as LChColor}
-                    colors={colors}
-                    leastUsedColor={leastUsedColor}
-                  />
-                )}
-              </Form.FieldValue>
-
-              <Form.Submit variant="icon" size="small">
-                {getText('manageLabelsModal.createLabelWithTitle', query)}
-              </Form.Submit>
-            </Button.Group>
-          </Form>
+          <NotFoundLabel
+            query={query}
+            onCreateLabel={onCreateLabel}
+            leastUsedColor={leastUsedColor}
+            colors={colors}
+          />
         )}
       >
         {(label) => (
@@ -446,5 +428,50 @@ function ColorSwitcher(props: ColorSwitcherProps) {
       onPress={rotateColor}
       style={{ backgroundColor: lChColorToCssColor(color) }}
     />
+  )
+}
+
+/**
+ * Props for a {@link NotFoundLabel}.
+ */
+interface NotFoundLabelProps {
+  readonly query: string
+  readonly onCreateLabel: (name: string, color: LChColor) => Promise<void>
+  readonly leastUsedColor: LChColor
+  readonly colors: readonly LChColor[]
+}
+
+/**
+ * A component that displays a label that does not exist.
+ * Offers a form to create a new label.
+ */
+function NotFoundLabel(props: NotFoundLabelProps) {
+  const { query, onCreateLabel, leastUsedColor, colors } = props
+
+  const { getText } = useText()
+
+  const form = Form.useForm({
+    schema: (z) => z.object({ name: z.string(), color: z.custom<LChColor>() }),
+    defaultValues: { name: query, color: leastUsedColor },
+    onSubmit: ({ name, color }) => onCreateLabel(name, color),
+  })
+
+  return (
+    <Button.Group verticalAlign="center" gap="xxsmall" align="center" className="my-4">
+      <Form.FieldValue form={form} name="color">
+        {(color) => (
+          <ColorSwitcher
+            name="color"
+            color={color}
+            colors={colors}
+            leastUsedColor={leastUsedColor}
+          />
+        )}
+      </Form.FieldValue>
+
+      <Form.Submit form={form} variant="icon" size="small">
+        {getText('manageLabelsModal.createLabelWithTitle', query)}
+      </Form.Submit>
+    </Button.Group>
   )
 }

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -122,11 +122,16 @@ function ManageLabelsForm(props: ManageLabelsModalProps) {
       if (name === 'labels') {
         const value = form.getValues('labels')
 
+        form.clearErrors()
+
         const labelNames = value
           .map((label) => allLabels.find((l) => l.id === label)?.value)
           .filter((label) => label !== undefined)
 
-        void associateTag([item.id, labelNames, item.title])
+        void associateTag([item.id, labelNames, item.title]).catch(() => {
+          form.setFormError(getText('arbitraryMutationError'))
+          form.resetField('labels')
+        })
       }
     },
     defaultValues: { labels: itemLabels.map((label) => label.id), query: '' },
@@ -164,7 +169,7 @@ function ManageLabelsForm(props: ManageLabelsModalProps) {
                     style={{ backgroundColor: lChColorToCssColor(label.color) }}
                     className={styles.label()}
                   >
-                    <Text truncate color="invert">
+                    <Text truncate color="invert" textSelection="none">
                       {label.value}
                     </Text>
                   </Tag>

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -1,30 +1,38 @@
 /** @file A modal to select labels for an asset. */
-import { useState } from 'react'
 
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 
-import {
-  Button,
-  ButtonGroup,
-  Checkbox,
-  DialogTrigger,
-  Form,
-  Input,
-  Popover,
-  Text,
-} from '#/components/AriaComponents'
-import ColorPicker from '#/components/ColorPicker'
-import Label from '#/components/dashboard/Label'
-import FocusRing from '#/components/styled/FocusRing'
+import { Button, Dialog, Form, Input, Popover, Separator, Text } from '#/components/AriaComponents'
 import { backendMutationOptions, backendQueryOptions } from '#/hooks/backendHooks'
-import { useToastAndLog } from '#/hooks/toastAndLogHooks'
-import { useAsset } from '#/layouts/Drive/assetsTableItemsHooks'
-import ConfirmDeleteModal from '#/modals/ConfirmDeleteModal'
 import type Backend from '#/services/Backend'
-import { findLeastUsedColor, LabelName, type AnyAsset, type LChColor } from '#/services/Backend'
-import { regexEscape } from '#/utilities/string'
+import {
+  COLORS,
+  colorsAreEqual,
+  findLeastUsedColor,
+  LabelName,
+  lChColorToCssColor,
+  type AnyAsset,
+  type Label,
+  type LChColor,
+} from '#/services/Backend'
+import { tv } from '#/utilities/tailwindVariants'
 import { useMutationCallback } from '#/utilities/tanstackQuery'
 import { useText } from '$/providers/react'
+import {
+  ListBox,
+  ListBoxItem,
+  Tag,
+  TagGroup,
+  TagList,
+  useFilter,
+  type Selection,
+} from 'react-aria-components'
+import { AnimatedBackground } from '../components/AnimatedBackground'
+import { Check } from '#/components/AriaComponents'
+import ColorPicker from '#/components/ColorPicker'
+import { Scroller } from '#/components/Scroller'
+import { useEventCallback } from '#/hooks/eventCallbackHooks'
+import ConfirmDeleteModal from './ConfirmDeleteModal'
 
 /** Props for a {@link ManageLabelsModal}. */
 export interface ManageLabelsModalProps<Asset extends AnyAsset = AnyAsset> {
@@ -42,9 +50,11 @@ export default function ManageLabelsModal<Asset extends AnyAsset = AnyAsset>(
   props: ManageLabelsModalProps<Asset>,
 ) {
   const { triggerRef } = props
+
   return (
     <Popover
-      size="xsmall"
+      size="custom"
+      className="max-w-64 overflow-y-hidden"
       {...(triggerRef ? { triggerRef } : {})}
       shouldCloseOnInteractOutside={() => true}
     >
@@ -53,116 +63,383 @@ export default function ManageLabelsModal<Asset extends AnyAsset = AnyAsset>(
   )
 }
 
+const MANAGE_LABELS_MODAL_STYLES = tv({
+  base: 'flex flex-wrap gap-4 max-w-full flex-1 basis-0 min-h-0',
+  slots: {
+    allLabels: 'flex flex-col w-full px-1.5 pr-0 min-h-0',
+    labels: 'flex flex-col',
+    label:
+      'flex flex-none items-center justify-center max-w-full min-w-10 px-1.5 py-0 rounded-3xl bg-primary',
+    itemLabels: 'inline-flex flex-none max-w-full w-full flex-wrap gap-0.5 px-2',
+    itemLabelsList: 'inline-flex max-w-full flex-wrap gap-0.5',
+    input: 'w-full flex-1 px-1 py-1',
+  },
+})
+
 /**
  * Form for {@link ManageLabelsModal}.
  */
 function ManageLabelsForm(props: ManageLabelsModalProps) {
-  const { backend, item: itemRaw } = props
+  const { backend, item } = props
 
-  const item = useAsset(itemRaw.id) ?? itemRaw
-
-  const [id, setId] = useState(0)
   const { getText } = useText()
-  const toastAndLog = useToastAndLog()
-  const { data: allLabels = [] } = useQuery(backendQueryOptions(backend, 'listTags', []))
-  const [color, setColor] = useState<LChColor | null>(null)
+  const { data: allLabels } = useSuspenseQuery(backendQueryOptions(backend, 'listTags', []))
   const leastUsedColor = findLeastUsedColor(allLabels)
+
+  const itemLabels =
+    item.labels
+      ?.map((labelName) => allLabels.find((label) => label.value === labelName))
+      .filter((label) => label !== undefined) ?? []
+
+  const styles = MANAGE_LABELS_MODAL_STYLES()
 
   const createTag = useMutationCallback(backendMutationOptions(backend, 'createTag'))
   const associateTag = useMutationCallback(backendMutationOptions(backend, 'associateTag'))
   const deleteTag = useMutationCallback(backendMutationOptions(backend, 'deleteTag'))
 
+  const createLabel = useEventCallback(async (name: string, color?: LChColor) => {
+    const labelName = LabelName(name)
+    const newLabel = await createTag([{ value: labelName, color: color ?? leastUsedColor }])
+
+    form.setValue('labels', [...selectedLabels, newLabel.id])
+  })
+
+  const deleteLabel = useEventCallback((label: Label) => {
+    form.setValue(
+      'labels',
+      selectedLabels.filter((id) => id !== label.id),
+    )
+    return deleteTag([label.id, label.value])
+  })
+
   const form = Form.useForm({
     schema: (z) =>
       z.object({
         labels: z.string().array().readonly(),
-        name: z.string(),
+        query: z.string(),
       }),
-    defaultValues: { labels: item.labels ?? [], name: '' },
-    onSubmit: async ({ name }) => {
-      const labelName = LabelName(name)
-      try {
-        await createTag([{ value: labelName, color: color ?? leastUsedColor }])
-        const newLabels = [...(item.labels ?? []), labelName]
-        await associateTag([item.id, newLabels, item.title])
-        form.resetField('labels', { defaultValue: newLabels })
-        setId((currentId) => currentId + 1)
-      } catch (error) {
-        toastAndLog(null, error)
+    onChange: (name) => {
+      if (name === 'labels') {
+        const value = form.getValues('labels')
+
+        const labelNames = value
+          .map((label) => allLabels.find((l) => l.id === label)?.value)
+          .filter((label) => label !== undefined)
+
+        void associateTag([item.id, labelNames, item.title])
       }
     },
+    defaultValues: { labels: itemLabels.map((label) => label.id), query: '' },
   })
 
-  const query = Form.useWatch({ control: form.control, name: 'name' })
-  const labels = Form.useWatch({ control: form.control, name: 'labels' })
-
-  const regex = new RegExp(regexEscape(query), 'i')
-  const canSelectColor =
-    query !== '' && allLabels.every((label) => label.value.toLowerCase() !== query.toLowerCase())
-  const canCreateNewLabel = canSelectColor
+  const selectedLabels = Form.useWatch({ control: form.control, name: 'labels' })
 
   return (
-    <Form key={id} form={form}>
-      <Text.Heading slot="title" level={2} variant="subtitle">
-        {getText('labels')}
-      </Text.Heading>
-      <ButtonGroup className="relative">
-        <Input
-          form={form}
-          name="name"
-          autoFocus
-          type="text"
-          size="small"
-          placeholder={getText('labelSearchPlaceholder')}
-        />
-        <Form.Submit isDisabled={!canCreateNewLabel}>{getText('create')}</Form.Submit>
-      </ButtonGroup>
-      {canSelectColor && <ColorPicker setColor={setColor} className="w-full" />}
-      <Checkbox.Group
-        form={form}
-        name="labels"
-        fullWidth
-        className="max-h-80 overflow-auto"
-        onChange={async (values) => {
-          await associateTag([item.id, values.map(LabelName), item.title])
-        }}
-      >
-        {allLabels
-          .filter((label) => regex.test(label.value))
-          .map((label) => {
-            const isActive = labels.includes(label.value)
-            return (
-              <div className="group flex w-full items-center justify-between">
-                <Checkbox key={label.id} value={String(label.value)}>
-                  <Label active={isActive} color={label.color} onPress={() => {}}>
-                    {label.value}
-                  </Label>
-                </Checkbox>
+    <Form form={form} gap="none" className="flex max-h-[inherit] w-full flex-col">
+      <Input
+        name="query"
+        type="search"
+        variant="custom"
+        size="small"
+        fieldClassName={styles.input()}
+        placeholder={getText('search.placeholder')}
+        autoFocus
+      />
 
-                <FocusRing placement="after">
-                  <DialogTrigger>
-                    <Button
-                      variant="icon"
-                      icon="trash"
-                      extraClickZone={false}
-                      aria-label={getText('delete')}
-                      tooltipPlacement="right"
-                      showIconOnHover
-                      className="relative mr-1 flex size-4 text-delete transition-all after:absolute after:-inset-1 after:rounded-button-focus-ring group-has-[[data-focus-visible]]:active group-hover:active"
-                    />
-                    <ConfirmDeleteModal
-                      cannotUndo
-                      actionText={getText('deleteLabelActionText', label.value)}
-                      onConfirm={async () => {
-                        await deleteTag([label.id, label.value])
-                      }}
-                    />
-                  </DialogTrigger>
-                </FocusRing>
-              </div>
-            )
-          })}
-      </Checkbox.Group>
+      {selectedLabels.length > 0 && (
+        <div className={styles.itemLabels()}>
+          <Scroller background="secondary">
+            <TagGroup className="contents" aria-label={getText('manageLabelsModal.selectedLabels')}>
+              <TagList
+                className="flex w-full gap-1"
+                items={selectedLabels
+                  .map((label) => allLabels.find((allLabelsItem) => allLabelsItem.id === label))
+                  .filter((label) => label !== undefined)}
+              >
+                {(label) => (
+                  <Tag
+                    key={label.id}
+                    id={label.id}
+                    textValue={label.value}
+                    style={{ backgroundColor: lChColorToCssColor(label.color) }}
+                    className={styles.label()}
+                  >
+                    <Text truncate color="invert">
+                      {label.value}
+                    </Text>
+                  </Tag>
+                )}
+              </TagList>
+            </TagGroup>
+          </Scroller>
+        </div>
+      )}
+
+      <Separator className="my-2" />
+
+      <div className={styles.allLabels()}>
+        <Text variant="body" color="muted" weight="semibold" className="ml-2">
+          {getText('manageLabelsModal.allLabels')}
+        </Text>
+
+        <Form.FieldValue form={form} name="query">
+          {(query) => (
+            <Form.Controller
+              control={form.control}
+              name="labels"
+              render={({ field }) => (
+                <AllLabels
+                  colors={COLORS}
+                  leastUsedColor={leastUsedColor}
+                  labels={allLabels}
+                  selectedLabels={field.value}
+                  defaultSelectedKeys={itemLabels.map((label) => label.id)}
+                  onSelectionChange={(keys) => {
+                    const newLabels = (() => {
+                      if (keys instanceof Set) {
+                        return Array.from(keys)
+                          .map((key) => allLabels.find((label) => label.id === key))
+                          .filter((label) => label !== undefined)
+                      }
+
+                      return allLabels
+                    })()
+
+                    field.onChange(newLabels.map((label) => label.id))
+                  }}
+                  query={query}
+                  onCreateLabel={createLabel}
+                  onDeleteLabel={deleteLabel}
+                />
+              )}
+            />
+          )}
+        </Form.FieldValue>
+      </div>
+
+      <div className="flex w-full flex-col gap-2 px-2 py-2">
+        <Form.FormError />
+
+        <Button.Group width="full" align="between" gap="small">
+          <Popover.Trigger>
+            <Button variant="icon" size="small" fullWidth icon="add">
+              {getText('manageLabelsModal.createLabel')}
+            </Button>
+
+            <Popover>
+              <Form
+                schema={(z) =>
+                  z.object({
+                    name: z
+                      .string()
+                      .trim()
+                      .min(1)
+                      .refine((value) => !allLabels.some((label) => label.value === value), {
+                        message: getText('manageLabelsModal.labelAlreadyExists'),
+                      }),
+                    color: z.custom<LChColor>(),
+                  })
+                }
+                defaultValues={{ name: '', color: leastUsedColor }}
+                method="dialog"
+                onSubmit={({ name, color }) => createLabel(name, color)}
+              >
+                <Input name="name" label={getText('name')} autoFocus />
+
+                <Form.Controller
+                  name="color"
+                  render={({ field }) => (
+                    <Form.Field name="color" label={getText('manageLabelsModal.chooseColor')}>
+                      <ColorPicker
+                        aria-label={getText('manageLabelsModal.chooseColor')}
+                        name="color"
+                        defaultValue={lChColorToCssColor(leastUsedColor)}
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        value={lChColorToCssColor(field.value)}
+                        setColor={(color) => {
+                          field.onChange(color)
+                        }}
+                      />
+                    </Form.Field>
+                  )}
+                />
+
+                <Form.Submit className="ml-auto min-w-12" size="small">
+                  {getText('manageLabelsModal.createLabel')}
+                </Form.Submit>
+
+                <Form.FormError />
+              </Form>
+            </Popover>
+          </Popover.Trigger>
+        </Button.Group>
+      </div>
     </Form>
+  )
+}
+
+/**
+ * Props for a {@link AllLabels}.
+ */
+interface AllLabelsProps {
+  readonly colors: readonly LChColor[]
+  readonly leastUsedColor: LChColor
+  readonly labels: readonly Label[]
+  readonly selectedLabels: readonly string[]
+  readonly query: string
+  readonly defaultSelectedKeys: readonly string[]
+  readonly onSelectionChange: (keys: Selection) => void
+  readonly onCreateLabel: (name: string, color: LChColor) => Promise<void>
+  readonly onDeleteLabel: (label: Label) => Promise<void>
+}
+
+/**
+ * A list of all labels.
+ */
+function AllLabels(props: AllLabelsProps) {
+  const {
+    labels,
+    query,
+    onCreateLabel,
+    onDeleteLabel,
+    colors,
+    leastUsedColor,
+    defaultSelectedKeys,
+    selectedLabels,
+    onSelectionChange,
+  } = props
+
+  const { getText } = useText()
+
+  const filter = useFilter({ sensitivity: 'base' })
+
+  const filteredLabels = labels.filter((label) => filter.contains(label.value, query))
+
+  return (
+    <AnimatedBackground>
+      <ListBox
+        items={filteredLabels}
+        className="flex max-h-72 flex-col overflow-y-auto overflow-x-hidden scroll-offset-edge-0"
+        aria-label={getText('manageLabelsModal.allLabels')}
+        selectionMode="multiple"
+        selectedKeys={selectedLabels}
+        defaultSelectedKeys={defaultSelectedKeys}
+        onSelectionChange={onSelectionChange}
+        renderEmptyState={() => (
+          <Form
+            className="my-4"
+            schema={(z) => z.object({ name: z.string(), color: z.custom<LChColor>() })}
+            defaultValues={{ name: query, color: leastUsedColor }}
+            onSubmit={({ name, color }) => onCreateLabel(name, color)}
+          >
+            <Button.Group verticalAlign="center" gap="xxsmall" align="center">
+              <Form.FieldValue name="color">
+                {(color) => (
+                  <ColorSwitcher
+                    name="color"
+                    // This is safe because the form schema ensures that the color is a valid LChColor.
+                    // eslint-disable-next-line no-restricted-syntax
+                    color={color as LChColor}
+                    colors={colors}
+                    leastUsedColor={leastUsedColor}
+                  />
+                )}
+              </Form.FieldValue>
+
+              <Form.Submit variant="icon" size="small">
+                {getText('manageLabelsModal.createLabelWithTitle', query)}
+              </Form.Submit>
+            </Button.Group>
+          </Form>
+        )}
+      >
+        {(label) => (
+          <ListBoxItem
+            key={label.id}
+            id={label.id}
+            textValue={label.value}
+            className="group rounded-3xl pressed:bg-primary/5"
+          >
+            {({ isSelected, isPressed, isHovered }) => (
+              <AnimatedBackground.Item
+                className="flex w-full items-center gap-2 px-2 py-0.5"
+                isSelected={isHovered || isPressed}
+                animationClassName="bg-primary/5 rounded-3xl"
+              >
+                <Check isSelected={isSelected} isPressed={isPressed} />
+
+                <div
+                  className="aspect-square w-4 flex-none rounded-full"
+                  style={{ backgroundColor: lChColorToCssColor(label.color) }}
+                />
+
+                <Text truncate nowrap textSelection="none">
+                  {label.value}
+                </Text>
+
+                <Dialog.Trigger>
+                  <Button
+                    variant="icon"
+                    aria-label={getText('delete')}
+                    icon="trash_small"
+                    size="small"
+                    className="ml-auto opacity-0 transition-opacity duration-75 group-hover:opacity-100"
+                  />
+
+                  <ConfirmDeleteModal
+                    cannotUndo
+                    actionText={getText('deleteLabelActionText', label.value)}
+                    actionButtonLabel={getText('delete')}
+                    onConfirm={() => onDeleteLabel(label)}
+                  />
+                </Dialog.Trigger>
+              </AnimatedBackground.Item>
+            )}
+          </ListBoxItem>
+        )}
+      </ListBox>
+    </AnimatedBackground>
+  )
+}
+
+/**
+ * Props for a {@link ColorSwitcher}.
+ */
+interface ColorSwitcherProps {
+  readonly name: string
+  readonly color: LChColor
+  readonly colors: readonly LChColor[]
+  readonly leastUsedColor: LChColor
+}
+
+/**
+ * A color picker for a label.
+ */
+function ColorSwitcher(props: ColorSwitcherProps) {
+  const { name, color, colors, leastUsedColor } = props
+
+  const { getText } = useText()
+
+  const { formInstance } = Form.useFieldRegister({
+    name,
+  })
+
+  const rotateColor = useEventCallback(() => {
+    const index = colors.findIndex((item) => colorsAreEqual(item, color))
+    const nextColor = colors[(index + 1) % colors.length]
+
+    formInstance.setValue(name, nextColor ?? leastUsedColor)
+  })
+
+  return (
+    <Button
+      variant="icon"
+      size="custom"
+      className="aspect-square h-4 w-4"
+      tooltip={getText('manageLabelsModal.nextColor')}
+      aria-label={getText('manageLabelsModal.nextColor')}
+      onPress={rotateColor}
+      style={{ backgroundColor: lChColorToCssColor(color) }}
+    />
   )
 }

--- a/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
+++ b/app/gui/src/dashboard/modals/ManageLabelsModal.tsx
@@ -2,8 +2,21 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query'
 
-import { Button, Dialog, Form, Input, Popover, Separator, Text } from '#/components/AriaComponents'
+import { AnimatedBackground } from '#/components/AnimatedBackground'
+import {
+  Button,
+  Check,
+  Dialog,
+  Form,
+  Input,
+  Popover,
+  Separator,
+  Text,
+} from '#/components/AriaComponents'
+import ColorPicker from '#/components/ColorPicker'
+import { Scroller } from '#/components/Scroller'
 import { backendMutationOptions, backendQueryOptions } from '#/hooks/backendHooks'
+import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import type Backend from '#/services/Backend'
 import {
   COLORS,
@@ -27,11 +40,6 @@ import {
   useFilter,
   type Selection,
 } from 'react-aria-components'
-import { AnimatedBackground } from '../components/AnimatedBackground'
-import { Check } from '#/components/AriaComponents'
-import ColorPicker from '#/components/ColorPicker'
-import { Scroller } from '#/components/Scroller'
-import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import ConfirmDeleteModal from './ConfirmDeleteModal'
 
 /** Props for a {@link ManageLabelsModal}. */

--- a/app/gui/tailwind.config.ts
+++ b/app/gui/tailwind.config.ts
@@ -470,6 +470,10 @@ inset 0 -36px 51px -51px #00000014`,
             '@apply opacity-75 cursor-not-allowed': '',
           },
 
+          '.scroll-offset-edge-0': {
+            '--scrollbar-offset-edge': '0px',
+          },
+
           '.scroll-offset-edge-s': {
             '--scrollbar-offset-edge': '2px',
           },


### PR DESCRIPTION
### Pull Request Description

- Closes https://github.com/enso-org/cloud-v2/issues/1963

This PR reimplements the labels management dialog from scratch.


https://github.com/user-attachments/assets/bedaf4fd-da48-4d73-9081-ef02b3dcc8d2



<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
