### PR TITLE
Bump max memory for GUI builds

### DIFF
--- a/app/gui/package.json
+++ b/app/gui/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "typecheck": "vue-tsc --noEmit -p tsconfig.app.json",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vite build",
     "build-cloud": "cross-env ENSO_IDE_CLOUD_BUILD=true corepack pnpm run build",
     "preview": "vite preview",
     "lint": "eslint . --cache --max-warnings=0",


### PR DESCRIPTION
2GB more should be plenty to make nightlies pass again.
