### PR TITLE
Remove unused imports from tests

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -7,7 +7,7 @@ import Standard.Base.Errors.Common.Index_Out_Of_Bounds
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Internal.Rounding_Helpers
-from Standard.Base.Metadata.Widget import Numeric_Input, Text_Input
+from Standard.Base.Metadata.Widget import Text_Input
 from Standard.Base.Widget_Helpers import make_format_chooser
 
 import Standard.Table.Fill_With.Fill_With

--- a/test/AWS_Tests/src/Inter_Backend_File_Operations_Spec.enso
+++ b/test/AWS_Tests/src/Inter_Backend_File_Operations_Spec.enso
@@ -11,7 +11,6 @@ import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.AWS import S3_File
 
 from Standard.Test import all
 

--- a/test/AWS_Tests/src/Redshift_Spec.enso
+++ b/test/AWS_Tests/src/Redshift_Spec.enso
@@ -5,7 +5,6 @@ from Standard.Table import Table, Value_Type, Bits
 
 from Standard.Database import all
 import Standard.Database.Feature.Feature
-import Standard.Database.Dialect_Flag.Dialect_Flag
 
 from Standard.AWS import Redshift_Details, AWS_Credential
 

--- a/test/AWS_Tests/src/S3_Spec.enso
+++ b/test/AWS_Tests/src/S3_Spec.enso
@@ -12,7 +12,7 @@ from Standard.AWS.Errors import AWS_SDK_Error, More_Records_Available, S3_Error,
 import Standard.AWS.Internal.S3_Path.S3_Path
 
 # Needed for custom formats test
-from Standard.Table import Table, Excel_Format, Delimited_Format
+from Standard.Table import Table
 # Needed for correct `Table.should_equal`
 import enso_dev.Table_Tests.Util
 

--- a/test/Base_Tests/src/Data/Array_Spec.enso
+++ b/test/Base_Tests/src/Data/Array_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Empty_Error.Empty_Error
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
-import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Test import all
 

--- a/test/Base_Tests/src/Data/Regression_Spec.enso
+++ b/test/Base_Tests/src/Data/Regression_Spec.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Nothing, Vector, Number, Float, True, False, Regression
+from Standard.Base import Nothing, Float, Regression
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Test import all

--- a/test/Base_Tests/src/Data/Round_Spec.enso
+++ b/test/Base_Tests/src/Data/Round_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Deprecated.Deprecated
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Test import all
 

--- a/test/Base_Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Regex_Spec.enso
@@ -4,7 +4,6 @@ import Standard.Base.Data.Text.Span.Utf_16_Span
 import Standard.Base.Data.Text.Regex.Match.Match
 import Standard.Base.Data.Text.Regex.No_Such_Group
 import Standard.Base.Data.Text.Regex.Regex_Syntax_Error
-import Standard.Base.Data.Text.Regex.Internal.Replacer.Replacer
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 

--- a/test/Base_Tests/src/Data/XML/XML_Spec.enso
+++ b/test/Base_Tests/src/Data/XML/XML_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Errors.Common.Syntax_Error
 import Standard.Base.Errors.File_Error.File_Error
 from Standard.Base.Runtime import assert
 

--- a/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Data_Link_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Cloud_Data_Link_Spec.enso
@@ -1,10 +1,8 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Enso_Cloud.Errors.Missing_Data_Link_Library
-import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Errors.Unimplemented.Unimplemented
 import Standard.Base.Enso_Cloud.Enso_File.Enso_Asset_Type
 

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_Cloud_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_Cloud_Spec.enso
@@ -3,7 +3,6 @@ import Standard.Base.Enso_Cloud.Errors.Cloud_Session_Expired
 import Standard.Base.Enso_Cloud.Errors.Enso_Cloud_Error
 import Standard.Base.Enso_Cloud.Errors.Not_Logged_In
 import Standard.Base.Errors.Common.No_Such_Conversion
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Test import all

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Cloud_Caching_Settings
-import Standard.Base.Enso_Cloud.Errors.Enso_Cloud_Error
 import Standard.Base.Errors.Common.Forbidden_Operation
-import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Unimplemented.Unimplemented

--- a/test/Base_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
@@ -5,7 +5,6 @@ import Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret_Error
 import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Network.HTTP.Request.Request
 import Standard.Base.Runtime.Context
 from Standard.Base.Enso_Cloud.Enso_Secret import as_hideable_value

