### PR TITLE
Consistency of `--jvm` CLI options: allowing optional JVM path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 #### Enso Language & Runtime
 
+- [Allow optional path for `--jvm` option of `project-manager`][13225]
 - [Prevent `Meta` access to private constructors and private fields][12905]
 - [Encapsulating Private_Access constructor][#12976]
 - [Upgrading Truffle][12500] (including its
@@ -59,6 +60,7 @@
 [12976]: https://github.com/enso-org/enso/pull/12976
 [12855]: https://github.com/enso-org/enso/pull/12855
 [12905]: https://github.com/enso-org/enso/pull/12905
+[13225]: https://github.com/enso-org/enso/pull/13225
 
 # Enso 2025.1
 

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -74,7 +74,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     versionOverride: Option[SemVer],
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     additionalArguments: Seq[String]
   ): Int = {
     val actualPath = path.getOrElse(Launcher.workingDirectory.resolve(name))
@@ -89,7 +89,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             path                = actualPath,
             name                = name,
             engineVersion       = version,
-            jvmMode             = jvmMode,
+            jvm                 = jvm,
             normalizedName      = normalizedName,
             projectTemplate     = projectTemplate,
             authorName          = globalConfig.authorName,
@@ -212,7 +212,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     logLevel: Level,
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     additionalArguments: Seq[String]
   ): Int = {
     runner
@@ -223,7 +223,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             versionOverride,
             logLevel,
             cliOptions.internalOptions.logMasking,
-            jvmMode,
+            jvm,
             additionalArguments
           )
           .get,
@@ -257,7 +257,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     logLevel: Level,
     useSystemJVM: Boolean,
     jvmOpts: Seq[(String, String)],
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     additionalArguments: Seq[String]
   ): Int = {
     val exitCode = runner
@@ -268,7 +268,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
             versionOverride,
             logLevel,
             cliOptions.internalOptions.logMasking,
-            jvmMode,
+            jvm,
             additionalArguments
           )
           .get,

