### PR TITLE
Automatically select the only available session

### DIFF
--- a/app/ydoc-server/src/auth.ts
+++ b/app/ydoc-server/src/auth.ts
@@ -1,7 +1,7 @@
 /** @file Utility methods for ydoc server authentication. */
 
 export type ConnectionData = {
-  lsUrl: string | undefined
+  lsUrl: string | null
   doc: string
   user: string
 }

--- a/app/ydoc-server/src/auth.ts
+++ b/app/ydoc-server/src/auth.ts
@@ -1,7 +1,7 @@
 /** @file Utility methods for ydoc server authentication. */
 
 export type ConnectionData = {
-  lsUrl: string
+  lsUrl: string | undefined
   doc: string
   user: string
 }

--- a/app/ydoc-server/src/index.ts
+++ b/app/ydoc-server/src/index.ts
@@ -87,7 +87,8 @@ export async function createGatewayServer(
     const { pathname, query } = parse(request.url, true)
     if (pathname == null) return callback(null, null)
     const doc = docName(pathname)
-    const lsUrl = overrideLanguageServerUrl ?? (query.ls as string)
+    const lsUrl =
+      overrideLanguageServerUrl ?? (typeof query.ls === 'string' ? (query.ls as string) : null)
     const data = doc != null ? { lsUrl, doc, user } : null
     callback(null, data)
   }

--- a/app/ydoc-server/src/index.ts
+++ b/app/ydoc-server/src/index.ts
@@ -87,8 +87,8 @@ export async function createGatewayServer(
     const { pathname, query } = parse(request.url, true)
     if (pathname == null) return callback(null, null)
     const doc = docName(pathname)
-    const lsUrl = overrideLanguageServerUrl ?? query.ls
-    const data = doc != null && typeof lsUrl === 'string' ? { lsUrl, doc, user } : null
+    const lsUrl = overrideLanguageServerUrl ?? (query.ls as string)
+    const data = doc != null ? { lsUrl, doc, user } : null
     callback(null, data)
   }
 }

--- a/app/ydoc-server/src/ydoc.ts
+++ b/app/ydoc-server/src/ydoc.ts
@@ -96,7 +96,7 @@ export class WSSharedDoc {
  */
 export function setupGatewayClient(ws: WS, lsUrl: string | undefined | null, docName: string) {
   let lsSession: LanguageServerSession
-  console.log(`setupGwC: ${lsUrl} and name: ${docName}`)
+  console.log(`setupGatewayClient(${lsUrl ? 'lsUrl: ' + lsUrl : 'no lsUrl'}, docName: ${docName})`)
   if (lsUrl) {
     lsSession = LanguageServerSession.get(lsUrl)
   } else {
@@ -109,7 +109,6 @@ export function setupGatewayClient(ws: WS, lsUrl: string | undefined | null, doc
   }
 
   const wsDoc = lsSession.getYDoc(docName)
-  console.log(`lsSession: ${lsSession} wsDoc: ${wsDoc}`)
   if (wsDoc == null) {
     console.error(`Document '${docName}' not found in language server session '${lsUrl}'.`)
     ws.close()

--- a/app/ydoc-server/src/ydoc.ts
+++ b/app/ydoc-server/src/ydoc.ts
@@ -94,9 +94,22 @@ export class WSSharedDoc {
  * @param docName The name of the document to synchronize. When the document name is `index`, the
  * document is considered to be the root document of the `DistributedProject` data model.
  */
-export function setupGatewayClient(ws: WS, lsUrl: string, docName: string) {
-  const lsSession = LanguageServerSession.get(lsUrl)
+export function setupGatewayClient(ws: WS, lsUrl: string | undefined | null, docName: string) {
+  let lsSession: LanguageServerSession
+  console.log(`setupGwC: ${lsUrl} and name: ${docName}`)
+  if (lsUrl) {
+    lsSession = LanguageServerSession.get(lsUrl)
+  } else {
+    const anySession = LanguageServerSession.sessions.values().next().value
+    if (anySession) {
+      lsSession = anySession
+    } else {
+      throw `There are too many sessions: ${Array.from(LanguageServerSession.sessions.keys())} - specify one via ?ls=... parameter!`
+    }
+  }
+
   const wsDoc = lsSession.getYDoc(docName)
+  console.log(`lsSession: ${lsSession} wsDoc: ${wsDoc}`)
   if (wsDoc == null) {
     console.error(`Document '${docName}' not found in language server session '${lsUrl}'.`)
     ws.close()


### PR DESCRIPTION
### Pull Request Description

- #13159 has introduced `WebSocketClient`
- however (as the current [instructions demonstrate](https://github.com/enso-org/enso/pull/13159#issuecomment-2908870681)) connecting the `WebSocketClient` to development Y.doc server isn't easy
- with the change in this PR, it gets simpler
- [follow the steps](https://github.com/enso-org/enso/pull/13159#issuecomment-2908870681) and just connect to `attachProvider('ws://localhost:5976/project/', 'index', doc) `


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
- [x] Manually tested by [following the documentation](https://github.com/enso-org/enso/pull/13159#issuecomment-2908870681) steps