--- a/test/Base_Tests/src/Network/Http/Http_Auto_Parse_Spec.enso
+++ b/test/Base_Tests/src/Network/Http/Http_Auto_Parse_Spec.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 import Standard.Base.Data.Base_64.Base_64
 import Standard.Base.Errors.Encoding_Error.Encoding_Error
 
-import Standard.Base.Network.HTTP.Response.Response
 
 from Standard.Test import all
 

--- a/test/Base_Tests/src/Network/Http_Spec.enso
+++ b/test/Base_Tests/src/Network/Http_Spec.enso
@@ -3,7 +3,6 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.Common.Syntax_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Network.HTTP.Cache_Policy.Cache_Policy
 import Standard.Base.Network.HTTP.HTTP_Error.HTTP_Error
 import Standard.Base.Network.HTTP.Request.Request
 import Standard.Base.Network.HTTP.Response.Response

--- a/test/Base_Tests/src/Runtime/GC_Example.enso
+++ b/test/Base_Tests/src/Runtime/GC_Example.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 import Standard.Base.Runtime.Ref.Ref
 

--- a/test/Base_Tests/src/Runtime/Missing_Required_Arguments_Spec.enso
+++ b/test/Base_Tests/src/Runtime/Missing_Required_Arguments_Spec.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Not_Invokable
 
-import Standard.Base.Runtime.Ref.Ref
-
 from Standard.Test import all
 
 
@@ -42,7 +40,7 @@ add_specs suite_builder = suite_builder.group "Missing_Argument" group_builder->
         r1.catch.argument_name . should_equal "xyz"
         r1.catch.function_name . should_equal "Missing_Required_Arguments_Spec.my_function"
         r1.catch.call_location.file.name . should_equal "Missing_Required_Arguments_Spec.enso"
-        r1.catch.call_location.start_line . should_equal 40
+        r1.catch.call_location.start_line . should_equal 38
         r1.catch.to_display_text . should_equal "Provide a value for the argument `xyz`."
 
         r2 = my_function_2

--- a/test/Base_Tests/src/Runtime/Stack_Size_Spec.enso
+++ b/test/Base_Tests/src/Runtime/Stack_Size_Spec.enso
@@ -14,7 +14,6 @@ private
 
 from Standard.Base import all
 import Standard.Base.Data.Vector.Builder as Vector_Builder
-import Standard.Base.Runtime.Ref.Ref
 import Standard.Base.System.Process.Process_Builder.Process_Result
 
 from Standard.Test import all

--- a/test/Base_Tests/src/Semantic/Multi_Value_Convert_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_Convert_Spec.enso
@@ -3,7 +3,6 @@ from Standard.Test import all
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Common.No_Such_Method
 
-import project.Data.Complex.Complex
 
 type A
     A value

--- a/test/Base_Tests/src/System/File_Read_Spec.enso
+++ b/test/Base_Tests/src/System/File_Read_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Vector.Map_Error
 import Standard.Base.Errors.Common.Failed_To_Load
 import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.File_Error.File_Error

--- a/test/Benchmarks/src/Main.enso
+++ b/test/Benchmarks/src/Main.enso
@@ -46,7 +46,6 @@ import project.Vector.Operations
 import project.Vector.Sort
 import project.Vector.Zip_Benchmark
 import project.Warnings
-from Standard.Base.Runtime import Debug
 
 all_benchmarks : Vector Bench.All
 all_benchmarks =

--- a/test/Benchmarks/src/Map/Hash_Map.enso
+++ b/test/Benchmarks/src/Map/Hash_Map.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-from Standard.Table import Column, Value_Type, Auto, Bits
 
 from Standard.Test import Bench
 

--- a/test/Benchmarks/src/Runtime/Managed_Resources.enso
+++ b/test/Benchmarks/src/Runtime/Managed_Resources.enso
@@ -1,10 +1,8 @@
 from Standard.Base import all
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
-import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Bench
 
-from project.Config import extended_tests
 
 options = Bench.options . set_warmup (Bench.phase_conf 2 3) . set_measure (Bench.phase_conf 2 3)
 

--- a/test/Benchmarks/src/Sieve/Sieve_Ascribed.enso
+++ b/test/Benchmarks/src/Sieve/Sieve_Ascribed.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Any, Meta, Integer, True, False, Nothing
+from Standard.Base import Meta, Integer, True, False, Nothing
 
 type Gen
     Generator n:Integer

