### PR TITLE
Support schemas in the Hyper table Viz

### DIFF
--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -309,7 +309,7 @@ test('GenericGrid Table Visualisation Test - single column - no links', async ({
     /* eslint-disable camelcase */
     {
       type: 'Generic_Grid',
-      headers: [{visualization_header:'table'}],
+      headers: [{ visualization_header: 'table' }],
       data: [['Sheet1', 'Sheet2', 'Sheet3']],
     },
     /* eslint-enable camelcase */
@@ -319,7 +319,6 @@ test('GenericGrid Table Visualisation Test - single column - no links', async ({
   await expect(tableVisualization).toContainText('Sheet2')
   await expect(tableVisualization).toContainText('Sheet3')
 })
-
 
 test('GenericGrid Table Visualisation Test - two column - link on second', async ({ page }) => {
   await initGraph(page)
@@ -337,8 +336,14 @@ test('GenericGrid Table Visualisation Test - two column - link on second', async
     /* eslint-disable camelcase */
     {
       type: 'Generic_Grid',
-      headers: [{visualization_header:'table'}, {visualization_header:'number', get_child_node_action:'read {{#number}} {{@table}}'}],
-      data: [['SheetA', 'SheetB', 'SheetC'], ['1', '2', '3']],
+      headers: [
+        { visualization_header: 'table' },
+        { visualization_header: 'number', get_child_node_action: 'read {{#number}} {{@table}}' },
+      ],
+      data: [
+        ['SheetA', 'SheetB', 'SheetC'],
+        ['1', '2', '3'],
+      ],
     },
     /* eslint-enable camelcase */
   )
@@ -359,7 +364,7 @@ test('GenericGrid Table Visualisation Test - two column - link on second', async
   const textWidget = newNode.locator('.WidgetText')
   await expect(textWidget).toBeVisible()
   await expect(textWidget.getByTestId('widget-text-content')).toHaveText('SheetB')
-  
+
   const numberWidget = newNode.locator('.WidgetNumber')
   await expect(numberWidget).toBeVisible()
   await expect(numberWidget).toHaveValue('2')

--- a/app/gui/integration-test/project-view/tableVisualisation.spec.ts
+++ b/app/gui/integration-test/project-view/tableVisualisation.spec.ts
@@ -292,3 +292,75 @@ test('get_child_node_action temmplate Test as text', async ({ page }) => {
   await expect(textWidget).toBeVisible()
   await expect(textWidget.getByTestId('widget-text-content')).toHaveText('2')
 })
+
+test('GenericGrid Table Visualisation Test - single column - no links', async ({ page }) => {
+  await initGraph(page)
+
+  const aggregatedNode = graphNodeByBinding(page, 'aggregated')
+  await aggregatedNode.click()
+  await page.keyboard.press('Space')
+  await page.waitForTimeout(1000)
+  const tableVisualization = locate.tableVisualization(page)
+  await expect(tableVisualization).toExist()
+
+  await mockVisualizationDataUpdate(
+    page,
+    'Standard.Visualization.Table.Visualization.prepare_visualization',
+    /* eslint-disable camelcase */
+    {
+      type: 'Generic_Grid',
+      headers: [{visualization_header:'table'}],
+      data: [['Sheet1', 'Sheet2', 'Sheet3']],
+    },
+    /* eslint-enable camelcase */
+  )
+  await expect(tableVisualization).toContainText('table')
+  await expect(tableVisualization).toContainText('Sheet1')
+  await expect(tableVisualization).toContainText('Sheet2')
+  await expect(tableVisualization).toContainText('Sheet3')
+})
+
+
+test('GenericGrid Table Visualisation Test - two column - link on second', async ({ page }) => {
+  await initGraph(page)
+
+  const aggregatedNode = graphNodeByBinding(page, 'aggregated')
+  await aggregatedNode.click()
+  await page.keyboard.press('Space')
+  await page.waitForTimeout(1000)
+  const tableVisualization = locate.tableVisualization(page)
+  await expect(tableVisualization).toExist()
+
+  await mockVisualizationDataUpdate(
+    page,
+    'Standard.Visualization.Table.Visualization.prepare_visualization',
+    /* eslint-disable camelcase */
+    {
+      type: 'Generic_Grid',
+      headers: [{visualization_header:'table'}, {visualization_header:'number', get_child_node_action:'read {{#number}} {{@table}}'}],
+      data: [['SheetA', 'SheetB', 'SheetC'], ['1', '2', '3']],
+    },
+    /* eslint-enable camelcase */
+  )
+  await expect(tableVisualization).toContainText('table')
+  await expect(tableVisualization).toContainText('SheetA')
+  await expect(tableVisualization).toContainText('SheetB')
+  await expect(tableVisualization).toContainText('SheetC')
+  await expect(tableVisualization).toContainText('number')
+  await expect(tableVisualization).toContainText('1')
+  await expect(tableVisualization).toContainText('2')
+  await expect(tableVisualization).toContainText('3')
+  const value2 = tableVisualization.getByText('2')
+  await value2.dblclick()
+  const newNode = graphNodeByBinding(page, 'node1')
+
+  await expect(newNode).toContainText('read')
+
+  const textWidget = newNode.locator('.WidgetText')
+  await expect(textWidget).toBeVisible()
+  await expect(textWidget.getByTestId('widget-text-content')).toHaveText('SheetB')
+  
+  const numberWidget = newNode.locator('.WidgetNumber')
+  await expect(numberWidget).toBeVisible()
+  await expect(numberWidget).toHaveValue('2')
+})

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -38,6 +38,7 @@ import { ComponentExposed } from 'vue-component-type-helpers'
 import { TableVisualisationTooltip } from './TableVisualization/TableVisualisationTooltip'
 import {
   Error,
+  GenericGrid,
   SingleColumnOfActions,
   isError,
   isGenericGrid,
@@ -71,6 +72,7 @@ type Data =
   | ObjectMatrix
   | EnsoTableOrColumn
   | SingleColumnOfActions
+  | GenericGrid
 
 interface ValueType {
   constructor: string
@@ -873,7 +875,6 @@ watchEffect(() => {
         tooltipValue: header.child_label,
         headerName: header.visualization_header,
         getChildAction: header.get_child_node_action,
-        args: header.args,
       });
     } else {
       return toField(header.visualization_header);

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -40,6 +40,7 @@ import {
   Error,
   SingleColumnOfActions,
   isError,
+  isGenericGrid,
   isSingleColumnOfActions,
 } from './TableVisualization/TableVisualisationTypes'
 import {
@@ -865,6 +866,20 @@ watchEffect(() => {
       }),
     ]
     rowData.value = data_.data.map((name) => ({ Value: name }))
+  } else if (isGenericGrid(data_)) {
+    columnDefs.value = data_.headers.map((header) => {
+      if (header.get_child_node_action) {
+      return toLinkField(header.visualization_header, {
+        tooltipValue: header.child_label,
+        headerName: header.visualization_header,
+        getChildAction: header.get_child_node_action,
+        args: header.args,
+      });
+    } else {
+      return toField(header.visualization_header);
+    }
+  })
+  rowData.value = data_.data ? createRowsForTable(data_.data, 0, false) : []
   } else if (Array.isArray(data_.json)) {
     columnDefs.value = [
       toLinkField(INDEX_FIELD_NAME, {

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -871,16 +871,16 @@ watchEffect(() => {
   } else if (isGenericGrid(data_)) {
     columnDefs.value = data_.headers.map((header) => {
       if (header.get_child_node_action) {
-      return toLinkField(header.visualization_header, {
-        tooltipValue: header.child_label,
-        headerName: header.visualization_header,
-        getChildAction: header.get_child_node_action,
-      });
-    } else {
-      return toField(header.visualization_header);
-    }
-  })
-  rowData.value = data_.data ? createRowsForTable(data_.data, 0, false) : []
+        return toLinkField(header.visualization_header, {
+          tooltipValue: header.child_label,
+          headerName: header.visualization_header,
+          getChildAction: header.get_child_node_action,
+        })
+      } else {
+        return toField(header.visualization_header)
+      }
+    })
+    rowData.value = data_.data ? createRowsForTable(data_.data, 0, false) : []
   } else if (Array.isArray(data_.json)) {
     columnDefs.value = [
       toLinkField(INDEX_FIELD_NAME, {

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -880,7 +880,7 @@ watchEffect(() => {
         return toField(header.visualization_header)
       }
     })
-    rowData.value = data_.data ? createRowsForTable(data_.data, 0, false) : []
+    rowData.value = createRowsForTable(data_.data, 0, false)
   } else if (Array.isArray(data_.json)) {
     columnDefs.value = [
       toLinkField(INDEX_FIELD_NAME, {

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
@@ -43,6 +43,9 @@ export interface GenericGrid {
   type: 'Generic_Grid'
   headers: Header[]
   data: unknown[][]
+
+  // TODO: Remove all_rows_count – not used, but we need to fix the type logic
+  all_rows_count: number
 }
 export interface Header {
   visualization_header: string

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
@@ -38,3 +38,25 @@ export function isSingleColumnOfActions(data: unknown): data is SingleColumnOfAc
     Array.isArray((data as any).data)
   )
 }
+
+export interface GenericGrid {
+  type: 'Generic_Grid'
+  all_rows_count: number
+  headers: Header[]
+  data: unknown[][]
+  }
+export interface Header {
+  visualization_header: string
+  get_child_node_action?: string
+  child_label?: string
+}
+
+/** Is this a Table Viz for a generic grid? */
+export function isGenericGrid(data: unknown): data is GenericGrid {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as any).type === 'Generic_Grid' 
+  )
+}

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
@@ -43,7 +43,7 @@ export interface GenericGrid {
   type: 'Generic_Grid'
   headers: Header[]
   data: unknown[][]
-  }
+}
 export interface Header {
   visualization_header: string
   get_child_node_action?: string
@@ -56,6 +56,6 @@ export function isGenericGrid(data: unknown): data is GenericGrid {
     typeof data === 'object' &&
     data !== null &&
     'type' in data &&
-    (data as any).type === 'Generic_Grid' 
+    (data as any).type === 'Generic_Grid'
   )
 }

--- a/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization/TableVisualisationTypes.ts
@@ -41,7 +41,6 @@ export function isSingleColumnOfActions(data: unknown): data is SingleColumnOfAc
 
 export interface GenericGrid {
   type: 'Generic_Grid'
-  all_rows_count: number
   headers: Header[]
   data: unknown[][]
   }

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Visualization/Table_Viz_Data.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Visualization/Table_Viz_Data.md
@@ -2,6 +2,10 @@
 ## module Standard.Base.Visualization.Table_Viz_Data
 - type Table_Viz_Data
     - Error error_display_text:Standard.Base.Any.Any
+    - GenericGrid headers:Standard.Base.Any.Any data:Standard.Base.Any.Any
     - SingleColumnOfActions js_value:Standard.Base.Any.Any data:Standard.Base.Any.Any title:Standard.Base.Any.Any tooltip:Standard.Base.Any.Any child_node_action:Standard.Base.Any.Any
     - Value json:Standard.Base.Data.Json.JS_Object
     - get_json self -> Standard.Base.Data.Json.JS_Object
+- type Table_Viz_Header
+    - Label name:Standard.Base.Any.Any
+    - Link name:Standard.Base.Any.Any tooltip:Standard.Base.Any.Any action:Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Visualization/Table_Viz_Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Visualization/Table_Viz_Data.enso
@@ -17,15 +17,30 @@ type Table_Viz_Data
     ## Table Viz for a single column of clickable items
     SingleColumnOfActions js_value data title tooltip child_node_action
 
+    ## Table Viz for a generic grid
+    GenericGrid headers data
+
     ## produces the json to send across to the ts visualisation code
     get_json self -> JS_Object =
         case self of    
             Table_Viz_Data.Value _ -> self.json
             Table_Viz_Data.Error _ -> _make_json_for_error self.error_display_text
             Table_Viz_Data.SingleColumnOfActions _ _ _ _ _ -> _make_json_for_single_column_of_actions self.js_value self.data self.title self.tooltip self.child_node_action
+            Table_Viz_Data.GenericGrid _ _ -> _make_json_for_generic_grid self.headers self.data
+
+type Table_Viz_Header
+    Link name tooltip action
+    Label name
+
+private _make_json_for_generic_grid headers data =
+    JS_Object.from_pairs [["type", "Generic_Grid"], ["data", data], ["headers", headers.map _make_json_for_header]]
+
+private _make_json_for_header header = case header of
+    Table_Viz_Header.Label _ -> JS_Object.from_pairs [["visualization_header", header.name]]
+    Table_Viz_Header.Link _ _ _ -> JS_Object.from_pairs [["visualization_header", header.name], ["child_label", header.tooltip], ["get_child_node_action", header.action]]
 
 private _make_json_for_single_column_of_actions js_value data title tooltip child_node_action =
-    JS_Object.from_pairs [["json", js_value], ["data", data], ["visualization_header", title], ["child_label", tooltip], ["get_child_node_action", child_node_action], ["type", "Single_Column_Of_Actions"]]
+    JS_Object.from_pairs [["type", "Single_Column_Of_Actions"], ["json", js_value], ["data", data], ["visualization_header", title], ["child_label", tooltip], ["get_child_node_action", child_node_action]]
 
 private _make_json_for_error error_display_text =
     pairs = [["type", "Error"], ["error", error_display_text]]

--- a/distribution/lib/Standard/Tableau/0.0.0-dev/src/Hyper_File.enso
+++ b/distribution/lib/Standard/Tableau/0.0.0-dev/src/Hyper_File.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import Single_Choice
-from Standard.Base.Visualization.Table_Viz_Data import Table_Viz_Data
+from Standard.Base.Visualization.Table_Viz_Data import Table_Viz_Data, Table_Viz_Header
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table
@@ -108,5 +108,7 @@ make_table_selector hyper_file:Hyper_File cache=Nothing =
 
 ## PRIVATE
 Table_Viz_Data.from (that:Hyper_File) = 
-    viz_data = that.tables.map t->t.table.to_text
-    Table_Viz_Data.SingleColumnOfActions that.to_js_object viz_data "tables" "table" "read"
+    schemas = that.tables.map t->t.schema.to_text
+    tables = that.tables.map t->t.table.to_text
+    if schemas.distinct.length <= 1 then (Table_Viz_Data.GenericGrid [Table_Viz_Header.Link "Table" "Table" "read {{@Table}}"] [tables]) else
+        (Table_Viz_Data.GenericGrid [Table_Viz_Header.Label "Schema", Table_Viz_Header.Link "Table" "Table" "read {{@Table}} {{@Schema}}"] [schemas, tables])


### PR DESCRIPTION
### Pull Request Description

Single schema doesn't show schemas and just reads table

![image](https://github.com/user-attachments/assets/0d5ccff5-1d59-47f9-a103-8b3bb33a9233)

Multiple schemas shows them and reads with table and schema

![image](https://github.com/user-attachments/assets/93a593de-8e33-480b-8a32-58d9293b1b0e)

The generic grid will eventually replace SingleColumnOfActions and probably some others in the big switch statement, but will be a future MR.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
