### PR TITLE
Generate .enso-source files, even when not using Frgaal compiler

### DIFF
--- a/project/FrgaalJavaCompiler.scala
+++ b/project/FrgaalJavaCompiler.scala
@@ -281,10 +281,32 @@ object FrgaalJavaCompiler {
         ensoProperties.setProperty("java.home", v.toString())
       )
 
-      Using(new FileWriter(ensoConfig)) { w =>
-        ensoProperties.store(w, "# Enso compiler configuration")
+      def changeInProperties: Boolean = {
+        if (ensoConfig.exists()) {
+          val original = new java.util.Properties();
+          Using(new java.io.FileReader(ensoConfig)) { r =>
+            original.load(r);
+          }
+          if (original == ensoProperties) {
+            return false
+          }
+        }
+        true
       }
-      Using(new FileWriter(ensoMarker)) { _ => }
+      if (changeInProperties) {
+        Using(new FileWriter(ensoConfig)) { w =>
+          ensoProperties.store(w, "# Enso compiler configuration")
+        }
+        Using(new FileWriter(ensoMarker, true)) { w =>
+          w.write(
+            "Updated " + ensoConfig + " on " + new java.util.Date() + "\n"
+          )
+        }
+      } else {
+        log.debug(
+          s"[FrgaalJavaCompiler] no change in: ${ensoConfig}"
+        )
+      }
     } else {
       throw new IllegalStateException(
         "Cannot write Enso source options to " + shared + " values:\n" +

--- a/project/FrgaalJavaCompiler.scala
+++ b/project/FrgaalJavaCompiler.scala
@@ -76,7 +76,8 @@ object FrgaalJavaCompiler {
     if (frgaalOnClasspath.isEmpty) {
       throw new RuntimeException("Failed to resolve Frgaal compiler. Aborting!")
     }
-    val frgaalJavac = new FrgaalJavaCompiler(
+    val withFrgaalJavac = new FrgaalJavaCompiler(
+      sbtCompilers.javaTools.javac(),
       javaHome,
       frgaalOnClasspath.get,
       javaSourceDir           = javaSourceDir,
@@ -85,24 +86,21 @@ object FrgaalJavaCompiler {
       shouldNotLimitModules   = shouldNotLimitModules
     )
 
-    var javac = if (Integer.parseInt(javaVersion) <= 21) {
-      frgaalJavac
-    } else {
-      sbtCompilers.javaTools.javac()
-    }
     val javadoc   = sbtCompilers.javaTools.javadoc()
-    val javaTools = sbt.internal.inc.javac.JavaTools(javac, javadoc)
+    val javaTools = sbt.internal.inc.javac.JavaTools(withFrgaalJavac, javadoc)
     xsbti.compile.Compilers.of(sbtCompilers.scalac, javaTools)
   }
 
   /** Helper method to launch programs.
     */
   def launch(
+    original: XJavaCompiler,
     javaHome: Option[Path],
     compilerJar: Path,
     sources0: Seq[VirtualFile],
     options: Seq[String],
     output: Output,
+    incToolOptions: IncToolOptions,
     log: Logger,
     reporter: Reporter,
     source: Option[String],
@@ -301,6 +299,17 @@ object FrgaalJavaCompiler {
       )
     val allArguments = outputOption ++ frgaalOptions ++ nonJArgs ++ allSources
 
+    if (Integer.parseInt(target) >= 24) {
+      return original.run(
+        sources0.toArray,
+        options.toArray,
+        output,
+        incToolOptions,
+        reporter,
+        log
+      )
+    }
+
     withArgumentFile(allArguments) { argsFile =>
       // List of modules that Frgaal can use for compilation
       val limitModules = Seq(
@@ -404,6 +413,7 @@ object FrgaalJavaCompiler {
 
 /** An implementation of compiling java which forks Frgaal instance. */
 final class FrgaalJavaCompiler(
+  val original: XJavaCompiler,
   javaHome: Option[Path],
   compilerPath: Path,
   target: String,
@@ -421,11 +431,13 @@ final class FrgaalJavaCompiler(
     log: XLogger
   ): Boolean =
     FrgaalJavaCompiler.launch(
+      original,
       javaHome,
       compilerPath,
       sources,
       options,
       output,
+      incToolOptions,
       log,
       reporter,
       source,

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/DotEnsoSourceFiles.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/DotEnsoSourceFiles.java
@@ -1,0 +1,199 @@
+package org.enso.tools.enso4igv;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Level;
+import static org.enso.tools.enso4igv.Installer.LOG;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.spi.java.project.support.ProjectPlatform;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Exceptions;
+
+/** Support for reading the value from the .enso-source files. */
+abstract class DotEnsoSourceFiles {
+    /** directory with the .enso-source* files */
+    private final FileObject dir;
+
+    DotEnsoSourceFiles(FileObject dir) {
+        this.dir = dir;
+    }
+
+    SourceGroup[] getSourceGroups() {
+        var sources = new ArrayList<SourceGroup>();
+        String platformPath = null;
+        var roots = new LinkedHashSet<FileObject>();
+        var modulePath = new LinkedHashSet<FileObject>();
+        var generatedSources = new LinkedHashSet<FileObject>();
+        var source = "21";
+        var options = new ArrayList<String>();
+        for (var ch : dir.getChildren()) {
+            if (ch.getNameExt().startsWith(".enso-sources-")) {
+                Properties p = new Properties();
+                try (InputStream is = ch.getInputStream()) {
+                    p.load(is);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+                if (p.get("java.home") instanceof String javaHome) {
+                    platformPath = javaHome;
+                }
+
+                for (var i = 0; ; i++) {
+                    final String prop = p.getProperty("options." + i);
+                    if (prop == null) {
+                        break;
+                    }
+                    var next = p.getProperty("options." + (i + 1));
+                    if ("-source".equals(prop) && next != null) {
+                        source = next;
+                        i++;
+                        continue;
+                    }
+                    if ("-classpath".equals(prop) && next != null) {
+                        var paths = next.split(File.pathSeparator);
+                        for (var element : paths) {
+                            FileObject fo = findProjectFileObject(element);
+                            if (fo != null) {
+                                if (fo.isFolder()) {
+                                    roots.add(fo);
+                                } else {
+                                    var jarRoot = FileUtil.getArchiveRoot(fo);
+                                    roots.add(jarRoot);
+                                }
+                            }
+                        }
+                        i++;
+                        continue;
+                    }
+                    if ("--module-path".equals(prop) && next != null) {
+                        var paths = next.split(File.pathSeparator);
+                        for (var element : paths) {
+                            FileObject fo = findProjectFileObject(element);
+                            if (fo != null) {
+                                if (fo.isFolder()) {
+                                    modulePath.add(fo);
+                                } else {
+                                    var jarRoot = FileUtil.getArchiveRoot(fo);
+                                    modulePath.add(jarRoot);
+                                }
+                            }
+                        }
+                        i++;
+                        continue;
+                    }
+                    if ("-s".equals(prop) && next != null) {
+                        var fo = FileUtil.toFileObject(new File(next));
+                        if (fo != null) {
+                            generatedSources.add(fo);
+                        }
+                    }
+                    options.add(prop);
+                }
+                var srcRoots = new LinkedHashSet<FileObject>();
+
+                var inputSrc = p.getProperty("input");
+                var inputDir = findProjectFileObject(inputSrc);
+                if (inputDir != null) {
+                  var addSibblings = true;
+                  if (inputDir.getNameExt().equals("org")) {
+                    // lib/rust/parser doesn't follow typical project conventions
+                    inputDir = inputDir.getParent();
+                    addSibblings = false;
+                  }
+                  srcRoots.add(inputDir);
+                  if (addSibblings) {
+                    for (var sibbling : inputDir.getParent().getChildren()) {
+                      if (sibbling.isFolder() && sibbling != inputDir) {
+                        srcRoots.add(sibbling);
+                      }
+                    }
+                  }
+                } else {
+                  var srcDir = findProjectFileObject("src");
+                  if (srcDir != null) {
+                    for (var group : srcDir.getChildren()) {
+                      if (group.isFolder()) {
+                        for (var child : group.getChildren()) {
+                          if (child.isFolder()) {
+                            srcRoots.add(child);
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                srcRoots.addAll(generatedSources);
+
+                var outputSrc = p.getProperty("output");
+                FileObject outputDir = findProjectFileObject(outputSrc);
+
+                var generatedSrc = p.getProperty("generated");
+                FileObject generatedDir = findProjectFileObject(generatedSrc);
+                if (generatedDir != null) {
+                  srcRoots.add(generatedDir);
+                }
+
+                for (var r : srcRoots) {
+                  assert r.isFolder() : "Expecting folders in " + srcRoots;
+                }
+
+                var cp = ClassPathSupport.createClassPath(roots.toArray(new FileObject[0]));
+                var moduleCp = ClassPathSupport.createClassPath(modulePath.toArray(new FileObject[0]));
+                var srcCp = ClassPathSupport.createClassPath(srcRoots.toArray(new FileObject[0]));
+                var s = createSourceGroup(cp, moduleCp, srcCp, platformPath, outputDir, source, options);
+                if (s.getRootFolder() == null) {
+                    LOG.log(Level.WARNING, "Cannot find root folder for {0}", dir);
+                } else {
+                    if ("main".equals(s.getName())) {
+                      sources.add(0, s);
+                    } else {
+                      sources.add(s);
+                    }
+                }
+            }
+        }
+        if (dir.getFileObject("src") instanceof FileObject src && src.isFolder()) {
+            for (var kind : src.getChildren()) {
+              TYPE: for (var type : kind.getChildren()) {
+                    for (var e : sources) {
+                      if (e.getRootFolder().equals(type)) {
+                        continue TYPE;
+                      }
+                    }
+
+                    var s = new EnsoSbtClassPathProvider.OtherEnsoSources(kind.getNameExt(), type);
+                    sources.add(s);
+                }
+            }
+        }
+        return sources.toArray(new SourceGroup[0]);
+    }
+
+    protected abstract EnsoSbtClassPathProvider.EnsoSources createSourceGroup(
+        ClassPath cp, ClassPath moduleCp, ClassPath srcCp,
+        String platformPath,
+        FileObject outputDir, String source, List<String> options
+    );
+
+    private FileObject findProjectFileObject(String path) {
+        if (path == null) {
+            return null;
+        }
+        if (path.startsWith("./")) {
+            return dir.getFileObject(path.substring(2));
+        } else {
+            return FileUtil.toFileObject(new File(path));
+        }
+    }
+
+
+}

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -95,158 +95,27 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
     }
 
     private static SourceGroup[] computeSbtClassPath(EnsoSbtProject prj) {
-        var sources = new ArrayList<SourceGroup>();
-        var platform = JavaPlatform.getDefault();
-        var roots = new LinkedHashSet<FileObject>();
-        var modulePath = new LinkedHashSet<FileObject>();
-        var generatedSources = new LinkedHashSet<FileObject>();
-        var source = "21";
-        var options = new ArrayList<String>();
-        for (var ch : prj.getProjectDirectory().getChildren()) {
-            if (ch.getNameExt().startsWith(".enso-sources-")) {
-                Properties p = new Properties();
-                try (InputStream is = ch.getInputStream()) {
-                    p.load(is);
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-                if (p.get("java.home") instanceof String javaHome) {
-                    var javaHomeFile = new File(javaHome);
+        class ConstructSourceGroupsFromDotEnsoSourceFiles extends DotEnsoSourceFiles {
+            ConstructSourceGroupsFromDotEnsoSourceFiles(FileObject projectDirectory) {
+                super(projectDirectory);
+            }
+
+            @Override
+            protected EnsoSources createSourceGroup(ClassPath cp, ClassPath moduleCp, ClassPath srcCp, String platformPath, FileObject outputDir, String source, List<String> options) {
+                var platform = JavaPlatform.getDefault();
+                if (platformPath != null) {
+                    var javaHomeFile = new File(platformPath);
                     var javaHomeFo = FileUtil.toFileObject(javaHomeFile);
                     if (javaHomeFo != null) {
                       platform = ProjectPlatform.forProject(prj, javaHomeFo, javaHomeFile.getName(), "j2se");
                     }
                 }
-
-                for (var i = 0; ; i++) {
-                    final String prop = p.getProperty("options." + i);
-                    if (prop == null) {
-                        break;
-                    }
-                    var next = p.getProperty("options." + (i + 1));
-                    if ("-source".equals(prop) && next != null) {
-                        source = next;
-                        i++;
-                        continue;
-                    }
-                    if ("-classpath".equals(prop) && next != null) {
-                        var paths = next.split(File.pathSeparator);
-                        for (var element : paths) {
-                            FileObject fo = findProjectFileObject(prj, element);
-                            if (fo != null) {
-                                if (fo.isFolder()) {
-                                    roots.add(fo);
-                                } else {
-                                    var jarRoot = FileUtil.getArchiveRoot(fo);
-                                    roots.add(jarRoot);
-                                }
-                            }
-                        }
-                        i++;
-                        continue;
-                    }
-                    if ("--module-path".equals(prop) && next != null) {
-                        var paths = next.split(File.pathSeparator);
-                        for (var element : paths) {
-                            FileObject fo = findProjectFileObject(prj, element);
-                            if (fo != null) {
-                                if (fo.isFolder()) {
-                                    modulePath.add(fo);
-                                } else {
-                                    var jarRoot = FileUtil.getArchiveRoot(fo);
-                                    modulePath.add(jarRoot);
-                                }
-                            }
-                        }
-                        i++;
-                        continue;
-                    }
-                    if ("-s".equals(prop) && next != null) {
-                        var fo = FileUtil.toFileObject(new File(next));
-                        if (fo != null) {
-                            generatedSources.add(fo);
-                        }
-                    }
-                    options.add(prop);
-                }
-                var srcRoots = new LinkedHashSet<FileObject>();
-
-                var inputSrc = p.getProperty("input");
-                var inputDir = findProjectFileObject(prj, inputSrc);
-                if (inputDir != null) {
-                  var addSibblings = true;
-                  if (inputDir.getNameExt().equals("org")) {
-                    // lib/rust/parser doesn't follow typical project conventions
-                    inputDir = inputDir.getParent();
-                    addSibblings = false;
-                  }
-                  srcRoots.add(inputDir);
-                  if (addSibblings) {
-                    for (var sibbling : inputDir.getParent().getChildren()) {
-                      if (sibbling.isFolder() && sibbling != inputDir) {
-                        srcRoots.add(sibbling);
-                      }
-                    }
-                  }
-                } else {
-                  var srcDir = prj.getProjectDirectory().getFileObject("src");
-                  if (srcDir != null) {
-                    for (var group : srcDir.getChildren()) {
-                      if (group.isFolder()) {
-                        for (var child : group.getChildren()) {
-                          if (child.isFolder()) {
-                            srcRoots.add(child);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                srcRoots.addAll(generatedSources);
-
-                var outputSrc = p.getProperty("output");
-                FileObject outputDir = findProjectFileObject(prj, outputSrc);
-
-                var generatedSrc = p.getProperty("generated");
-                FileObject generatedDir = findProjectFileObject(prj, generatedSrc);
-                if (generatedDir != null) {
-                  srcRoots.add(generatedDir);
-                }
-
-                for (var r : srcRoots) {
-                  assert r.isFolder() : "Expecting folders in " + srcRoots;
-                }
-
-                var cp = ClassPathSupport.createClassPath(roots.toArray(new FileObject[0]));
-                var moduleCp = ClassPathSupport.createClassPath(modulePath.toArray(new FileObject[0]));
-                var srcCp = ClassPathSupport.createClassPath(srcRoots.toArray(new FileObject[0]));
-                var s = new EnsoSources(cp, moduleCp, srcCp, platform, outputDir, source, options);
-                if (s.getRootFolder() == null) {
-                    LOG.log(Level.WARNING, "Cannot find root folder for " + prj);
-                } else {
-                    if ("main".equals(s.getName())) {
-                      sources.add(0, s);
-                    } else {
-                      sources.add(s);
-                    }
-                }
+                return new EnsoSbtClassPathProvider.EnsoSources(cp, moduleCp, srcCp, platform, outputDir, source, options);
             }
-        }
-        if (prj.getProjectDirectory().getFileObject("src") instanceof FileObject src && src.isFolder()) {
-            for (var kind : src.getChildren()) {
-              TYPE: for (var type : kind.getChildren()) {
-                    for (var e : sources) {
-                      if (e.getRootFolder().equals(type)) {
-                        continue TYPE;
-                      }
-                    }
 
-                    var s = new OtherEnsoSources(kind.getNameExt(), type);
-                    sources.add(s);
-                }
-            }
         }
-        return sources.toArray(new SourceGroup[0]);
+        var dotEnsoSourceFiles = new ConstructSourceGroupsFromDotEnsoSourceFiles(prj.getProjectDirectory());
+        return dotEnsoSourceFiles.getSourceGroups();
     }
 
     private static FileObject findProjectFileObject(EnsoSbtProject prj, String path) {


### PR DESCRIPTION
### Pull Request Description

Make sure `.enso-source*` files are generated even when regular JDK's `javac` compiler is used for compilation. Only rewrite the files, when their content is changed. Extract reading of those files into a separate class.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests seem to pass