--- a/test/Benchmarks/src/Sieve/Sieve_Ascribed_With_Return_Checks.enso
+++ b/test/Benchmarks/src/Sieve/Sieve_Ascribed_With_Return_Checks.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Any, Meta, Integer, Boolean, True, False, Nothing
+from Standard.Base import Meta, Integer, Boolean, True, False, Nothing
 
 type Gen
     Generator n:Integer

--- a/test/Benchmarks/src/Sieve/Sieve_Original.enso
+++ b/test/Benchmarks/src/Sieve/Sieve_Original.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Any, Meta, Integer, True, False, Nothing
+from Standard.Base import Meta, Integer, True, False, Nothing
 
 type Gen
     Generator n:Integer

--- a/test/Benchmarks/src/Sieve/Sieve_Without_Types.enso
+++ b/test/Benchmarks/src/Sieve/Sieve_Without_Types.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Any, Meta, Integer, True, False, Nothing
+from Standard.Base import Meta, True, False, Nothing
 
 type Gen
     Generator n

--- a/test/Benchmarks/src/Statistics/Count_Min_Max.enso
+++ b/test/Benchmarks/src/Statistics/Count_Min_Max.enso
@@ -1,4 +1,4 @@
-from Standard.Base import IO, Integer, Vector
+from Standard.Base import Integer, Vector
 from Standard.Base.Data.Statistics import all
 import Standard.Base.Data.Range
 

--- a/test/Benchmarks/src/Table/Internal/Multi_Value_Key.enso
+++ b/test/Benchmarks/src/Table/Internal/Multi_Value_Key.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Value_Type, Aggregate_Column
+from Standard.Table import Table, Value_Type
 import Standard.Table.In_Memory_Column.In_Memory_Column
 import Standard.Table.Internal.Multi_Value_Key.Ordered_Multi_Value_Key
 import Standard.Table.Internal.Multi_Value_Key.Unordered_Multi_Value_Key

--- a/test/Benchmarks/src/Table/Sorting.enso
+++ b/test/Benchmarks/src/Table/Sorting.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Sort_Column
+from Standard.Table import Table
 
 from Standard.Test import Bench
 

--- a/test/Benchmarks/src/Vector/Zip_Benchmark.enso
+++ b/test/Benchmarks/src/Vector/Zip_Benchmark.enso
@@ -1,7 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-from Standard.Base.Data.Array_Proxy import Array_Proxy
 
 from Standard.Test import Bench
 

--- a/test/Benchmarks/src/Warnings.enso
+++ b/test/Benchmarks/src/Warnings.enso
@@ -1,7 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-from Standard.Base.Data.Array_Proxy import Array_Proxy
 
 from Standard.Test import Bench
 

--- a/test/Generic_JDBC_Tests/src/Generic_JDBC_Connection_Spec.enso
+++ b/test/Generic_JDBC_Tests/src/Generic_JDBC_Connection_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Test.Spec_Result.Spec_Result
 from Standard.Test import all
 
 import Standard.Database.Errors.SQL_Error

--- a/test/Generic_JDBC_Tests/src/H2_Spec.enso
+++ b/test/Generic_JDBC_Tests/src/H2_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Test.Spec_Result.Spec_Result
 from Standard.Test import all
 
 import Standard.Database.Connection.Database
@@ -8,7 +7,6 @@ import Standard.Database.Errors.SQL_Error
 import Standard.Database.SQL_Query.SQL_Query
 
 import Standard.Generic_JDBC.Generic_JDBC_Connection.Generic_JDBC_Connection
-import Standard.Generic_JDBC.Generic_JDBC_Connection.Generic_JDBC_Details
 
 import project.Generic_JDBC_Connection_Spec
 

--- a/test/Microsoft_Tests/src/SQLServer_Spec.enso
+++ b/test/Microsoft_Tests/src/SQLServer_Spec.enso
@@ -1,16 +1,11 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Ref.Ref
 
-from Standard.Table import Column, Table, Value_Type, Aggregate_Column, Bits, expr
-from Standard.Table.Errors import Invalid_Column_Names, Inexact_Type_Coercion, Duplicate_Output_Column_Names
+from Standard.Table import Column, Table, Value_Type, Aggregate_Column, Bits
 
-import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Feature.Feature
 import Standard.Database.Dialect_Flag.Dialect_Flag
-import Standard.Database.SQL_Type.SQL_Type
 import Standard.Database.Internal.Replace_Params.Replace_Params
 from Standard.Database import all
 from Standard.Database.Errors import all
