### PR TITLE
Remove libenso_parser.so duplicated native lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -952,7 +952,11 @@ lazy val `syntax-rust-definition` = project
     Compile / sourceGenerators += generateParserJavaSources,
     Compile / resourceGenerators += generateRustParserLib,
     Compile / javaSource := baseDirectory.value / "generate-java" / "java",
-    Compile / compile / javacOptions ++= Seq("-source", "11", "-target", "11")
+    Compile / compile / javacOptions ++= Seq("-source", "11", "-target", "11"),
+    // The only managedResource is the native library produced by the
+    // `cargo` command. Setting it explictly to empty seq so that this native
+    // library will not get included into the `jar` produced by `packageBin` task.
+    Compile / managedResources := Seq.empty
   )
 
 lazy val `scala-yaml` = (project in file("lib/scala/yaml"))

--- a/build.sbt
+++ b/build.sbt
@@ -972,7 +972,8 @@ lazy val `syntax-rust-definition` = project
         shouldContainAll = true
       )
     },
-    Compile / exportedModule := assembly.value
+    Compile / exportedModule := assembly.value,
+    Compile / exportedModuleBin := assembly.value
   )
 
 lazy val `scala-yaml` = (project in file("lib/scala/yaml"))

--- a/build.sbt
+++ b/build.sbt
@@ -953,10 +953,26 @@ lazy val `syntax-rust-definition` = project
     Compile / resourceGenerators += generateRustParserLib,
     Compile / javaSource := baseDirectory.value / "generate-java" / "java",
     Compile / compile / javacOptions ++= Seq("-source", "11", "-target", "11"),
-    // The only managedResource is the native library produced by the
-    // `cargo` command. Setting it explictly to empty seq so that this native
-    // library will not get included into the `jar` produced by `packageBin` task.
-    Compile / managedResources := Seq.empty
+    // Make sure the native library is not packaged in the exported `jar`.
+    assembly / assemblyMergeStrategy := {
+      case PathList(file)
+          if file.endsWith(".so") || file.endsWith(".dll") || file
+            .endsWith(".dylib") =>
+        MergeStrategy.discard
+      case _ =>
+        MergeStrategy.first
+    },
+    assembly / assemblyExcludedJars := {
+      JPMSUtils.filterModulesFromClasspath(
+        (Compile / fullClasspath).value,
+        slf4jApi,
+        streams.value.log,
+        javaModuleName.value,
+        scalaBinaryVersion.value,
+        shouldContainAll = true
+      )
+    },
+    Compile / exportedModule := assembly.value
   )
 
 lazy val `scala-yaml` = (project in file("lib/scala/yaml"))

--- a/test/Base_Tests/data/native_libs.json
+++ b/test/Base_Tests/data/native_libs.json
@@ -104,9 +104,6 @@
     "META-INF/resources/windows/amd64/lib-graalpython/python-native.dll",
     "META-INF/resources/windows/amd64/lib-graalpython/pythonjni.dll"
   ],
-  "component/syntax-rust-definition.jar": [
-    "libenso_parser.so"
-  ],
   "component/jline-native-3.26.3.jar": [
     "org/jline/nativ/FreeBSD/x86/libjlinenative.so",
     "org/jline/nativ/FreeBSD/x86_64/libjlinenative.so",


### PR DESCRIPTION
Closes #13155

### Pull Request Description

`libenso_parser.so` was duplicated, and one of the duplicates was inside the `syntax-rust-definition.jar`. This PR ensures that the native library will not get packaged inside the `syntax-rust-definition/exportedModule` sbt task.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
