### PR TITLE
Disable date browser picker 

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -712,7 +712,7 @@ function toField(
       filterOptions: filterOptions,
       buttons: filterButtons,
       refreshValuesOnOpen: true,
-      browserDatePicker: false
+      browserDatePicker: false,
     },
     headerComponentParams: {
       template,

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -712,6 +712,7 @@ function toField(
       filterOptions: filterOptions,
       buttons: filterButtons,
       refreshValuesOnOpen: true,
+      browserDatePicker: false
     },
     headerComponentParams: {
       template,


### PR DESCRIPTION
 - closes #12885 

In the date filter in ag grid the date is displayed in dd/mm/yyyy. We want it displayed in ISO (yyyy-mm-dd) format. To do this with the date picker component we are required to create a custom component and integrate this with the filter. Alternatively, we can disable the date picker then the default is set to iso format and the user just inputs dates as if it is text. 

Before:
![date-format-before](https://github.com/user-attachments/assets/873b1176-b37b-4e65-b1fb-793b22773d20)

After:  
![date-format-after](https://github.com/user-attachments/assets/b6b02f0e-a6e9-4ff0-aea3-cf6386049c35)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
