### PR TITLE
Fix invalid linker name for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,3 +47,8 @@ build --@rules_rust//rust/toolchain/channel=nightly
 
 ## Allow local overrides of bazel configuration
 try-import %workspace%/.bazelrc.local
+
+# Force the use of Clang for all builds. FuzzTest relies on Clang for sanitizer
+# coverage (https://clang.llvm.org/docs/SanitizerCoverage.html).
+build --action_env=CC=clang
+build --action_env=CXX=clang++

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,6 @@ build --@rules_rust//rust/toolchain/channel=nightly
 ## Allow local overrides of bazel configuration
 try-import %workspace%/.bazelrc.local
 
-# Force the use of Clang for all builds. FuzzTest relies on Clang for sanitizer
-# coverage (https://clang.llvm.org/docs/SanitizerCoverage.html).
+# Force the use of Clang for all builds (https://github.com/bazelbuild/bazel/issues/20838).
 build --action_env=CC=clang
 build --action_env=CXX=clang++


### PR DESCRIPTION
### Pull Request Description

As suggested here https://github.com/bazelbuild/bazel/issues/20838#issuecomment-2542240776 this PR fixes issues with invalid linker name when trying to run `pnpm i`

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