@@ -29,11 +24,8 @@ import enso_dev.Table_Tests.Database.Upload_Spec
 import enso_dev.Table_Tests.Database.Helpers.Name_Generator
 import enso_dev.Table_Tests.Common_Table_Operations
 from enso_dev.Table_Tests.Common_Table_Operations.Util import all
-from enso_dev.Table_Tests.Database.Types.Postgres_Type_Mapping_Spec import default_text
-from enso_dev.Table_Tests.Database.Postgres_Spec import Basic_Test_Data, Postgres_Tables_Data
 from enso_dev.Table_Tests.Util import all
 
-import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Cloud_Tests_Setup
 
 type SQLServer_Info_Data
     Value ~data

--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -3,15 +3,12 @@ import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Ref.Ref
-from Standard.Base.Enso_Cloud.Data_Link_Helpers import secure_value_to_json
 
 from Standard.Table import Column, Table, Value_Type, Aggregate_Column, Bits, expr
-from Standard.Table.Errors import Invalid_Column_Names, Inexact_Type_Coercion, Duplicate_Output_Column_Names
+from Standard.Table.Errors import Inexact_Type_Coercion, Duplicate_Output_Column_Names
 
-import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Feature.Feature
 import Standard.Database.Dialect_Flag.Dialect_Flag
-import Standard.Database.SQL_Type.SQL_Type
 import Standard.Database.Internal.Replace_Params.Replace_Params
 from Standard.Database import all
 from Standard.Database.Errors import all

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Floating_Point_Equality
 
-from Standard.Table import Table, Sort_Column, Value_Type, expr
+from Standard.Table import Sort_Column, Value_Type, expr
 from Standard.Table.Aggregate_Column.Aggregate_Column import all
 import Standard.Table.Expression.Expression_Error
 from Standard.Table.Errors import all

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -10,8 +10,6 @@ import Standard.Database.Feature.Feature
 from Standard.Test import all
 
 
-from project.Common_Table_Operations.Util import run_default_backend
-from project.Common_Table_Operations.Core_Spec import weird_names
 
 type Data
     Value ~connection

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -7,7 +7,7 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Meta.Type
 
-from Standard.Table import Bits, Column, Column_Ref, Value_Type
+from Standard.Table import Column, Column_Ref, Value_Type
 from Standard.Table.Errors import all
 
 from Standard.Database.Errors import all

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -6,7 +6,6 @@ from Standard.Table import Aggregate_Column, expr
 import Standard.Table.Expression.Expression_Error
 from Standard.Table.Errors import all
 
-from Standard.Database.Errors import SQL_Error
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/Common_Table_Operations/Date_Time_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Date_Time_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Table, Value_Type
-from Standard.Table.Errors import Inexact_Type_Coercion, Invalid_Value_Type
+from Standard.Table.Errors import Invalid_Value_Type
 
 from Standard.Database.Errors import Unsupported_Database_Operation, Unsupported_Database_Type
 import Standard.Database.Column_Description.Column_Description

--- a/test/Table_Tests/src/Common_Table_Operations/Distinct_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Distinct_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Floating_Point_Equality
 
-from Standard.Table import Sort_Column
 from Standard.Table.Errors import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Common.Floating_Point_Equality
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Value_Type, expr
+from Standard.Table import Value_Type, expr
 from Standard.Table.Errors import all
 import Standard.Table.Expression.Expression_Error
 import Standard.Base.Data.Text.Regex.Regex_Syntax_Error

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -10,7 +10,6 @@ from Standard.Table import all hiding Table
 from Standard.Table.Errors import all
 import Standard.Table.Expression.Expression_Error
 
-import Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
 import Standard.Database.Feature.Feature
 from Standard.Database.Errors import all
 

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Cross_Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Cross_Join_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Table import all
 from Standard.Table.Errors import all
@@ -13,7 +12,7 @@ from Standard.Database.Errors import all
 
 from Standard.Test import all
 
-from project.Common_Table_Operations.Util import expect_column_names, run_default_backend
+from project.Common_Table_Operations.Util import expect_column_names
 
 type Lazy_Ref
     Value ~get

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Lookup_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Lookup_Spec.enso
@@ -11,7 +11,7 @@ from Standard.Database.Errors import all
 
 from Standard.Test import all
 
