### PR TITLE
Distribute small JDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4099,6 +4099,18 @@ lazy val `engine-runner` = project
 lazy val buildSmallJdk =
   taskKey[File]("Build a minimal JDK used for native image generation")
 
+/**
+ * Command for building small JDK for the release.
+ * Use as `buildSmallJdkForRelease <targetDir>`.
+ */
+ThisBuild / commands += {
+  Command.single("buildSmallJdkForRelease") { (state, targetDir) =>
+    SmallJDK.buildSmallJDKForRelease(new File(targetDir))
+    state.log.info(s"Small JDK built in: $targetDir")
+    state
+  }
+}
+
 lazy val extraNITestLibs =
   taskKey[Seq[String]](
     "List of extra test libraries to be included in Native Image"

--- a/build.sbt
+++ b/build.sbt
@@ -3962,66 +3962,7 @@ lazy val `engine-runner` = project
     }.value,
     buildSmallJdk := {
       val smallJdkDirectory = (target.value / "jdk").getAbsoluteFile()
-      if (smallJdkDirectory.exists()) {
-        IO.delete(smallJdkDirectory)
-      }
-      val NI_MODULES =
-        "org.graalvm.nativeimage,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.base,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
-      val JDK_MODULES =
-        "java.naming,java.net.http,jdk.charsets,jdk.crypto.ec,jdk.localedata,jdk.httpserver,java.rmi"
-      val DEBUG_MODULES  = "jdk.jdwp.agent"
-      val PYTHON_MODULES = "jdk.security.auth,java.naming"
-
-      val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
-      val (jlink, modules, libDirs) = javaHome match {
-        case None =>
-          throw new RuntimeException("Missing java.home variable")
-        case Some(jh) =>
-          val exec = jh.resolve("bin").resolve("jlink")
-          val moduleJars = List(
-            "lib/svm/bin/../../graalvm/svm-driver.jar",
-            "lib/svm/bin/../builder/native-image-base.jar",
-            "lib/svm/bin/../builder/objectfile.jar",
-            "lib/svm/bin/../builder/pointsto.jar",
-            "lib/svm/bin/../builder/svm-enterprise.jar",
-            "lib/svm/bin/../builder/svm.jar",
-            "lib/svm/bin/../library-support.jar"
-          )
-          val targetLibDirs = List("graalvm", "svm", "static", "truffle")
-          (
-            exec,
-            moduleJars.map(jar => jh.resolve(jar).toString),
-            targetLibDirs.map(d => jh.resolve("lib").resolve(d))
-          )
-      }
-
-      var jlinkArgs = Seq(
-        "--module-path",
-        modules.mkString(File.pathSeparator),
-        "--output",
-        smallJdkDirectory.toString(),
-        "--add-modules",
-        s"$NI_MODULES,$JDK_MODULES,$DEBUG_MODULES,$PYTHON_MODULES"
-      )
-      val exitCode = scala.sys.process.Process(jlink.toString(), jlinkArgs).!
-      if (exitCode != 0) {
-        throw new RuntimeException(
-          s"Failed to execute $jlink ${jlinkArgs.mkString(" ")} - exit code: $exitCode"
-        )
-      }
-      libDirs.foreach(libDir =>
-        IO.copyDirectory(
-          libDir.toFile,
-          smallJdkDirectory.toPath
-            .resolve("lib")
-            .resolve(libDir.toFile.getName)
-            .toFile
-        )
-      )
-      assert(
-        smallJdkDirectory.exists(),
-        "Directory of small JDK " + smallJdkDirectory + " is not present"
-      )
+      SmallJDK.buildSmallJDKForNativeImage(smallJdkDirectory)
       smallJdkDirectory
     },
     rebuildNativeImage := Def

--- a/build.sbt
+++ b/build.sbt
@@ -4099,10 +4099,9 @@ lazy val `engine-runner` = project
 lazy val buildSmallJdk =
   taskKey[File]("Build a minimal JDK used for native image generation")
 
