### PR TITLE
Demo: Support displaying ExpressionUpdates found in AST metadata

### DIFF
--- a/app/gui/env.d.ts
+++ b/app/gui/env.d.ts
@@ -119,7 +119,7 @@ interface FileBrowserApi {
   readonly openFileBrowser: (
     kind: 'default' | 'directory' | 'file' | 'filePath',
     defaultPath?: string,
-    fileTypes?: FileFilter[],
+    fileTypes?: ReadonlyArray<FileFilter>,
   ) => Promise<string[] | undefined>
 }
 

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/browsableTypes.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/browsableTypes.ts
@@ -8,7 +8,7 @@ import { methodPointerEquals, type MethodPointer } from '@/util/methodPointer'
 import { ProjectPath, printAbsoluteProjectPath, type AbsoluteProjectPath } from '@/util/projectPath'
 import { qnJoin, type Identifier, type QualifiedName } from '@/util/qualifiedName'
 import { type ToValue } from '@/util/reactivity'
-import { computed, toValue, type ComputedRef } from 'vue'
+import { computed, toValue, type ComputedRef, type DeepReadonly } from 'vue'
 
 export type BrowserItem = 'file' | 'directory' | 'secret'
 
@@ -96,7 +96,7 @@ export function useBrowserTypeInfo({
   dynamicConfig,
 }: {
   reprType: ToValue<string | undefined>
-  dynamicConfig: ToValue<DynamicConfig | undefined>
+  dynamicConfig: ToValue<DeepReadonly<DynamicConfig> | undefined>
 }): ComputedRef<BrowserTypeInfo> {
   const reprTypeInfo = computed(() => {
     const type = toValue(reprType)

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/cloudBrowser.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/cloudBrowser.ts
@@ -7,7 +7,7 @@ import FileBrowserWidget from '@/components/widgets/FileBrowserWidget.vue'
 import { FileType } from '@/providers/widgetRegistry/configuration'
 import { type Icon } from '@/util/iconMetadata/iconName'
 import { type ToValue } from '@/util/reactivity'
-import { Component, computed, type ComputedRef, h, toValue } from 'vue'
+import { Component, computed, type ComputedRef, type DeepReadonly, h, toValue } from 'vue'
 
 const TYPES = new Map<BrowserItem, { label: string; icon?: Icon }>([
   ['directory', { label: 'Choose directory in cloud…' }],
@@ -27,7 +27,7 @@ export function useCloudBrowser({
   write: ToValue<boolean>
   currentPath: ToValue<string | undefined>
   setPath: (type: 'file' | 'secret', path: string) => void
-  fileTypes: ToValue<FileType[] | undefined>
+  fileTypes: ToValue<DeepReadonly<FileType[]> | undefined>
 }): ComputedRef<CustomDropdownItem[]> {
   function openCloudBrowser({ setActivity, close }: Actions) {
     setActivity(

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/localBrowser.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFileBrowser/localBrowser.ts
@@ -1,18 +1,18 @@
 import { type BrowserItem } from '@/components/GraphEditor/widgets/WidgetFileBrowser/browsableTypes'
 import { type CustomDropdownItem } from '@/components/GraphEditor/widgets/WidgetSelection/tags'
-import { FileType, isExtensions, isFileTypes } from '@/providers/widgetRegistry/configuration'
+import { isExtensions, isFileTypes, type FileType } from '@/providers/widgetRegistry/configuration'
 import { assert } from '@/util/assert'
 import { FileFilter } from '@/util/fileFilter'
 import { type ToValue } from '@/util/reactivity'
-import { computed, toValue, type ComputedRef } from 'vue'
+import { computed, toValue, type ComputedRef, type DeepReadonly } from 'vue'
 
 const LABELS = new Map<BrowserItem, string>([
   ['directory', 'Choose directory…'],
   ['file', 'Choose file…'],
 ])
 
-function fileTypesToFileFilters(fileTypes: FileType[]): FileFilter[] {
-  return fileTypes.flatMap((fileType) => {
+function fileTypesToFileFilters(fileTypes: DeepReadonly<FileType[]>): DeepReadonly<FileFilter>[] {
+  return fileTypes.flatMap((fileType): DeepReadonly<FileFilter>[] => {
     const name = fileType.label
     if (fileType.extensions.length > 0) {
       if (isFileTypes(fileType.extensions)) {
@@ -37,7 +37,7 @@ export function useLocalBrowser({
   write: ToValue<boolean>
   currentPath: ToValue<string | undefined>
   setPath: (type: 'file', path: string) => void
-  fileTypes: ToValue<FileType[] | undefined>
+  fileTypes: ToValue<DeepReadonly<FileType[]> | undefined>
 }): ComputedRef<CustomDropdownItem[]> {
   async function openFileBrowser() {
     if (!window.fileBrowserApi) {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction.vue
@@ -129,15 +129,19 @@ function handleArgUpdate(update: WidgetUpdate): HandledUpdate {
       const deletedArgIdx = argApp.argument.index
       if (deletedArgIdx != null && methodCallInfo.value) {
         // Grab original expression info data straight from DB, so we modify the original state.
-        const notAppliedArguments = graph.db.getExpressionInfo(
-          methodCallInfo.value.methodCallSource,
-        )?.methodCall?.notAppliedArguments
+        const expressionInfo = graph.db.getExpressionInfo(methodCallInfo.value.methodCallSource)
+        const notAppliedArguments = expressionInfo?.methodCall?.notAppliedArguments
         if (notAppliedArguments != null) {
           const insertAt = partitionPoint(notAppliedArguments, (i) => i < deletedArgIdx)
           if (notAppliedArguments[insertAt] != deletedArgIdx) {
             // Insert the deleted argument back to the method info. This directly modifies observable
             // data in `ComputedValueRegistry`. That's on purpose.
-            notAppliedArguments.splice(insertAt, 0, deletedArgIdx)
+            const newNotAppliedArguments = [...notAppliedArguments]
+            newNotAppliedArguments.splice(insertAt, 0, deletedArgIdx)
+            expressionInfo!.methodCall = {
+              ...expressionInfo!.methodCall!,
+              notAppliedArguments: newNotAppliedArguments,
+            }
           }
         }
       }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -22,8 +22,18 @@ import { targetIsOutside } from '@/util/autoBlur'
 import { ArgumentInfoKey } from '@/util/callTree'
 import { arrayEquals } from '@/util/data/array'
 import { type ToValue } from '@/util/reactivity'
-import type { RendererNode, VNode } from 'vue'
-import { computed, proxyRefs, ref, shallowRef, toValue, useTemplateRef, watch } from 'vue'
+import {
+  computed,
+  proxyRefs,
+  ref,
+  shallowRef,
+  toValue,
+  useTemplateRef,
+  watch,
+  type DeepReadonly,
+  type RendererNode,
+  type VNode,
+} from 'vue'
 import SelectionSubmenu from './WidgetSelection/SelectionSubmenu.vue'
 import { activityDropdownStyles } from './WidgetSelection/styles'
 import {
@@ -90,7 +100,7 @@ const dynamicTags = computed<(ExpressionTag | NestedChoiceTag)[]>(() => {
   const config = props.input.dynamicConfig
   if (config?.kind !== 'Single_Choice' && config?.kind !== 'Multiple_Choice') return []
 
-  const choiceToTag = (choice: Choice): ExpressionTag | NestedChoiceTag => {
+  const choiceToTag = (choice: DeepReadonly<Choice>): ExpressionTag | NestedChoiceTag => {
     if (choice.value instanceof Array) {
       return new NestedChoiceTag(choice.label ?? '…', choice.value.map(choiceToTag))
     } else {
@@ -351,7 +361,9 @@ const arrowLocation = ref()
 <script lang="ts">
 const CustomDropdownItemsKey: unique symbol = Symbol.for('WidgetInput:CustomDropdownItems')
 
-function isHandledByCheckboxWidget(parameter: SuggestionEntryArgument | undefined): boolean {
+function isHandledByCheckboxWidget(
+  parameter: DeepReadonly<SuggestionEntryArgument> | undefined,
+): boolean {
   return (
     parameter?.tagValues != null &&
     arrayEquals(Array.from(parameter.tagValues).sort(), ['False', 'True'])

--- a/app/gui/src/project-view/providers/widgetRegistry.ts
+++ b/app/gui/src/project-view/providers/widgetRegistry.ts
@@ -7,7 +7,7 @@ import type { Typename } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
 import { Result } from '@/util/data/result'
 import type { ViteHotContext } from 'vite/types/hot.js'
-import { computed, shallowReactive, type Component, type PropType } from 'vue'
+import { computed, shallowReactive, type Component, type DeepReadonly, type PropType } from 'vue'
 import type { WidgetEditHandlerParent } from './widgetRegistry/editHandler'
 
 export type WidgetComponent<T extends WidgetInput> = Component<WidgetProps<T>>
@@ -136,7 +136,7 @@ export interface WidgetInput {
   /** An expected type which widget should set. */
   expectedType?: Typename | undefined
   /** Configuration provided by engine. */
-  dynamicConfig?: WidgetConfiguration | undefined
+  dynamicConfig?: DeepReadonly<WidgetConfiguration> | undefined
   /** Force the widget to be a connectible port. */
   forcePort?: boolean
   editHandler?: WidgetEditHandlerParent | undefined

--- a/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
+++ b/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
@@ -1,3 +1,4 @@
+import { type DeepReadonly } from 'vue'
 import { z } from 'zod'
 
 /**
@@ -75,17 +76,21 @@ export type FileType = {
 }
 
 /** Whether FileType[] contains nested FileType objects. */
-export function isFileTypes(array: (FileType | string)[]): array is FileType[] {
+export function isFileTypes(
+  array: DeepReadonly<(FileType | string)[]>,
+): array is DeepReadonly<FileType[]> {
   return array.length == 0 || typeof array[0]! === 'object'
 }
 
 /** Whether FileType[] contains only string values. */
-export function isExtensions(array: (FileType | string)[]): array is string[] {
+export function isExtensions(
+  array: DeepReadonly<(FileType | string)[]>,
+): array is ReadonlyArray<string> {
   return array.length == 0 || typeof array[0]! === 'string'
 }
 
 /** Whether FileType[] contains a single '*' value, indicating that all files are allowed. */
-export function isGlobAll(array: (FileType | string)[]): boolean {
+export function isGlobAll(array: DeepReadonly<(FileType | string)[]>): boolean {
   return array.length === 1 && array[0]! === '*'
 }
 
@@ -252,9 +257,9 @@ export type ArgsWidgetConfiguration = z.infer<typeof argsWidgetConfigurationSche
  * applying those to an inherited config received from parent widget.
  */
 export function functionCallConfiguration(
-  parameters: ArgumentWidgetConfiguration[],
-  inherited?: FunctionCall,
-): FunctionCall {
+  parameters: DeepReadonly<ArgumentWidgetConfiguration[]>,
+  inherited?: DeepReadonly<FunctionCall>,
+): DeepReadonly<FunctionCall> {
   const parametersMap = new Map(inherited?.parameters)
   for (const [name, param] of parameters) {
     parametersMap.set(name, parametersMap.get(name) ?? param)
@@ -266,7 +271,7 @@ export function functionCallConfiguration(
 }
 
 /** Flatten possibly nested choice. */
-export function flattenChoice(choice: Choice): FlattenedChoice[] {
+export function flattenChoice(choice: DeepReadonly<Choice>): DeepReadonly<FlattenedChoice>[] {
   if (typeof choice.value === 'string') {
     return [choice as FlattenedChoice]
   }
@@ -274,7 +279,9 @@ export function flattenChoice(choice: Choice): FlattenedChoice[] {
 }
 
 /** A configuration for the inner widget of a single-choice selection widget. */
-export function singleChoiceConfiguration(config: SingleChoice): OneOfFunctionCalls {
+export function singleChoiceConfiguration(
+  config: DeepReadonly<SingleChoice>,
+): DeepReadonly<OneOfFunctionCalls> {
   const possibleChoices = config.values.flatMap(flattenChoice)
   return {
     kind: 'OneOfFunctionCalls',
@@ -285,7 +292,9 @@ export function singleChoiceConfiguration(config: SingleChoice): OneOfFunctionCa
 }
 
 /** A configuration for the inner widget of a multiple-choice selection widget. */
-export function multipleChoiceConfiguration(config: MultipleChoice): SomeOfFunctionCalls {
+export function multipleChoiceConfiguration(
+  config: DeepReadonly<MultipleChoice>,
+): DeepReadonly<SomeOfFunctionCalls> {
   const possibleChoices = config.values.flatMap(flattenChoice)
   return {
     kind: 'SomeOfFunctionCalls',

--- a/app/gui/src/project-view/stores/graph/graphDatabase.ts
+++ b/app/gui/src/project-view/stores/graph/graphDatabase.ts
@@ -46,7 +46,7 @@ import type { ExternalId, VisualizationMetadata } from 'ydoc-shared/yjsModel'
 import { isUuid, visMetadataEquals } from 'ydoc-shared/yjsModel'
 
 export interface MethodCallInfo {
-  methodCall: MethodCall
+  methodCall: DeepReadonly<MethodCall>
   methodCallSource: Ast.AstId
   suggestion: CallableSuggestionEntry
 }
@@ -209,7 +209,7 @@ export class GraphDb {
   }
 
   /** TODO: Add docs */
-  getMethodCall(id: AstId): MethodCall | undefined {
+  getMethodCall(id: AstId): DeepReadonly<MethodCall> | undefined {
     const info = this.getExpressionInfo(id)
     if (info == null) return
     if (info.methodCall) return info.methodCall
@@ -448,6 +448,10 @@ export class GraphDb {
     if (changes.has('colorOverride')) {
       node.colorOverride = changes.get('colorOverride')
     }
+    if (changes.has('expressionUpdate')) {
+      const update = changes.get('expressionUpdate')
+      if (update) this.valuesRegistry.processUpdates([update])
+    }
   }
 
   /** TODO: Add docs */
@@ -498,7 +502,7 @@ export class GraphDb {
         value.methodCall != null &&
         methodPointerEquals(value.methodCall.methodPointer, oldMethodPointer)
       ) {
-        value.methodCall.methodPointer = newMethodPointer
+        value.methodCall = { ...value.methodCall, methodPointer: newMethodPointer }
       }
     }
 

--- a/app/gui/src/project-view/stores/graph/index.ts
+++ b/app/gui/src/project-view/stores/graph/index.ts
@@ -42,6 +42,7 @@ import {
   toRef,
   watch,
   watchEffect,
+  type DeepReadonly,
   type Ref,
   type ShallowRef,
 } from 'vue'
@@ -51,6 +52,8 @@ import { reachable } from 'ydoc-shared/util/data/graph'
 import type { LocalUserActionOrigin, Origin, VisualizationMetadata } from 'ydoc-shared/yjsModel'
 import { defaultLocalOrigin, visMetadataEquals } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
+
+const POPULATE_EU_METADATA_FROM_LS = false
 
 const FALLBACK_BINDING_PREFIX = 'node'
 
@@ -146,6 +149,18 @@ export const [provideGraphStore, useGraphStore] = createContextStore(
         })
       },
     )
+
+    if (POPULATE_EU_METADATA_FROM_LS) {
+      proj.executionContext.on('expressionUpdates', (updates: DeepReadonly<ExpressionUpdate[]>) => {
+        if (!syncModule.value) return
+        for (const update of updates) {
+          const astId = db.idFromExternal(update.expressionId)
+          const ast = syncModule.value.tryGet(astId)
+          if (!ast) continue
+          ;(ast as any).fields.get('metadata').set('expressionUpdate', update)
+        }
+      })
+    }
 
     const immediateMethodAst = computed<Result<Ast.FunctionDef>>(() =>
       syncModule.value ? getExecutedMethodAst(syncModule.value) : Err('AST not yet initialized'),

--- a/app/gui/src/project-view/stores/project/computedValueRegistry.ts
+++ b/app/gui/src/project-view/stores/project/computedValueRegistry.ts
@@ -7,7 +7,7 @@ import { arrayEquals } from '@/util/equals'
 import { parseMethodPointer, type MethodCall } from '@/util/methodPointer'
 import { type ProjectPath } from '@/util/projectPath'
 import { clamp } from 'enso-common/src/utilities/data/math'
-import { markRaw } from 'vue'
+import { markRaw, type DeepReadonly } from 'vue'
 import type {
   ExpressionId,
   ExpressionUpdate,
@@ -18,12 +18,12 @@ import type {
 import { isSome } from 'ydoc-shared/util/data/opt'
 
 export interface ExpressionInfo {
-  typename: ProjectPath | undefined
-  hiddenTypes: ProjectPath[]
+  typename: DeepReadonly<ProjectPath> | undefined
+  hiddenTypes: DeepReadonly<ProjectPath[]>
   rawTypename: string | undefined
-  methodCall: MethodCall | undefined
-  payload: ExpressionUpdatePayload
-  profilingInfo: ProfilingInfo[]
+  methodCall: DeepReadonly<MethodCall> | undefined
+  payload: DeepReadonly<ExpressionUpdatePayload>
+  profilingInfo: DeepReadonly<ProfilingInfo[]>
   /**
    * This value is incremented when a new evaluation is reported, so that when interpreting the
    * `progress` in a `Pending` payload, we can distinguish an incremental update from a separate
@@ -36,11 +36,15 @@ export interface ExpressionInfo {
  * If the given expression is currently evaluating, returns the progress as a percentage. Otherwise,
  * returns `undefined`.
  */
-export function evaluationProgress(expressionInfo: ExpressionInfo | undefined): number | undefined {
+export function evaluationProgress(
+  expressionInfo: DeepReadonly<ExpressionInfo> | undefined,
+): number | undefined {
   return payloadProgress(expressionInfo?.payload)
 }
 
-function payloadProgress(payload: ExpressionUpdatePayload | undefined): number | undefined {
+function payloadProgress(
+  payload: DeepReadonly<ExpressionUpdatePayload> | undefined,
+): number | undefined {
   if (!payload) return
   if (payload.type !== 'Pending') return
   const rawProgress = payload.progress
@@ -55,8 +59,6 @@ class ComputedValueDb extends ReactiveDb<ExpressionId, ExpressionInfo> {
 /** This class holds the computed values that have been received from the language server. */
 export class ComputedValueRegistry {
   public db = new ComputedValueDb()
-  private _updateHandler = this.processUpdates.bind(this)
-  private executionContext: ExecutionContext | undefined
 
   private constructor(private readonly projectNames: ProjectNameStore) {
     markRaw(this)
@@ -64,13 +66,10 @@ export class ComputedValueRegistry {
 
   /** TODO: Add docs */
   static WithExecutionContext(
-    executionContext: ExecutionContext,
+    _executionContext: ExecutionContext,
     projectNames: ProjectNameStore,
   ): ComputedValueRegistry {
-    const self = new ComputedValueRegistry(projectNames)
-    self.executionContext = executionContext
-    executionContext.on('expressionUpdates', self._updateHandler)
-    return self
+    return new ComputedValueRegistry(projectNames)
   }
 
   /** TODO: Add docs */
@@ -79,7 +78,7 @@ export class ComputedValueRegistry {
   }
 
   /** TODO: Add docs */
-  processUpdates(updates: ExpressionUpdate[]) {
+  processUpdates(updates: DeepReadonly<ExpressionUpdate[]>) {
     for (const update of updates) {
       const info = this.db.get(update.expressionId)
       if (info) updateInfo(info, update, this.projectNames)
@@ -93,16 +92,14 @@ export class ComputedValueRegistry {
   }
 
   /** TODO: Add docs */
-  dispose() {
-    this.executionContext?.off('expressionUpdates', this._updateHandler)
-  }
+  dispose() {}
 }
 
 function updateInfo(
   info: ExpressionInfo,
-  update: ExpressionUpdate,
+  update: DeepReadonly<ExpressionUpdate>,
   projectNames: ProjectNameStore,
-) {
+): void {
   const newInfo = combineInfo(info, update, projectNames)
   if (newInfo.typename !== info.typename) info.typename = newInfo.typename
   if (!arrayEquals(newInfo.hiddenTypes, info.hiddenTypes, (a, b) => a.equals(b)))
@@ -130,20 +127,20 @@ function updateInfo(
  * The qualified names are validated and stored as {@link ProjectPath}s.
  */
 export function translateMethodCall(
-  ls: LSMethodCall,
+  ls: DeepReadonly<LSMethodCall>,
   projectNames: ProjectNameStore,
 ): Result<MethodCall> {
   const methodPointer = parseMethodPointer(ls.methodPointer, projectNames)
   if (!methodPointer.ok) return methodPointer
   return Ok({
     methodPointer: methodPointer.value,
-    notAppliedArguments: ls.notAppliedArguments,
+    notAppliedArguments: [...ls.notAppliedArguments],
   })
 }
 
 function combineInfo(
-  info: ExpressionInfo | undefined,
-  update: ExpressionUpdate,
+  info: DeepReadonly<ExpressionInfo> | undefined,
+  update: DeepReadonly<ExpressionUpdate>,
   projectNames: ProjectNameStore,
 ): ExpressionInfo {
   const isPending = update.payload.type === 'Pending'
@@ -191,8 +188,8 @@ function combineInfo(
 }
 
 function updateProgressIsNewEvaluation(
-  payload0: ExpressionUpdatePayload,
-  payload1: ExpressionUpdatePayload,
+  payload0: DeepReadonly<ExpressionUpdatePayload>,
+  payload1: DeepReadonly<ExpressionUpdatePayload>,
 ) {
   const progress1 = payloadProgress(payload1)
   // Current evaluation completed.

--- a/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/entry.ts
@@ -10,6 +10,7 @@ import {
   type IdentifierOrOperatorIdentifier,
   type QualifiedName,
 } from '@/util/qualifiedName'
+import type { DeepReadonly } from 'vue'
 import {
   type SuggestionEntryArgument,
   type SuggestionEntryScope,
@@ -157,7 +158,9 @@ export function entryIsStatic(
 }
 
 /** Get the MethodPointer pointing to definition represented by the entry. */
-export function entryMethodPointer(entry: SuggestionEntry | undefined): MethodPointer | undefined {
+export function entryMethodPointer(
+  entry: DeepReadonly<SuggestionEntry> | undefined,
+): MethodPointer | undefined {
   if (entry == null || entry.kind !== SuggestionKind.Method) return
   return {
     module: entry.definedIn,

--- a/app/gui/src/project-view/util/callTree.ts
+++ b/app/gui/src/project-view/util/callTree.ts
@@ -12,6 +12,7 @@ import {
 import { Ast } from '@/util/ast'
 import type { AstId } from '@/util/ast/abstract'
 import { findLastIndex, tryGetIndex } from '@/util/data/array'
+import type { DeepReadonly } from 'vue'
 import type { ExternalId } from 'ydoc-shared/yjsModel'
 import { assert } from './assert'
 
@@ -24,10 +25,10 @@ class ArgumentFactory {
   constructor(
     private callId: string,
     private kind: ApplicationKind,
-    private widgetCfg: widgetCfg.FunctionCall | undefined,
+    private widgetCfg: DeepReadonly<widgetCfg.FunctionCall> | undefined,
   ) {}
 
-  placeholder(index: number, info: SuggestionEntryArgument, insertAsNamed: boolean) {
+  placeholder(index: number, info: DeepReadonly<SuggestionEntryArgument>, insertAsNamed: boolean) {
     return new ArgumentPlaceholder(
       this.callId,
       this.kind,
@@ -41,7 +42,7 @@ class ArgumentFactory {
   argument(
     ast: Ast.Expression,
     index: number | undefined,
-    info: SuggestionEntryArgument | undefined,
+    info: DeepReadonly<SuggestionEntryArgument> | undefined,
   ) {
     return new ArgumentAst(
       this.callId,
@@ -64,9 +65,9 @@ abstract class Argument {
   protected constructor(
     public callId: string,
     public kind: ApplicationKind,
-    public dynamicConfig: DynamicConfig | undefined,
+    public dynamicConfig: DeepReadonly<DynamicConfig> | undefined,
     public index: number | undefined,
-    public argInfo: SuggestionEntryArgument | undefined,
+    public argInfo: DeepReadonly<SuggestionEntryArgument> | undefined,
   ) {}
 
   abstract get portId(): PortId
@@ -102,9 +103,9 @@ export class ArgumentPlaceholder extends Argument {
   constructor(
     callId: string,
     kind: ApplicationKind,
-    dynamicConfig: DynamicConfig | undefined,
+    dynamicConfig: DeepReadonly<DynamicConfig> | undefined,
     index: number,
-    argInfo: SuggestionEntryArgument,
+    argInfo: DeepReadonly<SuggestionEntryArgument>,
     public insertAsNamed: boolean,
   ) {
     super(callId, kind, dynamicConfig, index, argInfo)
@@ -136,9 +137,9 @@ export class ArgumentAst extends Argument {
   constructor(
     callId: string,
     kind: ApplicationKind,
-    dynamicConfig: DynamicConfig | undefined,
+    dynamicConfig: DeepReadonly<DynamicConfig> | undefined,
     index: number | undefined,
-    argInfo: SuggestionEntryArgument | undefined,
+    argInfo: DeepReadonly<SuggestionEntryArgument> | undefined,
     public ast: Ast.Expression,
   ) {
     super(callId, kind, dynamicConfig, index, argInfo)
@@ -225,11 +226,14 @@ export class ArgumentApplication {
     public target: ArgumentApplication | Ast.Expression | ArgumentPlaceholder | ArgumentAst,
     public infixOperator: Ast.Token | undefined,
     public argument: ArgumentAst | ArgumentPlaceholder,
-    public calledFunction: CallableSuggestionEntry | undefined,
+    public calledFunction: DeepReadonly<CallableSuggestionEntry> | undefined,
     public isInnermost: boolean,
   ) {}
 
-  private static FromInterpretedInfix(interpreted: InterpretedInfix, callInfo: CallInfo) {
+  private static FromInterpretedInfix(
+    interpreted: InterpretedInfix,
+    callInfo: DeepReadonly<CallInfo>,
+  ) {
     const { suggestion, widgetCfg } = callInfo
 
     const makeArg = new ArgumentFactory(interpreted.appTree.id, ApplicationKind.Infix, widgetCfg)
@@ -250,7 +254,10 @@ export class ArgumentApplication {
     )
   }
 
-  private static FromInterpretedPrefix(interpreted: InterpretedPrefix, callInfo: CallInfo) {
+  private static FromInterpretedPrefix(
+    interpreted: InterpretedPrefix,
+    callInfo: DeepReadonly<CallInfo>,
+  ) {
     const { notAppliedArguments, suggestion, widgetCfg, subjectAsSelf } = callInfo
 
     const knownArguments = suggestion?.arguments
@@ -406,7 +413,7 @@ export class ArgumentApplication {
   /** TODO: Add docs */
   static FromInterpretedWithInfo(
     interpreted: InterpretedCall,
-    callInfo: CallInfo = {},
+    callInfo: DeepReadonly<CallInfo> = {},
   ): ArgumentApplication | Ast.Expression {
     if (interpreted.kind === 'infix') {
       return ArgumentApplication.FromInterpretedInfix(interpreted, callInfo)
@@ -561,7 +568,7 @@ declare module '@/providers/widgetRegistry' {
     [ArgumentApplicationKey]?: ArgumentApplication
     [ArgumentInfoKey]?: {
       appKind: ApplicationKind
-      info: SuggestionEntryArgument | undefined
+      info: DeepReadonly<SuggestionEntryArgument> | undefined
       argId: string | undefined
     }
   }

--- a/app/gui/src/project-view/util/data/array.ts
+++ b/app/gui/src/project-view/util/data/array.ts
@@ -31,7 +31,7 @@ export function findIndexOpt<T>(
  * @see The original docs for the equivalent function in Rust: {@link https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point}
  */
 export function partitionPoint<T>(
-  array: T[],
+  array: ReadonlyArray<T>,
   pred: (elem: T) => boolean,
   start = 0,
   end = array.length,

--- a/app/gui/src/project-view/util/equals.ts
+++ b/app/gui/src/project-view/util/equals.ts
@@ -10,12 +10,12 @@ export function defaultEquality(a: unknown, b: unknown): boolean {
  * @param eq equality function for elements. When not specified, `===` operator is used.
  * @returns true if arrays are equal.
  */
-export function arrayEquals<T>(
-  a: Array<T>,
-  b: Array<T>,
-  eq: (a: T, b: T) => boolean = defaultEquality,
+export function arrayEquals<A, B = A>(
+  a: ReadonlyArray<A>,
+  b: ReadonlyArray<B>,
+  eq: (a: A, b: B) => boolean = defaultEquality,
 ) {
-  if (a === b) return true
+  if (a === (b as unknown)) return true
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; ++i) {
     const aVal = a[i]

--- a/app/gui/src/project-view/util/fileFilter.ts
+++ b/app/gui/src/project-view/util/fileFilter.ts
@@ -1,5 +1,5 @@
 /** Describes allowed file types in the file browser. */
 export interface FileFilter {
-  name: string
-  extensions: 'all' | string[]
+  readonly name: string
+  readonly extensions: 'all' | ReadonlyArray<string>
 }

--- a/app/ydoc-shared/src/ast/mutableModule.ts
+++ b/app/ydoc-shared/src/ast/mutableModule.ts
@@ -379,6 +379,7 @@ export class MutableModule implements Module {
     const metadataFields = setAll(metadata, {
       externalId: newExternalId(),
       widget: new Y.Map<unknown>(),
+      expressionUpdate: undefined,
     })
     const fields = setAll(map_, {
       id,
@@ -495,8 +496,9 @@ class UpdateBuilder {
     for (const entry of changes) {
       const [key, value] = entry
       if (key === 'metadata') {
-        assert(value instanceof Y.Map)
-        metadataChanges = new Map<string, unknown>(value.entries())
+        if (value instanceof Y.Map) {
+          metadataChanges = new Map<string, unknown>(value.entries())
+        }
       } else {
         fieldsChanged = true
       }

--- a/app/ydoc-shared/src/ast/tree.ts
+++ b/app/ydoc-shared/src/ast/tree.ts
@@ -1,6 +1,7 @@
 // Declaration-merging is used to implement mixin types in this file.
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 import * as Y from 'yjs'
+import type { ExpressionUpdate } from '../languageServerTypes'
 import { assert, assertDefined, assertEqual, bail } from '../util/assert'
 import type { Result } from '../util/data/result'
 import { Err, Ok } from '../util/data/result'
@@ -111,6 +112,7 @@ export function parentId(ast: Ast): AstId | undefined {
 export interface MetadataFields {
   externalId: ExternalId
   widget: Y.Map<unknown>
+  expressionUpdate: ExpressionUpdate | undefined
 }
 export interface NodeMetadataFields {
   position?: { x: number; y: number } | undefined


### PR DESCRIPTION
### Pull Request Description

Demo to test using `ExpressionUpdate` info provided by the backend through AST metadata (#11159).

This is not intended to be a production implementation of the functionality; that would require a deeper refactor--we can do away with the `ComputedValueRegistry` and access the EU info directly from the metadata.

The approach here is: Instead of a EU data flow like:
`ExecutionContext -> ComputedValueRegistry -> data users`
This PR switches to:
`EU metadata -> ComputedValueRegistry -> data users`
So that when the backend populates the data in `ast.fields.get('metadata').get('expressionUpdate')`, the GUI will render it.

To check that this EU data flow is working, this PR also includes a bridge `ExecutionContext -> EU metadata`, which can be turned on to enable compatibility with the *current* backend (see the `POPULATE_EU_METADATA_FROM_LS` hardcoded flag).

CC @JaroslavTulach

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