-from project.Common_Table_Operations.Util import run_default_backend, within_table
+from project.Common_Table_Operations.Util import run_default_backend
 import project.Util
 
 main filter=Nothing = run_default_backend add_specs filter

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
@@ -12,7 +12,6 @@ import Standard.Database.Feature.Feature
 from Standard.Test import all
 
 from project.Common_Table_Operations.Util import all
-from project.Common_Table_Operations.Date_Time_Spec import as_local_date_time_repr
 import project.Util
 
 main filter=Nothing = run_default_backend add_specs filter

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Zip_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Zip_Spec.enso
@@ -1,12 +1,10 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Table import all
 from Standard.Table.Errors import all
 
 from Standard.Database import all
-from Standard.Database.Errors import Unsupported_Database_Operation, Integrity_Error
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Database.Internal.Replace_Params.Replace_Params
 
 from Standard.Test import Test
 import Standard.Test.Frame_Hider

--- a/test/Table_Tests/src/Common_Table_Operations/Map_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Map_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
-from Standard.Table import Value_Type, Auto, Bits
+from Standard.Table import Value_Type, Bits
 from Standard.Table.Errors import Invalid_Value_Type
 
 from Standard.Database.Errors import Unsupported_Database_Operation

--- a/test/Table_Tests/src/Common_Table_Operations/Map_To_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Map_To_Table_Spec.enso
@@ -1,6 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Errors.Common.Assertion_Error
-import Standard.Base.Errors.Empty_Error.Empty_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Value_Type

--- a/test/Table_Tests/src/Common_Table_Operations/Nothing_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Nothing_Spec.enso
@@ -6,7 +6,6 @@ from Standard.Table import all
 import Standard.Database.DB_Column.DB_Column
 import Standard.Database.Feature.Feature
 
-from Standard.Test import Test
 import Standard.Test.Extensions
 
 from project.Common_Table_Operations.Util import run_default_backend

--- a/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Common.Incomparable_Values
 
-from Standard.Table import Sort_Column
 from Standard.Table.Errors import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Database.Feature.Feature
 from Standard.Database.Errors import all
-from Standard.Table import Position, Value_Type, Bits, Table
+from Standard.Table import Position, Value_Type, Table
 from Standard.Table.Errors import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/Common_Table_Operations/Text_Cleanse_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Text_Cleanse_Spec.enso
@@ -3,17 +3,13 @@ from Standard.Base import all
 import project.Util
 from project.Util import all
 
-import Standard.Base.Errors.Common.Arithmetic_Error
-import Standard.Base.Errors.Common.Index_Out_Of_Bounds
-import Standard.Base.Errors.Common.Type_Error
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Test.Extensions
 
 from Standard.Database.Errors import all
 import Standard.Database.Feature.Feature
 
-from Standard.Table import Column, Table, Value_Type, Auto, Bits
-from Standard.Table.Errors import Invalid_Value_Type, Invalid_Column_Names
+from Standard.Table import Column, Table
+from Standard.Table.Errors import Invalid_Value_Type
 from project.Common_Table_Operations.Util import run_default_backend, build_sorted_table
 
 from Standard.Test import all

--- a/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
@@ -5,7 +5,6 @@ from Standard.Table.Errors import all
 from Standard.Test import all
 
 
-from project.Common_Table_Operations.Util import run_default_backend
 
 
 type Data

--- a/test/Table_Tests/src/Common_Table_Operations/Util.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Util.enso
@@ -1,5 +1,5 @@
 from Standard.Base import all
-from Standard.Table import Column, Table, Value_Type
+from Standard.Table import Column, Value_Type
 
 import Standard.Database.DB_Table.DB_Table
 

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -1,14 +1,11 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_State.Illegal_State
 
-from Standard.Table import Sort_Column, Value_Type, Blank_Selector, Aggregate_Column
-from Standard.Table.Errors import No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column
+from Standard.Table import Value_Type, Blank_Selector, Aggregate_Column
+from Standard.Table.Errors import Missing_Input_Columns, No_Such_Column
 
 from Standard.Database import all
 import Standard.Database.DB_Column.DB_Column
 import Standard.Database.Dialect
-import Standard.Database.SQL_Type.SQL_Type
-from Standard.Database.Errors import Unsupported_Database_Operation
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/Database/Common/Audit_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Audit_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
-import Standard.Base.Enso_Cloud.Internal.Audit_Log.Audit_Log
 
 from Standard.Table import Table
 
@@ -10,7 +9,7 @@ from Standard.Test import all
 
 import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Cloud_Tests_Setup
 import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Temporary_Directory