-/**
- * Command for building small JDK for the release.
- * Use as `buildSmallJdkForRelease <targetDir>`.
- */
+/** Command for building small JDK for the release.
+  * Use as `buildSmallJdkForRelease <targetDir>`.
+  */
 ThisBuild / commands += {
   Command.single("buildSmallJdkForRelease") { (state, targetDir) =>
     SmallJDK.buildSmallJDKForRelease(new File(targetDir))

--- a/build_tools/build/paths.yaml
+++ b/build_tools/build/paths.yaml
@@ -104,6 +104,7 @@
     generated-java/:
     rust/:
     test-results/:
+    small-jdk/:
   test/:
     Benchmarks/:
   tools/:

--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -153,6 +153,11 @@ pub struct BuildConfigurationFlags {
     ///
     /// Note that this does not run the benchmarks, only ensures that they are buildable.
     pub build_benchmarks: bool,
+    /// Whether the small JDK should be build with `jlink` before running
+    /// any tests.
+    pub build_small_jdk: bool,
+    /// If `build_small_jdk` is true, this is the directory where the small JDK will be placed.
+    pub small_jdk_dir: Option<PathBuf>,
     /// Whether the Enso-written benchmarks should be checked whether they compile.
     ///
     /// Note that this does not run benchmark, only ensures that they are buildable.
@@ -299,6 +304,8 @@ impl Default for BuildConfigurationFlags {
             test_jvm: false,
             test_standard_library: None,
             extra_engine_runner_args: None,
+            build_small_jdk: false,
+            small_jdk_dir: None,
             build_benchmarks: false,
             check_enso_benchmarks: false,
             execute_benchmarks: default(),

--- a/build_tools/build/src/engine/bundle.rs
+++ b/build_tools/build/src/engine/bundle.rs
@@ -50,10 +50,7 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
     /// ```text
     /// H:\NBO\enso\built-distribution\enso-engine-0.0.0-SNAPSHOT.2022-01-19-windows-amd64\enso-0.0.0-SNAPSHOT.2022-01-19
     /// ```
-    fn create(
-        &self,
-        repo_root: &RepoRoot
-    ) -> BoxFuture<'static, Result> {
+    fn create(&self, repo_root: &RepoRoot) -> BoxFuture<'static, Result> {
         let bundle_dir = self.as_ref().to_path_buf();
         let base_component = self.base_component(repo_root);
         let engine_src_path =

--- a/build_tools/build/src/engine/bundle.rs
+++ b/build_tools/build/src/engine/bundle.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 use crate::engine::artifact::IsArtifact;
 use crate::paths::generated::RepoRoot;
 
-use ide_ci::cache::goodie::graalvm::locate_graal;
-
 
 
 /// Version of the bundled GraalVM.
@@ -46,7 +44,6 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
     /// Creates a bundle for a given component. This requires already built:
     ///  * the base component package (e.g. launcher package for launcher bundle);
     ///  * the engine package;
-    ///  * the GraalVM package.
     ///  *
     ///
     /// `bundle_dir` is like:
@@ -55,8 +52,7 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
     /// ```
     fn create(
         &self,
-        repo_root: &RepoRoot,
-        graal_version: &GraalVmVersion,
+        repo_root: &RepoRoot
     ) -> BoxFuture<'static, Result> {
         let bundle_dir = self.as_ref().to_path_buf();
         let base_component = self.base_component(repo_root);

--- a/build_tools/build/src/engine/bundle.rs
+++ b/build_tools/build/src/engine/bundle.rs
@@ -65,7 +65,14 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
         let engine_target_dir = self.engine_dir();
         let graalvm_dir = self.graalvm_dir();
         let distribution_marker = self.distribution_marker();
-        let graalvm_version = graal_version.clone();
+        let small_jdk_dir = repo_root.target.small_jdk.clone();
+        if !small_jdk_dir.exists() {
+            return futures::future::err(anyhow::anyhow!(
+                "Small JDK directory does not exist in {}. It should have been built",
+                small_jdk_dir.display()
+            ))
+            .boxed();
+        }
 
         async move {
             ide_ci::fs::tokio::remove_dir_if_exists(&bundle_dir).await?;
@@ -73,8 +80,8 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
             ide_ci::fs::copy(&base_component, bundle_dir)?;
             // Add engine.
             ide_ci::fs::mirror_directory(&engine_src_path, &engine_target_dir).await?;
-            // Add GraalVM runtime.
-            place_graal_under(graalvm_dir, &graalvm_version).await?;
+            // Add runtime
+            ide_ci::fs::mirror_directory(&small_jdk_dir, &graalvm_dir).await?;
             // Add portable distribution marker.
             ide_ci::fs::create(distribution_marker)?;
             Ok(())
@@ -121,18 +128,4 @@ impl IsBundle for crate::paths::generated::LauncherBundle {
     fn distribution_marker(&self) -> PathBuf {
         self.enso_portable.to_path_buf()
     }
-}
-
-/// Places a copy of the GraalVM's installation directory in the target directory.
-///
-/// The GraalVM installation will be located using [`locate_graal`] function.
-#[context("Failed to place a GraalVM package under {}.", target_directory.as_ref().display())]
-pub async fn place_graal_under(
-    target_directory: impl AsRef<Path>,
-    graal_version: &GraalVmVersion,
-) -> Result {
-    let graal_path = locate_graal()?;
-    let graal_dirname =
-        format!("graalvm-ce-java{}-{}", graal_version.graal, graal_version.packages);
-    ide_ci::fs::mirror_directory(&graal_path, target_directory.as_ref().join(graal_dirname)).await
 }

--- a/build_tools/build/src/engine/bundle.rs
+++ b/build_tools/build/src/engine/bundle.rs
@@ -50,13 +50,19 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
     /// ```text
     /// H:\NBO\enso\built-distribution\enso-engine-0.0.0-SNAPSHOT.2022-01-19-windows-amd64\enso-0.0.0-SNAPSHOT.2022-01-19
     /// ```
-    fn create(&self, repo_root: &RepoRoot) -> BoxFuture<'static, Result> {
+    fn create(
+        &self,
+        repo_root: &RepoRoot,
+        graal_version: &GraalVmVersion,
+    ) -> BoxFuture<'static, Result> {
         let bundle_dir = self.as_ref().to_path_buf();
         let base_component = self.base_component(repo_root);
         let engine_src_path =
             repo_root.built_distribution.enso_engine_triple.engine_package.clone();
         let engine_target_dir = self.engine_dir();
-        let graalvm_dir = self.graalvm_dir();
+        let graal_dirname =
+            format!("graalvm-ce-java{}-{}", graal_version.graal, graal_version.packages);
+        let graalvm_target_dir = self.graalvm_dir().join(graal_dirname);
         let distribution_marker = self.distribution_marker();
         let small_jdk_dir = repo_root.target.small_jdk.clone();
         if !small_jdk_dir.exists() {
@@ -74,7 +80,7 @@ pub trait IsBundle: AsRef<Path> + IsArtifact {
             // Add engine.
             ide_ci::fs::mirror_directory(&engine_src_path, &engine_target_dir).await?;
             // Add runtime
-            ide_ci::fs::mirror_directory(&small_jdk_dir, &graalvm_dir).await?;
+            ide_ci::fs::mirror_directory(&small_jdk_dir, &graalvm_target_dir).await?;
             // Add portable distribution marker.
             ide_ci::fs::create(distribution_marker)?;
             Ok(())

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -187,6 +187,22 @@ impl RunContext {
         graalpy.install_if_missing(&self.cache).await?;
         ide_ci::programs::graalpy::GraalPy.require_present().await?;
 
+        if self.config.build_small_jdk {
+            let sbt = engine::sbt::Context {
+                repo_root:         self.paths.repo_root.path.clone(),
+                system_properties: default(),
+            };
+            if self.config.small_jdk_dir.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
+                ));
+            }
+            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
+            debug!("Building small JDK in {}", target_dir.display());
+            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
+            sbt.call_arg(sbt_cmd).await?;
+        }
+
         if self.config.test_java_generated_from_rust {
             // Ensure all runtime dependencies are resolved and exported so that they can be
             // appended to classpath
@@ -281,41 +297,31 @@ impl RunContext {
         // we don't want to call this in environments like GH-hosted runners.
 
         // === Build project-manager distribution and native image ===
-        let mut tasks: Vec<String> = vec![];
+        let mut tasks = vec![];
         let mut run_sbt_clean = false;
         if self.config.build_engine_package {
             run_sbt_clean = true;
-            tasks.push("buildEngineDistribution".to_string());
+            tasks.push("buildEngineDistribution");
         }
         if self.config.build_native_ydoc {
-            tasks.push("ydoc-server/buildNativeImage".to_string());
+            tasks.push("ydoc-server/buildNativeImage");
         }
         if self.config.build_project_manager_package() {
-            tasks.push("buildProjectManagerDistribution".to_string());
+            tasks.push("buildProjectManagerDistribution");
         }
         if self.config.build_launcher_package() {
-            tasks.push("buildLauncherDistribution".to_string());
+            tasks.push("buildLauncherDistribution");
         }
         if self.config.run_enso_lint {
-            tasks.push("lintEnso".to_string());
-        }
-        if self.config.build_small_jdk {
-            if self.config.small_jdk_dir.is_none() {
-                return Err(anyhow::anyhow!(
-                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
-                ));
-            }
-            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
-            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
-            tasks.push(sbt_cmd);
+            tasks.push("lintEnso");
         }
 
         if !tasks.is_empty() {
             debug!("Building distributions and native images.");
             let mut command = if crate::ci::big_memory_machine() {
-                Sbt::concurrent_tasks(tasks.iter().map(|s| s.as_str()))
+                Sbt::concurrent_tasks(tasks)
             } else {
-                Sbt::sequential_tasks(tasks.iter().map(|s| s.as_str()))
+                Sbt::sequential_tasks(tasks)
             };
             command = if run_sbt_clean {
                 Sbt::sequential_tasks(vec!["clean", &command])

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -187,22 +187,6 @@ impl RunContext {
         graalpy.install_if_missing(&self.cache).await?;
         ide_ci::programs::graalpy::GraalPy.require_present().await?;
 
-        if self.config.build_small_jdk {
-            let sbt = engine::sbt::Context {
-                repo_root:         self.paths.repo_root.path.clone(),
-                system_properties: default(),
-            };
-            if self.config.small_jdk_dir.is_none() {
-                return Err(anyhow::anyhow!(
-                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
-                ));
-            }
-            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
-            debug!("Building small JDK in {}", target_dir.display());
-            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
-            sbt.call_arg(sbt_cmd).await?;
-        }
-
         if self.config.test_java_generated_from_rust {
             // Ensure all runtime dependencies are resolved and exported so that they can be
             // appended to classpath
@@ -329,6 +313,18 @@ impl RunContext {
                 command
             };
             sbt.call_arg(command).await?;
+        }
+
+        if self.config.build_small_jdk {
+            if self.config.small_jdk_dir.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
+                ));
+            }
+            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
+            debug!("Building small JDK in {}", target_dir.display());
+            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
+            sbt.call_arg(sbt_cmd).await?;
         }
 
         // === End of Build project-manager distribution and native image ===

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -19,6 +19,7 @@ use crate::paths::TargetTriple;
 use crate::paths::ENSO_TEST_JUNIT_DIR;
 use crate::project::ProcessWrapper;
 
+use aws_sdk_ecr::error;
 use ide_ci::actions::workflow::is_in_env;
 use ide_ci::actions::workflow::MessageLevel;
 use ide_ci::cache;
@@ -186,6 +187,22 @@ impl RunContext {
         };
         graalpy.install_if_missing(&self.cache).await?;
         ide_ci::programs::graalpy::GraalPy.require_present().await?;
+
+        if self.config.build_small_jdk {
+            let sbt = engine::sbt::Context {
+                repo_root:         self.paths.repo_root.path.clone(),
+                system_properties: default(),
+            };
+            if self.config.small_jdk_dir.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
+                ));
+            }
+            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
+            debug!("Building small JDK in {}", target_dir.display());
+            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
+            sbt.call_arg(sbt_cmd).await?;
+        }
 
         if self.config.test_java_generated_from_rust {
             // Ensure all runtime dependencies are resolved and exported so that they can be

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -470,8 +470,9 @@ impl RunContext {
             }
         }
 
+        let graal_version = engine::deduce_graal_bundle(&self.repo_root.build_sbt).await?;
         for bundle in ret.bundles() {
-            bundle.create(&self.repo_root).await?;
+            bundle.create(&self.repo_root, &graal_version).await?;
         }
 
         scala_test_result?;

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -187,22 +187,6 @@ impl RunContext {
         graalpy.install_if_missing(&self.cache).await?;
         ide_ci::programs::graalpy::GraalPy.require_present().await?;
 
-        if self.config.build_small_jdk {
-            let sbt = engine::sbt::Context {
-                repo_root:         self.paths.repo_root.path.clone(),
-                system_properties: default(),
-            };
-            if self.config.small_jdk_dir.is_none() {
-                return Err(anyhow::anyhow!(
-                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
-                ));
-            }
-            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
-            debug!("Building small JDK in {}", target_dir.display());
-            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
-            sbt.call_arg(sbt_cmd).await?;
-        }
-
         if self.config.test_java_generated_from_rust {
             // Ensure all runtime dependencies are resolved and exported so that they can be
             // appended to classpath
@@ -297,31 +281,41 @@ impl RunContext {
         // we don't want to call this in environments like GH-hosted runners.
 
         // === Build project-manager distribution and native image ===
-        let mut tasks = vec![];
+        let mut tasks: Vec<String> = vec![];
         let mut run_sbt_clean = false;
         if self.config.build_engine_package {
             run_sbt_clean = true;
-            tasks.push("buildEngineDistribution");
+            tasks.push("buildEngineDistribution".to_string());
         }
         if self.config.build_native_ydoc {
-            tasks.push("ydoc-server/buildNativeImage");
+            tasks.push("ydoc-server/buildNativeImage".to_string());
         }
         if self.config.build_project_manager_package() {
-            tasks.push("buildProjectManagerDistribution");
+            tasks.push("buildProjectManagerDistribution".to_string());
         }
         if self.config.build_launcher_package() {
-            tasks.push("buildLauncherDistribution");
+            tasks.push("buildLauncherDistribution".to_string());
         }
         if self.config.run_enso_lint {
-            tasks.push("lintEnso");
+            tasks.push("lintEnso".to_string());
+        }
+        if self.config.build_small_jdk {
+            if self.config.small_jdk_dir.is_none() {
+                return Err(anyhow::anyhow!(
+                    "Small JDK directory is not set. Please set `small_jdk_dir` in the build configuration."
+                ));
+            }
+            let target_dir = self.config.small_jdk_dir.as_ref().unwrap();
+            let sbt_cmd = format!("buildSmallJdkForRelease {}", target_dir.as_str());
+            tasks.push(sbt_cmd);
         }
 
         if !tasks.is_empty() {
             debug!("Building distributions and native images.");
             let mut command = if crate::ci::big_memory_machine() {
-                Sbt::concurrent_tasks(tasks)
+                Sbt::concurrent_tasks(tasks.iter().map(|s| s.as_str()))
             } else {
-                Sbt::sequential_tasks(tasks)
+                Sbt::sequential_tasks(tasks.iter().map(|s| s.as_str()))
             };
             command = if run_sbt_clean {
                 Sbt::sequential_tasks(vec!["clean", &command])

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -19,7 +19,6 @@ use crate::paths::TargetTriple;
 use crate::paths::ENSO_TEST_JUNIT_DIR;
 use crate::project::ProcessWrapper;
 
-use aws_sdk_ecr::error;
 use ide_ci::actions::workflow::is_in_env;
 use ide_ci::actions::workflow::MessageLevel;
 use ide_ci::cache;
@@ -475,9 +474,8 @@ impl RunContext {
             }
         }
 
-        let graal_version = engine::deduce_graal_bundle(&self.repo_root.build_sbt).await?;
         for bundle in ret.bundles() {
-            bundle.create(&self.repo_root, &graal_version).await?;
+            bundle.create(&self.repo_root).await?;
         }
 
         scala_test_result?;

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -89,8 +89,19 @@ impl BuiltEnso {
             .engine_package
             .bin
             .join(filename);
+        let small_jdk_dir = &self.paths.repo_root.target.small_jdk;
+        if !small_jdk_dir.path.exists() {
+            bail!("Small JDK directory does not exist: {}", small_jdk_dir.path.display());
+        }
+        let small_jdk_dir_absolutized = small_jdk_dir.path.absolutize()?;
+        let small_jdk_dir_path = small_jdk_dir_absolutized.as_str();
         let benchmarks = Command::new(&enso)
-            .args(["--jvm", "--run", self.paths.repo_root.test.benchmarks.as_str()])
+            .args([
+                "--jvm",
+                small_jdk_dir_path,
+                "--run",
+                self.paths.repo_root.test.benchmarks.as_str(),
+            ])
             .set_env(ENSO_BENCHMARK_TEST_DRY_RUN, &Boolean::from(opt.dry_run))?
             .run_ok()
             .await;

--- a/build_tools/build/src/project/backend.rs
+++ b/build_tools/build/src/project/backend.rs
@@ -144,13 +144,18 @@ impl IsTarget for Backend {
         let WithDestination { inner, destination } = job;
         let target_os = self.target_os;
         let this = *self;
+        let small_jdk_dir = context.repo_root.target.small_jdk.clone().to_path_buf();
         async move {
             ensure!(
                 target_os == TARGET_OS,
                 "Enso Project Manager cannot be built on '{target_os}' for target '{TARGET_OS}'.",
             );
-            let config =
-                BuildConfigurationFlags { build_project_manager_bundle: true, ..default() };
+            let config = BuildConfigurationFlags {
+                build_project_manager_bundle: true,
+                build_small_jdk: true,
+                small_jdk_dir: Some(small_jdk_dir),
+                ..default()
+            };
             let context = inner.prepare_context(context, config)?;
             let artifacts = context.build().await?;
             let project_manager =

--- a/build_tools/build/src/project/runtime.rs
+++ b/build_tools/build/src/project/runtime.rs
@@ -42,7 +42,13 @@ impl IsTarget for Runtime {
         context: Context,
         job: WithDestination<Self::BuildInput>,
     ) -> BoxFuture<'static, Result<Self::Artifact>> {
-        let config = BuildConfigurationFlags { build_engine_package: true, ..default() };
+        let small_jdk_dir = context.repo_root.target.small_jdk.clone().to_path_buf();
+        let config = BuildConfigurationFlags {
+            build_engine_package: true,
+            build_small_jdk: true,
+            small_jdk_dir: Some(small_jdk_dir),
+            ..default()
+        };
         let this = *self;
         let WithDestination { inner, destination } = job;
         let triple = TargetTriple::new(inner.versions);

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -354,10 +354,13 @@ impl Processor {
                             command: enso_build::engine::ReleaseCommand::Upload,
                         },
                     );
+                    let small_jdk_dir = self.context.repo_root.target.small_jdk.path.clone();
                     let config = enso_build::engine::BuildConfigurationFlags {
                         build_engine_package: true,
                         build_launcher_bundle: true,
                         build_project_manager_bundle: true,
+                        build_small_jdk: true,
+                        small_jdk_dir: Some(small_jdk_dir.clone()),
                         verify_packages: true,
                         ..default()
                     };

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -411,11 +411,18 @@ impl Processor {
                             config.check_enso_benchmarks = TARGET_OS == OS::Linux;
                         }
                         Tests::StandardLibrary => {
+                            config.build_small_jdk = true;
+                            let small_jdk_dir =
+                                self.context.repo_root.target.small_jdk.path.clone();
+                            config.small_jdk_dir = Some(small_jdk_dir.clone());
                             config.test_standard_library =
                                 Some(StandardLibraryTestsSelection::blacklist(vec![
                                     "Examples_Tests".to_string(),
                                 ]));
                             config.add_engine_runner_arg("--jvm");
+                            config.add_engine_runner_arg(
+                                small_jdk_dir.to_string_lossy().to_string().as_str(),
+                            );
                             config.use_native_runner = true;
                         }
                         Tests::StandardLibraryInNative => {

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -346,6 +346,7 @@ impl Processor {
                 let input = Backend::resolve(self, input);
                 let repo = self.remote_repo.clone();
                 let context = self.context();
+                let small_jdk_dir = context.repo_root.target.small_jdk.path.clone();
                 async move {
                     let input = input.await?;
                     let operation = enso_build::engine::Operation::Release(
@@ -354,13 +355,12 @@ impl Processor {
                             command: enso_build::engine::ReleaseCommand::Upload,
                         },
                     );
-                    let small_jdk_dir = self.context.repo_root.target.small_jdk.path.clone();
                     let config = enso_build::engine::BuildConfigurationFlags {
                         build_engine_package: true,
                         build_launcher_bundle: true,
                         build_project_manager_bundle: true,
                         build_small_jdk: true,
-                        small_jdk_dir: Some(small_jdk_dir.clone()),
+                        small_jdk_dir: Some(small_jdk_dir),
                         verify_packages: true,
                         ..default()
                     };

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -87,23 +87,6 @@ object SmallJDK {
   def buildSmallJDKForRelease(
     smallJdkDirectory: File
   ): Unit = {
-    val modules_ = Seq(
-      "java.base",
-      "java.net.http",
-      "java.naming",
-      "jdk.charsets",
-      "jdk.unsupported",
-      "jdk.graal.compiler",
-      "jdk.graal.compiler.management",
-      "jdk.zipfs",
-      "org.graalvm.nativeimage",
-      "org.graalvm.truffle.compiler",
-      "org.graalvm.word",
-    )
-    val defaultCmdLine = Seq(
-      "--no-header-files",
-      "--no-man-pages",
-    )
     val mp = modulePath()
       .map(_.toAbsolutePath.toString)
       .mkString(File.pathSeparator)

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -1,13 +1,48 @@
 import sbt.io.IO
 
 import java.io.File
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import scala.collection.immutable.Seq
 
 /**
  * Building small JDK distributions with `jlink` command
  */
 object SmallJDK {
+
+  private val NI_BUILDER_MODULES = Seq(
+    "org.graalvm.nativeimage.builder",
+    "org.graalvm.nativeimage.driver",
+    "org.graalvm.nativeimage.librarysupport",
+    "org.graalvm.nativeimage.objectfile",
+    "org.graalvm.nativeimage.pointsto",
+  )
+
+  private val NI_BASE_MODULES = Seq(
+    "org.graalvm.nativeimage",
+    "org.graalvm.nativeimage.base",
+    "com.oracle.graal.graal_enterprise",
+    "com.oracle.svm.svm_enterprise",
+  )
+
+  private val JDK_MODULES = Seq(
+    "java.naming",
+    "java.net.http",
+    "java.rmi",
+    "jdk.charsets",
+    "jdk.crypto.ec",
+    "jdk.httpserver",
+    "jdk.localedata",
+  )
+
+  private val DEBUG_MODULES = Seq(
+    "jdk.jdwp.agent"
+  )
+
+  private val PYTHON_MODULES = Seq(
+    "java.naming",
+    "jdk.security.auth",
+  )
+
   /**
    * Builds a small JDK appropriate for building native image.
    * @param smallJdkDirectory Target directory. If non empty, will be deleted.
@@ -18,51 +53,93 @@ object SmallJDK {
     if (smallJdkDirectory.exists()) {
       IO.delete(smallJdkDirectory)
     }
-    val NI_MODULES =
-      "org.graalvm.nativeimage,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.base,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
-    val JDK_MODULES =
-      "java.naming,java.net.http,jdk.charsets,jdk.crypto.ec,jdk.localedata,jdk.httpserver,java.rmi"
-    val DEBUG_MODULES  = "jdk.jdwp.agent"
-    val PYTHON_MODULES = "jdk.security.auth,java.naming"
+    val niModules = (NI_BASE_MODULES ++ NI_BUILDER_MODULES).mkString(",")
+    val jdkModules = JDK_MODULES.mkString(",")
+    val debugModules  = DEBUG_MODULES.mkString(",")
+    val pythonModules = PYTHON_MODULES.mkString(",")
 
-    val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
-    val (jlink, modules, libDirs) = javaHome match {
-      case None =>
-        throw new RuntimeException("Missing java.home variable")
-      case Some(jh) =>
-        val exec = jh.resolve("bin").resolve("jlink")
-        val moduleJars = List(
-          "lib/svm/bin/../../graalvm/svm-driver.jar",
-          "lib/svm/bin/../builder/native-image-base.jar",
-          "lib/svm/bin/../builder/objectfile.jar",
-          "lib/svm/bin/../builder/pointsto.jar",
-          "lib/svm/bin/../builder/svm-enterprise.jar",
-          "lib/svm/bin/../builder/svm.jar",
-          "lib/svm/bin/../library-support.jar"
-        )
-        val targetLibDirs = List("graalvm", "svm", "static", "truffle")
-        (
-          exec,
-          moduleJars.map(jar => jh.resolve(jar).toString),
-          targetLibDirs.map(d => jh.resolve("lib").resolve(d))
-        )
-    }
+    val mp = modulePath()
+      .map(_.toAbsolutePath.toString)
+      .mkString(File.pathSeparator)
 
     val jlinkArgs = Seq(
       "--module-path",
-      modules.mkString(File.pathSeparator),
+      mp,
       "--output",
-      smallJdkDirectory.toString(),
+      smallJdkDirectory.toString,
       "--add-modules",
-      s"$NI_MODULES,$JDK_MODULES,$DEBUG_MODULES,$PYTHON_MODULES"
+      s"$niModules,$jdkModules,$debugModules,$pythonModules"
     )
-    val exitCode = scala.sys.process.Process(jlink.toString(), jlinkArgs).!
+    runJlink(jlinkArgs)
+    copyLibDirs(smallJdkDirectory)
+    assert(
+      smallJdkDirectory.exists(),
+      "Directory of small JDK " + smallJdkDirectory + " is not present"
+    )
+  }
+
+  /**
+   * Builds a small JDK with `jlink` appropriate for running
+   * Enso in `--jvm` mode.
+   * @param smallJdkDirectory Target directory. If not empty,
+   *                          will be deleted.
+   */
+  def buildSmallJDKForRelease(
+    smallJdkDirectory: File
+  ): Unit = {
+    val modules_ = Seq(
+      "java.base",
+      "java.net.http",
+      "java.naming",
+      "jdk.charsets",
+      "jdk.unsupported",
+      "jdk.graal.compiler",
+      "jdk.graal.compiler.management",
+      "jdk.zipfs",
+      "org.graalvm.nativeimage",
+      "org.graalvm.truffle.compiler",
+      "org.graalvm.word",
+    )
+    val defaultCmdLine = Seq(
+      "--no-header-files",
+      "--no-man-pages",
+    )
+    val mp = modulePath()
+      .map(_.toAbsolutePath.toString)
+      .mkString(File.pathSeparator)
+    val modules = JDK_MODULES ++ NI_BASE_MODULES ++ PYTHON_MODULES
+    val jlinkArgs = Seq(
+      "--no-header-files",
+      "--no-man-pages",
+      "--module-path",
+      mp,
+      "--output",
+      smallJdkDirectory.toString,
+      "--add-modules",
+      modules.mkString(",")
+    )
+    runJlink(jlinkArgs)
+    copyLibDirs(smallJdkDirectory)
+    assert(
+      smallJdkDirectory.exists(),
+      "Directory of small JDK " + smallJdkDirectory +
+        " was not created."
+    )
+  }
+
+  private def runJlink(
+    args: Seq[String]
+  ): Unit = {
+    val exitCode = scala.sys.process.Process(jlink().toString, args).!
     if (exitCode != 0) {
       throw new RuntimeException(
-        s"Failed to execute $jlink ${jlinkArgs.mkString(" ")} - exit code: $exitCode"
+        s"Failed to execute ${jlink()} ${args.mkString(" ")} - exit code: $exitCode"
       )
     }
-    libDirs.foreach(libDir =>
+  }
+
+  private def copyLibDirs(smallJdkDirectory: File): Unit = {
+    libDirs().foreach(libDir =>
       IO.copyDirectory(
         libDir.toFile,
         smallJdkDirectory.toPath
@@ -71,9 +148,45 @@ object SmallJDK {
           .toFile
       )
     )
-    assert(
-      smallJdkDirectory.exists(),
-      "Directory of small JDK " + smallJdkDirectory + " is not present"
+  }
+
+  private def javaHome(): Path = {
+    val prop = System.getProperty("java.home")
+    if (prop == null) {
+      throw new RuntimeException("Missing java.home prop")
+    } else {
+      Path.of(prop)
+    }
+  }
+
+  private def jlink(): Path = {
+    javaHome().resolve("bin").resolve("jlink")
+  }
+
+  private def modulePath(): List[Path] = {
+    val moduleJars = List(
+      "lib/svm/bin/../../graalvm/svm-driver.jar",
+      "lib/svm/bin/../builder/native-image-base.jar",
+      "lib/svm/bin/../builder/objectfile.jar",
+      "lib/svm/bin/../builder/pointsto.jar",
+      "lib/svm/bin/../builder/svm-enterprise.jar",
+      "lib/svm/bin/../builder/svm.jar",
+      "lib/svm/bin/../library-support.jar"
     )
+    moduleJars.map { jar =>
+      javaHome().resolve(jar)
+    }
+  }
+
+  private def libDirs(): List[Path] = {
+    val targetLibDirs = List(
+      "graalvm",
+      "svm",
+      "static",
+      "truffle"
+    )
+    targetLibDirs.map { d =>
+      javaHome().resolve("lib").resolve(d)
+    }
   }
 }

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -87,6 +87,9 @@ object SmallJDK {
   def buildSmallJDKForRelease(
     smallJdkDirectory: File
   ): Unit = {
+    if (smallJdkDirectory.exists()) {
+      IO.delete(smallJdkDirectory)
+    }
     val mp = modulePath()
       .map(_.toAbsolutePath.toString)
       .mkString(File.pathSeparator)

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -1,0 +1,79 @@
+import sbt.io.IO
+
+import java.io.File
+import java.nio.file.Paths
+import scala.collection.immutable.Seq
+
+/**
+ * Building small JDK distributions with `jlink` command
+ */
+object SmallJDK {
+  /**
+   * Builds a small JDK appropriate for building native image.
+   * @param smallJdkDirectory Target directory. If non empty, will be deleted.
+   */
+  def buildSmallJDKForNativeImage(
+    smallJdkDirectory: File
+  ): Unit = {
+    if (smallJdkDirectory.exists()) {
+      IO.delete(smallJdkDirectory)
+    }
+    val NI_MODULES =
+      "org.graalvm.nativeimage,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.base,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
+    val JDK_MODULES =
+      "java.naming,java.net.http,jdk.charsets,jdk.crypto.ec,jdk.localedata,jdk.httpserver,java.rmi"
+    val DEBUG_MODULES  = "jdk.jdwp.agent"
+    val PYTHON_MODULES = "jdk.security.auth,java.naming"
+
+    val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
+    val (jlink, modules, libDirs) = javaHome match {
+      case None =>
+        throw new RuntimeException("Missing java.home variable")
+      case Some(jh) =>
+        val exec = jh.resolve("bin").resolve("jlink")
+        val moduleJars = List(
+          "lib/svm/bin/../../graalvm/svm-driver.jar",
+          "lib/svm/bin/../builder/native-image-base.jar",
+          "lib/svm/bin/../builder/objectfile.jar",
+          "lib/svm/bin/../builder/pointsto.jar",
+          "lib/svm/bin/../builder/svm-enterprise.jar",
+          "lib/svm/bin/../builder/svm.jar",
+          "lib/svm/bin/../library-support.jar"
+        )
+        val targetLibDirs = List("graalvm", "svm", "static", "truffle")
+        (
+          exec,
+          moduleJars.map(jar => jh.resolve(jar).toString),
+          targetLibDirs.map(d => jh.resolve("lib").resolve(d))
+        )
+    }
+
+    val jlinkArgs = Seq(
+      "--module-path",
+      modules.mkString(File.pathSeparator),
+      "--output",
+      smallJdkDirectory.toString(),
+      "--add-modules",
+      s"$NI_MODULES,$JDK_MODULES,$DEBUG_MODULES,$PYTHON_MODULES"
+    )
+    val exitCode = scala.sys.process.Process(jlink.toString(), jlinkArgs).!
+    if (exitCode != 0) {
+      throw new RuntimeException(
+        s"Failed to execute $jlink ${jlinkArgs.mkString(" ")} - exit code: $exitCode"
+      )
+    }
+    libDirs.foreach(libDir =>
+      IO.copyDirectory(
+        libDir.toFile,
+        smallJdkDirectory.toPath
+          .resolve("lib")
+          .resolve(libDir.toFile.getName)
+          .toFile
+      )
+    )
+    assert(
+      smallJdkDirectory.exists(),
+      "Directory of small JDK " + smallJdkDirectory + " is not present"
+    )
+  }
+}

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -4,9 +4,8 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 import scala.collection.immutable.Seq
 
-/**
- * Building small JDK distributions with `jlink` command
- */
+/** Building small JDK distributions with `jlink` command
+  */
 object SmallJDK {
 
   private val NI_BUILDER_MODULES = Seq(
@@ -14,14 +13,14 @@ object SmallJDK {
     "org.graalvm.nativeimage.driver",
     "org.graalvm.nativeimage.librarysupport",
     "org.graalvm.nativeimage.objectfile",
-    "org.graalvm.nativeimage.pointsto",
+    "org.graalvm.nativeimage.pointsto"
   )
 
   private val NI_BASE_MODULES = Seq(
     "org.graalvm.nativeimage",
     "org.graalvm.nativeimage.base",
     "com.oracle.graal.graal_enterprise",
-    "com.oracle.svm.svm_enterprise",
+    "com.oracle.svm.svm_enterprise"
   )
 
   private val JDK_MODULES = Seq(
@@ -31,7 +30,7 @@ object SmallJDK {
     "jdk.charsets",
     "jdk.crypto.ec",
     "jdk.httpserver",
-    "jdk.localedata",
+    "jdk.localedata"
   )
 
   private val DEBUG_MODULES = Seq(
@@ -40,21 +39,20 @@ object SmallJDK {
 
   private val PYTHON_MODULES = Seq(
     "java.naming",
-    "jdk.security.auth",
+    "jdk.security.auth"
   )
 
-  /**
-   * Builds a small JDK appropriate for building native image.
-   * @param smallJdkDirectory Target directory. If non empty, will be deleted.
-   */
+  /** Builds a small JDK appropriate for building native image.
+    * @param smallJdkDirectory Target directory. If non empty, will be deleted.
+    */
   def buildSmallJDKForNativeImage(
     smallJdkDirectory: File
   ): Unit = {
     if (smallJdkDirectory.exists()) {
       IO.delete(smallJdkDirectory)
     }
-    val niModules = (NI_BASE_MODULES ++ NI_BUILDER_MODULES).mkString(",")
-    val jdkModules = JDK_MODULES.mkString(",")
+    val niModules     = (NI_BASE_MODULES ++ NI_BUILDER_MODULES).mkString(",")
+    val jdkModules    = JDK_MODULES.mkString(",")
     val debugModules  = DEBUG_MODULES.mkString(",")
     val pythonModules = PYTHON_MODULES.mkString(",")
 
@@ -78,12 +76,11 @@ object SmallJDK {
     )
   }
 
-  /**
-   * Builds a small JDK with `jlink` appropriate for running
-   * Enso in `--jvm` mode.
-   * @param smallJdkDirectory Target directory. If not empty,
-   *                          will be deleted.
-   */
+  /** Builds a small JDK with `jlink` appropriate for running
+    * Enso in `--jvm` mode.
+    * @param smallJdkDirectory Target directory. If not empty,
+    *                          will be deleted.
+    */
   def buildSmallJDKForRelease(
     smallJdkDirectory: File
   ): Unit = {
@@ -109,7 +106,7 @@ object SmallJDK {
     assert(
       smallJdkDirectory.exists(),
       "Directory of small JDK " + smallJdkDirectory +
-        " was not created."
+      " was not created."
     )
   }
 

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -43,13 +43,13 @@ object SmallJDK {
   )
 
   /** Builds a small JDK appropriate for building native image.
-    * @param smallJdkDirectory Target directory. If non empty, will be deleted.
+    * @param targetJdkDirectory Target directory. If non empty, will be deleted.
     */
   def buildSmallJDKForNativeImage(
-    smallJdkDirectory: File
+    targetJdkDirectory: File
   ): Unit = {
-    if (smallJdkDirectory.exists()) {
-      IO.delete(smallJdkDirectory)
+    if (targetJdkDirectory.exists()) {
+      IO.delete(targetJdkDirectory)
     }
     val niModules     = (NI_BASE_MODULES ++ NI_BUILDER_MODULES).mkString(",")
     val jdkModules    = JDK_MODULES.mkString(",")
@@ -64,28 +64,28 @@ object SmallJDK {
       "--module-path",
       mp,
       "--output",
-      smallJdkDirectory.toString,
+      targetJdkDirectory.toString,
       "--add-modules",
       s"$niModules,$jdkModules,$debugModules,$pythonModules"
     )
     runJlink(jlinkArgs)
-    copyLibDirs(smallJdkDirectory)
+    copyLibDirs(targetJdkDirectory)
     assert(
-      smallJdkDirectory.exists(),
-      "Directory of small JDK " + smallJdkDirectory + " is not present"
+      targetJdkDirectory.exists(),
+      "Directory of small JDK " + targetJdkDirectory + " is not present"
     )
   }
 
   /** Builds a small JDK with `jlink` appropriate for running
     * Enso in `--jvm` mode.
-    * @param smallJdkDirectory Target directory. If not empty,
+    * @param targetJdkDirectory Target directory. If not empty,
     *                          will be deleted.
     */
   def buildSmallJDKForRelease(
-    smallJdkDirectory: File
+    targetJdkDirectory: File
   ): Unit = {
-    if (smallJdkDirectory.exists()) {
-      IO.delete(smallJdkDirectory)
+    if (targetJdkDirectory.exists()) {
+      IO.delete(targetJdkDirectory)
     }
     val mp = modulePath()
       .map(_.toAbsolutePath.toString)
@@ -97,15 +97,15 @@ object SmallJDK {
       "--module-path",
       mp,
       "--output",
-      smallJdkDirectory.toString,
+      targetJdkDirectory.toString,
       "--add-modules",
       modules.mkString(",")
     )
     runJlink(jlinkArgs)
-    copyLibDirs(smallJdkDirectory)
+    copyLibDirs(targetJdkDirectory)
     assert(
-      smallJdkDirectory.exists(),
-      "Directory of small JDK " + smallJdkDirectory +
+      targetJdkDirectory.exists(),
+      "Directory of small JDK " + targetJdkDirectory +
       " was not created."
     )
   }


### PR DESCRIPTION
Closes #13145

### Pull Request Description

Not using the whole huge JDK in release. Instead, build a smaller JDK with the `jlink` command. This should decrease the size of the release by roughly 150 MB.

### Important Notes

- All stdlib tests that use explicit `--jvm` argument receive the directory with small jdk.
  - This means that all the std lib tests that run in JVM mode now run on the small JDK.
- New `sbt` command introduced: `sbt buildSmallJdkForRelease <target-dir>` that builds the small JDK used for release inside the given directory.
- There are now two small JDKs built - one that is used only for building the native image in `engine-runner`, and the new one that is built for the release. Both of them are almost the same, with the exception that the new one does not include modules needed to build native images.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Ensure small JDK is inside packaged inside the release.
- [x] Ensure release size decreased. 
- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
