### PR TITLE
Improve sbt clean

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4940,7 +4940,11 @@ lazy val `std-base` = project
           previousRun        = None
         )
       result
-    }
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`base-polyglot-root`)
+    }.value
   )
   .dependsOn(`common-polyglot-core-utils`)
 
@@ -5126,7 +5130,11 @@ lazy val `std-table` = project
           previousRun       = None
         )
       result
-    }
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`table-polyglot-root`)
+    }.value
   )
   .dependsOn(`poi-wrapper`)
   .dependsOn(`std-base` % "provided")
@@ -5210,7 +5218,12 @@ lazy val `std-image` = project
         result
       }
       .dependsOn(cleanPolyglotRoot)
-      .value
+      .value,
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`image-polyglot-root`)
+      IO.delete(`image-native-libs`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
 
@@ -5243,7 +5256,11 @@ lazy val `std-generic-jdbc` = project
           previousRun = None
         )
       result
-    }
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`generic-jdbc-polyglot-root`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5334,7 +5351,12 @@ lazy val `std-google-api` = project
         result
       }
       .dependsOn(cleanPolyglotRoot)
-      .value
+      .value,
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`google-api-polyglot-root`)
+      IO.delete(`google-api-native-libs`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5411,7 +5433,12 @@ lazy val `std-database` = project
         result
       }
       .dependsOn(cleanPolyglotRoot)
-      .value
+      .value,
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`database-polyglot-root`)
+      IO.delete(`database-native-libs`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5453,7 +5480,12 @@ lazy val `std-aws` = project
           previousRun = None
         )
       result
-    }
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`std-aws-polyglot-root`)
+    }.value
+
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5537,7 +5569,13 @@ lazy val `std-snowflake` = project
         result
       }
       .dependsOn(cleanPolyglotRoot)
-      .value
+      .value,
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`std-snowflake-polyglot-root`)
+      IO.delete(`std-snowflake-native-libs`)
+    }.value
+
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5597,7 +5635,11 @@ lazy val `std-microsoft` = project
           previousRun       = None
         )
       result
-    }
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`std-microsoft-polyglot-root`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5767,7 +5809,12 @@ lazy val `std-tableau` = project
         result
       }
       .dependsOn(cleanPolyglotRoot)
-      .value
+      .value,
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(`std-tableau-polyglot-root`)
+      IO.delete(`std-tableau-native-libs`)
+    }.value
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -5500,7 +5500,6 @@ lazy val `std-aws` = project
       val _ = clean.value
       IO.delete(`std-aws-polyglot-root`)
     }.value
-
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")
@@ -5590,7 +5589,6 @@ lazy val `std-snowflake` = project
       IO.delete(`std-snowflake-polyglot-root`)
       IO.delete(`std-snowflake-native-libs`)
     }.value
-
   )
   .dependsOn(`std-base` % "provided")
   .dependsOn(`std-table` % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -423,6 +423,19 @@ lazy val enso = (project in file("."))
   .settings(
     commands ++= Seq(packageBuilder.makePackages, packageBuilder.makeBundles)
   )
+  .settings(
+    cleanFiles ++= {
+      Seq(
+        engineDistributionRoot.value,
+        launcherDistributionRoot.value,
+        projectManagerDistributionRoot.value
+      )
+    },
+    clean := Def.task {
+      val _ = clean.value
+      IO.delete(packageBuilder.artifactRoot)
+    }.value
+  )
 
 // ============================================================================
 // === Dependency Versions ====================================================
@@ -4181,6 +4194,9 @@ lazy val launcher = project
         "ensoup"
       )
       .value,
+    cleanFiles += {
+      new File("ensoup")
+    },
     assembly / test := {},
     assembly / assemblyOutputPath := file("launcher.jar"),
     assembly / assemblyMergeStrategy := {

--- a/build.sbt
+++ b/build.sbt
@@ -424,16 +424,15 @@ lazy val enso = (project in file("."))
     commands ++= Seq(packageBuilder.makePackages, packageBuilder.makeBundles)
   )
   .settings(
-    cleanFiles ++= {
-      Seq(
-        engineDistributionRoot.value,
-        launcherDistributionRoot.value,
-        projectManagerDistributionRoot.value
-      )
-    },
     clean := Def.task {
       val _ = clean.value
-      IO.delete(packageBuilder.artifactRoot)
+      val filesToDelete = Seq(
+        engineDistributionRoot.value,
+        launcherDistributionRoot.value,
+        projectManagerDistributionRoot.value,
+        packageBuilder.artifactRoot
+      )
+      IO.delete(filesToDelete)
     }.value
   )
 

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -679,7 +679,7 @@ object DistributionPackage {
     ensoVersion: String,
     graalVersion: String,
     graalJavaVersion: String,
-    artifactRoot: File
+    val artifactRoot: File
   ) {
 
     def artifactName(


### PR DESCRIPTION
### Pull Request Description

Improve sbt clean:
- `enso/clean` now deletes `built-distribution` and other stuff that was generated during the build
- `std-*/clean` deletes the `distribution/lib/**/polyglot` directories.

Motivation:
Native library extraction into `distribution/lib/**/polyglot` directories is causing problems for the incremental compilation. Moreover, checking out a different revision, while having old `built-distribution` around, is also asking for troubles.