-from enso_dev.Base_Tests.Network.Enso_Cloud.Audit_Log_Spec import Audit_Log_Event, get_audit_log_events
+from enso_dev.Base_Tests.Network.Enso_Cloud.Audit_Log_Spec import get_audit_log_events
 
 import project.Database.Postgres_Spec.Temporary_Data_Link_File
 from project.Database.Postgres_Spec import get_configured_connection_details

--- a/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-from Standard.Base.Runtime import assert
 
-from Standard.Table import Table, Sort_Column, Aggregate_Column, expr
+from Standard.Table import Table, expr
 from Standard.Table.Errors import all
 
 from Standard.Database import all

--- a/test/Table_Tests/src/Database/Common/IR_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/IR_Spec.enso
@@ -5,7 +5,6 @@ from Standard.Table import Join_Condition, Join_Kind, Table
 
 from Standard.Database import all
 import Standard.Database.DB_Column.DB_Column
-import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 
 from Standard.Test import all
 import Standard.Test.Suite.Suite_Builder

--- a/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Join_Kind, Aggregate_Column, Value_Type, expr
-from Standard.Table.Errors import No_Such_Column, Name_Too_Long, Truncated_Column_Names, Duplicate_Output_Column_Names
+from Standard.Table.Errors import Name_Too_Long, Truncated_Column_Names, Duplicate_Output_Column_Names
 
 from Standard.Database import all
 from Standard.Database.Dialect import Temp_Table_Style

--- a/test/Table_Tests/src/Database/JDBC/Generic_JDBC_Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/JDBC/Generic_JDBC_Postgres_Spec.enso
@@ -1,8 +1,5 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Aggregate_Column, Value_Type, Table, Bits
-from Standard.Table.Errors import Inexact_Type_Coercion
 
 from Standard.Database import all
 from Standard.Database.Errors import all
@@ -10,7 +7,6 @@ from Standard.Database.Errors import all
 from Standard.Test import all
 
 import project.Database.Helpers.Name_Generator
-from project.Database.Postgres_Spec import create_connection_builder
 
 import Standard.Generic_JDBC.Generic_JDBC_Connection.Generic_JDBC_Connection
 

--- a/test/Table_Tests/src/Database/JDBC/Generic_JDBC_SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/JDBC/Generic_JDBC_SQLite_Spec.enso
@@ -1,8 +1,5 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Aggregate_Column, Value_Type, Table, Bits
-from Standard.Table.Errors import Inexact_Type_Coercion
 
 from Standard.Database import all
 from Standard.Database.Errors import all
@@ -10,7 +7,6 @@ from Standard.Database.Errors import all
 from Standard.Test import all
 
 import project.Database.Helpers.Name_Generator
-from project.Database.Postgres_Spec import create_connection_builder
 
 import Standard.Generic_JDBC.Generic_JDBC_Connection.Generic_JDBC_Connection
 

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -6,12 +6,11 @@ import Standard.Base.Runtime.Ref.Ref
 import Standard.Base.System.File.Data_Link_Access.Data_Link_Access
 
 from Standard.Table import Column, Table, Value_Type, Aggregate_Column, Bits, expr
-from Standard.Table.Errors import Invalid_Column_Names, Inexact_Type_Coercion, Duplicate_Output_Column_Names
+from Standard.Table.Errors import Inexact_Type_Coercion, Duplicate_Output_Column_Names
 
 import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Feature.Feature
 import Standard.Database.Dialect_Flag.Dialect_Flag
-import Standard.Database.SQL_Type.SQL_Type
 import Standard.Database.Internal.Postgres.Pgpass
 import Standard.Database.Internal.Replace_Params.Replace_Params
 from Standard.Database import all
@@ -35,7 +34,6 @@ from project.Common_Table_Operations.Util import all
 from project.Database.Types.Postgres_Type_Mapping_Spec import default_text
 
 import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Cloud_Tests_Setup
-import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Temporary_Directory
 import enso_dev.Base_Tests.Network.Http.Http_Test_Setup
 import enso_dev.Generic_JDBC_Tests.Generic_JDBC_Connection_Spec
 import enso_dev.Table_Tests

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -5,14 +5,13 @@ import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Runtime.Context
 
-from Standard.Table import Table, Value_Type, Bits
+from Standard.Table import Table, Value_Type
 from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names
 
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Feature.Feature
-import Standard.Database.Dialect_Flag.Dialect_Flag
 from Standard.Database import all
