### PR TITLE
Don't use `--enable-preview` option needlessly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2734,7 +2734,7 @@ def customFrgaalJavaCompilerSettings(targetJdk: String) = {
       frgaalSourceLevel
     ) ++
     (if (Integer.parseInt(targetJdk) <= 21) {
-       Seq("--enable-preview")
+       Seq()
      } else {
        Seq("-target", "21")
      })
@@ -2747,8 +2747,7 @@ lazy val instrumentationSettings =
     commands += WithDebugCommand.withDebug,
     Compile / javacOptions --= Seq(
       "-source",
-      frgaalSourceLevel,
-      "--enable-preview"
+      frgaalSourceLevel
     ),
     libraryDependencies ++= Seq(
       "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",
@@ -3194,8 +3193,7 @@ lazy val `runtime-benchmarks` =
         Some("org.enso.interpreter.bench.benchmarks.RuntimeBenchmarksRunner"),
       javacOptions --= Seq(
         "-source",
-        frgaalSourceLevel,
-        "--enable-preview"
+        frgaalSourceLevel
       ),
       parallelExecution := false,
       Compile / moduleDependencies ++= {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -25,14 +25,13 @@ public final class BigIntegerBuilder extends TypedBuilder<BigInteger> {
 
   @Override
   public boolean canRetypeTo(StorageType<?> type) {
-    return type instanceof FloatType
-        || type instanceof BigDecimalType;
+    return type instanceof FloatType || type instanceof BigDecimalType;
   }
 
   @Override
   public Builder retypeTo(StorageType<?> type) {
     switch (type) {
-      case FloatType _ -> {
+      case FloatType floatType -> {
         // Needs to be an InferredDoubleBuilder so we can keep the raw data.
         var res = new InferredDoubleBuilder(currentSize, problemAggregator);
         for (int i = 0; i < currentSize; i++) {
@@ -44,7 +43,7 @@ public final class BigIntegerBuilder extends TypedBuilder<BigInteger> {
         }
         return res;
       }
-      case BigDecimalType _ -> {
+      case BigDecimalType bigDecimalType -> {
         var res = Builder.getForBigDecimal(data.length);
         for (int i = 0; i < currentSize; i++) {
           if (data[i] == null) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -1,5 +1,10 @@
 package org.enso.table.data.column.builder;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
@@ -17,19 +22,12 @@ import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.problems.ProblemAggregator;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
-
 /** Interface defining a builder for creating columns dynamically. */
 public interface Builder {
   /**
-   * The maximum size of a builder.
-   * Currently, just the maximum value of an integer, but should be tested and limited.
-   * For array based builders, must be less than the maximum array size.
-   * */
+   * The maximum size of a builder. Currently, just the maximum value of an integer, but should be
+   * tested and limited. For array based builders, must be less than the maximum array size.
+   */
   int MAX_SIZE = Integer.MAX_VALUE;
 
   /** Checks that the size is within the maximum allowed. */
@@ -38,7 +36,7 @@ public interface Builder {
       throw new IllegalArgumentException("Columns cannot exceed " + MAX_SIZE + " rows.");
     }
 
-    return (int)size;
+    return (int) size;
   }
 
   /**
@@ -50,17 +48,17 @@ public interface Builder {
   static Builder getForType(StorageType<?> type, long size, ProblemAggregator problemAggregator) {
     Builder builder =
         switch (type) {
-          case AnyObjectType _ -> getForAnyObject(size);
-          case BooleanType _ -> getForBoolean(size);
-          case DateType _ -> getForDate(size);
-          case DateTimeType _ -> getForDateTime(size);
-          case TimeOfDayType _ -> getForTime(size);
+          case AnyObjectType t -> getForAnyObject(size);
+          case BooleanType t -> getForBoolean(size);
+          case DateType t -> getForDate(size);
+          case DateTimeType t -> getForDateTime(size);
+          case TimeOfDayType t -> getForTime(size);
           case FloatType floatType -> getForDouble(floatType, size, problemAggregator);
           case IntegerType integerType -> getForLong(integerType, size, problemAggregator);
           case TextType textType -> getForText(textType, size);
-          case BigDecimalType _ -> getForBigDecimal(size);
-          case BigIntegerType _ -> getForBigInteger(size, problemAggregator);
-          case NullType x -> new NullBuilder();
+          case BigDecimalType t -> getForBigDecimal(size);
+          case BigIntegerType t -> getForBigInteger(size, problemAggregator);
+          case NullType t -> new NullBuilder();
           case null -> getInferredBuilder(size, problemAggregator);
         };
 
@@ -121,8 +119,7 @@ public interface Builder {
   }
 
   /**
-   * Constructs a builder for storing objects.
-   * No operations will be supported on this builder.
+   * Constructs a builder for storing objects. No operations will be supported on this builder.
    *
    * @param size the initial size of the builder.
    */
@@ -141,7 +138,8 @@ public interface Builder {
     return new BigDecimalBuilder(checkedSize);
   }
 
-  static BuilderForType<BigInteger> getForBigInteger(long size, ProblemAggregator problemAggregator) {
+  static BuilderForType<BigInteger> getForBigInteger(
+      long size, ProblemAggregator problemAggregator) {
     int checkedSize = checkSize(size);
     return new BigIntegerBuilder(checkedSize, problemAggregator);
   }

--- a/std-bits/tableau/src/main/java/org/enso/tableau/HyperFormat.java
+++ b/std-bits/tableau/src/main/java/org/enso/tableau/HyperFormat.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,7 +16,6 @@ import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
@@ -25,17 +25,16 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
-
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
 import org.enso.table.data.column.storage.ColumnDoubleStorage;
 import org.enso.table.data.column.storage.ColumnLongStorage;
 import org.enso.table.data.column.storage.type.BigDecimalType;
-import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.TextType;
-import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.DateTimeType;
 import org.enso.table.data.column.storage.type.DateType;
+import org.enso.table.data.column.storage.type.FloatType;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
@@ -331,74 +330,79 @@ public class HyperFormat {
     }
   }
 
-  public static void writeTable(String path, String schemaName, String tableName, Table table) throws IOException {
+  public static void writeTable(String path, String schemaName, String tableName, Table table)
+      throws IOException {
     getProcess();
-    try (var connection = new Connection(process.getEndpoint(), path, CreateMode.CREATE_IF_NOT_EXISTS)) {
+    try (var connection =
+        new Connection(process.getEndpoint(), path, CreateMode.CREATE_IF_NOT_EXISTS)) {
       var tableDef = createTable(schemaName, tableName, table.getColumns(), connection);
       insertData(table, tableDef, connection);
     }
   }
 
-  private static TableDefinition createTable(String schemaName, String tableName, Column[] columns, Connection connection) {
-      final var sn = new SchemaName(schemaName);
-      if (!connection.getCatalog().getSchemaNames().contains(sn)) {
-          connection.getCatalog().createSchema(sn);
-      }
-      
-      var tableDef = new TableDefinition(new TableName(schemaName, tableName));
-      for (var col : columns) {
-        String columnName = col.getName();
-        var storage = col.getStorage();
-        switch (storage.getType()) {
-          case TextType _ -> tableDef.addColumn(columnName, SqlType.text());
-          case IntegerType _ -> tableDef.addColumn(columnName, SqlType.bigInt());
-          case FloatType _ -> tableDef.addColumn(columnName, SqlType.doublePrecision());
-          case BooleanType _ -> tableDef.addColumn(columnName, SqlType.bool());
-          case DateType _ -> tableDef.addColumn(columnName, SqlType.date());
-          case TimeOfDayType _ -> tableDef.addColumn(columnName, SqlType.time());
-          case DateTimeType _ -> tableDef.addColumn(columnName, SqlType.timestampTz());
+  private static TableDefinition createTable(
+      String schemaName, String tableName, Column[] columns, Connection connection) {
+    final var sn = new SchemaName(schemaName);
+    if (!connection.getCatalog().getSchemaNames().contains(sn)) {
+      connection.getCatalog().createSchema(sn);
+    }
+
+    var tableDef = new TableDefinition(new TableName(schemaName, tableName));
+    for (var col : columns) {
+      String columnName = col.getName();
+      var storage = col.getStorage();
+      switch (storage.getType()) {
+        case TextType t -> tableDef.addColumn(columnName, SqlType.text());
+        case IntegerType t -> tableDef.addColumn(columnName, SqlType.bigInt());
+        case FloatType t -> tableDef.addColumn(columnName, SqlType.doublePrecision());
+        case BooleanType t -> tableDef.addColumn(columnName, SqlType.bool());
+        case DateType t -> tableDef.addColumn(columnName, SqlType.date());
+        case TimeOfDayType t -> tableDef.addColumn(columnName, SqlType.time());
+        case DateTimeType t -> tableDef.addColumn(columnName, SqlType.timestampTz());
           // https://tableau.github.io/hyper-db/docs/sql/datatype/numeric
-          // Precisions over 18 require 128-bit for internal storage. Processing 128-bit numeric values is 
-          // often slower than processing 64-bit values, so it is advisable to use a sensible precision for 
+          // Precisions over 18 require 128-bit for internal storage. Processing 128-bit numeric
+          // values is
+          // often slower than processing 64-bit values, so it is advisable to use a sensible
+          // precision for
           // the use case at hand instead of always using the maximum precision by default.
-          case BigDecimalType _ -> tableDef.addColumn(columnName, SqlType.numeric(18, 9));
-          default -> throw new HyperUnsupportedTypeError(storage.getType().toString());
-        }
+        case BigDecimalType t -> tableDef.addColumn(columnName, SqlType.numeric(18, 9));
+        default -> throw new HyperUnsupportedTypeError(storage.getType().toString());
       }
-      connection.executeCommand("DROP TABLE IF EXISTS \""+schemaName+"\".\""+tableName+"\"");
-      connection.getCatalog().createTable(tableDef);
-      return tableDef;
+    }
+    connection.executeCommand("DROP TABLE IF EXISTS \"" + schemaName + "\".\"" + tableName + "\"");
+    connection.getCatalog().createTable(tableDef);
+    return tableDef;
   }
 
-  private static void insertData(Table table, TableDefinition tableDef, Connection connection){
-      int numberOfRows = table.rowCount();
-      int numberOfColumns = table.getColumns().length;
-      Inserter inserter = new Inserter(connection, tableDef);
-      for (int row = 0; row < numberOfRows; ++row) {
-        for (int col = 0; col < numberOfColumns; ++col) {
-          var storage = table.getColumns()[col].getStorage();
-          if (storage.isNothing(row)) {
-            inserter.addNull();
-          } else if (storage instanceof ColumnDoubleStorage doubleStorage) {
-            inserter.add(doubleStorage.getItemAsDouble(row));
-          } else if (storage instanceof ColumnLongStorage longStorage) {
-            inserter.add(longStorage.getItemAsLong(row));
-          } else if (storage instanceof ColumnBooleanStorage boolStorage) {
-            inserter.add(boolStorage.getItemAsBoolean(row));
-          } else {
-            Object value = storage.getItemBoxed(row);
-            switch (value) {
-              case String s -> inserter.add(s);
-              case LocalDate ld -> inserter.add(ld);
-              case LocalTime lt -> inserter.add(lt);
-              case ZonedDateTime zdt -> inserter.add(zdt);
-              case BigDecimal bd -> inserter.add(bd);
-              default -> throw new HyperUnsupportedTypeError(value.toString());
-            }
+  private static void insertData(Table table, TableDefinition tableDef, Connection connection) {
+    int numberOfRows = table.rowCount();
+    int numberOfColumns = table.getColumns().length;
+    Inserter inserter = new Inserter(connection, tableDef);
+    for (int row = 0; row < numberOfRows; ++row) {
+      for (int col = 0; col < numberOfColumns; ++col) {
+        var storage = table.getColumns()[col].getStorage();
+        if (storage.isNothing(row)) {
+          inserter.addNull();
+        } else if (storage instanceof ColumnDoubleStorage doubleStorage) {
+          inserter.add(doubleStorage.getItemAsDouble(row));
+        } else if (storage instanceof ColumnLongStorage longStorage) {
+          inserter.add(longStorage.getItemAsLong(row));
+        } else if (storage instanceof ColumnBooleanStorage boolStorage) {
+          inserter.add(boolStorage.getItemAsBoolean(row));
+        } else {
+          Object value = storage.getItemBoxed(row);
+          switch (value) {
+            case String s -> inserter.add(s);
+            case LocalDate ld -> inserter.add(ld);
+            case LocalTime lt -> inserter.add(lt);
+            case ZonedDateTime zdt -> inserter.add(zdt);
+            case BigDecimal bd -> inserter.add(bd);
+            default -> throw new HyperUnsupportedTypeError(value.toString());
           }
         }
-        inserter.endRow();
       }
-      inserter.execute();
+      inserter.endRow();
+    }
+    inserter.execute();
   }
 }


### PR DESCRIPTION
### Pull Request Description

The usage of `--enable-preview` is causing problems when switching between frgaal and javac. JDK's compiler only allows `--enable-preview` with the latest `--target` e.g. `24`. This affects also other JDK utilities like `javadoc`. As a result I was unable to use `persistance/doc` to generate Javadoc when working on #13201.

The only reason why we are using`--enable-preview` is **usage of `_` in `switch` statements**. It is not really convincing reason for requiring preview mode. Hence this PR removes `--enable-preview` setting from `build.sbt` and changes the affected code to give the variable another name than `_`.

### Important Notes

The best solution would be for frgaal to `--enable-preview` by default (at the end the language is controlled by version of the frgaal compiler, no need for another switch) or offer some other (JDK javac unknown) option `-Denable.preview=true` to enable preview or offer an option to _disable preview_. That way it would be easier to switch between frgaal and latest JDK's `javadoc` without changing the arguments for the compilation. That's however a discussion to be held elsewhere.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
