### PR TITLE
Fix issue with `buildEngineDistribution` taking too long

### DIFF
--- a/project/AnalysisOfExtractedNativeLibs.scala
+++ b/project/AnalysisOfExtractedNativeLibs.scala
@@ -4,16 +4,19 @@ import java.io.File
   * @param libs extracted native libs
   */
 case class AnalysisOfExtractedNativeLibs(
-  libs: List[ExtractedNativeLibSummary]
+  libs: Map[String, ExtractedNativeLibSummary]
 ) {
   def first: Option[ExtractedNativeLibSummary] = {
     assert(libs.size == 1)
-    libs.headOption
+    libs.values.headOption
   }
-  def forJar(srcJar: File): Option[ExtractedNativeLibSummary] =
-    libs.find(_.from == srcJar)
 
-  def isOutdated: Boolean = libs.exists(_.isOutdated)
+  def forJar(srcJar: File): Option[ExtractedNativeLibSummary] =
+    libs.values.find(_.from == srcJar)
+
+  def isOutdated: Boolean = libs.values.exists(_.isOutdated)
+
+  def size: Int = libs.size
 
   def appended(
     other: AnalysisOfExtractedNativeLibs
@@ -25,13 +28,13 @@ object AnalysisOfExtractedNativeLibs {
   import sjsonnew.{:*:, LList, LNil}
   import sbt.util.CacheImplicits._
 
-  implicit val encode
-    : sjsonnew.IsoLList.Aux[AnalysisOfExtractedNativeLibs, sjsonnew.LCons[List[
-      ExtractedNativeLibSummary
-    ], sjsonnew.LList.LNil0]] = LList.iso(
+  implicit val encode: sjsonnew.IsoLList.Aux[
+    AnalysisOfExtractedNativeLibs,
+    sjsonnew.LCons[Map[String, ExtractedNativeLibSummary], sjsonnew.LList.LNil0]
+  ] = LList.iso(
     { p: AnalysisOfExtractedNativeLibs => ("libs", p.libs) :*: LNil },
-    { case (_, from: List[ExtractedNativeLibSummary]) :*: LNil =>
-      AnalysisOfExtractedNativeLibs(from)
+    { case (_, libs: Map[String, ExtractedNativeLibSummary]) :*: LNil =>
+      AnalysisOfExtractedNativeLibs(libs)
     }
   )
 
@@ -39,8 +42,10 @@ object AnalysisOfExtractedNativeLibs {
     from: File,
     dynamicLibs: List[File],
     thinTarget: Option[File]
-  ): AnalysisOfExtractedNativeLibs =
+  ): AnalysisOfExtractedNativeLibs = {
+    val fromPath = from.getAbsolutePath
     AnalysisOfExtractedNativeLibs(
-      ExtractedNativeLibSummary(from, dynamicLibs, thinTarget) :: Nil
+      Map(fromPath -> ExtractedNativeLibSummary(from, dynamicLibs, thinTarget))
     )
+  }
 }

--- a/project/StdBits.scala
+++ b/project/StdBits.scala
@@ -112,7 +112,7 @@ object StdBits {
             val outdatedArtifact =
               !previousRun
                 .exists(analysis =>
-                  analysis.libs.exists(a =>
+                  analysis.libs.values.exists(a =>
                     a.matchesTargetArtifact(existing) && !a.isOutdated
                   )
                 )
@@ -336,7 +336,12 @@ object StdBits {
       extractedJnaLibs.getOrElse(Nil),
       Some(outputJnaJar)
     )
-    AnalysisOfExtractedNativeLibs(extractedTableau :: extractedJna :: Nil)
+    AnalysisOfExtractedNativeLibs(
+      Map(
+        tableauNativeLibJar.getAbsolutePath -> extractedTableau,
+        jnaJar.getAbsolutePath              -> extractedJna
+      )
+    )
   }
 
   /** Extract native libraries from `grpc-netty-shaded-<version>.jar` and put them under


### PR DESCRIPTION
### Pull Request Description

Fixes the issue with `buildEngineDistribution` command taking too long.

### Important Notes

In sbt, we are using [AnalysisOfExtractedNativeLibs](https://github.com/enso-org/enso/blob/860b170364bb2d180c67e8dd379816470d42df0e/project/AnalysisOfExtractedNativeLibs.scala) for caching. There used to be a `List` inside of it and every `buildEngineDistribution` command was just appending to the List, until the sbt process was killed with out of memory error.

This PR fixes this issue by using `Map` instead of `List`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
