### PR TITLE
Avoid the need for `-H:+ForeignAPISupport`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4014,7 +4014,6 @@ lazy val `engine-runner` = project
               "-H:+AddAllCharsets",
               "-H:+IncludeAllLocales",
               "-H:+RunReachabilityHandlersConcurrently",
-              "-H:+ForeignAPISupport",
               "-R:-InstallSegfaultHandler",
               // Workaround a problem with build-/runtime-initialization conflict
               // by disabling this service provider
@@ -4341,7 +4340,6 @@ lazy val `os-environment` =
           additionalOptions = Seq(
             "-ea",
             "--features=org.enso.os.environment.TestCollectorFeature",
-            "-H:+ForeignAPISupport",
             "-R:-InstallSegfaultHandler"
           ) ++ (if (GraalVM.EnsoLauncher.debug) {
                   // useful perf & debug switches:

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
@@ -23,6 +23,7 @@ import org.graalvm.nativeimage.c.function.CEntryPointLiteral;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.word.PointerBase;
 import org.graalvm.word.WordFactory;
 
 /** Channel connects two {@link JVM} instances. */
@@ -185,13 +186,13 @@ public final class Channel implements AutoCloseable {
     var channel = ID_TO_CHANNEL.get(id);
     assert channel != null : "There must be a channel " + id + " but " + ID_TO_CHANNEL;
     try {
-      var buf = CTypeConversion.asByteBuffer(data, (int) size);
+      var buf = asNativeByteBuffer(data, size);
       var len = handleWithChannel(channel, buf);
       return len;
     } catch (Throwable ex) {
       channel.printStackTrace(ex, true);
       var bytes = ex.getMessage() == null ? new byte[0] : ex.getMessage().getBytes();
-      var buf = CTypeConversion.asByteBuffer(data, (int) size).order(ByteOrder.BIG_ENDIAN);
+      var buf = asNativeByteBuffer(data, size);
       buf.putInt(bytes.length);
       buf.put(bytes);
       return -2L;
@@ -270,7 +271,7 @@ public final class Channel implements AutoCloseable {
       ByteBuffer buffer;
       if (ImageInfo.inImageRuntimeCode()) {
         var memory = UnmanagedMemory.malloc(size);
-        buffer = CTypeConversion.asByteBuffer(memory, size);
+        buffer = asNativeByteBuffer(memory, size);
         buffer.put(0, bytes);
         address = memory.rawValue();
         len = toHotSpotMessage(address, size);
@@ -302,6 +303,11 @@ public final class Channel implements AutoCloseable {
         UnmanagedMemory.free(WordFactory.pointer(address));
       }
     }
+  }
+
+  private static ByteBuffer asNativeByteBuffer(PointerBase memory, long size) {
+    var bufferSize = Math.toIntExact(size);
+    return CTypeConversion.asByteBuffer(memory, bufferSize).order(ByteOrder.BIG_ENDIAN);
   }
 
   private static long handleJvmMessage(long id, long address, long size) throws Throwable {

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
@@ -7,6 +7,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -188,10 +189,10 @@ public final class Channel implements AutoCloseable {
       return len;
     } catch (Throwable ex) {
       channel.printStackTrace(ex, true);
-      var exceptionMessage =
-          ex.getMessage()
-              .subSequence(0, Math.min(ex.getMessage().length(), (int) Math.min(2048, size)));
-      CTypeConversion.toCString(exceptionMessage, data, WordFactory.unsigned(size));
+      var bytes = ex.getMessage() == null ? new byte[0] : ex.getMessage().getBytes();
+      var buf = CTypeConversion.asByteBuffer(data, (int) size).order(ByteOrder.BIG_ENDIAN);
+      buf.putInt(bytes.length);
+      buf.put(bytes);
       return -2L;
     }
   }
@@ -283,7 +284,11 @@ public final class Channel implements AutoCloseable {
       }
       if (len == -2) {
         // signals exception
-        var exceptionMessage = "No message yet"; // memory.getString(0);
+        buffer.position(0);
+        var msgLen = buffer.getInt();
+        var msgBytes = new byte[msgLen];
+        buffer.get(msgBytes);
+        var exceptionMessage = new String(msgBytes);
         throw new IllegalStateException(exceptionMessage);
       }
       assert len >= 0;

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
@@ -185,7 +185,8 @@ public final class Channel implements AutoCloseable {
     var channel = ID_TO_CHANNEL.get(id);
     assert channel != null : "There must be a channel " + id + " but " + ID_TO_CHANNEL;
     try {
-      var len = handleWithChannel(channel, data.rawValue(), size);
+      var buf = CTypeConversion.asByteBuffer(data, (int) size);
+      var len = handleWithChannel(channel, buf);
       return len;
     } catch (Throwable ex) {
       channel.printStackTrace(ex, true);
@@ -197,15 +198,13 @@ public final class Channel implements AutoCloseable {
     }
   }
 
-  private static long handleWithChannel(Channel channel, long address, long size) throws Throwable {
-    var seg = MemorySegment.ofAddress(address).reinterpret(size);
-    var buf = seg.asByteBuffer();
+  private static long handleWithChannel(Channel channel, ByteBuffer buf) throws Throwable {
     var ref = channel.pool.read(buf, null);
     var msg = ref.get(Function.class);
     @SuppressWarnings("unchecked")
     var res = msg.apply(channel);
     var bytes = Persistables.POOL.write(res, null);
-    seg.copyFrom(MemorySegment.ofArray(bytes));
+    buf.put(0, bytes);
     return bytes.length;
   }
 
@@ -307,7 +306,8 @@ public final class Channel implements AutoCloseable {
 
   private static long handleJvmMessage(long id, long address, long size) throws Throwable {
     var channel = ID_TO_CHANNEL.get(id);
-    return handleWithChannel(channel, address, size);
+    var seg = MemorySegment.ofAddress(address).reinterpret(size);
+    return handleWithChannel(channel, seg.asByteBuffer());
   }
 
   @Override

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/Channel.java
@@ -1,12 +1,12 @@
 package org.enso.os.environment.jni;
 
 import java.io.IOException;
-import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -16,6 +16,7 @@ import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.function.CEntryPointLiteral;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
@@ -164,11 +165,7 @@ public final class Channel implements AutoCloseable {
    *     from this method
    */
   public final <R> R execute(Class<R> resultType, Function<Channel, R> msg) {
-    if (this.isolate == -1) {
-      return executeImpl(pool, resultType, msg, this::toHotSpotMessage);
-    } else {
-      return executeImpl(pool, resultType, msg, this::toSubstrateMessage);
-    }
+    return executeImpl(pool, resultType, msg);
   }
 
   private static final CEntryPointLiteral<CFunctionPointer> CALLBACK_FN =
@@ -211,14 +208,13 @@ public final class Channel implements AutoCloseable {
     return bytes.length;
   }
 
-  private long toHotSpotMessage(MemorySegment segment) {
+  private long toHotSpotMessage(long address, long size) {
     var fn = env.getFunctions();
-    long address = segment.address();
     assert address > 0 : "We need an address";
     var arg = StackValue.get(3, JNI.JValue.class);
     arg.addressOf(0).setLong(id);
     arg.addressOf(1).setLong(address);
-    arg.addressOf(2).setLong(segment.byteSize());
+    arg.addressOf(2).setLong(size);
     var replySize = fn.getCallStaticLongMethodA().call(env, channelClass, channelHandle, arg);
     checkForException(env);
     return replySize;
@@ -261,29 +257,46 @@ public final class Channel implements AutoCloseable {
     }
   }
 
-  static <R> R executeImpl(
-      Persistance.Pool pool,
-      Class<R> replyType,
-      Function<Channel, R> msg,
-      Function<MemorySegment, Long> send) {
-    try (var arena = Arena.ofConfined()) {
+  private <R> R executeImpl( //
+      Persistance.Pool pool, //
+      Class<R> replyType, //
+      Function<Channel, R> msg //
+      ) {
+    var address = 0L;
+    try {
       var bytes = pool.write(msg, null);
-      var memory = arena.allocate(Math.max(bytes.length, 4096));
-      memory.copyFrom(MemorySegment.ofArray(bytes));
-      long len = send.apply(memory);
+      var size = Math.max(bytes.length, 4096);
+      long len;
+      ByteBuffer buffer;
+      if (ImageInfo.inImageRuntimeCode()) {
+        var memory = UnmanagedMemory.malloc(size);
+        buffer = CTypeConversion.asByteBuffer(memory, size);
+        buffer.put(0, bytes);
+        address = memory.rawValue();
+        len = toHotSpotMessage(address, size);
+      } else {
+        buffer = ByteBuffer.allocateDirect(size);
+        var memory = MemorySegment.ofBuffer(buffer);
+        memory.copyFrom(MemorySegment.ofArray(bytes));
+        address = memory.address();
+        len = toSubstrateMessage(memory);
+      }
       if (len == -2) {
         // signals exception
-        var exceptionMessage = memory.getString(0);
+        var exceptionMessage = "No message yet"; // memory.getString(0);
         throw new IllegalStateException(exceptionMessage);
       }
       assert len >= 0;
-      var reply = memory.asByteBuffer();
-      reply.position(0);
-      reply.limit((int) len);
-      var result = pool.read(reply, null);
+      buffer.position(0);
+      buffer.limit((int) len);
+      var result = pool.read(buffer, null);
       return result.get(replyType);
     } catch (IOException ex) {
       throw new IllegalStateException(ex);
+    } finally {
+      if (ImageInfo.inImageRuntimeCode()) {
+        UnmanagedMemory.free(WordFactory.pointer(address));
+      }
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Modifies #13206 to not need `+H:ForeignAPISupport` by alternatively using `UnmanagedMemory` and `ByteBuffer` on each side of the `Channel`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
