### PR TITLE
Moving Numeric Comparators to new framework.

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -958,7 +958,8 @@ apply_unary_map column:Column new_name:Text function expected_result_type:Value_
         In_Memory_Column.from_java_column map_column
 
 private _java_other other =
-    if other.is_a Column then (other:In_Memory_Column).java_column else other
+    if other.is_a Column then (other:In_Memory_Column).java_column else
+        enso_to_java other
 
 private _call_comparator left other new_name ~comparator fallback =
     case (Comparators.isSupported (left:In_Memory_Column).java_column) of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -82,7 +82,7 @@ type In_Memory_Column_Implementation
             if (a.is_a Float) || (b.is_a Float) then
                 problem_builder.reportFloatingPointEquality -1
             a == b
-        _call_comparator this_column other new_name (Comparators.eq (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.eq (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     equals_ignore_case this_column (other : Column | Any) locale:Locale=Locale.default -> Column =
         ## TODO currently this always runs the fallback which is slow due to the
@@ -103,35 +103,35 @@ type In_Memory_Column_Implementation
             if (a.is_a Float) || (b.is_a Float) then
                 problem_builder.reportFloatingPointEquality -1
             a != b
-        _call_comparator this_column other new_name (Comparators.notEq (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.notEq (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     greater_than_eq this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a >= b
-        _call_comparator this_column other new_name (Comparators.greaterThanEq (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.greaterThanEq (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     less_than_eq this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a <= b
-        _call_comparator this_column other new_name (Comparators.lessThanEq (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.lessThanEq (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     greater_than this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a > b
-        _call_comparator this_column other new_name (Comparators.greaterThan (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.greaterThan (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     less_than this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a < b
-        _call_comparator this_column other new_name (Comparators.lessThan (this_column:In_Memory_Column).java_column other) fallback
+        _call_comparator this_column other new_name (Comparators.lessThan (this_column:In_Memory_Column).java_column (_java_other other)) fallback
 
     between this_column (lower : Column | Any) (upper : Column | Any) -> Column = Value_Type.expect_comparable this_column lower <| Value_Type.expect_comparable this_column upper <|
         new_name = naming_helper.concat <|
@@ -957,6 +957,9 @@ apply_unary_map column:Column new_name:Text function expected_result_type:Value_
         map_column = UnaryOperation.mapFunction (column:In_Memory_Column).java_column function nothing_unchanged storage_type new_name java_problem_aggregator
         In_Memory_Column.from_java_column map_column
 
+private _java_other other =
+    if other.is_a Column then (other:In_Memory_Column).java_column else other
+
 private _call_comparator left other new_name ~comparator fallback =
     case (Comparators.isSupported (left:In_Memory_Column).java_column) of
         True -> _call_binary_operator left other new_name comparator
@@ -967,7 +970,7 @@ private _call_comparator left other new_name ~comparator fallback =
 
 private _call_binary_operator left:In_Memory_Column other new_name ~operation =
     Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->
-        java_column = operation.apply left.java_column (if other.is_a Column then (other:In_Memory_Column).java_column else other) new_name java_problem_aggregator
+        java_column = operation.apply left.java_column (_java_other other) new_name java_problem_aggregator
         In_Memory_Column.from_java_column java_column
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -960,7 +960,10 @@ apply_unary_map column:Column new_name:Text function expected_result_type:Value_
 private _call_comparator left other new_name ~comparator fallback =
     case (Comparators.isSupported (left:In_Memory_Column).java_column) of
         True -> _call_binary_operator left other new_name comparator
-        False -> run_binary_op left fallback other new_name expected_result_type=Value_Type.Boolean
+        False ->
+            Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->
+                fallback_fn = fallback java_problem_aggregator
+                run_binary_op left fallback_fn other new_name skip_nulls=True expected_result_type=Value_Type.Boolean
 
 private _call_binary_operator left:In_Memory_Column other new_name ~operation =
     Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -82,8 +82,7 @@ type In_Memory_Column_Implementation
             if (a.is_a Float) || (b.is_a Float) then
                 problem_builder.reportFloatingPointEquality -1
             a == b
-        _call_comparator this_column other new_name (Comparators.eq (this_column:In_Memory_Column).java_column) <|
-            run_vectorized_binary_op_with_fallback_problem_handling this_column Java_Storage.Maps.EQ other fallback_fn=fallback new_name=new_name expected_result_type=Value_Type.Boolean skip_nulls=True
+        _call_comparator this_column other new_name (Comparators.eq (this_column:In_Memory_Column).java_column other) fallback
 
     equals_ignore_case this_column (other : Column | Any) locale:Locale=Locale.default -> Column =
         ## TODO currently this always runs the fallback which is slow due to the
@@ -100,28 +99,39 @@ type In_Memory_Column_Implementation
 
     not_equals this_column (other : Column | Any) -> Column =
         new_name = naming_helper.binary_operation_name "!=" this_column other
-        _call_comparator this_column other new_name (Comparators.notEq (this_column:In_Memory_Column).java_column) <|
-            (this_column == other).not . rename new_name
+        fallback problem_builder a b =
+            if (a.is_a Float) || (b.is_a Float) then
+                problem_builder.reportFloatingPointEquality -1
+            a != b
+        _call_comparator this_column other new_name (Comparators.notEq (this_column:In_Memory_Column).java_column other) fallback
 
     greater_than_eq this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">=" this_column other
-        _call_comparator this_column other new_name (Comparators.greaterThanEq (this_column:In_Memory_Column).java_column) <|
-            run_vectorized_binary_op this_column Java_Storage.Maps.GTE new_name=new_name fallback_fn=(>=) other expected_result_type=Value_Type.Boolean
+        fallback problem_builder a b =
+            _ = problem_builder
+            a >= b
+        _call_comparator this_column other new_name (Comparators.greaterThanEq (this_column:In_Memory_Column).java_column other) fallback
 
     less_than_eq this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<=" this_column other
-        _call_comparator this_column other new_name (Comparators.lessThanEq (this_column:In_Memory_Column).java_column) <|
-            run_vectorized_binary_op this_column Java_Storage.Maps.LTE new_name=new_name fallback_fn=(<=) other expected_result_type=Value_Type.Boolean
+        fallback problem_builder a b =
+            _ = problem_builder
+            a <= b
+        _call_comparator this_column other new_name (Comparators.lessThanEq (this_column:In_Memory_Column).java_column other) fallback
 
     greater_than this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">" this_column other
-        _call_comparator this_column other new_name (Comparators.greaterThan (this_column:In_Memory_Column).java_column) <|
-            run_vectorized_binary_op this_column Java_Storage.Maps.GT new_name=new_name fallback_fn=(>) other expected_result_type=Value_Type.Boolean
+        fallback problem_builder a b =
+            _ = problem_builder
+            a > b
+        _call_comparator this_column other new_name (Comparators.greaterThan (this_column:In_Memory_Column).java_column other) fallback
 
     less_than this_column (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<" this_column other
-        _call_comparator this_column other new_name (Comparators.lessThan (this_column:In_Memory_Column).java_column) <|
-            run_vectorized_binary_op this_column Java_Storage.Maps.LT new_name=new_name fallback_fn=(<) other expected_result_type=Value_Type.Boolean
+        fallback problem_builder a b =
+            _ = problem_builder
+            a < b
+        _call_comparator this_column other new_name (Comparators.lessThan (this_column:In_Memory_Column).java_column other) fallback
 
     between this_column (lower : Column | Any) (upper : Column | Any) -> Column = Value_Type.expect_comparable this_column lower <| Value_Type.expect_comparable this_column upper <|
         new_name = naming_helper.concat <|
@@ -947,11 +957,10 @@ apply_unary_map column:Column new_name:Text function expected_result_type:Value_
         map_column = UnaryOperation.mapFunction (column:In_Memory_Column).java_column function nothing_unchanged storage_type new_name java_problem_aggregator
         In_Memory_Column.from_java_column map_column
 
-## PRIVATE
-   Temporary function to determine if to use the Comparators statics or embedded operations.
-private _call_comparator left:In_Memory_Column other new_name ~comparator ~enso_action =
-    if (Comparators.isSupported left.java_column) == False then enso_action else
-        _call_binary_operator left other new_name comparator
+private _call_comparator left:In_Memory_Column other new_name ~comparator fallback =
+    case (Comparators.isSupported left.java_column) of
+        True -> _call_binary_operator left other new_name comparator
+        False -> run_binary_op left fallback other new_name expected_result_type=Value_Type.Boolean
 
 private _call_binary_operator left:In_Memory_Column other new_name ~operation =
     Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -957,8 +957,8 @@ apply_unary_map column:Column new_name:Text function expected_result_type:Value_
         map_column = UnaryOperation.mapFunction (column:In_Memory_Column).java_column function nothing_unchanged storage_type new_name java_problem_aggregator
         In_Memory_Column.from_java_column map_column
 
-private _call_comparator left:In_Memory_Column other new_name ~comparator fallback =
-    case (Comparators.isSupported left.java_column) of
+private _call_comparator left other new_name ~comparator fallback =
+    case (Comparators.isSupported (left:In_Memory_Column).java_column) of
         True -> _call_binary_operator left other new_name comparator
         False -> run_binary_op left fallback other new_name expected_result_type=Value_Type.Boolean
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
@@ -154,8 +154,14 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected Double doSingle(Double left, Double right, long index) {
-      throw new IllegalStateException("This method should not be called directly.");
+    protected Double doSingle(Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
+      if (left == null) {
+        return right;
+      } else if (right == null) {
+        return left;
+      } else {
+        return operation.doDouble(left, right, index);
+      }
     }
   }
 
@@ -166,7 +172,7 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected BigDecimal doSingle(BigDecimal left, BigDecimal right, long index) {
+    protected BigDecimal doSingle(BigDecimal left, BigDecimal right, long index, MapOperationProblemAggregator problemAggregator) {
       return left == null
           ? right
           : (right == null ? left : operation.doBigDecimal(left, right, index));
@@ -180,7 +186,7 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected BigInteger doSingle(BigInteger left, BigInteger right, long index) {
+    protected BigInteger doSingle(BigInteger left, BigInteger right, long index, MapOperationProblemAggregator problemAggregator) {
       return left == null
           ? right
           : (right == null ? left : operation.doBigInteger(left, right, index));
@@ -229,8 +235,14 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected Long doSingle(Long left, Long right, long index) {
-      throw new IllegalStateException("This method should not be called directly.");
+    protected Long doSingle(Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
+      if (left == null) {
+        return right;
+      } else if (right == null) {
+        return left;
+      } else {
+        return operation.doLong(left, right, index);
+      }
     }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
@@ -213,7 +213,7 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
       return StorageIterators.zipOverLongStorages(
           (ColumnLongStorage) left,
           (ColumnLongStorage) right,
-          s -> adapter.getValidType().makeBuilder(s, problemAggregator),
+          s -> IntegerType.INT_64.makeBuilder(s, problemAggregator),
           true,
           (index, value1, isNothing1, value2, isNothing2) -> {
             if (isNothing1 && isNothing2) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
@@ -154,7 +154,8 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected Double doSingle(Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Double doSingle(
+        Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
       if (left == null) {
         return right;
       } else if (right == null) {
@@ -172,7 +173,11 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected BigDecimal doSingle(BigDecimal left, BigDecimal right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected BigDecimal doSingle(
+        BigDecimal left,
+        BigDecimal right,
+        long index,
+        MapOperationProblemAggregator problemAggregator) {
       return left == null
           ? right
           : (right == null ? left : operation.doBigDecimal(left, right, index));
@@ -186,7 +191,11 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected BigInteger doSingle(BigInteger left, BigInteger right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected BigInteger doSingle(
+        BigInteger left,
+        BigInteger right,
+        long index,
+        MapOperationProblemAggregator problemAggregator) {
       return left == null
           ? right
           : (right == null ? left : operation.doBigInteger(left, right, index));
@@ -235,7 +244,8 @@ public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperatio
     }
 
     @Override
-    protected Long doSingle(Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Long doSingle(
+        Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
       if (left == null) {
         return right;
       } else if (right == null) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryCoalescingOperationNumeric.java
@@ -6,16 +6,11 @@ import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.ColumnDoubleStorage;
 import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.ColumnStorageFacade;
-import org.enso.table.data.column.storage.PreciseTypeOptions;
-import org.enso.table.data.column.storage.numeric.DoubleStorageFacade;
 import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
-import org.enso.table.data.table.Column;
 
 /**
  * A binary coalescing operation for numeric types. This class is used to perform operations on two
@@ -26,7 +21,7 @@ import org.enso.table.data.table.Column;
  *
  * @param <T> the type of the elements in the column
  */
-public abstract class BinaryCoalescingOperationNumeric<T> implements BinaryOperation<T> {
+public abstract class BinaryCoalescingOperationNumeric<T> extends BinaryOperationNumeric<T, T> {
   /**
    * An abstract class representing a numeric operation. This class defines the methods that must be
    * implemented by any numeric operation.
@@ -103,112 +98,24 @@ public abstract class BinaryCoalescingOperationNumeric<T> implements BinaryOpera
     }
   }
 
-  private static StorageType<?> storageTypeForObject(Object right) {
-    if (right == null) {
-      return NullType.INSTANCE;
-    }
-
-    if (right instanceof Column rightColumn) {
-      return rightColumn.getStorage().getType();
-    }
-
-    return StorageType.forBoxedItem(right, PreciseTypeOptions.DEFAULT);
-  }
-
-  protected final StorageType<T> validType;
   protected final NumericOperation operation;
-  protected final StorageType<?>[] validInputs;
 
   protected BinaryCoalescingOperationNumeric(
-      StorageType<T> validType, NumericOperation operation, StorageType<?>... validInputs) {
-    this.validType = validType;
+      NumericColumnAdapter<T> adapter, StorageType<T> returnType, NumericOperation operation) {
+    super(adapter, false, returnType);
     this.operation = operation;
-    this.validInputs = validInputs;
   }
 
   @Override
-  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
-    var leftType = left.getType();
-    if (validType.isOfType(leftType)) {
-      return true;
-    }
-
-    for (var validInput : validInputs) {
-      if (validInput.isOfType(leftType)) {
-        return true;
-      }
-    }
-
-    return false;
+  protected ColumnStorage<T> applyNullMap(
+      ColumnStorage<?> left, MapOperationProblemAggregator problemAggregator) {
+    return adapter.asTypedStorage(left);
   }
-
-  @Override
-  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return canApplyMap(left, null) && canApplyMap(right, null);
-  }
-
-  @Override
-  public ColumnStorage<T> applyMap(
-      ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
-    if (rightValue == null) {
-      return asTypedStorage(left);
-    }
-
-    T rightValueTyped = validType.valueAsType(rightValue);
-    if (rightValueTyped == null) {
-      throw new IllegalArgumentException(
-          "Unsupported right value type " + rightValue.getClass() + ".");
-    }
-
-    return innerApplyMap(asTypedStorage(left), rightValueTyped, problemAggregator);
-  }
-
-  @Override
-  public ColumnStorage<T> applyZip(
-      ColumnStorage<?> left,
-      ColumnStorage<?> right,
-      MapOperationProblemAggregator problemAggregator) {
-    if (NullType.INSTANCE.isOfType(right.getType())) {
-      return validType.asTypedStorage(left);
-    }
-
-    return innerApplyZip(asTypedStorage(left), asTypedStorage(right), problemAggregator);
-  }
-
-  protected abstract ColumnStorage<T> asTypedStorage(ColumnStorage<?> storage);
-
-  protected abstract ColumnStorage<T> innerApplyMap(
-      ColumnStorage<T> left, T right, MapOperationProblemAggregator problemAggregator);
-
-  protected abstract ColumnStorage<T> innerApplyZip(
-      ColumnStorage<T> left,
-      ColumnStorage<T> right,
-      MapOperationProblemAggregator problemAggregator);
 
   private static class BinaryCoalescingOperationDouble
       extends BinaryCoalescingOperationNumeric<Double> {
     public BinaryCoalescingOperationDouble(NumericOperation operation) {
-      super(
-          FloatType.FLOAT_64,
-          operation,
-          BigDecimalType.INSTANCE,
-          BigIntegerType.INSTANCE,
-          IntegerType.INT_64);
-    }
-
-    @Override
-    protected ColumnDoubleStorage asTypedStorage(ColumnStorage<?> storage) {
-      return switch (storage.getType()) {
-        case FloatType floatType -> floatType.asTypedStorage(storage);
-        case BigDecimalType bigDecimalType -> DoubleStorageFacade.forBigDecimal(
-            bigDecimalType.asTypedStorage(storage));
-        case BigIntegerType bigIntegerType -> DoubleStorageFacade.forBigInteger(
-            bigIntegerType.asTypedStorage(storage));
-        case IntegerType integerType -> DoubleStorageFacade.forLong(
-            integerType.asTypedStorage(storage));
-        default -> throw new IllegalArgumentException(
-            "Unsupported storage type: " + storage.getType());
-      };
+      super(DoubleColumnAdapter.INSTANCE, FloatType.FLOAT_64, operation);
     }
 
     @Override
@@ -245,107 +152,45 @@ public abstract class BinaryCoalescingOperationNumeric<T> implements BinaryOpera
             }
           });
     }
-  }
-
-  private abstract static class BinaryCoalescingOperationBigNumber<T>
-      extends BinaryCoalescingOperationNumeric<T> {
-    protected BinaryCoalescingOperationBigNumber(
-        StorageType<T> validType, NumericOperation operation, StorageType<?>... validInputs) {
-      super(validType, operation, validInputs);
-    }
 
     @Override
-    protected ColumnStorage<T> innerApplyMap(
-        ColumnStorage<T> left, T right, MapOperationProblemAggregator problemAggregator) {
-      return StorageIterators.mapOverStorage(
-          left,
-          false,
-          validType.makeBuilder(left.getSize(), problemAggregator),
-          (index, value) -> value == null ? right : doSingle(value, right, index));
+    protected Double doSingle(Double left, Double right, long index) {
+      throw new IllegalStateException("This method should not be called directly.");
     }
-
-    @Override
-    protected ColumnStorage<T> innerApplyZip(
-        ColumnStorage<T> left,
-        ColumnStorage<T> right,
-        MapOperationProblemAggregator problemAggregator) {
-      return StorageIterators.zipOverStorages(
-          left,
-          right,
-          size -> validType.makeBuilder(size, problemAggregator),
-          false,
-          (index, x, y) -> {
-            if (x == null) {
-              return y;
-            } else {
-              return y == null ? x : doSingle(x, y, index);
-            }
-          });
-    }
-
-    protected abstract T doSingle(T left, T right, long index);
   }
 
   private static class BinaryCoalescingOperationBigDecimal
-      extends BinaryCoalescingOperationBigNumber<BigDecimal> {
+      extends BinaryCoalescingOperationNumeric<BigDecimal> {
     public BinaryCoalescingOperationBigDecimal(NumericOperation operation) {
-      super(BigDecimalType.INSTANCE, operation, BigIntegerType.INSTANCE, IntegerType.INT_64);
-    }
-
-    @Override
-    protected ColumnStorage<BigDecimal> asTypedStorage(ColumnStorage<?> storage) {
-      return switch (storage.getType()) {
-        case BigDecimalType bigDecimalType -> bigDecimalType.asTypedStorage(storage);
-        case BigIntegerType bigIntegerType -> new ColumnStorageFacade<>(
-            bigIntegerType.asTypedStorage(storage), BigDecimal::new);
-        case IntegerType integerType -> new ColumnStorageFacade<>(
-            integerType.asTypedStorage(storage), BigDecimal::valueOf);
-        default -> throw new IllegalArgumentException(
-            "Unsupported storage type: " + storage.getType());
-      };
+      super(BigDecimalColumnAdapter.INSTANCE, BigDecimalType.INSTANCE, operation);
     }
 
     @Override
     protected BigDecimal doSingle(BigDecimal left, BigDecimal right, long index) {
-      return operation.doBigDecimal(left, right, index);
+      return left == null
+          ? right
+          : (right == null ? left : operation.doBigDecimal(left, right, index));
     }
   }
 
   private static class BinaryCoalescingOperationBigInteger
-      extends BinaryCoalescingOperationBigNumber<BigInteger> {
+      extends BinaryCoalescingOperationNumeric<BigInteger> {
     public BinaryCoalescingOperationBigInteger(NumericOperation operation) {
-      super(BigIntegerType.INSTANCE, operation, IntegerType.INT_64);
-    }
-
-    @Override
-    protected ColumnStorage<BigInteger> asTypedStorage(ColumnStorage<?> storage) {
-      return switch (storage.getType()) {
-        case BigIntegerType bigIntegerType -> bigIntegerType.asTypedStorage(storage);
-        case IntegerType integerType -> new ColumnStorageFacade<>(
-            integerType.asTypedStorage(storage), BigInteger::valueOf);
-        default -> throw new IllegalArgumentException(
-            "Unsupported storage type: " + storage.getType());
-      };
+      super(BigIntegerColumnAdapter.INSTANCE, BigIntegerType.INSTANCE, operation);
     }
 
     @Override
     protected BigInteger doSingle(BigInteger left, BigInteger right, long index) {
-      return operation.doBigInteger(left, right, index);
+      return left == null
+          ? right
+          : (right == null ? left : operation.doBigInteger(left, right, index));
     }
   }
 
   private static class BinaryCoalescingOperationLong
       extends BinaryCoalescingOperationNumeric<Long> {
     public BinaryCoalescingOperationLong(NumericOperation operation) {
-      super(IntegerType.INT_64, operation);
-    }
-
-    @Override
-    protected ColumnLongStorage asTypedStorage(ColumnStorage<?> storage) {
-      if (storage.getType() instanceof IntegerType integerType) {
-        return integerType.asTypedStorage(storage);
-      }
-      throw new IllegalArgumentException("Unsupported storage type: " + storage.getType());
+      super(LongColumnAdapter.INSTANCE, IntegerType.INT_64, operation);
     }
 
     @Override
@@ -368,7 +213,7 @@ public abstract class BinaryCoalescingOperationNumeric<T> implements BinaryOpera
       return StorageIterators.zipOverLongStorages(
           (ColumnLongStorage) left,
           (ColumnLongStorage) right,
-          s -> validType.makeBuilder(s, problemAggregator),
+          s -> adapter.getValidType().makeBuilder(s, problemAggregator),
           true,
           (index, value1, isNothing1, value2, isNothing2) -> {
             if (isNothing1 && isNothing2) {
@@ -381,6 +226,11 @@ public abstract class BinaryCoalescingOperationNumeric<T> implements BinaryOpera
               return operation.doLong(value1, value2, index);
             }
           });
+    }
+
+    @Override
+    protected Long doSingle(Long left, Long right, long index) {
+      throw new IllegalStateException("This method should not be called directly.");
     }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
@@ -1,11 +1,13 @@
 package org.enso.table.data.column.operation;
 
 import org.enso.base.CompareException;
+import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.BuilderForBoolean;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
+import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
@@ -20,6 +22,8 @@ import org.enso.table.problems.ProblemAggregator;
  */
 public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean> {
   private final boolean preserveNulls;
+  protected final boolean throwOnOther;
+  protected final boolean valueOnOther;
 
   public BinaryOperationBoolean() {
     this(true, false);
@@ -28,22 +32,23 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
   protected BinaryOperationBoolean(boolean preserveNulls, boolean allowNullType) {
     super(BooleanType.INSTANCE, allowNullType);
     this.preserveNulls = preserveNulls;
+    this.throwOnOther = true;
+    this.valueOnOther = false;
   }
 
-  protected ColumnStorage<Boolean> throwUnsupported(
-      ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
-    // If all are Nothing then will return a Nothing Boolean Storage
-    return StorageIterators.buildOverStorage(
-        left,
-        BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
-        (b, index, value) -> {
-          throw new IllegalArgumentException(
-              "Unsupported right value type " + rightValue.getClass() + ".");
-        });
+  protected BinaryOperationBoolean(
+      boolean preserveNulls, boolean allowNullType, boolean valueOnOther) {
+    super(BooleanType.INSTANCE, allowNullType);
+    this.preserveNulls = preserveNulls;
+    this.throwOnOther = false;
+    this.valueOnOther = valueOnOther;
   }
 
-  protected RuntimeException makeCompareError(Object left, Object right) {
-    return new CompareException(left, right);
+  protected boolean onIncomparable(Object left, Object right) {
+    if (throwOnOther) {
+      throw new CompareException(left, right);
+    }
+    return valueOnOther;
   }
 
   @Override
@@ -57,7 +62,11 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
     }
 
     if (rightValue != null && !(rightValue instanceof Boolean)) {
-      return throwUnsupported(left, rightValue, problemAggregator);
+      // If all are Nothing then will return a Nothing Boolean Storage
+      return StorageIterators.buildOverStorage(
+          left,
+          BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+          (b, index, value) -> b.appendBoolean(onIncomparable(value, rightValue)));
     }
 
     boolean rightIsNothing = rightValue == null;
@@ -92,6 +101,27 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
   }
 
   @Override
+  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
+    if (!canApplyMap(left, right)) {
+      return false;
+    }
+
+    // If not throwing on other types, we can apply the operation
+    // Otherwise, we allow Any, Boolean, and Null types on the right
+    if (!throwOnOther) {
+      return true;
+    }
+
+    var rightType = right.getType();
+    return switch (rightType) {
+      case NullType nt -> true;
+      case BooleanType bt -> true;
+      case AnyObjectType ay -> true;
+      default -> false;
+    };
+  }
+
+  @Override
   public final ColumnStorage<Boolean> applyZip(
       ColumnStorage<?> left,
       ColumnStorage<?> right,
@@ -113,6 +143,23 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
       if (result != null) {
         return result;
       }
+    }
+
+    if (!BooleanType.INSTANCE.isOfType(right.getType())) {
+      // Have a mismatch in types (could be AnyObjectType)
+      return StorageIterators.zipOverStorages(
+          BooleanType.INSTANCE.asTypedStorage(left),
+          right,
+          Builder::getForBoolean,
+          preserveNulls,
+          (index, leftValue, rightValue) -> {
+            boolean leftBoolean = leftValue != null && (boolean) leftValue;
+            Boolean typedRightValue = BooleanType.INSTANCE.valueAsType(rightValue);
+            boolean rightBoolean = typedRightValue != null && typedRightValue;
+            return rightValue != null && typedRightValue == null
+                ? onIncomparable(leftValue, rightValue)
+                : applySingle(leftBoolean, leftValue == null, rightBoolean, rightValue == null);
+          });
     }
 
     return StorageIterators.zipOverBooleanStorages(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
@@ -30,13 +30,15 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
     this.preserveNulls = preserveNulls;
   }
 
-  protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+  protected ColumnStorage<Boolean> throwUnsupported(
+      ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
     // If all are Nothing then will return a Nothing Boolean Storage
     return StorageIterators.buildOverStorage(
         left,
         BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
         (b, index, value) -> {
-          throw new IllegalArgumentException("Unsupported right value type " + rightValue.getClass() + ".");
+          throw new IllegalArgumentException(
+              "Unsupported right value type " + rightValue.getClass() + ".");
         });
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationBoolean.java
@@ -1,5 +1,6 @@
 package org.enso.table.data.column.operation;
 
+import org.enso.base.CompareException;
 import org.enso.table.data.column.builder.BuilderForBoolean;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.BoolStorage;
@@ -29,6 +30,20 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
     this.preserveNulls = preserveNulls;
   }
 
+  protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+    // If all are Nothing then will return a Nothing Boolean Storage
+    return StorageIterators.buildOverStorage(
+        left,
+        BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+        (b, index, value) -> {
+          throw new IllegalArgumentException("Unsupported right value type " + rightValue.getClass() + ".");
+        });
+  }
+
+  protected RuntimeException makeCompareError(Object left, Object right) {
+    return new CompareException(left, right);
+  }
+
   @Override
   public final ColumnStorage<Boolean> applyMap(
       ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
@@ -40,8 +55,7 @@ public abstract class BinaryOperationBoolean extends BinaryOperationBase<Boolean
     }
 
     if (rightValue != null && !(rightValue instanceof Boolean)) {
-      throw new IllegalArgumentException(
-          "Unsupported right value type " + rightValue.getClass() + ".");
+      return throwUnsupported(left, rightValue, problemAggregator);
     }
 
     boolean rightIsNothing = rightValue == null;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -2,9 +2,7 @@ package org.enso.table.data.column.operation;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-
 import org.enso.base.CompareException;
-import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
@@ -175,7 +173,8 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
         (index, x, y) -> doSingle(x, y, index, problemAggregator));
   }
 
-  protected abstract R doSingle(T left, T right, long index, MapOperationProblemAggregator problemAggregator);
+  protected abstract R doSingle(
+      T left, T right, long index, MapOperationProblemAggregator problemAggregator);
 
   protected interface NumericColumnAdapter<T> {
     StorageType<T> getValidType();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -143,7 +143,7 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
             T rightValueTyped = adapter.getValidType().valueAsType(rightValue);
             return rightValue != null && rightValueTyped == null
                 ? onIncomparable(leftValue, rightValue)
-                : doSingle(leftValue, rightValueTyped, index);
+                : doSingle(leftValue, rightValueTyped, index, problemAggregator);
           });
     }
 
@@ -160,7 +160,7 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
         left,
         preserveNulls,
         returnType.makeBuilder(left.getSize(), problemAggregator),
-        (index, value) -> doSingle(value, right, index));
+        (index, value) -> doSingle(value, right, index, problemAggregator));
   }
 
   protected ColumnStorage<R> innerApplyZip(
@@ -172,10 +172,10 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
         right,
         size -> returnType.makeBuilder(size, problemAggregator),
         preserveNulls,
-        (index, x, y) -> doSingle(x, y, index));
+        (index, x, y) -> doSingle(x, y, index, problemAggregator));
   }
 
-  protected abstract R doSingle(T left, T right, long index);
+  protected abstract R doSingle(T left, T right, long index, MapOperationProblemAggregator problemAggregator);
 
   protected interface NumericColumnAdapter<T> {
     StorageType<T> getValidType();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -2,6 +2,8 @@ package org.enso.table.data.column.operation;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+
+import org.enso.base.CompareException;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
@@ -10,6 +12,7 @@ import org.enso.table.data.column.storage.PreciseTypeOptions;
 import org.enso.table.data.column.storage.numeric.DoubleStorageFacade;
 import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.BigIntegerType;
+import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.NullType;
@@ -31,6 +34,8 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
 
   protected final NumericColumnAdapter<T> adapter;
   private final boolean preserveNulls;
+  protected final boolean throwOnOther;
+  protected final R valueOnOther;
   protected final StorageType<R> returnType;
 
   protected BinaryOperationNumeric(
@@ -40,6 +45,27 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
     this.adapter = adapter;
     this.preserveNulls = preserveNulls;
     this.returnType = returnType;
+    this.throwOnOther = true;
+    this.valueOnOther = null;
+  }
+
+  protected BinaryOperationNumeric(
+      final NumericColumnAdapter<T> adapter,
+      final boolean preserveNulls,
+      final StorageType<R> returnType,
+      final R valueOnOther) {
+    this.adapter = adapter;
+    this.preserveNulls = preserveNulls;
+    this.returnType = returnType;
+    this.throwOnOther = false;
+    this.valueOnOther = valueOnOther;
+  }
+
+  protected R onIncomparable(Object left, Object right) {
+    if (throwOnOther) {
+      throw new CompareException(left, right);
+    }
+    return valueOnOther;
   }
 
   @Override
@@ -60,7 +86,22 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
 
   @Override
   public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return canApplyMap(left, null) && canApplyMap(right, null);
+    if (!canApplyMap(left, null)) {
+      return false;
+    }
+
+    // If not throwing on other types, we can apply the operation
+    // Otherwise, we allow Any and Null types on the right or support type.
+    if (!throwOnOther) {
+      return true;
+    }
+
+    var rightType = right.getType();
+    return switch (rightType) {
+      case NullType nt -> true;
+      case BooleanType bt -> true;
+      default -> canApplyMap(right, null);
+    };
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -34,7 +34,9 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
   protected final StorageType<R> returnType;
 
   protected BinaryOperationNumeric(
-      final NumericColumnAdapter<T> adapter, final boolean preserveNulls, final StorageType<R> returnType) {
+      final NumericColumnAdapter<T> adapter,
+      final boolean preserveNulls,
+      final StorageType<R> returnType) {
     this.adapter = adapter;
     this.preserveNulls = preserveNulls;
     this.returnType = returnType;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -4,19 +4,14 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.enso.base.CompareException;
+import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.ColumnStorageFacade;
 import org.enso.table.data.column.storage.PreciseTypeOptions;
 import org.enso.table.data.column.storage.numeric.DoubleStorageFacade;
-import org.enso.table.data.column.storage.type.BigDecimalType;
-import org.enso.table.data.column.storage.type.BigIntegerType;
-import org.enso.table.data.column.storage.type.BooleanType;
-import org.enso.table.data.column.storage.type.FloatType;
-import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.NullType;
-import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.data.column.storage.type.*;
 import org.enso.table.data.table.Column;
 
 public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R> {
@@ -99,7 +94,7 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
     var rightType = right.getType();
     return switch (rightType) {
       case NullType nt -> true;
-      case BooleanType bt -> true;
+      case AnyObjectType at -> true;
       default -> canApplyMap(right, null);
     };
   }
@@ -107,14 +102,19 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
   @Override
   public ColumnStorage<R> applyMap(
       ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+    assert canApplyMap(left, rightValue);
+
     if (rightValue == null) {
       return applyNullMap(left, problemAggregator);
     }
 
     T rightValueTyped = adapter.getValidType().valueAsType(rightValue);
     if (rightValueTyped == null) {
-      throw new IllegalArgumentException(
-          "Unsupported right value type " + rightValue.getClass() + ".");
+      // If all are Nothing then will return a Nothing Boolean Storage
+      return StorageIterators.buildOverStorage(
+          left,
+          returnType.makeBuilder(left.getSize(), problemAggregator),
+          (b, index, value) -> b.append(onIncomparable(value, rightValue)));
     }
 
     return innerApplyMap(adapter.asTypedStorage(left), rightValueTyped, problemAggregator);
@@ -125,8 +125,26 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
       ColumnStorage<?> left,
       ColumnStorage<?> right,
       MapOperationProblemAggregator problemAggregator) {
+    assert canApplyZip(left, right);
+
     if (NullType.INSTANCE.isOfType(right.getType())) {
       return applyNullMap(left, problemAggregator);
+    }
+
+    // Handle the case where right is Any or another type
+    if (!adapter.getValidType().isOfType(right.getType())) {
+      // Have a mismatch in types (could be AnyObjectType)
+      return StorageIterators.zipOverStorages(
+          adapter.asTypedStorage(left),
+          right,
+          size -> returnType.makeBuilder(size, problemAggregator),
+          preserveNulls,
+          (index, leftValue, rightValue) -> {
+            T rightValueTyped = adapter.getValidType().valueAsType(rightValue);
+            return rightValue != null && rightValueTyped == null
+                ? onIncomparable(leftValue, rightValue)
+                : doSingle(leftValue, rightValueTyped, index);
+          });
     }
 
     return innerApplyZip(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -1,0 +1,239 @@
+package org.enso.table.data.column.operation;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
+import org.enso.table.data.column.storage.ColumnLongStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
+import org.enso.table.data.column.storage.ColumnStorageFacade;
+import org.enso.table.data.column.storage.PreciseTypeOptions;
+import org.enso.table.data.column.storage.numeric.DoubleStorageFacade;
+import org.enso.table.data.column.storage.type.BigDecimalType;
+import org.enso.table.data.column.storage.type.BigIntegerType;
+import org.enso.table.data.column.storage.type.FloatType;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.data.column.storage.type.NullType;
+import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.data.table.Column;
+
+public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R> {
+  protected static StorageType<?> storageTypeForObject(Object right) {
+    if (right == null) {
+      return NullType.INSTANCE;
+    }
+
+    if (right instanceof Column rightColumn) {
+      return rightColumn.getStorage().getType();
+    }
+
+    return StorageType.forBoxedItem(right, PreciseTypeOptions.DEFAULT);
+  }
+
+  protected final NumericColumnAdapter<T> adapter;
+  private final boolean preserveNulls;
+  protected final StorageType<R> returnType;
+
+  protected BinaryOperationNumeric(
+      final NumericColumnAdapter<T> adapter, final boolean preserveNulls, final StorageType<R> returnType) {
+    this.adapter = adapter;
+    this.preserveNulls = preserveNulls;
+    this.returnType = returnType;
+  }
+
+  @Override
+  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
+    var leftType = left.getType();
+    if (adapter.getValidType().isOfType(leftType)) {
+      return true;
+    }
+
+    for (var validInput : adapter.getValidInputs()) {
+      if (validInput.isOfType(leftType)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
+    return canApplyMap(left, null) && canApplyMap(right, null);
+  }
+
+  @Override
+  public ColumnStorage<R> applyMap(
+      ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+    if (rightValue == null) {
+      return applyNullMap(left, problemAggregator);
+    }
+
+    T rightValueTyped = adapter.getValidType().valueAsType(rightValue);
+    if (rightValueTyped == null) {
+      throw new IllegalArgumentException(
+          "Unsupported right value type " + rightValue.getClass() + ".");
+    }
+
+    return innerApplyMap(adapter.asTypedStorage(left), rightValueTyped, problemAggregator);
+  }
+
+  @Override
+  public ColumnStorage<R> applyZip(
+      ColumnStorage<?> left,
+      ColumnStorage<?> right,
+      MapOperationProblemAggregator problemAggregator) {
+    if (NullType.INSTANCE.isOfType(right.getType())) {
+      return applyNullMap(left, problemAggregator);
+    }
+
+    return innerApplyZip(
+        adapter.asTypedStorage(left), adapter.asTypedStorage(right), problemAggregator);
+  }
+
+  protected abstract ColumnStorage<R> applyNullMap(
+      ColumnStorage<?> left, MapOperationProblemAggregator problemAggregator);
+
+  protected ColumnStorage<R> innerApplyMap(
+      ColumnStorage<T> left, T right, MapOperationProblemAggregator problemAggregator) {
+    return StorageIterators.mapOverStorage(
+        left,
+        preserveNulls,
+        returnType.makeBuilder(left.getSize(), problemAggregator),
+        (index, value) -> doSingle(value, right, index));
+  }
+
+  protected ColumnStorage<R> innerApplyZip(
+      ColumnStorage<T> left,
+      ColumnStorage<T> right,
+      MapOperationProblemAggregator problemAggregator) {
+    return StorageIterators.zipOverStorages(
+        left,
+        right,
+        size -> returnType.makeBuilder(size, problemAggregator),
+        preserveNulls,
+        (index, x, y) -> doSingle(x, y, index));
+  }
+
+  protected abstract R doSingle(T left, T right, long index);
+
+  protected interface NumericColumnAdapter<T> {
+    StorageType<T> getValidType();
+
+    StorageType<?>[] getValidInputs();
+
+    ColumnStorage<T> asTypedStorage(ColumnStorage<?> storage);
+  }
+
+  protected static class DoubleColumnAdapter implements NumericColumnAdapter<Double> {
+    public static final NumericColumnAdapter<Double> INSTANCE = new DoubleColumnAdapter();
+
+    private static final StorageType<?>[] VALID_TYPES =
+        new StorageType[] {BigDecimalType.INSTANCE, BigIntegerType.INSTANCE, IntegerType.INT_64};
+
+    @Override
+    public StorageType<Double> getValidType() {
+      return FloatType.FLOAT_64;
+    }
+
+    @Override
+    public StorageType<?>[] getValidInputs() {
+      return VALID_TYPES;
+    }
+
+    @Override
+    public ColumnStorage<Double> asTypedStorage(ColumnStorage<?> storage) {
+      return switch (storage.getType()) {
+        case FloatType floatType -> floatType.asTypedStorage(storage);
+        case BigDecimalType bigDecimalType -> DoubleStorageFacade.forBigDecimal(
+            bigDecimalType.asTypedStorage(storage));
+        case BigIntegerType bigIntegerType -> DoubleStorageFacade.forBigInteger(
+            bigIntegerType.asTypedStorage(storage));
+        case IntegerType integerType -> DoubleStorageFacade.forLong(
+            integerType.asTypedStorage(storage));
+        default -> throw new IllegalArgumentException(
+            "Unsupported storage type: " + storage.getType());
+      };
+    }
+  }
+
+  protected static class BigDecimalColumnAdapter implements NumericColumnAdapter<BigDecimal> {
+    public static final NumericColumnAdapter<BigDecimal> INSTANCE = new BigDecimalColumnAdapter();
+
+    private static final StorageType<?>[] VALID_TYPES =
+        new StorageType[] {BigIntegerType.INSTANCE, IntegerType.INT_64};
+
+    @Override
+    public StorageType<BigDecimal> getValidType() {
+      return BigDecimalType.INSTANCE;
+    }
+
+    @Override
+    public StorageType<?>[] getValidInputs() {
+      return VALID_TYPES;
+    }
+
+    @Override
+    public ColumnStorage<BigDecimal> asTypedStorage(ColumnStorage<?> storage) {
+      return switch (storage.getType()) {
+        case BigDecimalType bigDecimalType -> bigDecimalType.asTypedStorage(storage);
+        case BigIntegerType bigIntegerType -> new ColumnStorageFacade<>(
+            bigIntegerType.asTypedStorage(storage), BigDecimal::new);
+        case IntegerType integerType -> new ColumnStorageFacade<>(
+            integerType.asTypedStorage(storage), BigDecimal::valueOf);
+        default -> throw new IllegalArgumentException(
+            "Unsupported storage type: " + storage.getType());
+      };
+    }
+  }
+
+  protected static class BigIntegerColumnAdapter implements NumericColumnAdapter<BigInteger> {
+    public static final NumericColumnAdapter<BigInteger> INSTANCE = new BigIntegerColumnAdapter();
+
+    private static final StorageType<?>[] VALID_TYPES = new StorageType[] {IntegerType.INT_64};
+
+    @Override
+    public StorageType<BigInteger> getValidType() {
+      return BigIntegerType.INSTANCE;
+    }
+
+    @Override
+    public StorageType<?>[] getValidInputs() {
+      return VALID_TYPES;
+    }
+
+    @Override
+    public ColumnStorage<BigInteger> asTypedStorage(ColumnStorage<?> storage) {
+      return switch (storage.getType()) {
+        case BigIntegerType bigIntegerType -> bigIntegerType.asTypedStorage(storage);
+        case IntegerType integerType -> new ColumnStorageFacade<>(
+            integerType.asTypedStorage(storage), BigInteger::valueOf);
+        default -> throw new IllegalArgumentException(
+            "Unsupported storage type: " + storage.getType());
+      };
+    }
+  }
+
+  protected static class LongColumnAdapter implements NumericColumnAdapter<Long> {
+    public static final NumericColumnAdapter<Long> INSTANCE = new LongColumnAdapter();
+
+    private static final StorageType<?>[] VALID_TYPES = new StorageType[0];
+
+    @Override
+    public StorageType<Long> getValidType() {
+      return IntegerType.INT_64;
+    }
+
+    @Override
+    public StorageType<?>[] getValidInputs() {
+      return VALID_TYPES;
+    }
+
+    @Override
+    public ColumnLongStorage asTypedStorage(ColumnStorage<?> storage) {
+      if (storage.getType() instanceof IntegerType integerType) {
+        return integerType.asTypedStorage(storage);
+      }
+      throw new IllegalArgumentException("Unsupported storage type: " + storage.getType());
+    }
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/BinaryOperationNumeric.java
@@ -19,7 +19,7 @@ public abstract class BinaryOperationNumeric<T, R> implements BinaryOperation<R>
     }
 
     if (right instanceof Column rightColumn) {
-      return rightColumn.getStorage().getType();
+      return BinaryOperation.getInferredStorage(rightColumn).getType();
     }
 
     return StorageType.forBoxedItem(right, PreciseTypeOptions.DEFAULT);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
@@ -9,7 +9,7 @@ import org.enso.table.data.column.operation.unary.NotOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
 
-public final class BooleanComparators {
+final class BooleanComparators {
   public static final BinaryOperation<Boolean> EQ =
       new BinaryOperationBoolean(true, false, false) {
         @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
@@ -4,17 +4,14 @@ import java.util.BitSet;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.operation.BinaryOperationBoolean;
-import org.enso.table.data.column.operation.StorageIterators;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.unary.NotOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
-import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.type.BooleanType;
 
 public final class BooleanComparators {
   public static final BinaryOperation<Boolean> EQ =
-      new BinaryOperationBoolean() {
+      new BinaryOperationBoolean(true, false, false) {
         @Override
         protected Boolean applySingle(
             boolean left, boolean isNothing, boolean right, boolean isNothingRight) {
@@ -29,22 +26,10 @@ public final class BooleanComparators {
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean ? left : NotOperation.applySpecializedBoolStorage(left);
         }
-
-        @Override
-        protected ColumnStorage<Boolean> throwUnsupported(
-            ColumnStorage<?> left,
-            Object rightValue,
-            MapOperationProblemAggregator problemAggregator) {
-          // If all are Nothing then will return a Nothing Boolean Storage
-          return StorageIterators.buildOverStorage(
-              left,
-              BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
-              (b, index, value) -> b.appendBoolean(false));
-        }
       };
 
   public static final BinaryOperation<Boolean> NEQ =
-      new BinaryOperationBoolean() {
+      new BinaryOperationBoolean(true, false, true) {
         @Override
         protected Boolean applySingle(
             boolean left, boolean isNothing, boolean right, boolean isNothingRight) {
@@ -58,18 +43,6 @@ public final class BooleanComparators {
             boolean rightIsNothing,
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean ? NotOperation.applySpecializedBoolStorage(left) : left;
-        }
-
-        @Override
-        protected ColumnStorage<Boolean> throwUnsupported(
-            ColumnStorage<?> left,
-            Object rightValue,
-            MapOperationProblemAggregator problemAggregator) {
-          // If all are Nothing then will return a Nothing Boolean Storage
-          return StorageIterators.buildOverStorage(
-              left,
-              BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
-              (b, index, value) -> b.appendBoolean(true));
         }
       };
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
@@ -4,10 +4,13 @@ import java.util.BitSet;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.operation.BinaryOperationBoolean;
+import org.enso.table.data.column.operation.StorageIterators;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.unary.NotOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
+import org.enso.table.data.column.storage.type.BooleanType;
 
 public final class BooleanComparators {
   public static final BinaryOperation<Boolean> EQ =
@@ -26,6 +29,15 @@ public final class BooleanComparators {
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean ? left : NotOperation.applySpecializedBoolStorage(left);
         }
+
+        @Override
+        protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+          // If all are Nothing then will return a Nothing Boolean Storage
+          return StorageIterators.buildOverStorage(
+              left,
+              BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+              (b, index, value) -> b.appendBoolean(false));
+        }
       };
 
   public static final BinaryOperation<Boolean> NEQ =
@@ -43,6 +55,15 @@ public final class BooleanComparators {
             boolean rightIsNothing,
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean ? NotOperation.applySpecializedBoolStorage(left) : left;
+        }
+
+        @Override
+        protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+          // If all are Nothing then will return a Nothing Boolean Storage
+          return StorageIterators.buildOverStorage(
+              left,
+              BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+              (b, index, value) -> b.appendBoolean(true));
         }
       };
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
@@ -31,7 +31,10 @@ public final class BooleanComparators {
         }
 
         @Override
-        protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+        protected ColumnStorage<Boolean> throwUnsupported(
+            ColumnStorage<?> left,
+            Object rightValue,
+            MapOperationProblemAggregator problemAggregator) {
           // If all are Nothing then will return a Nothing Boolean Storage
           return StorageIterators.buildOverStorage(
               left,
@@ -58,7 +61,10 @@ public final class BooleanComparators {
         }
 
         @Override
-        protected ColumnStorage<Boolean> throwUnsupported(ColumnStorage<?> left, Object rightValue, MapOperationProblemAggregator problemAggregator) {
+        protected ColumnStorage<Boolean> throwUnsupported(
+            ColumnStorage<?> left,
+            Object rightValue,
+            MapOperationProblemAggregator problemAggregator) {
           // If all are Nothing then will return a Nothing Boolean Storage
           return StorageIterators.buildOverStorage(
               left,

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
@@ -5,6 +5,7 @@ import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.DateTimeType;
 import org.enso.table.data.column.storage.type.DateType;
 import org.enso.table.data.column.storage.type.NullType;
+import org.enso.table.data.column.storage.type.NumericType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.data.table.Column;
@@ -23,10 +24,11 @@ public final class Comparators {
         || storageType instanceof DateTimeType
         || storageType instanceof TextType
         || storageType instanceof NullType
-        || storageType instanceof BooleanType;
+        || storageType instanceof BooleanType
+        || storageType instanceof NumericType;
   }
 
-  public static BinaryOperation<Boolean> eq(Column left) {
+  public static BinaryOperation<Boolean> eq(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -35,11 +37,12 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.EQ;
       case TextType tt -> StringComparators.EQ;
       case BooleanType bt -> BooleanComparators.EQ;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
 
-  public static BinaryOperation<Boolean> notEq(Column left) {
+  public static BinaryOperation<Boolean> notEq(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -48,11 +51,12 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.NEQ;
       case TextType tt -> StringComparators.NEQ;
       case BooleanType bt -> BooleanComparators.NEQ;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.NOT_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
 
-  public static BinaryOperation<Boolean> lessThan(Column left) {
+  public static BinaryOperation<Boolean> lessThan(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -61,11 +65,12 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.LT;
       case TextType tt -> StringComparators.LT;
       case BooleanType bt -> BooleanComparators.LT;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.LESS_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
 
-  public static BinaryOperation<Boolean> lessThanEq(Column left) {
+  public static BinaryOperation<Boolean> lessThanEq(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -74,11 +79,12 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.LTE;
       case TextType tt -> StringComparators.LTE;
       case BooleanType bt -> BooleanComparators.LTE;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.LESS_OR_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
 
-  public static BinaryOperation<Boolean> greaterThan(Column left) {
+  public static BinaryOperation<Boolean> greaterThan(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -87,11 +93,12 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.GT;
       case TextType tt -> StringComparators.GT;
       case BooleanType bt -> BooleanComparators.GT;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.GREATER_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
 
-  public static BinaryOperation greaterThanEq(Column left) {
+  public static BinaryOperation greaterThanEq(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;
@@ -100,6 +107,7 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.GTE;
       case TextType tt -> StringComparators.GTE;
       case BooleanType bt -> BooleanComparators.GTE;
+      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.GREATER_OR_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
@@ -38,7 +38,7 @@ public final class Comparators {
       case TextType tt -> StringComparators.EQ;
       case BooleanType bt -> BooleanComparators.EQ;
       case NumericType nt -> NumericComparators.create(
-          leftStorage.getType(), right, NumericComparators.EQUAL_OPERATION);
+          leftStorage.getType(), right, NumericComparators.EQUAL_OPERATION, false);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -53,7 +53,7 @@ public final class Comparators {
       case TextType tt -> StringComparators.NEQ;
       case BooleanType bt -> BooleanComparators.NEQ;
       case NumericType nt -> NumericComparators.create(
-          leftStorage.getType(), right, NumericComparators.NOT_EQUAL_OPERATION);
+          leftStorage.getType(), right, NumericComparators.NOT_EQUAL_OPERATION, true);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -103,7 +103,7 @@ public final class Comparators {
     };
   }
 
-  public static BinaryOperation greaterThanEq(Column left, Object right) {
+  public static BinaryOperation<Boolean> greaterThanEq(Column left, Object right) {
     var leftStorage = BinaryOperation.getInferredStorage(left);
     return switch (leftStorage.getType()) {
       case NullType nt -> NullComparators.INSTANCE;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/Comparators.java
@@ -37,7 +37,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.EQ;
       case TextType tt -> StringComparators.EQ;
       case BooleanType bt -> BooleanComparators.EQ;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.EQUAL_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -51,7 +52,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.NEQ;
       case TextType tt -> StringComparators.NEQ;
       case BooleanType bt -> BooleanComparators.NEQ;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.NOT_EQUAL_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.NOT_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -65,7 +67,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.LT;
       case TextType tt -> StringComparators.LT;
       case BooleanType bt -> BooleanComparators.LT;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.LESS_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.LESS_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -79,7 +82,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.LTE;
       case TextType tt -> StringComparators.LTE;
       case BooleanType bt -> BooleanComparators.LTE;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.LESS_OR_EQUAL_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.LESS_OR_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -93,7 +97,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.GT;
       case TextType tt -> StringComparators.GT;
       case BooleanType bt -> BooleanComparators.GT;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.GREATER_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.GREATER_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }
@@ -107,7 +112,8 @@ public final class Comparators {
       case TimeOfDayType tm -> TimeOfDayComparators.GTE;
       case TextType tt -> StringComparators.GTE;
       case BooleanType bt -> BooleanComparators.GTE;
-      case NumericType nt -> NumericComparators.create(leftStorage.getType(), right, NumericComparators.GREATER_OR_EQUAL_OPERATION);
+      case NumericType nt -> NumericComparators.create(
+          leftStorage.getType(), right, NumericComparators.GREATER_OR_EQUAL_OPERATION);
       default -> throw new IllegalArgumentException("Unsupported StorageType");
     };
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
@@ -7,20 +7,28 @@ import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.DateType;
 
-public final class DateComparators extends GenericComparators<LocalDate> {
-  public static final DateComparators EQ = new DateComparators(LocalDate::isEqual, false);
-  public static final DateComparators NEQ = new DateComparators((a, b) -> !a.isEqual(b), false);
+public class DateComparators extends GenericComparators<LocalDate> {
+  public static final DateComparators EQ = new DateComparators(LocalDate::isEqual) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return false;
+    }
+  };
+
+  public static final DateComparators NEQ = new DateComparators((a, b) -> !a.isEqual(b)) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return true;
+    }
+  };
+
   public static final DateComparators LT = new DateComparators(LocalDate::isBefore);
   public static final DateComparators LTE = new DateComparators((a, b) -> !a.isAfter(b));
   public static final DateComparators GT = new DateComparators(LocalDate::isAfter);
   public static final DateComparators GTE = new DateComparators((a, b) -> !a.isBefore(b));
 
   private DateComparators(BiPredicate<LocalDate, LocalDate> comparator) {
-    this(comparator, true);
-  }
-
-  private DateComparators(BiPredicate<LocalDate, LocalDate> comparator, boolean throwOnOther) {
-    super(comparator, throwOnOther);
+    super(comparator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.DateType;
 
-public final class DateComparators {
+final class DateComparators {
   public static final BinaryOperation<Boolean> EQ =
       new GenericComparators<>(DateType.INSTANCE, LocalDate::isEqual, false);
   public static final BinaryOperation<Boolean> NEQ =

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateComparators.java
@@ -1,58 +1,20 @@
 package org.enso.table.data.column.operation.comparators;
 
 import java.time.LocalDate;
-import java.util.function.BiPredicate;
-import org.enso.base.polyglot.Polyglot_Utils;
-import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.type.AnyObjectType;
+import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.DateType;
 
-public class DateComparators extends GenericComparators<LocalDate> {
-  public static final DateComparators EQ = new DateComparators(LocalDate::isEqual) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return false;
-    }
-  };
-
-  public static final DateComparators NEQ = new DateComparators((a, b) -> !a.isEqual(b)) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return true;
-    }
-  };
-
-  public static final DateComparators LT = new DateComparators(LocalDate::isBefore);
-  public static final DateComparators LTE = new DateComparators((a, b) -> !a.isAfter(b));
-  public static final DateComparators GT = new DateComparators(LocalDate::isAfter);
-  public static final DateComparators GTE = new DateComparators((a, b) -> !a.isBefore(b));
-
-  private DateComparators(BiPredicate<LocalDate, LocalDate> comparator) {
-    super(comparator);
-  }
-
-  @Override
-  protected ColumnStorage<LocalDate> asTypedStorage(ColumnStorage<?> storage) {
-    return DateType.INSTANCE.asTypedStorage(storage);
-  }
-
-  @Override
-  protected LocalDate asTypedValue(Object value) {
-    Object adapted = Polyglot_Utils.convertPolyglotValue(value);
-    if (adapted instanceof LocalDate localDate) {
-      return localDate;
-    }
-    return null;
-  }
-
-  @Override
-  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
-    return left.getType() instanceof DateType;
-  }
-
-  @Override
-  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return left.getType() instanceof DateType
-        && (right.getType() instanceof DateType || right.getType() instanceof AnyObjectType);
-  }
+public final class DateComparators {
+  public static final BinaryOperation<Boolean> EQ =
+      new GenericComparators<>(DateType.INSTANCE, LocalDate::isEqual, false);
+  public static final BinaryOperation<Boolean> NEQ =
+      new GenericComparators<>(DateType.INSTANCE, (a, b) -> !a.isEqual(b), true);
+  public static final BinaryOperation<Boolean> LT =
+      new GenericComparators<>(DateType.INSTANCE, LocalDate::isBefore);
+  public static final BinaryOperation<Boolean> LTE =
+      new GenericComparators<>(DateType.INSTANCE, (a, b) -> !a.isAfter(b));
+  public static final BinaryOperation<Boolean> GT =
+      new GenericComparators<>(DateType.INSTANCE, LocalDate::isAfter);
+  public static final BinaryOperation<Boolean> GTE =
+      new GenericComparators<>(DateType.INSTANCE, (a, b) -> !a.isBefore(b));
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
@@ -1,59 +1,20 @@
 package org.enso.table.data.column.operation.comparators;
 
 import java.time.ZonedDateTime;
-import java.util.function.BiPredicate;
-import org.enso.base.polyglot.Polyglot_Utils;
-import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.type.AnyObjectType;
+import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.DateTimeType;
 
-public class DateTimeComparators extends GenericComparators<ZonedDateTime> {
-  public static final DateTimeComparators EQ = new DateTimeComparators(ZonedDateTime::isEqual) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return false;
-    }
-  };
-
-  public static final DateTimeComparators NEQ = new DateTimeComparators((a, b) -> !a.equals(b)) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return true;
-    }
-  };
-
-  public static final DateTimeComparators LT = new DateTimeComparators(ZonedDateTime::isBefore);
-  public static final DateTimeComparators LTE = new DateTimeComparators((a, b) -> !a.isAfter(b));
-  public static final DateTimeComparators GT = new DateTimeComparators(ZonedDateTime::isAfter);
-  public static final DateTimeComparators GTE = new DateTimeComparators((a, b) -> !a.isBefore(b));
-
-  private DateTimeComparators(
-      BiPredicate<ZonedDateTime, ZonedDateTime> comparator) {
-    super(comparator);
-  }
-
-  @Override
-  protected ColumnStorage<ZonedDateTime> asTypedStorage(ColumnStorage<?> storage) {
-    return DateTimeType.INSTANCE.asTypedStorage(storage);
-  }
-
-  @Override
-  protected ZonedDateTime asTypedValue(Object value) {
-    Object adapted = Polyglot_Utils.convertPolyglotValue(value);
-    if (adapted instanceof ZonedDateTime zonedDateTime) {
-      return zonedDateTime;
-    }
-    return null;
-  }
-
-  @Override
-  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
-    return left.getType() instanceof DateTimeType;
-  }
-
-  @Override
-  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return left.getType() instanceof DateTimeType
-        && (right.getType() instanceof DateTimeType || right.getType() instanceof AnyObjectType);
-  }
+public final class DateTimeComparators {
+  public static final BinaryOperation<Boolean> EQ =
+      new GenericComparators<>(DateTimeType.INSTANCE, ZonedDateTime::isEqual, false);
+  public static final BinaryOperation<Boolean> NEQ =
+      new GenericComparators<>(DateTimeType.INSTANCE, (a, b) -> !a.equals(b), true);
+  public static final BinaryOperation<Boolean> LT =
+      new GenericComparators<>(DateTimeType.INSTANCE, ZonedDateTime::isBefore);
+  public static final BinaryOperation<Boolean> LTE =
+      new GenericComparators<>(DateTimeType.INSTANCE, (a, b) -> !a.isAfter(b));
+  public static final BinaryOperation<Boolean> GT =
+      new GenericComparators<>(DateTimeType.INSTANCE, ZonedDateTime::isAfter);
+  public static final BinaryOperation<Boolean> GTE =
+      new GenericComparators<>(DateTimeType.INSTANCE, (a, b) -> !a.isBefore(b));
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.DateTimeType;
 
-public final class DateTimeComparators {
+final class DateTimeComparators {
   public static final BinaryOperation<Boolean> EQ =
       new GenericComparators<>(DateTimeType.INSTANCE, ZonedDateTime::isEqual, false);
   public static final BinaryOperation<Boolean> NEQ =

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/DateTimeComparators.java
@@ -7,23 +7,29 @@ import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.DateTimeType;
 
-public final class DateTimeComparators extends GenericComparators<ZonedDateTime> {
-  public static final DateTimeComparators EQ =
-      new DateTimeComparators(ZonedDateTime::isEqual, false);
-  public static final DateTimeComparators NEQ =
-      new DateTimeComparators((a, b) -> !a.equals(b), false);
+public class DateTimeComparators extends GenericComparators<ZonedDateTime> {
+  public static final DateTimeComparators EQ = new DateTimeComparators(ZonedDateTime::isEqual) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return false;
+    }
+  };
+
+  public static final DateTimeComparators NEQ = new DateTimeComparators((a, b) -> !a.equals(b)) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return true;
+    }
+  };
+
   public static final DateTimeComparators LT = new DateTimeComparators(ZonedDateTime::isBefore);
   public static final DateTimeComparators LTE = new DateTimeComparators((a, b) -> !a.isAfter(b));
   public static final DateTimeComparators GT = new DateTimeComparators(ZonedDateTime::isAfter);
   public static final DateTimeComparators GTE = new DateTimeComparators((a, b) -> !a.isBefore(b));
 
-  private DateTimeComparators(BiPredicate<ZonedDateTime, ZonedDateTime> comparator) {
-    this(comparator, true);
-  }
-
   private DateTimeComparators(
-      BiPredicate<ZonedDateTime, ZonedDateTime> comparator, boolean throwOnOther) {
-    super(comparator, throwOnOther);
+      BiPredicate<ZonedDateTime, ZonedDateTime> comparator) {
+    super(comparator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/GenericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/GenericComparators.java
@@ -13,19 +13,17 @@ import org.enso.table.data.column.storage.type.NullType;
 
 public abstract class GenericComparators<T> implements BinaryOperation<Boolean> {
   protected final BiPredicate<T, T> comparator;
-  protected final boolean throwOnOther;
 
-  protected GenericComparators(BiPredicate<T, T> comparator, boolean throwOnOther) {
+  protected GenericComparators(BiPredicate<T, T> comparator) {
     this.comparator = comparator;
-    this.throwOnOther = throwOnOther;
   }
 
   protected abstract T asTypedValue(Object value);
 
   protected abstract ColumnStorage<T> asTypedStorage(ColumnStorage<?> storage);
 
-  protected RuntimeException makeCompareError(Object left, Object right) {
-    return new CompareException(left, right);
+  protected boolean onIncomparable(Object left, Object right) {
+    throw new CompareException(left, right);
   }
 
   @Override
@@ -49,17 +47,12 @@ public abstract class GenericComparators<T> implements BinaryOperation<Boolean> 
           typedLeft,
           builder,
           (b, index, value) -> b.appendBoolean(comparator.test(value, typedRight)));
-    } else if (throwOnOther) {
+    } else {
       // If all are Nothing then will return a Nothing Boolean Storage
       return StorageIterators.buildOverStorage(
           typedLeft,
           builder,
-          (b, index, value) -> {
-            throw makeCompareError(value, rightValue);
-          });
-    } else {
-      return StorageIterators.buildOverStorage(
-          typedLeft, builder, (b, index, value) -> b.appendBoolean(false));
+          (b, index, value) -> b.appendBoolean(onIncomparable(value, rightValue)));
     }
   }
 
@@ -88,15 +81,9 @@ public abstract class GenericComparators<T> implements BinaryOperation<Boolean> 
           true,
           (index, leftValue, rightValue) -> {
             T typedRightValue = asTypedValue(rightValue);
-            if (typedRightValue == null) {
-              if (throwOnOther) {
-                throw makeCompareError(leftValue, rightValue);
-              } else {
-                return false;
-              }
-            } else {
-              return comparator.test(leftValue, typedRightValue);
-            }
+            return typedRightValue == null
+                ? onIncomparable(leftValue, rightValue)
+                : comparator.test(leftValue, typedRightValue);
           });
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/GenericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/GenericComparators.java
@@ -10,24 +10,48 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.NullType;
+import org.enso.table.data.column.storage.type.StorageType;
 
-public abstract class GenericComparators<T> implements BinaryOperation<Boolean> {
+public class GenericComparators<T> implements BinaryOperation<Boolean> {
+  protected final StorageType<T> valueType;
   protected final BiPredicate<T, T> comparator;
+  protected final boolean throwOnOther;
+  protected final boolean valueOnOther;
 
-  protected GenericComparators(BiPredicate<T, T> comparator) {
+  public GenericComparators(StorageType<T> valueType, BiPredicate<T, T> comparator) {
+    this.valueType = valueType;
     this.comparator = comparator;
+    this.throwOnOther = true;
+    this.valueOnOther = false;
   }
 
-  protected abstract T asTypedValue(Object value);
+  public GenericComparators(
+      StorageType<T> valueType, BiPredicate<T, T> comparator, boolean valueOnOther) {
+    this.valueType = valueType;
+    this.comparator = comparator;
+    this.throwOnOther = false;
+    this.valueOnOther = valueOnOther;
+  }
 
-  protected abstract ColumnStorage<T> asTypedStorage(ColumnStorage<?> storage);
+  protected T asTypedValue(Object value) {
+    return valueType.valueAsType(value);
+  }
+
+  protected ColumnStorage<T> asTypedStorage(ColumnStorage<?> storage) {
+    return valueType.asTypedStorage(storage);
+  }
 
   protected boolean onIncomparable(Object left, Object right) {
-    throw new CompareException(left, right);
+    if (throwOnOther) {
+      throw new CompareException(left, right);
+    }
+    return valueOnOther;
   }
 
   @Override
-  public abstract boolean canApplyMap(ColumnStorage<?> left, Object rightValue);
+  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
+    return valueType.isOfType(left.getType());
+  }
 
   @Override
   public ColumnStorage<Boolean> applyMap(
@@ -57,7 +81,12 @@ public abstract class GenericComparators<T> implements BinaryOperation<Boolean> 
   }
 
   @Override
-  public abstract boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right);
+  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
+    return valueType.isOfType(left.getType())
+        && (!throwOnOther
+            || valueType.isOfType(right.getType())
+            || right.getType() instanceof AnyObjectType);
+  }
 
   @Override
   public ColumnStorage<Boolean> applyZip(
@@ -72,7 +101,7 @@ public abstract class GenericComparators<T> implements BinaryOperation<Boolean> 
     assert canApplyZip(left, right);
 
     var typedLeft = asTypedStorage(left);
-    if (right.getType() instanceof AnyObjectType) {
+    if (!valueType.isOfType(right.getType())) {
       // Fall back to iterating over each.
       return StorageIterators.zipOverStorages(
           typedLeft,

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NullComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NullComparators.java
@@ -6,7 +6,7 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.NullType;
 
-public final class NullComparators implements BinaryOperation<Boolean> {
+final class NullComparators implements BinaryOperation<Boolean> {
   public static final NullComparators INSTANCE = new NullComparators();
 
   private NullComparators() {}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -258,8 +258,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(Double left, Double right, long index) {
-      throw new IllegalStateException("This method should not be called directly.");
+    protected Boolean doSingle(Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
+      return comparator.doDouble(left, right, index, problemAggregator);
     }
   }
 
@@ -273,7 +273,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(BigDecimal left, BigDecimal right, long index) {
+    protected Boolean doSingle(BigDecimal left, BigDecimal right, long index, MapOperationProblemAggregator problemAggregator) {
       return comparator.doBigDecimal(left, right, index);
     }
   }
@@ -288,7 +288,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(BigInteger left, BigInteger right, long index) {
+    protected Boolean doSingle(BigInteger left, BigInteger right, long index, MapOperationProblemAggregator problemAggregator) {
       return comparator.doBigInteger(left, right, index);
     }
   }
@@ -329,8 +329,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(Long left, Long right, long index) {
-      throw new IllegalStateException("This method should not be called directly.");
+    protected Boolean doSingle(Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
+      return comparator.doLong(left, right, index);
     }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -237,7 +237,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
       double rightAsDouble = right;
       return StorageIterators.buildOverDoubleStorage(
           (ColumnDoubleStorage) left,
-          false,
+          true,
           BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
           (builder, index, value, isNothing) ->
               builder.appendBoolean(comparator.doDouble(value, rightAsDouble, index, problemAggregator)));
@@ -252,7 +252,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
           (ColumnDoubleStorage) left,
           (ColumnDoubleStorage) right,
           s -> BooleanType.INSTANCE.makeBuilder(s, problemAggregator),
-          false,
+          true,
           (index, value1, isNothing1, value2, isNothing2) ->
               comparator.doDouble(value1, value2, index, problemAggregator));
     }
@@ -308,7 +308,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
       long rightAsLong = right;
       return StorageIterators.buildOverLongStorage(
           (ColumnLongStorage) left,
-          false,
+          true,
           BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
           (builder, index, value, isNothing) ->
               builder.appendBoolean(comparator.doLong(value, right, index)));

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -23,7 +23,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
    * implemented by any numeric operation.
    */
   public abstract static class NumericComparator {
-    abstract boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator);
+    abstract boolean doDouble(
+        double a, double b, long ix, MapOperationProblemAggregator problemAggregator);
 
     abstract boolean doLong(long a, long b, long ix);
 
@@ -35,8 +36,9 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
-          problemAggregator.reportFloatingPointEquality((int)ix);
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+          problemAggregator.reportFloatingPointEquality((int) ix);
           return a == b;
         }
 
@@ -59,8 +61,9 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator NOT_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
-          problemAggregator.reportFloatingPointEquality((int)ix);
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+          problemAggregator.reportFloatingPointEquality((int) ix);
           return a != b;
         }
 
@@ -83,7 +86,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator GREATER_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a > b;
         }
 
@@ -106,7 +110,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator GREATER_OR_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a >= b;
         }
 
@@ -129,7 +134,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator LESS_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a < b;
         }
 
@@ -152,7 +158,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
   public static final NumericComparator LESS_OR_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+        boolean doDouble(
+            double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a <= b;
         }
 
@@ -211,7 +218,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     this.comparator = comparator;
   }
 
-  protected NumericComparators(NumericColumnAdapter<T> adapter, NumericComparator comparator, boolean valueOnOther) {
+  protected NumericComparators(
+      NumericColumnAdapter<T> adapter, NumericComparator comparator, boolean valueOnOther) {
     super(adapter, true, BooleanType.INSTANCE, valueOnOther);
     this.comparator = comparator;
   }
@@ -240,7 +248,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
           true,
           BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
           (builder, index, value, isNothing) ->
-              builder.appendBoolean(comparator.doDouble(value, rightAsDouble, index, problemAggregator)));
+              builder.appendBoolean(
+                  comparator.doDouble(value, rightAsDouble, index, problemAggregator)));
     }
 
     @Override
@@ -258,7 +267,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Boolean doSingle(
+        Double left, Double right, long index, MapOperationProblemAggregator problemAggregator) {
       return comparator.doDouble(left, right, index, problemAggregator);
     }
   }
@@ -273,7 +283,11 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(BigDecimal left, BigDecimal right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Boolean doSingle(
+        BigDecimal left,
+        BigDecimal right,
+        long index,
+        MapOperationProblemAggregator problemAggregator) {
       return comparator.doBigDecimal(left, right, index);
     }
   }
@@ -288,7 +302,11 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(BigInteger left, BigInteger right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Boolean doSingle(
+        BigInteger left,
+        BigInteger right,
+        long index,
+        MapOperationProblemAggregator problemAggregator) {
       return comparator.doBigInteger(left, right, index);
     }
   }
@@ -329,7 +347,8 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
     }
 
     @Override
-    protected Boolean doSingle(Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
+    protected Boolean doSingle(
+        Long left, Long right, long index, MapOperationProblemAggregator problemAggregator) {
       return comparator.doLong(left, right, index);
     }
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -17,7 +17,7 @@ import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 
-public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> {
+abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> {
   /**
    * An abstract class representing a numeric operation. This class defines the methods that must be
    * implemented by any numeric operation.
@@ -172,7 +172,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
         }
       };
 
-  public static BinaryOperation<Boolean> create(
+  static BinaryOperation<Boolean> create(
       StorageType<?> leftType, Object right, NumericComparator comparator) {
     var rightType = storageTypeForObject(right);
     if (leftType instanceof FloatType || rightType instanceof FloatType) {
@@ -188,10 +188,31 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     }
   }
 
+  static BinaryOperation<Boolean> create(
+      StorageType<?> leftType, Object right, NumericComparator comparator, boolean valueOnOther) {
+    var rightType = storageTypeForObject(right);
+    if (leftType instanceof FloatType || rightType instanceof FloatType) {
+      return new NumericComparatorsDouble(comparator, valueOnOther);
+    } else if (leftType instanceof BigDecimalType || rightType instanceof BigDecimalType) {
+      return new NumericComparatorsBigDecimal(comparator, valueOnOther);
+    } else if (leftType instanceof BigIntegerType || rightType instanceof BigIntegerType) {
+      return new NumericComparatorsBigInteger(comparator, valueOnOther);
+    } else if (leftType instanceof IntegerType || rightType instanceof IntegerType) {
+      return new NumericComparatorsLong(comparator, valueOnOther);
+    } else {
+      throw new IllegalArgumentException("Unsupported type: " + leftType + " or " + rightType);
+    }
+  }
+
   protected final NumericComparator comparator;
 
   protected NumericComparators(NumericColumnAdapter<T> adapter, NumericComparator comparator) {
     super(adapter, true, BooleanType.INSTANCE);
+    this.comparator = comparator;
+  }
+
+  protected NumericComparators(NumericColumnAdapter<T> adapter, NumericComparator comparator, boolean valueOnOther) {
+    super(adapter, true, BooleanType.INSTANCE, valueOnOther);
     this.comparator = comparator;
   }
 
@@ -204,6 +225,10 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   private static class NumericComparatorsDouble extends NumericComparators<Double> {
     public NumericComparatorsDouble(NumericComparator comparator) {
       super(DoubleColumnAdapter.INSTANCE, comparator);
+    }
+
+    public NumericComparatorsDouble(NumericComparator comparator, boolean valueOnOther) {
+      super(DoubleColumnAdapter.INSTANCE, comparator, valueOnOther);
     }
 
     @Override
@@ -243,6 +268,10 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
       super(BigDecimalColumnAdapter.INSTANCE, comparator);
     }
 
+    public NumericComparatorsBigDecimal(NumericComparator comparator, boolean valueOnOther) {
+      super(BigDecimalColumnAdapter.INSTANCE, comparator, valueOnOther);
+    }
+
     @Override
     protected Boolean doSingle(BigDecimal left, BigDecimal right, long index) {
       return comparator.doBigDecimal(left, right, index);
@@ -254,6 +283,10 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
       super(BigIntegerColumnAdapter.INSTANCE, comparator);
     }
 
+    public NumericComparatorsBigInteger(NumericComparator comparator, boolean valueOnOther) {
+      super(BigIntegerColumnAdapter.INSTANCE, comparator, valueOnOther);
+    }
+
     @Override
     protected Boolean doSingle(BigInteger left, BigInteger right, long index) {
       return comparator.doBigInteger(left, right, index);
@@ -263,6 +296,10 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   private static class NumericComparatorsLong extends NumericComparators<Long> {
     public NumericComparatorsLong(NumericComparator operation) {
       super(LongColumnAdapter.INSTANCE, operation);
+    }
+
+    public NumericComparatorsLong(NumericComparator operation, boolean valueOnOther) {
+      super(LongColumnAdapter.INSTANCE, operation, valueOnOther);
     }
 
     @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -1,0 +1,298 @@
+package org.enso.table.data.column.operation.comparators;
+
+import org.enso.table.data.column.operation.BinaryOperation;
+import org.enso.table.data.column.operation.BinaryOperationNumeric;
+import org.enso.table.data.column.operation.StorageIterators;
+import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
+import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.ColumnDoubleStorage;
+import org.enso.table.data.column.storage.ColumnLongStorage;
+import org.enso.table.data.column.storage.ColumnStorage;
+import org.enso.table.data.column.storage.type.BigDecimalType;
+import org.enso.table.data.column.storage.type.BigIntegerType;
+import org.enso.table.data.column.storage.type.BooleanType;
+import org.enso.table.data.column.storage.type.FloatType;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.data.column.storage.type.StorageType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> {
+  /**
+   * An abstract class representing a numeric operation. This class defines the methods that must be
+   * implemented by any numeric operation.
+   */
+  public abstract static class NumericComparator {
+    abstract boolean doDouble(double a, double b, long ix);
+
+    abstract boolean doLong(long a, long b, long ix);
+
+    abstract boolean doBigInteger(BigInteger a, BigInteger b, long ix);
+
+    abstract boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix);
+  }
+
+  public static final NumericComparator EQUAL_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a == b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a == b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return a.equals(b);
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return a.equals(b);
+    }
+  };
+
+  public static final NumericComparator NOT_EQUAL_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a != b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a != b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return !a.equals(b);
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return !a.equals(b);
+    }
+  };
+
+  public static final NumericComparator GREATER_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a > b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a > b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return a.compareTo(b) > 0;
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return a.compareTo(b) > 0;
+    }
+  };
+
+  public static final NumericComparator GREATER_OR_EQUAL_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a >= b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a >= b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return a.compareTo(b) >= 0;
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return a.compareTo(b) >= 0;
+    }
+  };
+
+  public static final NumericComparator LESS_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a < b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a < b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return a.compareTo(b) < 0;
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return a.compareTo(b) < 0;
+    }
+  };
+
+  public static final NumericComparator LESS_OR_EQUAL_OPERATION = new NumericComparator() {
+    @Override
+    boolean doDouble(double a, double b, long ix) {
+      return a <= b;
+    }
+
+    @Override
+    boolean doLong(long a, long b, long ix) {
+      return a <= b;
+    }
+
+    @Override
+    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+      return a.compareTo(b) <= 0;
+    }
+
+    @Override
+    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+      return a.compareTo(b) <= 0;
+    }
+  };
+
+
+  public static BinaryOperation<Boolean> create(
+      StorageType<?> leftType, Object right, NumericComparator comparator) {
+    var rightType = storageTypeForObject(right);
+    if (leftType instanceof FloatType || rightType instanceof FloatType) {
+      return new NumericComparatorsDouble(comparator);
+    } else if (leftType instanceof BigDecimalType || rightType instanceof BigDecimalType) {
+      return new NumericComparatorsBigDecimal(comparator);
+    } else if (leftType instanceof BigIntegerType || rightType instanceof BigIntegerType) {
+      return new NumericComparatorsBigInteger(comparator);
+    } else if (leftType instanceof IntegerType || rightType instanceof IntegerType) {
+      return new NumericComparatorsLong(comparator);
+    } else {
+      throw new IllegalArgumentException("Unsupported type: " + leftType);
+    }
+  }
+
+  protected final NumericComparator comparator;
+
+  protected NumericComparators(
+      NumericColumnAdapter<T> adapter, NumericComparator comparator) {
+    super(adapter, true, BooleanType.INSTANCE);
+    this.comparator = comparator;
+  }
+
+  @Override
+  protected ColumnStorage<Boolean> applyNullMap(
+      ColumnStorage<?> left, MapOperationProblemAggregator problemAggregator) {
+    return BoolStorage.makeEmpty(left.getSize());
+  }
+
+  private static class NumericComparatorsDouble
+      extends NumericComparators<Double> {
+    public NumericComparatorsDouble(NumericComparator comparator) {
+      super(DoubleColumnAdapter.INSTANCE, comparator);
+    }
+
+    @Override
+    protected ColumnStorage<Boolean> innerApplyMap(
+        ColumnStorage<Double> left, Double right, MapOperationProblemAggregator problemAggregator) {
+      double rightAsDouble = right;
+      return StorageIterators.buildOverDoubleStorage(
+          (ColumnDoubleStorage) left,
+          false,
+          BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+          (builder, index, value, isNothing) ->
+              builder.appendBoolean(comparator.doDouble(value, right, index)));
+    }
+
+    @Override
+    protected ColumnStorage<Boolean> innerApplyZip(
+        ColumnStorage<Double> left,
+        ColumnStorage<Double> right,
+        MapOperationProblemAggregator problemAggregator) {
+      return StorageIterators.zipOverDoubleStorages(
+          (ColumnDoubleStorage) left,
+          (ColumnDoubleStorage) right,
+          s -> BooleanType.INSTANCE.makeBuilder(s, problemAggregator),
+          false,
+          (index, value1, isNothing1, value2, isNothing2) ->
+              comparator.doDouble(value1, value2, index));
+    }
+
+    @Override
+    protected Boolean doSingle(Double left, Double right, long index) {
+      throw new IllegalStateException("This method should not be called directly.");
+    }
+  }
+
+  private static class NumericComparatorsBigDecimal
+      extends NumericComparators<BigDecimal> {
+    public NumericComparatorsBigDecimal(NumericComparator comparator) {
+      super(BigDecimalColumnAdapter.INSTANCE, comparator);
+    }
+
+    @Override
+    protected Boolean doSingle(BigDecimal left, BigDecimal right, long index) {
+      return comparator.doBigDecimal(left, right, index);
+    }
+  }
+
+  private static class NumericComparatorsBigInteger
+      extends NumericComparators<BigInteger> {
+    public NumericComparatorsBigInteger(NumericComparator comparator) {
+      super(BigIntegerColumnAdapter.INSTANCE, comparator);
+    }
+
+    @Override
+    protected Boolean doSingle(BigInteger left, BigInteger right, long index) {
+      return comparator.doBigInteger(left, right, index);
+    }
+  }
+
+  private static class NumericComparatorsLong
+      extends NumericComparators<Long> {
+    public NumericComparatorsLong(NumericComparator operation) {
+      super(LongColumnAdapter.INSTANCE, operation);
+    }
+
+    @Override
+    protected ColumnStorage<Boolean> innerApplyMap(
+        ColumnStorage<Long> left, Long right, MapOperationProblemAggregator problemAggregator) {
+      long rightAsLong = right;
+      return StorageIterators.buildOverLongStorage(
+          (ColumnLongStorage) left,
+          false,
+          BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
+          (builder, index, value, isNothing) ->
+              builder.appendBoolean(comparator.doLong(value, right, index)));
+    }
+
+    @Override
+    protected ColumnStorage<Boolean> innerApplyZip(
+        ColumnStorage<Long> left,
+        ColumnStorage<Long> right,
+        MapOperationProblemAggregator problemAggregator) {
+      return StorageIterators.zipOverLongStorages(
+          (ColumnLongStorage) left,
+          (ColumnLongStorage) right,
+          s -> BooleanType.INSTANCE.makeBuilder(s, problemAggregator),
+          true,
+          (index, value1, isNothing1, value2, isNothing2) ->
+              comparator.doLong(value1, value2, index));
+    }
+
+    @Override
+    protected Boolean doSingle(Long left, Long right, long index) {
+      throw new IllegalStateException("This method should not be called directly.");
+    }
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -49,7 +49,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
 
         @Override
         boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-          return a.equals(b);
+          return a.compareTo(b) == 0;
         }
 
         @Override
@@ -74,7 +74,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
 
         @Override
         boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-          return !a.equals(b);
+          return a.compareTo(b) != 0;
         }
 
         @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -23,7 +23,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
    * implemented by any numeric operation.
    */
   public abstract static class NumericComparator {
-    abstract boolean doDouble(double a, double b, long ix);
+    abstract boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator);
 
     abstract boolean doLong(long a, long b, long ix);
 
@@ -35,7 +35,8 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+          problemAggregator.reportFloatingPointEquality((int)ix);
           return a == b;
         }
 
@@ -58,7 +59,8 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator NOT_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
+          problemAggregator.reportFloatingPointEquality((int)ix);
           return a != b;
         }
 
@@ -81,7 +83,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator GREATER_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a > b;
         }
 
@@ -104,7 +106,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator GREATER_OR_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a >= b;
         }
 
@@ -127,7 +129,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator LESS_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a < b;
         }
 
@@ -150,7 +152,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
   public static final NumericComparator LESS_OR_EQUAL_OPERATION =
       new NumericComparator() {
         @Override
-        boolean doDouble(double a, double b, long ix) {
+        boolean doDouble(double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           return a <= b;
         }
 
@@ -182,7 +184,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     } else if (leftType instanceof IntegerType || rightType instanceof IntegerType) {
       return new NumericComparatorsLong(comparator);
     } else {
-      throw new IllegalArgumentException("Unsupported type: " + leftType);
+      throw new IllegalArgumentException("Unsupported type: " + leftType + " or " + rightType);
     }
   }
 
@@ -213,7 +215,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
           false,
           BooleanType.INSTANCE.makeBuilder(left.getSize(), problemAggregator),
           (builder, index, value, isNothing) ->
-              builder.appendBoolean(comparator.doDouble(value, right, index)));
+              builder.appendBoolean(comparator.doDouble(value, rightAsDouble, index, problemAggregator)));
     }
 
     @Override
@@ -227,7 +229,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
           s -> BooleanType.INSTANCE.makeBuilder(s, problemAggregator),
           false,
           (index, value1, isNothing1, value2, isNothing2) ->
-              comparator.doDouble(value1, value2, index));
+              comparator.doDouble(value1, value2, index, problemAggregator));
     }
 
     @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -1,5 +1,7 @@
 package org.enso.table.data.column.operation.comparators;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.operation.BinaryOperationNumeric;
 import org.enso.table.data.column.operation.StorageIterators;
@@ -14,9 +16,6 @@ import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
 
 public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> {
   /**
@@ -33,138 +32,143 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     abstract boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix);
   }
 
-  public static final NumericComparator EQUAL_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a == b;
-    }
+  public static final NumericComparator EQUAL_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a == b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a == b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a == b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return a.equals(b);
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return a.equals(b);
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return a.equals(b);
-    }
-  };
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return a.equals(b);
+        }
+      };
 
-  public static final NumericComparator NOT_EQUAL_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a != b;
-    }
+  public static final NumericComparator NOT_EQUAL_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a != b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a != b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a != b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return !a.equals(b);
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return !a.equals(b);
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return !a.equals(b);
-    }
-  };
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return !a.equals(b);
+        }
+      };
 
-  public static final NumericComparator GREATER_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a > b;
-    }
+  public static final NumericComparator GREATER_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a > b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a > b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a > b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return a.compareTo(b) > 0;
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return a.compareTo(b) > 0;
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return a.compareTo(b) > 0;
-    }
-  };
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return a.compareTo(b) > 0;
+        }
+      };
 
-  public static final NumericComparator GREATER_OR_EQUAL_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a >= b;
-    }
+  public static final NumericComparator GREATER_OR_EQUAL_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a >= b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a >= b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a >= b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return a.compareTo(b) >= 0;
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return a.compareTo(b) >= 0;
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return a.compareTo(b) >= 0;
-    }
-  };
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return a.compareTo(b) >= 0;
+        }
+      };
 
-  public static final NumericComparator LESS_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a < b;
-    }
+  public static final NumericComparator LESS_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a < b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a < b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a < b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return a.compareTo(b) < 0;
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return a.compareTo(b) < 0;
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return a.compareTo(b) < 0;
-    }
-  };
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return a.compareTo(b) < 0;
+        }
+      };
 
-  public static final NumericComparator LESS_OR_EQUAL_OPERATION = new NumericComparator() {
-    @Override
-    boolean doDouble(double a, double b, long ix) {
-      return a <= b;
-    }
+  public static final NumericComparator LESS_OR_EQUAL_OPERATION =
+      new NumericComparator() {
+        @Override
+        boolean doDouble(double a, double b, long ix) {
+          return a <= b;
+        }
 
-    @Override
-    boolean doLong(long a, long b, long ix) {
-      return a <= b;
-    }
+        @Override
+        boolean doLong(long a, long b, long ix) {
+          return a <= b;
+        }
 
-    @Override
-    boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
-      return a.compareTo(b) <= 0;
-    }
+        @Override
+        boolean doBigDecimal(BigDecimal a, BigDecimal b, long ix) {
+          return a.compareTo(b) <= 0;
+        }
 
-    @Override
-    boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
-      return a.compareTo(b) <= 0;
-    }
-  };
-
+        @Override
+        boolean doBigInteger(BigInteger a, BigInteger b, long ix) {
+          return a.compareTo(b) <= 0;
+        }
+      };
 
   public static BinaryOperation<Boolean> create(
       StorageType<?> leftType, Object right, NumericComparator comparator) {
@@ -184,8 +188,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
 
   protected final NumericComparator comparator;
 
-  protected NumericComparators(
-      NumericColumnAdapter<T> adapter, NumericComparator comparator) {
+  protected NumericComparators(NumericColumnAdapter<T> adapter, NumericComparator comparator) {
     super(adapter, true, BooleanType.INSTANCE);
     this.comparator = comparator;
   }
@@ -196,8 +199,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     return BoolStorage.makeEmpty(left.getSize());
   }
 
-  private static class NumericComparatorsDouble
-      extends NumericComparators<Double> {
+  private static class NumericComparatorsDouble extends NumericComparators<Double> {
     public NumericComparatorsDouble(NumericComparator comparator) {
       super(DoubleColumnAdapter.INSTANCE, comparator);
     }
@@ -234,8 +236,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     }
   }
 
-  private static class NumericComparatorsBigDecimal
-      extends NumericComparators<BigDecimal> {
+  private static class NumericComparatorsBigDecimal extends NumericComparators<BigDecimal> {
     public NumericComparatorsBigDecimal(NumericComparator comparator) {
       super(BigDecimalColumnAdapter.INSTANCE, comparator);
     }
@@ -246,8 +247,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     }
   }
 
-  private static class NumericComparatorsBigInteger
-      extends NumericComparators<BigInteger> {
+  private static class NumericComparatorsBigInteger extends NumericComparators<BigInteger> {
     public NumericComparatorsBigInteger(NumericComparator comparator) {
       super(BigIntegerColumnAdapter.INSTANCE, comparator);
     }
@@ -258,8 +258,7 @@ public abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Bo
     }
   }
 
-  private static class NumericComparatorsLong
-      extends NumericComparators<Long> {
+  private static class NumericComparatorsLong extends NumericComparators<Long> {
     public NumericComparatorsLong(NumericComparator operation) {
       super(LongColumnAdapter.INSTANCE, operation);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
@@ -6,10 +6,21 @@ import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.TextType;
 
-public final class StringComparators extends GenericComparators<String> {
-  public static final StringComparators EQ = new StringComparators(Text_Utils::equals, false);
-  public static final StringComparators NEQ =
-      new StringComparators((a, b) -> !Text_Utils.equals(a, b), false);
+public class StringComparators extends GenericComparators<String> {
+  public static final StringComparators EQ = new StringComparators(Text_Utils::equals) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return false;
+    }
+  };
+
+  public static final StringComparators NEQ = new StringComparators((a, b) -> !Text_Utils.equals(a, b)) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return true;
+    }
+  };
+
   public static final StringComparators LT =
       new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) < 0);
   public static final StringComparators LTE =
@@ -20,11 +31,7 @@ public final class StringComparators extends GenericComparators<String> {
       new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) >= 0);
 
   protected StringComparators(BiPredicate<String, String> comparator) {
-    this(comparator, true);
-  }
-
-  private StringComparators(BiPredicate<String, String> comparator, boolean throwOnOther) {
-    super(comparator, throwOnOther);
+    super(comparator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
@@ -4,7 +4,7 @@ import org.enso.base.Text_Utils;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.TextType;
 
-public final class StringComparators {
+final class StringComparators {
   public static final BinaryOperation<Boolean> EQ =
       new GenericComparators<>(TextType.VARIABLE_LENGTH, Text_Utils::equals, false);
   public static final BinaryOperation<Boolean> NEQ =

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/StringComparators.java
@@ -1,60 +1,24 @@
 package org.enso.table.data.column.operation.comparators;
 
-import java.util.function.BiPredicate;
 import org.enso.base.Text_Utils;
-import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.type.AnyObjectType;
+import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.TextType;
 
-public class StringComparators extends GenericComparators<String> {
-  public static final StringComparators EQ = new StringComparators(Text_Utils::equals) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return false;
-    }
-  };
-
-  public static final StringComparators NEQ = new StringComparators((a, b) -> !Text_Utils.equals(a, b)) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return true;
-    }
-  };
-
-  public static final StringComparators LT =
-      new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) < 0);
-  public static final StringComparators LTE =
-      new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) <= 0);
-  public static final StringComparators GT =
-      new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) > 0);
-  public static final StringComparators GTE =
-      new StringComparators((a, b) -> Text_Utils.compare_normalized(a, b) >= 0);
-
-  protected StringComparators(BiPredicate<String, String> comparator) {
-    super(comparator);
-  }
-
-  @Override
-  protected ColumnStorage<String> asTypedStorage(ColumnStorage<?> storage) {
-    return TextType.VARIABLE_LENGTH.asTypedStorage(storage);
-  }
-
-  @Override
-  protected String asTypedValue(Object value) {
-    if (value instanceof String stringValue) {
-      return stringValue;
-    }
-    return null;
-  }
-
-  @Override
-  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
-    return left.getType() instanceof TextType;
-  }
-
-  @Override
-  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return left.getType() instanceof TextType
-        && (right.getType() instanceof TextType || right.getType() instanceof AnyObjectType);
-  }
+public final class StringComparators {
+  public static final BinaryOperation<Boolean> EQ =
+      new GenericComparators<>(TextType.VARIABLE_LENGTH, Text_Utils::equals, false);
+  public static final BinaryOperation<Boolean> NEQ =
+      new GenericComparators<>(TextType.VARIABLE_LENGTH, (a, b) -> !Text_Utils.equals(a, b), false);
+  public static final BinaryOperation<Boolean> LT =
+      new GenericComparators<>(
+          TextType.VARIABLE_LENGTH, (a, b) -> Text_Utils.compare_normalized(a, b) < 0);
+  public static final BinaryOperation<Boolean> LTE =
+      new GenericComparators<>(
+          TextType.VARIABLE_LENGTH, (a, b) -> Text_Utils.compare_normalized(a, b) <= 0);
+  public static final BinaryOperation<Boolean> GT =
+      new GenericComparators<>(
+          TextType.VARIABLE_LENGTH, (a, b) -> Text_Utils.compare_normalized(a, b) > 0);
+  public static final BinaryOperation<Boolean> GTE =
+      new GenericComparators<>(
+          TextType.VARIABLE_LENGTH, (a, b) -> Text_Utils.compare_normalized(a, b) >= 0);
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
@@ -4,7 +4,7 @@ import java.time.LocalTime;
 import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 
-public final class TimeOfDayComparators {
+final class TimeOfDayComparators {
   public static final BinaryOperation<Boolean> EQ =
       new GenericComparators<>(TimeOfDayType.INSTANCE, LocalTime::equals, false);
   public static final BinaryOperation<Boolean> NEQ =

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
@@ -7,21 +7,28 @@ import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 
-public final class TimeOfDayComparators extends GenericComparators<LocalTime> {
-  public static final TimeOfDayComparators EQ = new TimeOfDayComparators(LocalTime::equals, false);
-  public static final TimeOfDayComparators NEQ =
-      new TimeOfDayComparators((a, b) -> !a.equals(b), false);
+public class TimeOfDayComparators extends GenericComparators<LocalTime> {
+  public static final TimeOfDayComparators EQ = new TimeOfDayComparators(LocalTime::equals) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return false;
+    }
+  };
+
+  public static final TimeOfDayComparators NEQ = new TimeOfDayComparators((a, b) -> !a.equals(b)) {
+    @Override
+    protected boolean onIncomparable(Object left, Object right) {
+      return true;
+    }
+  };
+
   public static final TimeOfDayComparators LT = new TimeOfDayComparators(LocalTime::isBefore);
   public static final TimeOfDayComparators LTE = new TimeOfDayComparators((a, b) -> !a.isAfter(b));
   public static final TimeOfDayComparators GT = new TimeOfDayComparators(LocalTime::isAfter);
   public static final TimeOfDayComparators GTE = new TimeOfDayComparators((a, b) -> !a.isBefore(b));
 
   private TimeOfDayComparators(BiPredicate<LocalTime, LocalTime> comparator) {
-    this(comparator, true);
-  }
-
-  private TimeOfDayComparators(BiPredicate<LocalTime, LocalTime> comparator, boolean throwOnOther) {
-    super(comparator, throwOnOther);
+    super(comparator);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/TimeOfDayComparators.java
@@ -1,58 +1,20 @@
 package org.enso.table.data.column.operation.comparators;
 
 import java.time.LocalTime;
-import java.util.function.BiPredicate;
-import org.enso.base.polyglot.Polyglot_Utils;
-import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.type.AnyObjectType;
+import org.enso.table.data.column.operation.BinaryOperation;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 
-public class TimeOfDayComparators extends GenericComparators<LocalTime> {
-  public static final TimeOfDayComparators EQ = new TimeOfDayComparators(LocalTime::equals) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return false;
-    }
-  };
-
-  public static final TimeOfDayComparators NEQ = new TimeOfDayComparators((a, b) -> !a.equals(b)) {
-    @Override
-    protected boolean onIncomparable(Object left, Object right) {
-      return true;
-    }
-  };
-
-  public static final TimeOfDayComparators LT = new TimeOfDayComparators(LocalTime::isBefore);
-  public static final TimeOfDayComparators LTE = new TimeOfDayComparators((a, b) -> !a.isAfter(b));
-  public static final TimeOfDayComparators GT = new TimeOfDayComparators(LocalTime::isAfter);
-  public static final TimeOfDayComparators GTE = new TimeOfDayComparators((a, b) -> !a.isBefore(b));
-
-  private TimeOfDayComparators(BiPredicate<LocalTime, LocalTime> comparator) {
-    super(comparator);
-  }
-
-  @Override
-  protected ColumnStorage<LocalTime> asTypedStorage(ColumnStorage<?> storage) {
-    return TimeOfDayType.INSTANCE.asTypedStorage(storage);
-  }
-
-  @Override
-  protected LocalTime asTypedValue(Object value) {
-    Object adapted = Polyglot_Utils.convertPolyglotValue(value);
-    if (adapted instanceof LocalTime localTime) {
-      return localTime;
-    }
-    return null;
-  }
-
-  @Override
-  public boolean canApplyMap(ColumnStorage<?> left, Object rightValue) {
-    return left.getType() instanceof TimeOfDayType;
-  }
-
-  @Override
-  public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return left.getType() instanceof TimeOfDayType
-        && (right.getType() instanceof TimeOfDayType || right.getType() instanceof AnyObjectType);
-  }
+public final class TimeOfDayComparators {
+  public static final BinaryOperation<Boolean> EQ =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, LocalTime::equals, false);
+  public static final BinaryOperation<Boolean> NEQ =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, (a, b) -> !a.equals(b), true);
+  public static final BinaryOperation<Boolean> LT =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, LocalTime::isBefore);
+  public static final BinaryOperation<Boolean> LTE =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, (a, b) -> !a.isAfter(b));
+  public static final BinaryOperation<Boolean> GT =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, LocalTime::isAfter);
+  public static final BinaryOperation<Boolean> GTE =
+      new GenericComparators<>(TimeOfDayType.INSTANCE, (a, b) -> !a.isBefore(b));
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/text/TextPredicates.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/text/TextPredicates.java
@@ -22,12 +22,12 @@ public final class TextPredicates extends GenericComparators<String> {
       new TextPredicates(TextPredicates::RegexMatchPredicate);
 
   private TextPredicates(BiPredicate<String, String> predicate) {
-    super(predicate, true);
+    super(predicate);
   }
 
   @Override
-  protected RuntimeException makeCompareError(Object left, Object right) {
-    return new UnexpectedTypeException("a Text", right.toString());
+  protected boolean onIncomparable(Object left, Object right) {
+    throw new UnexpectedTypeException("a Text", right.toString());
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/text/TextPredicates.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/text/TextPredicates.java
@@ -22,25 +22,12 @@ public final class TextPredicates extends GenericComparators<String> {
       new TextPredicates(TextPredicates::RegexMatchPredicate);
 
   private TextPredicates(BiPredicate<String, String> predicate) {
-    super(predicate);
+    super(TextType.VARIABLE_LENGTH, predicate);
   }
 
   @Override
   protected boolean onIncomparable(Object left, Object right) {
     throw new UnexpectedTypeException("a Text", right.toString());
-  }
-
-  @Override
-  protected ColumnStorage<String> asTypedStorage(ColumnStorage<?> storage) {
-    return TextType.VARIABLE_LENGTH.asTypedStorage(storage);
-  }
-
-  @Override
-  protected String asTypedValue(Object value) {
-    if (value instanceof String stringValue) {
-      return stringValue;
-    }
-    return null;
   }
 
   @Override
@@ -51,7 +38,7 @@ public final class TextPredicates extends GenericComparators<String> {
 
   @Override
   public boolean canApplyZip(ColumnStorage<?> left, ColumnStorage<?> right) {
-    return canApplyMap(left, null) && canApplyMap(right, null);
+    return canApplyMap(left, null);
   }
 
   private static final Map<String, Pattern> regexCache = new HashMap<>();


### PR DESCRIPTION
### Pull Request Description

- Simplified the `GenericComparator` so a lot less code for specific type versions (building on the generic `StorageType` work).
- Fix bugs with equals and not-equals when the right-hand value and column is not of same type (both Generic and Bool).
- Extracted a `BinaryOperationNumeric` base class from `BinaryCoalescingOperationNumeric`.
  *A fair amount of boilerplate is still needed for the comparators.*
- Added `NumericComparators` covering doing remaining typed comparisons.
- Simplified calling comparators from the `In_Memory_Implementation`.

ToDos:
- Review test cases for mixed matched types in comparators (did not fail any tests before).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
