### PR TITLE
Remove link_value_type attribute from Table Viz

### DIFF
--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -291,5 +291,4 @@ test('get_child_node_action temmplate Test as text', async ({ page }) => {
   const textWidget = newNode.locator('.WidgetText')
   await expect(textWidget).toBeVisible()
   await expect(textWidget.getByTestId('widget-text-content')).toHaveText('2')
-
 })

--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -221,3 +221,75 @@ test('Error Visualisation Test', async ({ page }) => {
   )
   await expect(tableVisualization).toContainText('This is an error message.')
 })
+
+test('get_child_node_action temmplate Test as number', async ({ page }) => {
+  await initGraph(page)
+
+  const aggregatedNode = graphNodeByBinding(page, 'aggregated')
+  await aggregatedNode.click()
+  await page.keyboard.press('Space')
+  await page.waitForTimeout(1000)
+  const tableVisualization = locate.tableVisualization(page)
+  await expect(tableVisualization).toExist()
+
+  await mockVisualizationDataUpdate(
+    page,
+    'Standard.Visualization.Table.Visualization.prepare_visualization',
+    /* eslint-disable camelcase */
+    {
+      type: 'Single_Column_Of_Actions',
+      visualization_header: 'table',
+      child_label: 'table',
+      data: ['1', '2', '3'],
+      get_child_node_action: 'read {{#Value}}',
+    },
+    /* eslint-enable camelcase */
+  )
+  await expect(tableVisualization).toContainText('table')
+  await expect(tableVisualization).toContainText('1')
+  await expect(tableVisualization).toContainText('2')
+  await expect(tableVisualization).toContainText('3')
+  const value2 = tableVisualization.getByText('2')
+  await value2.dblclick()
+  const newNode = graphNodeByBinding(page, 'node1')
+  await expect(newNode).toContainText('read')
+  const numberWidget = newNode.locator('.WidgetNumber')
+  await expect(numberWidget).toBeVisible()
+  await expect(numberWidget).toHaveValue('2')
+})
+
+test('get_child_node_action temmplate Test as text', async ({ page }) => {
+  await initGraph(page)
+
+  const aggregatedNode = graphNodeByBinding(page, 'aggregated')
+  await aggregatedNode.click()
+  await page.keyboard.press('Space')
+  await page.waitForTimeout(1000)
+  const tableVisualization = locate.tableVisualization(page)
+  await expect(tableVisualization).toExist()
+
+  await mockVisualizationDataUpdate(
+    page,
+    'Standard.Visualization.Table.Visualization.prepare_visualization',
+    /* eslint-disable camelcase */
+    {
+      type: 'Single_Column_Of_Actions',
+      visualization_header: 'table',
+      child_label: 'table',
+      data: ['1', '2', '3'],
+      get_child_node_action: 'read {{@Value}}',
+    },
+    /* eslint-enable camelcase */
+  )
+  await expect(tableVisualization).toContainText('table')
+  await expect(tableVisualization).toContainText('1')
+  await expect(tableVisualization).toContainText('2')
+  await expect(tableVisualization).toContainText('3')
+  const value2 = tableVisualization.getByText('2')
+  await value2.dblclick()
+  const newNode = graphNodeByBinding(page, 'node1')
+  const textWidget = newNode.locator('.WidgetText')
+  await expect(textWidget).toBeVisible()
+  await expect(textWidget.getByTestId('widget-text-content')).toHaveText('2')
+
+})

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -697,7 +697,7 @@ type ParsedTemplate = {
 };
 
 function parseTemplate(input: string, defaultSelector: string): ParsedTemplate {
-  const regex = /{{(#?)(\w+)}}/g;
+  const regex = /{{([#@]?)(\w+)}}/g;
   const keys: { name: string; numeric: boolean }[] = [];
   let pattern = input;
   

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -692,50 +692,50 @@ function toField(
 }
 
 type ParsedActionTemplate = {
-  pattern: string;
-  selectors: { name: string; numeric: boolean }[];
-};
+  pattern: string
+  selectors: { name: string; numeric: boolean }[]
+}
 
 function parseActionTemplate(input: string, defaultSelector: string): ParsedActionTemplate {
-  const regex = /{{([#@]?)(\w+)}}/g;
-  const selectors: { name: string; numeric: boolean }[] = [];
-  let pattern = input;
-  
-  pattern = pattern.replace(regex, (_, flag, key) => {
-    selectors.push({ name: key, numeric: flag === "#" });
-    return "__";
-  });
+  const regex = /{{([#@]?)(\w+)}}/g
+  const selectors: { name: string; numeric: boolean }[] = []
+  let pattern = input
 
-  pattern = "__." + pattern;
+  pattern = pattern.replace(regex, (_, flag, key) => {
+    selectors.push({ name: key, numeric: flag === '#' })
+    return '__'
+  })
+
+  pattern = '__.' + pattern
 
   // template didn't contain any {{}} placeholders so add a single default argument
   if (selectors.length === 0) {
-    selectors.push({ name: defaultSelector, numeric: false });
-    pattern = pattern + " __";
+    selectors.push({ name: defaultSelector, numeric: false })
+    pattern = pattern + ' __'
   }
 
-  return { pattern, selectors };
+  return { pattern, selectors }
 }
 
 function isNumber(value: unknown): value is number {
-  return typeof value === 'number' && !isNaN(value);
+  return typeof value === 'number' && !isNaN(value)
 }
 
 function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSelector: string) {
-  const parsedAction = parseActionTemplate(action, defaultSelector);
+  const parsedAction = parseActionTemplate(action, defaultSelector)
 
   return Pattern.new<Ast.Expression>((ast) => {
     const mappedExpressions = parsedAction.selectors.map(({ name, numeric }) => {
-      const value = params.data[name];
+      const value = params.data[name]
       const castedValue = numeric && !isNaN(Number(value)) ? Number(value) : value
-      return isNumber(castedValue)
-        ? Ast.tryNumberToEnso(castedValue, ast.module)!
-        : Ast.TextLiteral.new(castedValue, ast.module);
-    });
+      return isNumber(castedValue) ?
+          Ast.tryNumberToEnso(castedValue, ast.module)!
+        : Ast.TextLiteral.new(castedValue, ast.module)
+    })
 
-    const templatePattern = Pattern.parseExpression(parsedAction.pattern);
-    return templatePattern.instantiateCopied([ast, ...mappedExpressions]);;
-  });
+    const templatePattern = Pattern.parseExpression(parsedAction.pattern)
+    return templatePattern.instantiateCopied([ast, ...mappedExpressions])
+  })
 }
 
 /**
@@ -743,7 +743,7 @@ function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSe
  *
  * The action string should be of the format `at {{#fieldname}}` which will generate a Node `at 2`
  * or `at {{@fieldname}}` which will generate a Node `at "2"`
- * 
+ *
  * If the action contains no placeholders then the defaultSelector is used like so
  * `action {{@defaultSelector}}
  *
@@ -751,12 +751,8 @@ function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSe
  * @param defaultSelector - A fallback key used when the template contains no placeholders.
  * @param action - A template string with placeholders (e.g., `at {{@name}}`, `at {{#value}}`) used to generate the AST.
  */
-function createNode(
-  params: CellDoubleClickedEvent,
-  defaultSelector: string,
-  action: string,
-) {
-  const pattern = getAstPattern(params, action, defaultSelector);
+function createNode(params: CellDoubleClickedEvent, defaultSelector: string, action: string) {
+  const pattern = getAstPattern(params, action, defaultSelector)
 
   if (pattern) {
     config.createNodes({
@@ -769,15 +765,15 @@ function createNode(
 interface LinkFieldOptions {
   tooltipValue?: string | undefined
   headerName?: string | undefined
-  getChildAction?: string | undefined
+  getChildAction: string
 }
 
-function toLinkField(fieldName: string, options: LinkFieldOptions = {}): ColDef {
+function toLinkField(fieldName: string, options: LinkFieldOptions): ColDef {
   const { tooltipValue, headerName, getChildAction } = options
   return {
     headerName: headerName ? headerName : fieldName,
     field: fieldName,
-    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction!),
+    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction),
     tooltipValueGetter: (params: ITooltipParams) =>
       params.node?.rowPinned === 'top' ?
         null
@@ -808,7 +804,7 @@ watchEffect(() => {
         has_index_col: false,
         links: undefined,
         // eslint-disable-next-line camelcase
-        get_child_node_action: undefined,
+        get_child_node_action: '',
         // eslint-disable-next-line camelcase
         get_child_node_link_name: undefined,
         // eslint-disable-next-line camelcase

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -743,10 +743,8 @@ function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSe
  *
  * The action string should be of the format `at {{#fieldname}}` which will generate a Node `at 2`
  * or `at {{@fieldname}}` which will generate a Node `at "2"`
- *
  * If the action contains no placeholders then the defaultSelector is used like so
  * `action {{@defaultSelector}}`
- *
  * @param params - The grid cell event containing the clicked row's data.
  * @param defaultSelector - A fallback key used when the template contains no placeholders.
  * @param action - A template string with placeholders (e.g., `at {{@name}}`, `at {{#value}}`) used to generate the AST.

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -745,7 +745,7 @@ function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSe
  * or `at {{@fieldname}}` which will generate a Node `at "2"`
  *
  * If the action contains no placeholders then the defaultSelector is used like so
- * `action {{@defaultSelector}}
+ * `action {{@defaultSelector}}`
  *
  * @param params - The grid cell event containing the clicked row's data.
  * @param defaultSelector - A fallback key used when the template contains no placeholders.

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -109,7 +109,6 @@ interface EnsoTableOrColumn {
   links: string[] | undefined
   get_child_node_action: string
   get_child_node_link_name: string
-  link_value_type: string
   child_label: string
   visualization_header: string
   data_quality_metrics?: DataQualityMetric[]
@@ -692,29 +691,50 @@ function toField(
   }
 }
 
-function getAstPattern(selector?: string | number, action?: string) {
-  if (action && selector != null) {
-    return Pattern.new<Ast.Expression>((ast) =>
-      Ast.App.positional(
-        Ast.PropertyAccess.new(ast.module, ast, Ast.identifier(action)!),
-        typeof selector === 'number' ?
-          Ast.tryNumberToEnso(selector, ast.module)!
-        : Ast.TextLiteral.new(selector, ast.module),
-      ),
-    )
-  }
+type ParsedTemplate = {
+  pattern: string;
+  keys: { name: string; numeric: boolean }[];
+};
+
+function parseTemplate(input: string): ParsedTemplate {
+  const regex = /{{(#?)(\w+)}}/g;
+  const keys: { name: string; numeric: boolean }[] = [];
+  let pattern = input;
+  
+  pattern = pattern.replace(regex, (_, flag, key) => {
+    keys.push({ name: key, numeric: flag === "#" });
+    return "__";
+  });
+
+  pattern = "__." + pattern;
+
+  return { pattern, keys };
+}
+
+function getAstPattern(params: CellDoubleClickedEvent, action: string) {
+  const parsedAction = parseTemplate(action);
+
+  return Pattern.new<Ast.Expression>((ast) => {
+    const mappedExpressions = parsedAction.keys.map(({ name, numeric }) => {
+      const value = params.data[name];
+      const castedValue = numeric && !isNaN(Number(value)) ? Number(value) : value
+      return numeric
+        ? Ast.tryNumberToEnso(castedValue, ast.module)!
+        : Ast.TextLiteral.new(castedValue, ast.module);
+    });
+
+    const templatePattern = Pattern.parseExpression(parsedAction.pattern);
+    return templatePattern.instantiateCopied([ast, ...mappedExpressions]);;
+  });
 }
 
 function createNode(
   params: CellDoubleClickedEvent,
   selector: string,
-  action?: string,
-  castValueTypes?: string,
+  action: string,
 ) {
-  const selectorKey = params.data[selector]
-  const castSelector =
-    castValueTypes === 'number' && !isNaN(Number(selectorKey)) ? Number(selectorKey) : selectorKey
-  const pattern = getAstPattern(castSelector, action)
+  const pattern = getAstPattern(params, action);
+
   if (pattern) {
     config.createNodes({
       content: pattern,
@@ -727,15 +747,14 @@ interface LinkFieldOptions {
   tooltipValue?: string | undefined
   headerName?: string | undefined
   getChildAction?: string | undefined
-  castValueTypes?: string | undefined
 }
 
 function toLinkField(fieldName: string, options: LinkFieldOptions = {}): ColDef {
-  const { tooltipValue, headerName, getChildAction, castValueTypes } = options
+  const { tooltipValue, headerName, getChildAction } = options
   return {
     headerName: headerName ? headerName : fieldName,
     field: fieldName,
-    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction, castValueTypes),
+    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction),
     tooltipValueGetter: (params: ITooltipParams) =>
       params.node?.rowPinned === 'top' ?
         null
@@ -773,8 +792,6 @@ watchEffect(() => {
         child_label: undefined,
         // eslint-disable-next-line camelcase
         visualization_header: undefined,
-        // eslint-disable-next-line camelcase
-        link_value_type: undefined,
         // eslint-disable-next-line camelcase
         is_using_server_sort_and_filter: undefined,
         // eslint-disable-next-line camelcase
@@ -855,7 +872,6 @@ watchEffect(() => {
             tooltipValue: data_.child_label,
             headerName: data_.visualization_header,
             getChildAction: data_.get_child_node_action,
-            castValueTypes: data_.link_value_type,
           })
         }
         return toField(v, { index: i, valueType })

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -708,6 +708,7 @@ function parseActionTemplate(input: string, defaultSelector: string): ParsedActi
 
   pattern = "__." + pattern;
 
+  // template didn't contain any {{}} placeholders so add a single default argument
   if (selectors.length === 0) {
     selectors.push({ name: defaultSelector, numeric: false });
     pattern = pattern + " __";

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -691,29 +691,29 @@ function toField(
   }
 }
 
-type ParsedTemplate = {
+type ParsedActionTemplate = {
   pattern: string;
-  keys: { name: string; numeric: boolean }[];
+  selectors: { name: string; numeric: boolean }[];
 };
 
-function parseTemplate(input: string, defaultSelector: string): ParsedTemplate {
+function parseActionTemplate(input: string, defaultSelector: string): ParsedActionTemplate {
   const regex = /{{([#@]?)(\w+)}}/g;
-  const keys: { name: string; numeric: boolean }[] = [];
+  const selectors: { name: string; numeric: boolean }[] = [];
   let pattern = input;
   
   pattern = pattern.replace(regex, (_, flag, key) => {
-    keys.push({ name: key, numeric: flag === "#" });
+    selectors.push({ name: key, numeric: flag === "#" });
     return "__";
   });
 
   pattern = "__." + pattern;
 
-  if (keys.length === 0) {
-    keys.push({ name: defaultSelector, numeric: false });
+  if (selectors.length === 0) {
+    selectors.push({ name: defaultSelector, numeric: false });
     pattern = pattern + " __";
   }
 
-  return { pattern, keys };
+  return { pattern, selectors };
 }
 
 function isNumber(value: unknown): value is number {
@@ -721,10 +721,10 @@ function isNumber(value: unknown): value is number {
 }
 
 function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSelector: string) {
-  const parsedAction = parseTemplate(action, defaultSelector);
+  const parsedAction = parseActionTemplate(action, defaultSelector);
 
   return Pattern.new<Ast.Expression>((ast) => {
-    const mappedExpressions = parsedAction.keys.map(({ name, numeric }) => {
+    const mappedExpressions = parsedAction.selectors.map(({ name, numeric }) => {
       const value = params.data[name];
       const castedValue = numeric && !isNaN(Number(value)) ? Number(value) : value
       return isNumber(castedValue)
@@ -737,12 +737,25 @@ function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSe
   });
 }
 
+/**
+ * Creates a new node in the graph based on the given action template and data from a grid row.
+ *
+ * The action string should be of the format `at {{#fieldname}}` which will generate a Node `at 2`
+ * or `at {{@fieldname}}` which will generate a Node `at "2"`
+ * 
+ * If the action contains no placeholders then the defaultSelector is used like so
+ * `action {{@defaultSelector}}
+ *
+ * @param params - The grid cell event containing the clicked row's data.
+ * @param defaultSelector - A fallback key used when the template contains no placeholders.
+ * @param action - A template string with placeholders (e.g., `at {{@name}}`, `at {{#value}}`) used to generate the AST.
+ */
 function createNode(
   params: CellDoubleClickedEvent,
-  selector: string,
+  defaultSelector: string,
   action: string,
 ) {
-  const pattern = getAstPattern(params, action, selector);
+  const pattern = getAstPattern(params, action, defaultSelector);
 
   if (pattern) {
     config.createNodes({

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -696,7 +696,7 @@ type ParsedTemplate = {
   keys: { name: string; numeric: boolean }[];
 };
 
-function parseTemplate(input: string): ParsedTemplate {
+function parseTemplate(input: string, defaultSelector: string): ParsedTemplate {
   const regex = /{{(#?)(\w+)}}/g;
   const keys: { name: string; numeric: boolean }[] = [];
   let pattern = input;
@@ -708,17 +708,26 @@ function parseTemplate(input: string): ParsedTemplate {
 
   pattern = "__." + pattern;
 
+  if (keys.length === 0) {
+    keys.push({ name: defaultSelector, numeric: false });
+    pattern = pattern + " __";
+  }
+
   return { pattern, keys };
 }
 
-function getAstPattern(params: CellDoubleClickedEvent, action: string) {
-  const parsedAction = parseTemplate(action);
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !isNaN(value);
+}
+
+function getAstPattern(params: CellDoubleClickedEvent, action: string, defaultSelector: string) {
+  const parsedAction = parseTemplate(action, defaultSelector);
 
   return Pattern.new<Ast.Expression>((ast) => {
     const mappedExpressions = parsedAction.keys.map(({ name, numeric }) => {
       const value = params.data[name];
       const castedValue = numeric && !isNaN(Number(value)) ? Number(value) : value
-      return numeric
+      return isNumber(castedValue)
         ? Ast.tryNumberToEnso(castedValue, ast.module)!
         : Ast.TextLiteral.new(castedValue, ast.module);
     });
@@ -733,7 +742,7 @@ function createNode(
   selector: string,
   action: string,
 ) {
-  const pattern = getAstPattern(params, action);
+  const pattern = getAstPattern(params, action, selector);
 
   if (pattern) {
     config.createNodes({
@@ -754,7 +763,7 @@ function toLinkField(fieldName: string, options: LinkFieldOptions = {}): ColDef 
   return {
     headerName: headerName ? headerName : fieldName,
     field: fieldName,
-    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction),
+    onCellDoubleClicked: (params) => createNode(params, fieldName, getChildAction!),
     tooltipValueGetter: (params: ITooltipParams) =>
       params.node?.rowPinned === 'top' ?
         null

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -68,8 +68,9 @@ make_json_for_row row =
     column_names = row.column_names
     values = ((0.up_to row.length).map idx-> _make_json_for_value (row.get idx))
     data = ["data", [column_names, values]]
-    links = ["get_child_node_action", "at {{@column}}"]
-    JS_Object.from_pairs [header, all_rows, data, links, ["type", "Map"]]
+    links = ["get_child_node_action", "at"]
+    get_child_node_action_link_name = ["get_child_node_link_name", "column"]
+    JS_Object.from_pairs [header, all_rows, data, links, get_child_node_action_link_name, ["type", "Map"]]
 
 ## PRIVATE
    Render Vector to JSON

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -68,9 +68,8 @@ make_json_for_row row =
     column_names = row.column_names
     values = ((0.up_to row.length).map idx-> _make_json_for_value (row.get idx))
     data = ["data", [column_names, values]]
-    links = ["get_child_node_action", "at"]
-    get_child_node_action_link_name = ["get_child_node_link_name", "column"]
-    JS_Object.from_pairs [header, all_rows, data, links, get_child_node_action_link_name, ["type", "Map"]]
+    links = ["get_child_node_action", "at {{@column}}"]
+    JS_Object.from_pairs [header, all_rows, data, links, ["type", "Map"]]
 
 ## PRIVATE
    Render Vector to JSON
@@ -174,7 +173,8 @@ make_json_for_xml_element xml_element max_items type:Text="XML_Element" =
     map_vector = Warning.clear (attribs + children)
 
     data = ["data", [map_vector.map .first, map_vector.map .second, map_vector.map i-> i.at 2]]
-    get_child_node_fields = if type == "XML_Element" then [["get_child_node_action", "get"], ["get_child_node_link_name", "key"], ["link_value_type", "number"]] else [["get_child_node_action", "get_child_element"], ["get_child_node_link_name", "key"], ["link_value_type", "number"]]
+    child_node_action = if type == "XML_Element" then "get" else "get_child_element"
+    get_child_node_fields = [["get_child_node_action", child_node_action + " {{#key}}"], ["get_child_node_link_name", "key"]]
     JS_Object.from_pairs <| [header, data, all_rows, ["type", type]] + get_child_node_fields
 
 private _make_json_for_db_table t max_rows is_column =

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -137,7 +137,7 @@ make_json_for_dictionary dict max_items =
     as_vector = Warning.clear (dict.to_vector.take max_items)
     mapped = as_vector . map p-> [p.first.to_text, _make_json_for_value p.second]
     data = ["data", [mapped.map .first, mapped.map .second]]
-    links = ["get_child_node_action", "at"]
+    links = ["get_child_node_action", "at {{#key}}"]
     get_child_node_action_link_name = ["get_child_node_link_name", "key"]
     JS_Object.from_pairs [header, data, all_rows, links, get_child_node_action_link_name, ["type", "Map"], ["child_label", "value"]]
 


### PR DESCRIPTION
### Pull Request Description

Removes the link_value_type attribute and replaces it with a new syntax for get_child_node_action
e.g. at {{#key}} will create a new component parent.at 0
at {{@key}} will create a new component parent.at '0'

Fixes a defect in the dictionary viz link using this.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