--- a/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
@@ -79,7 +79,7 @@ object LauncherApplication {
         versionOverride,
         systemJVMOverride,
         jvmOpts,
-        jvmMode,
+        jvm,
         additionalArgs
       ) mapN {
         (
@@ -90,7 +90,7 @@ object LauncherApplication {
           versionOverride,
           systemJVMOverride,
           jvmOpts,
-          jvmMode,
+          jvm,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).newProject(
@@ -101,7 +101,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
-            jvmMode             = jvmMode,
+            jvm                 = Option(jvm),
             additionalArguments = additionalArgs
           )
       }
@@ -112,11 +112,12 @@ object LauncherApplication {
       "jvm",
       "These parameters will be passed to the launched JVM as -DKEY=VALUE."
     )
-  private def jvmMode =
-    Opts.flag(
+  private def jvm =
+    Opts.optionalParameter[Path](
       "jvm",
-      "Setting this flag runs Enso in JVM mode rather than the default native one.",
-      showInUsage = true
+      "path",
+      "Runs Enso in JVM mode rather than the default native one.",
+      true
     )
   private def systemJVMOverride =
     Opts.flag(
@@ -166,7 +167,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
-        jvmMode,
+        jvm,
         additionalArgs
       ) mapN {
         (
@@ -175,7 +176,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
-          jvmMode,
+          jvm,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runRun(
@@ -183,7 +184,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
-            jvmMode             = jvmMode,
+            jvm                 = Option(jvm),
             additionalArguments = additionalArgs,
             logLevel            = engineLogLevel
           )
@@ -255,7 +256,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
-        jvmMode,
+        jvm,
         additionalArgs
       ) mapN {
         (
@@ -271,7 +272,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
-          jvmMode,
+          jvm,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runLanguageServer(
@@ -283,7 +284,7 @@ object LauncherApplication {
               secureRpcPort  = secureRpcPort,
               dataPort       = dataPort,
               secureDataPort = secureDataPort,
-              jvmModeEnabled = jvmMode
+              jvm            = Option(jvm)
             ),
             contentRoot         = path,
             versionOverride     = versionOverride,
@@ -316,7 +317,7 @@ object LauncherApplication {
         engineLogLevel,
         systemJVMOverride,
         jvmOpts,
-        jvmMode,
+        jvm,
         additionalArgs
       ) mapN {
         (
@@ -325,7 +326,7 @@ object LauncherApplication {
           engineLogLevel,
           systemJVMOverride,
           jvmOpts,
-          jvmMode,
+          jvm,
           additionalArgs
         ) => (config: Config) =>
           Launcher(config).runRepl(
@@ -333,7 +334,7 @@ object LauncherApplication {
             versionOverride     = versionOverride,
             useSystemJVM        = systemJVMOverride,
             jvmOpts             = jvmOpts,
-            jvmMode             = jvmMode,
+            jvm                 = Option(jvm),
             additionalArguments = additionalArgs,
             logLevel            = engineLogLevel
           )

--- a/engine/launcher/src/main/scala/org/enso/launcher/components/LauncherRunner.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/components/LauncherRunner.scala
@@ -45,7 +45,7 @@ class LauncherRunner(
     versionOverride: Option[SemVer],
     logLevel: Level,
     logMasking: Boolean,
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     additionalArguments: Seq[String]
   ): Try[RunSettings] =
     Try {
@@ -68,7 +68,7 @@ class LauncherRunner(
       }
       RunSettings(
         version,
-        jvmMode,
+        jvm,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = workingDirectory,
@@ -85,7 +85,7 @@ class LauncherRunner(
     versionOverride: Option[SemVer],
     logLevel: Level,
     logMasking: Boolean,
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     additionalArguments: Seq[String]
   ): Try[RunSettings] =
     Try {
@@ -134,7 +134,7 @@ class LauncherRunner(
           }
       RunSettings(
         version,
-        jvmMode,
+        jvm,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = workingDirectory,
@@ -216,7 +216,7 @@ class LauncherRunner(
       (
         RunSettings(
           version,
-          jvmMode = false,
+          jvm = None,
           arguments,
           workingDirectory         = None,
           connectLoggerIfAvailable = false
@@ -267,7 +267,7 @@ class LauncherRunner(
         tokenOpts ++ hideProgressOpts
       RunSettings(
         version,
-        jvmMode = false,
+        jvm = None,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = None,
@@ -316,7 +316,7 @@ class LauncherRunner(
         hideProgressOpts
       RunSettings(
         version,
-        jvmMode = false,
+        jvm = None,
         arguments ++ setLogLevelArgs(logLevel, logMasking)
         ++ additionalArguments,
         workingDirectory         = None,

--- a/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
@@ -64,7 +64,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
 
       val runSettings = RunSettings(
         SemVer.of(0, 0, 0),
-        jvmMode = true,
+        jvm = Some(None),
         Seq("arg1", "--flag2"),
         workingDirectory         = None,
         connectLoggerIfAvailable = true
@@ -127,7 +127,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           path                = projectPath,
           name                = "ProjectName",
           engineVersion       = defaultEngineVersion,
-          jvmMode             = false,
+          jvm                 = None,
           normalizedName      = None,
           projectTemplate     = None,
           authorName          = Some(authorName),
@@ -156,7 +156,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           path                = projectPath,
           name                = "ProjectName",
           engineVersion       = defaultEngineVersion,
-          jvmMode             = false,
+          jvm                 = None,
           normalizedName      = Some(normalizedName),
           projectTemplate     = None,
           authorName          = None,
@@ -187,7 +187,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
             path                = projectPath,
             name                = "ProjectName2",
             engineVersion       = nightlyVersion,
-            jvmMode             = false,
+            jvm                 = None,
             normalizedName      = None,
             projectTemplate     = None,
             authorName          = None,
@@ -221,7 +221,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq("arg", "--flag"),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -248,7 +248,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -265,7 +265,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -282,7 +282,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -306,7 +306,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
         secureRpcPort  = None,
         dataPort       = 4321,
         secureDataPort = None,
-        jvmModeEnabled = false
+        jvm            = None
       )
       val runSettings = runner
         .languageServer(
@@ -359,7 +359,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -376,7 +376,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -392,7 +392,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -408,7 +408,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
             additionalArguments = Seq(),
             logLevel            = Level.INFO,
             logMasking          = true,
-            jvmMode             = false
+            jvm                 = None
           )
           .isFailure,
         "Running outside project without providing any paths should be an error"
@@ -436,7 +436,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 
@@ -462,7 +462,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
           additionalArguments = Seq(),
           logLevel            = Level.INFO,
           logMasking          = true,
-          jvmMode             = false
+          jvm                 = None
         )
         .get
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -7,16 +7,16 @@ import scala.util.Try
 
 object Cli {
 
-  val JSON_OPTION        = "json"
-  val HELP_OPTION        = "help"
-  val NO_LOG_MASKING     = "no-log-masking"
-  val VERBOSE_OPTION     = "verbose"
-  val VERSION_OPTION     = "version"
-  val PROFILING_PATH     = "profiling-path"
-  val PROFILING_TIME     = "profiling-time"
-  val PROJECTS_DIRECTORY = "projects-directory"
-  val PROJECT_LIST       = "project-list"
-  val JVM_MODE           = "jvm"
+  val JSON_OPTION            = "json"
+  val HELP_OPTION            = "help"
+  val NO_LOG_MASKING         = "no-log-masking"
+  val VERBOSE_OPTION         = "verbose"
+  val VERSION_OPTION         = "version"
+  val PROFILING_PATH         = "profiling-path"
+  val PROFILING_TIME         = "profiling-time"
+  val PROJECTS_DIRECTORY     = "projects-directory"
+  val PROJECT_LIST           = "project-list"
+  private[boot] val JVM_MODE = "jvm"
 
   val FILESYSTEM_EXISTS           = "filesystem-exists"
   val FILESYSTEM_LIST             = "filesystem-list"
@@ -93,8 +93,9 @@ object Cli {
       .desc("List user projects.")
       .build()
 
-    val jvmMode: cli.Option = cli.Option.builder
-      .hasArg(false)
+    private[boot] val jvmMode: cli.Option = cli.Option.builder
+      .hasArg(true)
+      .optionalArg(true)
       .longOpt(JVM_MODE)
       .desc("Run in JVM mode.")
       .build()

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
@@ -116,7 +116,7 @@ class MainModule[
     new ProjectCreationService[F](
       distributionConfiguration,
       loggingService,
-      processConfig.jvmMode
+      processConfig.jvm
     )
 
   lazy val globalConfigService =

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -210,7 +210,14 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
 
     val parseJvmMode = ZIO
       .attempt {
-        options.hasOption(Cli.JVM_MODE)
+        if (options.hasOption(Cli.JVM_MODE)) {
+          Some(
+            Option(options.getOptionValue(Cli.JVM_MODE))
+              .map(Paths.get(_).toAbsolutePath)
+          )
+        } else {
+          None
+        }
       }
       .catchAll { err =>
         printLineError(s"Invalid ${Cli.JVM_MODE} argument.") *> ZIO.fail(
@@ -309,7 +316,7 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
           logLevel,
           opts.profilingPath,
           opts.profilingTime,
-          opts.jvmMode,
+          opts.jvm,
           Seq()
         )
         exitCode <- mainProcess(procConf).fold(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
@@ -8,10 +8,10 @@ import scala.concurrent.duration.FiniteDuration
   *
   * @param profilingPath the path to the profiling output file
   * @param profilingTime the time limiting the profiling duration
-  * @param jvmMode if true, enables JVM mode
+  * @param jvm use JVM - default or with specific path
   */
 case class ProjectManagerOptions(
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],
-  jvmMode: Boolean
+  jvm: Option[Option[Path]]
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration/MainProcessConfig.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration/MainProcessConfig.scala
@@ -11,13 +11,13 @@ import scala.concurrent.duration.FiniteDuration
   * @param logLevel the logging level
   * @param profilingPath the path to the profiling out file
   * @param profilingTime the time limiting the profiling duration
-  * @param jvmMode if true, enables JVM mode
+  * @param jvm enable JVM mode with default or provided JVM
   * @param extraEnv extra environment variables
   */
 case class MainProcessConfig(
   logLevel: Level,
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],
-  jvmMode: Boolean,
+  jvm: Option[Option[Path]],
   extraEnv: Seq[(String, String)]
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -90,7 +90,7 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
       secureRpcPort  = secureRpcPort,
       dataPort       = dataPort,
       secureDataPort = secureDataPort,
-      jvmModeEnabled = descriptor.jvmModeEnabled
+      jvm            = descriptor.jvm
     )
     val configurationManager = new GlobalRunnerConfigurationManager(
       versionManager,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -79,15 +79,23 @@ class LanguageServerController(
 
   private val descriptor =
     LanguageServerDescriptor(
-      name                           = s"language-server-${project.id}",
-      rootId                         = UUID.randomUUID(),
-      rootPath                       = project.path.toString,
-      projectId                      = project.id,
-      networkConfig                  = networkConfig,
-      distributionConfiguration      = distributionConfiguration,
-      engineVersion                  = engineVersion,
-      jvmSettings                    = distributionConfiguration.defaultJVMSettings,
-      jvmModeEnabled                 = processConfig.jvmMode || project.isJvmModeEnabled(),
+      name                      = s"language-server-${project.id}",
+      rootId                    = UUID.randomUUID(),
+      rootPath                  = project.path.toString,
+      projectId                 = project.id,
+      networkConfig             = networkConfig,
+      distributionConfiguration = distributionConfiguration,
+      engineVersion             = engineVersion,
+      jvmSettings               = distributionConfiguration.defaultJVMSettings,
+      jvm = if (processConfig.jvm.isDefined) {
+        processConfig.jvm
+      } else {
+        if (project.isJvmModeEnabled()) {
+          Some(None)
+        } else {
+          None
+        }
+      },
       discardOutput                  = distributionConfiguration.shouldDiscardChildOutput,
       profilingPath                  = processConfig.profilingPath,
       profilingTime                  = processConfig.profilingTime,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.FiniteDuration
   *                                  versions
   * @param engineVersion version of the langauge server's engine to use
   * @param jvmSettings settings to use for the JVM that will host the engine
-  * @param jvmModeEnabled enables JVM mode if true
+  * @param jvm use JVM - default or provided one
   * @param discardOutput specifies if the process output should be discarded or
   *                      printed to parent's streams
   * @param profilingPath the language server profiling file path
@@ -45,7 +45,7 @@ case class LanguageServerDescriptor(
   distributionConfiguration: DistributionConfiguration,
   engineVersion: SemVer,
   jvmSettings: JVMSettings,
-  jvmModeEnabled: Boolean,
+  jvm: Option[Option[Path]],
   discardOutput: Boolean,
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -24,7 +24,7 @@ class ProjectCreationService[
 ](
   distributionConfiguration: DistributionConfiguration,
   loggingServiceDescriptor: LoggingServiceDescriptor,
-  jvmMode: Boolean
+  jvm: Option[Option[Path]]
 ) extends ProjectCreationServiceApi[F] {
 
   private lazy val logger = Logger[ProjectCreationService[F]]
@@ -62,7 +62,7 @@ class ProjectCreationService[
             path,
             name,
             engineVersion,
-            jvmMode,
+            jvm,
             None,
             projectTemplate,
             None,

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
@@ -95,7 +95,7 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
       logLevel      = if (debugLogs) Level.TRACE else Level.ERROR,
       profilingPath = profilingPath,
       profilingTime = None,
-      jvmMode       = false,
+      jvm           = None,
       extraEnv      = Seq()
     )
 
@@ -195,7 +195,7 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
     new ProjectCreationService[ZIO[ZAny, +*, +*]](
       distributionConfiguration,
       loggingService,
-      jvmMode = false
+      jvm = None
     )
 
   lazy val globalConfigService = new GlobalConfigService[ZIO[ZAny, +*, +*]](

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
@@ -11,7 +11,7 @@ import java.util.UUID
   * @param secureRpcPort an option secure RPC port that the server listen to
   * @param dataPort a data port that the server listen to
   * @param secureDataPort an optional secure data port that the server listen to
-  * @param jvmModeEnabled enables JVM mode if true
+  * @param jvm use JVM - default or provided
   */
 case class LanguageServerOptions(
   rootId: UUID,
@@ -21,5 +21,5 @@ case class LanguageServerOptions(
   secureRpcPort: Option[Int],
   dataPort: Int,
   secureDataPort: Option[Int],
-  jvmModeEnabled: Boolean
+  jvm: Option[Option[java.nio.file.Path]]
 )

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/RunSettings.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 /** Represents settings that are used to launch the runner JAR.
   *
   * @param engineVersion Enso engine version to use
-  * @param jvmMode Should Enso be run in JVM mode
+  * @param jvm use JVM - default or provided
   * @param runnerArguments arguments that should be passed to the runner
   * @param workingDirectory the working directory override
   * @param connectLoggerIfAvailable specifies if the ran component should
@@ -16,7 +16,7 @@ import java.nio.file.Path
   */
 case class RunSettings(
   engineVersion: SemVer,
-  jvmMode: Boolean,
+  jvm: Option[Option[Path]],
   runnerArguments: Seq[String],
   workingDirectory: Option[Path],
   connectLoggerIfAvailable: Boolean,

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -44,7 +44,7 @@ class Runner(
     path: Path,
     name: String,
     engineVersion: SemVer,
-    jvmMode: Boolean,
+    jvm: Option[Option[Path]],
     normalizedName: Option[String],
     projectTemplate: Option[String],
     authorName: Option[String],
@@ -80,7 +80,7 @@ class Runner(
       }
       RunSettings(
         engineVersion,
-        jvmMode,
+        jvm,
         arguments,
         workingDirectory         = None,
         connectLoggerIfAvailable = false
@@ -147,7 +147,7 @@ class Runner(
       val projectDirectory = Path.of(projectPath).toAbsolutePath.normalize
       RunSettings(
         version,
-        options.jvmModeEnabled,
+        options.jvm,
         arguments ++ additionalArguments,
         workingDirectory         = Some(projectDirectory.getParent),
         connectLoggerIfAvailable = true,
@@ -232,13 +232,19 @@ class Runner(
       case None =>
         runtimeVersionManager.withEngineAndRuntime(engineVersion) {
           (engine, runtime) =>
-            val ensoLauncher = Option(System.getenv(Runner.LAUNCHER_ENV_NAME))
-            val requiresJVMRunner =
-              ensoLauncher.exists(_.equals("shell")) || runSettings.jvmMode
-            if (requiresJVMRunner) {
+            if (runSettings.jvm.isDefined) {
+              val javaHome = runSettings.jvm.get
+              val javaExec = if (javaHome.isDefined) {
+                new JavaExecCommand(
+                  javaHome.get.resolve("bin").resolve("java").toString,
+                  javaHome.map(_.toString)
+                )
+              } else {
+                JavaExecCommand.forRuntime(runtime)
+              }
               prepareAndRunCommand(
                 engine,
-                JavaExecCommand.forRuntime(runtime)
+                javaExec
               )
             } else {
               NativeExecCommand.apply(
@@ -321,9 +327,4 @@ class Runner(
         globalConfigurationManager.defaultVersion
     }
   }
-}
-
-object Runner {
-
-  private val LAUNCHER_ENV_NAME = "ENSO_LAUNCHER"
 }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -234,14 +234,14 @@ class Runner(
           (engine, runtime) =>
             if (runSettings.jvm.isDefined) {
               val javaHome = runSettings.jvm.get
-              val javaExec = if (javaHome.isDefined) {
-                new JavaExecCommand(
-                  javaHome.get.resolve("bin").resolve("java").toString,
-                  javaHome.map(_.toString)
+              val javaExec = javaHome
+                .map(home =>
+                  new JavaExecCommand(
+                    home.resolve("bin").resolve("java").toString,
+                    javaHome.map(_.toString)
+                  )
                 )
-              } else {
-                JavaExecCommand.forRuntime(runtime)
-              }
+                .getOrElse(JavaExecCommand.forRuntime(runtime))
               prepareAndRunCommand(
                 engine,
                 javaExec


### PR DESCRIPTION
### Pull Request Description

Fixing [broken sbt command](https://github.com/enso-org/enso/pull/11965#discussion_r2108368112) by adding support for optional parameter to `--jvm` argument:
```
sbt:enso> runProjectManagerDistribution --debug
```
was broken by incorrect assumption that `--jvm` flags may take arguments. The `enso` one did accept argument, the `project-manager` one didn't. This PR fixes that by giving the `project-manager` `--jvm` flag an **optional path attribute**. 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [ ] Unit tests have been written where possible.