-from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation, Unsupported_Database_Type
+from Standard.Database.Errors import SQL_Error, Unsupported_Database_Type
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/Database/Types/Postgres_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/Postgres_Type_Mapping_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Aggregate_Column, Value_Type, Table, Bits
 from Standard.Table.Errors import Inexact_Type_Coercion

--- a/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
@@ -9,7 +9,6 @@ import Standard.Database.Extensions.Upload_Database_Table
 import Standard.Database.Extensions.Upload_In_Memory_Table
 import Standard.Database.Internal.SQLite.SQLite_Type_Mapping
 from Standard.Database import Database, SQLite, SQL_Query
-from Standard.Database.Errors import Unsupported_Database_Operation, Unsupported_Database_Type
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/Formatting/Data_Formatter_Spec.enso
+++ b/test/Table_Tests/src/Formatting/Data_Formatter_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 from Standard.Base.Data.Time.Errors import Date_Time_Format_Parse_Error, Suspicious_Date_Time_Format
 
-from Standard.Table import Table, Column, Data_Formatter, Value_Type
+from Standard.Table import Column, Data_Formatter, Value_Type
 from Standard.Table.Errors import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/IO/Data_Link_Formats_Spec.enso
+++ b/test/Table_Tests/src/IO/Data_Link_Formats_Spec.enso
@@ -6,7 +6,7 @@ from Standard.Table import all
 
 from Standard.Test import all
 
-from enso_dev.Base_Tests.Network.Http.Http_Test_Setup import base_url_with_slash, pending_has_url
+from enso_dev.Base_Tests.Network.Http.Http_Test_Setup import pending_has_url
 from enso_dev.Base_Tests.Network.Http.Http_Data_Link_Spec import replace_url_in_data_link
 
 import project.Util

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Column, Data_Formatter, Delimited_Format
+from Standard.Table import Table, Data_Formatter, Delimited_Format
 from Standard.Table.Extensions.Table_Conversions import all
 from Standard.Table.Errors import all
 

--- a/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Column, Data_Formatter, Match_Columns, Delimited_Format
+from Standard.Table import Table, Data_Formatter, Match_Columns, Delimited_Format
 from Standard.Table.Errors import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -8,8 +8,8 @@ import Standard.Base.Runtime.Context
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 import Standard.Base.Runtime.Ref.Ref
 
-from Standard.Table import Table, Match_Columns, Excel_Format, Excel_Range, Data_Formatter, Delimited_Format, Excel_Workbook, Value_Type
-from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet, No_Rows, No_Common_Type
+from Standard.Table import Table, Match_Columns, Excel_Range, Excel_Workbook, Value_Type
+from Standard.Table.Errors import Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet, No_Rows, No_Common_Type
 from Standard.Table.Extensions.Excel_Extensions import all
 import Standard.Table.Excel.Excel_Workbook.Return_As as Old_Return_As
 

--- a/test/Table_Tests/src/IO/Fetch_Spec.enso
+++ b/test/Table_Tests/src/IO/Fetch_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Data.Base_64.Base_64
 import Standard.Base.Errors.Common.Response_Too_Large
-import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Network.HTTP.Cache_Policy.Cache_Policy
 import Standard.Base.Network.HTTP.HTTP_Error.HTTP_Error
@@ -9,11 +8,9 @@ import Standard.Base.Network.HTTP.Request.Request
 import Standard.Base.Network.HTTP.Request_Body.Request_Body
 import Standard.Base.Network.HTTP.Request_Error
 import Standard.Base.Network.HTTP.Response.Response
-import Standard.Base.Runtime.Context
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Table import all
-import Standard.Table.Errors.Invalid_JSON_Format
 
 from Standard.Test import all
 import Standard.Test.Test_Environment

--- a/test/Table_Tests/src/IO/Fixed_Width_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Fixed_Width_Read_Spec.enso
@@ -17,7 +17,6 @@ import Standard.Test.Test_Environment
 
 import enso_dev.Base_Tests.Data.Text.Encoding_Spec
 
-from project.Common_Table_Operations.Util import run_default_backend
 
 polyglot java import org.enso.table.read.FixedWidthReader
 

--- a/test/Table_Tests/src/In_Memory/Builders_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Builders_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-from Standard.Table import Column
 import Standard.Table.Internal.Java_Exports
 import Standard.Table.Internal.Java_Problems
 

--- a/test/Table_Tests/src/In_Memory/Parse_To_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Parse_To_Table_Spec.enso
@@ -6,7 +6,6 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Test.Extensions
 
 from Standard.Table import Table, Bits, Value_Type
