### PR TITLE
Add default copy/paste handlers for CodeMirror editors

### DIFF
--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -1,3 +1,4 @@
+/** @file Tests for the multiline CodeMirror editor panels: documentation editor and code editor. */
 import type { Page } from '@playwright/test'
 import { test } from 'playwright/test'
 import * as actions from './actions'
@@ -50,9 +51,7 @@ test('Doc panel focus (regression #10471)', async ({ page }) => {
   const { rightDock } = await goToGraphAndGetDocs(page)
 
   // Open and focus code editor.
-  await page.keyboard.press(`${CONTROL_KEY}+\``)
-  const codeEditor = page.locator('.CodeEditor')
-  await expect(codeEditor).toBeVisible()
+  const { codeEditor } = await getCodeEditor(page)
   await codeEditor.click()
 
   await page.evaluate(() => {
@@ -66,13 +65,17 @@ test('Doc panel focus (regression #10471)', async ({ page }) => {
   await page.keyboard.press('S')
   await page.keyboard.press('T')
 
-  const content = await page.evaluate(() => {
-    const codeEditor = (window as any).__codeEditorApi
-    return codeEditor.textContent()
-  })
+  const content = await page.evaluate(() => (window as any).__codeEditorApi.textContent())
   expect(content.includes('The main TEST method')).toBe(true)
   await expect(rightDock).toContainText('The main TEST method')
 })
+
+async function getCodeEditor(page: Page) {
+  await page.keyboard.press(`${CONTROL_KEY}+\``)
+  const codeEditor = page.locator('.CodeEditor')
+  await expect(codeEditor).toBeVisible()
+  return { codeEditor }
+}
 
 test('Code editor with wide content does not take space from doc editor (#12476)', async ({
   page,
@@ -84,9 +87,7 @@ test('Code editor with wide content does not take space from doc editor (#12476)
     return (await rightDock.boundingBox())!.x
   }
   const docPosWithoutCodeEditor = await getDocX()
-  await page.keyboard.press(`${CONTROL_KEY}+\``)
-  const codeEditor = page.locator('.CodeEditor')
-  await expect(codeEditor).toBeVisible()
+  await getCodeEditor(page)
   const docPosWithCodeEditor = await getDocX()
 
   // Note that we compare `x` instead of `width`: This will catch either a change in width, or the
@@ -163,7 +164,7 @@ test('Insert link button inserts link and focuses editor', async ({ page }) => {
 test('Documentation editor: Editing with keyboard', async ({ page }) => {
   const { docsContent } = await goToGraphAndGetDocs(page)
 
-  await page.keyboard.press(`${CONTROL_KEY}+\``)
+  await getCodeEditor(page)
   const getGraphCode = () => page.evaluate(() => (window as any).__codeEditorApi.textContent())
 
   await docsContent
@@ -186,4 +187,21 @@ test('Documentation editor: Editing with keyboard', async ({ page }) => {
   await page.keyboard.type('Second line')
   const codeAfterAddingLine = await getGraphCode()
   expect(codeAfterAddingLine).toContain(`## # ${NEW_DOCS}\n   Second line`)
+})
+
+test('Code editor: Copy and paste', async ({ page }) => {
+  await actions.goToGraph(page)
+  const { codeEditor } = await getCodeEditor(page)
+  await codeEditor.click()
+  await page.evaluate(() => {
+    const codeEditor = (window as any).__codeEditorApi
+    const PLUS_TEN = ' + ten'
+    const plusTen = codeEditor.indexOf(PLUS_TEN)
+    codeEditor.select(plusTen, plusTen + PLUS_TEN.length)
+  })
+  await page.keyboard.press(`${CONTROL_KEY}+C`)
+  await page.keyboard.press(`${CONTROL_KEY}+V`)
+  await page.keyboard.press(`${CONTROL_KEY}+V`)
+  const codeAfterEdit = await page.evaluate(() => (window as any).__codeEditorApi.textContent())
+  expect(codeAfterEdit).toContain(' + ten + ten')
 })

--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -189,7 +189,9 @@ test('Documentation editor: Editing with keyboard', async ({ page }) => {
   expect(codeAfterAddingLine).toContain(`## # ${NEW_DOCS}\n   Second line`)
 })
 
-test('Code editor: Copy and paste', async ({ page }) => {
+test.skip('Code editor: Copy and paste (clipboard cannot be used in CI but test can be run locally)', async ({
+  page,
+}) => {
   await actions.goToGraph(page)
   const { codeEditor } = await getCodeEditor(page)
   await codeEditor.click()

--- a/app/gui/src/project-view/bindings.ts
+++ b/app/gui/src/project-view/bindings.ts
@@ -33,6 +33,9 @@ export const textEditorsCommonBindings = defineKeybinds('text-editors-common-bin
   moveRight: ['ArrowRight'],
   deleteBack: ['Backspace'],
   deleteForward: ['Delete'],
+  copy: ['Mod+C'],
+  cut: ['Mod+X'],
+  paste: ['Mod+V'],
 })
 
 export const textEditorsMultilineBindings = defineKeybinds('text-editors-multiline-bindings', {

--- a/app/gui/src/project-view/util/codemirror/keymap.ts
+++ b/app/gui/src/project-view/util/codemirror/keymap.ts
@@ -39,17 +39,25 @@ function bindCommands<T extends string>(
   )
 }
 
+const stopEvent = (event: Event) => {
+  event.stopImmediatePropagation()
+  return false
+}
+
 /** Key bindings applicable to all CodeMirror instances. */
 const baseKeymap: KeyBinding[] = [
   handlerToKeyBinding(
-    textEditorsCommonBindings.handler(
-      bindCommands({
+    textEditorsCommonBindings.handler({
+      ...bindCommands({
         moveLeft: commands.cursorCharLeft,
         moveRight: commands.cursorCharRight,
         deleteBack: commands.deleteCharBackward,
         deleteForward: commands.deleteCharForward,
       }),
-    ),
+      copy: stopEvent,
+      cut: stopEvent,
+      paste: stopEvent,
+    }),
     true,
   ),
   {
@@ -275,11 +283,6 @@ export const verticalMovementKeymap: KeyBinding[] = [
   { key: 'Ctrl-o', run: commands.splitLine, stopPropagation: true },
   { key: 'Ctrl-v', run: commands.cursorPageDown, stopPropagation: true },
 ]
-
-const stopEvent = (event: Event) => {
-  event.stopImmediatePropagation()
-  return false
-}
 
 const autoOrMultiHandlers = handlerToKeyBinding(
   textEditorsMultilineBindings.handler({


### PR DESCRIPTION
### Pull Request Description

Add default copy/paste handlers for CodeMirror editors

In editors that don't have special copy/paste handlers, this prevents the GraphEditor from handling the copy/paste events. Fixes #12954.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