-from Standard.Table.Errors import Invalid_Value_Type, Column_Count_Exceeded, Duplicate_Output_Column_Names, Missing_Input_Columns
 from Standard.Table.Extensions.Table_Conversions import all
 from Standard.Test import all
 from project.Util import all

--- a/test/Table_Tests/src/In_Memory/Table_Date_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Date_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Column, Delimited_Format, Data_Formatter, Value_Type
+from Standard.Table import Table, Column, Data_Formatter, Value_Type
 from Standard.Table.Extensions.Table_Conversions import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/In_Memory/Table_Date_Time_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Date_Time_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Delimited_Format, Column, Data_Formatter, Value_Type
+from Standard.Table import Table, Column, Data_Formatter, Value_Type
 from Standard.Table.Extensions.Table_Conversions import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/In_Memory/Table_Running_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Running_Spec.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 from Standard.Table import Column, Table, Bits, Value_Type
 from Standard.Test import all
 from Standard.Table.Errors import all
-import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from project.Util import all

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -7,14 +7,15 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Runtime.Debug
 
-from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Blank_Selector, Value_Type, Auto
-from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Invalid_Value_Type, Row_Count_Mismatch
+from Standard.Table import Table, Column, Aggregate_Column, Blank_Selector, Value_Type, Auto
+from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, No_Such_Column, Row_Count_Mismatch
 
 import Standard.Visualization
 
 import Standard.Database.Extensions.Upload_Database_Table
 import Standard.Database.Extensions.Upload_In_Memory_Table
-from Standard.Database import Database, SQLite
+import Standard.Database.Connection.Database
+import Standard.Database.Connection.SQLite.SQLite
 
 from Standard.Test import all
 

--- a/test/Table_Tests/src/In_Memory/Table_Time_Of_Day_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Time_Of_Day_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Delimited_Format, Column, Data_Formatter, Value_Type
+from Standard.Table import Table, Column, Data_Formatter, Value_Type
 from Standard.Table.Extensions.Table_Conversions import all
 
 from Standard.Test import all

--- a/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 from Standard.Table import Table
 from Standard.Test import all
 from Standard.Table.Errors import all
-import Standard.Base.Errors.Common.Type_Error
 
 ## Pretty xml makes the tests easier to read, 
    so this function allows to convert a pretty-formatted expected XML value

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Database.DB_Table.DB_Table
-import Standard.Database.DB_Column.DB_Column
 from Standard.Table import Column, Table
 
 from Standard.Test import all

--- a/test/Tableau_Tests/src/Write_Spec.enso
+++ b/test/Tableau_Tests/src/Write_Spec.enso
@@ -7,7 +7,6 @@ from Standard.Table import all
 from Standard.Table.Errors import all
 from Standard.Tableau import Hyper_File
 from Standard.Tableau.Hyper_Errors import all
-import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Test import all
 import enso_dev.Table_Tests.Util

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Column, Value_Type
+from Standard.Table import Table
 
 import Standard.Visualization.Scatter_Plot
 

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -3,16 +3,13 @@ from Standard.Base import all
 from Standard.Table import Table, Aggregate_Column, Value_Type
 
 from Standard.Database import all
-import Standard.Database.DB_Table.DB_Table
 
 import Standard.Visualization.Table.Visualization
 
 import Standard.Visualization.Helpers
-import Standard.Visualization.Id.Id
 
 from Standard.Test import all
 
-import Standard.Base.Errors.Common.Type_Error
 
 polyglot java import java.util.UUID
 

--- a/test/Visualization_Tests/src/Widgets/File_Format_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/File_Format_Widgets_Spec.enso
@@ -1,8 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Metadata.Choice
-import Standard.Base.Metadata.Widget
-import Standard.Base.Metadata.Display
 
 from Standard.Table import all
 from Standard.Database import all

--- a/test/Visualization_Tests/src/Widgets/Text_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Text_Widgets_Spec.enso
@@ -1,9 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Runtime.State
 
-import Standard.Base.Metadata.Choice
-import Standard.Base.Metadata.Widget
-import Standard.Base.Metadata.Display
 
 import Standard.Visualization.Widgets
 


### PR DESCRIPTION
Follow-up of #13274.

Blocks #13216.

Related to #12825

### Pull Request Description

Removes unused imports from tests.

### Important Notes

Touches only imports in `test/**/*.enso`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
