### PR TITLE
Can test multiple projects in runtime-compiler/test

### DIFF
--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/MultipleProjectsTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/MultipleProjectsTest.java
@@ -1,0 +1,69 @@
+package org.enso.compiler.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import org.enso.compiler.test.mock.WithCompilerContext;
+import org.enso.pkg.QualifiedName;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests multiple project compilation with the compiler with {@link WithCompilerContext mock
+ * compiler context}.
+ */
+public class MultipleProjectsTest {
+  @Rule public WithCompilerContext compilerCtx = WithCompilerContext.createDefault();
+
+  @Test
+  public void canImportType_FromDifferentProject() {
+    var libMod =
+        compilerCtx.createModule(
+            QualifiedName.fromString("local.Lib.Main"),
+            """
+            type Lib_Type
+            """);
+    var projMod =
+        compilerCtx.createModule(
+            QualifiedName.fromString("local.Proj.Main"),
+            """
+            from local.Lib import Lib_Type
+            """);
+    var compiler = compilerCtx.getCompiler();
+    var libCompilationRes = compiler.run(libMod);
+    assertThat(
+        String.format("Lib module compiled successfully: %s", libCompilationRes.compiledModules()),
+        libCompilationRes.compiledModules().size(),
+        is(greaterThan(1)));
+    var projCompilationRes = compiler.run(projMod);
+    assertThat(
+        "Proj module compiled successfully",
+        projCompilationRes.compiledModules().size(),
+        is(greaterThan(1)));
+  }
+
+  @Test
+  public void canImportType_FromTwoDifferentProjects() {
+    compilerCtx.createModule(
+        QualifiedName.fromString("local.Lib1.Main"),
+        """
+            type Lib1_Type
+            """);
+    compilerCtx.createModule(
+        QualifiedName.fromString("local.Lib2.Main"),
+        """
+            type Lib2_Type
+            """);
+    var mainMod =
+        compilerCtx.createModule(
+            QualifiedName.fromString("local.Proj.Main"),
+            """
+            from local.Lib1 import Lib1_Type
+            from local.Lib2 import Lib2_Type
+            """);
+    var res = compilerCtx.getCompiler().run(mainMod);
+    assertThat(
+        "Main module compiled successfully", res.compiledModules().size(), is(greaterThan(1)));
+  }
+}

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/SyntheticModulesTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/SyntheticModulesTest.java
@@ -1,0 +1,50 @@
+package org.enso.compiler.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.enso.compiler.CompilerResult;
+import org.enso.compiler.test.mock.WithCompilerContext;
+import org.enso.pkg.QualifiedName;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SyntheticModulesTest {
+  @Rule public WithCompilerContext compilerCtx = WithCompilerContext.createDefault();
+
+  @Test
+  public void testCompilationOfSyntheticModules() {
+    compilerCtx.createModule(
+        QualifiedName.fromString("local.Proj.A.B"), """
+            type B_Type
+            """);
+    var mainMod =
+        compilerCtx.createModule(
+            QualifiedName.fromString("local.Proj.Main"),
+            """
+            import project.A.B.B_Type
+            """);
+    var res = compilerCtx.getCompiler().run(mainMod);
+    assertSuccessfulCompilation(res);
+    var loadedModules = compilerCtx.getLoadedModules();
+    var parentMod =
+        loadedModules.stream()
+            .filter(m -> m.getName().toString().equals("local.Proj.A"))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("Synthetic module 'local.Proj.A' must be present"));
+    assertThat("Parent module is synthetic", parentMod.isSynthetic(), is(true));
+    var moduleRefs = parentMod.getDirectModulesRefs();
+    assertThat(
+        "Has single direct module reference",
+        moduleRefs,
+        is(List.of(QualifiedName.fromString("local.Proj.A.B"))));
+  }
+
+  private void assertSuccessfulCompilation(CompilerResult result) {
+    var compiledModules = result.compiledModules();
+    assertThat("Compiled modules are not empty", compiledModules.size(), is(greaterThan(1)));
+  }
+}

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockModule.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockModule.java
@@ -2,6 +2,8 @@ package org.enso.compiler.test.mock;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.enso.common.CompilationStage;
 import org.enso.compiler.context.CompilerContext;
 import org.enso.compiler.context.CompilerContext.ModuleScopeBuilder;
@@ -21,19 +23,35 @@ final class MockModule extends CompilerContext.Module {
   private final org.enso.pkg.Package<? extends Object> pkg;
   private final MockScopeBuilder scopeBuilder = new MockScopeBuilder();
   private final MockPackageRepository repo;
+  private final boolean isSynthetic;
+  private final List<QualifiedName> submoduleNames = new ArrayList<>();
 
   org.enso.compiler.core.ir.Module ir;
   BindingsMap bm;
   CompilationStage stage;
 
+  /**
+   * @param pkg Package that the module belongs to.
+   * @param qName Qualified name of the module.
+   * @param path Path to the file in the virtual FS.
+   * @param code Content of the module
+   * @param repo
+   * @param isSynthetic
+   */
   MockModule(
-      Package<?> pkg, QualifiedName qName, String path, String code, MockPackageRepository repo) {
+      Package<?> pkg,
+      QualifiedName qName,
+      String path,
+      String code,
+      MockPackageRepository repo,
+      boolean isSynthetic) {
     this.pkg = pkg;
     this.qName = qName;
     this.path = path;
     this.code = code;
     this.stage = CompilationStage.INITIAL;
     this.repo = repo;
+    this.isSynthetic = isSynthetic;
   }
 
   @Override
@@ -89,8 +107,12 @@ final class MockModule extends CompilerContext.Module {
   }
 
   @Override
-  public java.util.List<QualifiedName> getDirectModulesRefs() {
-    return java.util.List.of();
+  public List<QualifiedName> getDirectModulesRefs() {
+    return submoduleNames;
+  }
+
+  public void addSubmodule(QualifiedName submoduleName) {
+    submoduleNames.add(submoduleName);
   }
 
   @Override
@@ -100,7 +122,7 @@ final class MockModule extends CompilerContext.Module {
 
   @Override
   public boolean isSynthetic() {
-    return false;
+    return isSynthetic;
   }
 
   @Override

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockPackageRepository.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockPackageRepository.java
@@ -30,10 +30,19 @@ import scala.util.Left;
 import scala.util.Right;
 
 /**
- * {@link PackageRepository} emulating {@link org.apache.commons.vfs2.FileObject} as its type member
- * ({@code PackageRepository#TFile}).
+ * Implementation of {@link PackageRepository} with {@link Path} as its type member ({@code
+ * PackageRepository#TFile}).
+ *
+ * <p>Currently, it is located in test sources, but ultimately, we would like to use it as an
+ * alternative to {@code DefaultPackageRepository} which depends on Truffle file system.
+ *
+ * <p>All the {@link Path} objects passed to or returned from this class are assumed to be created
+ * by the {@link VirtualFileSystem}.
+ *
+ * @see #createModule(QualifiedName, String)
  */
 final class MockPackageRepository implements PackageRepository {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(MockPackageRepository.class);
   private final VirtualFileSystem vfs;
   private final Path vfsRoot;
@@ -77,12 +86,18 @@ final class MockPackageRepository implements PackageRepository {
   }
 
   /**
-   * Creates a module. If the package of the module does not exist, it is created. If the module
-   * with the given name already exists, an {@link IllegalArgumentException} is thrown.
+   * Creates a module. If the package of the module does not exist, it is created. Note that the
+   * package name is derived from the first two items of the qualified name of the module.
    *
-   * @param modName
-   * @param content
-   * @return
+   * <p>If the module with the given name already exists, an {@link IllegalArgumentException} is
+   * thrown.
+   *
+   * @param modName Qualified name of the module. If the name is longer than 3, for example {@code
+   *     local.Proj.A.B.C}, all intermediate synthetic parent modules will be created. For example
+   *     for {@code local.Proj.A.B.C}, synthetic parent modules for {@code local.Proj.A} and {@code
+   *     local.Proj.A.B} will be created.
+   * @param content Content for the module. Can be empty, but not null.
+   * @return Created module. Not null
    */
   Module createModule(QualifiedName modName, String content) {
     assert !modName.isSimple();
@@ -100,24 +115,71 @@ final class MockPackageRepository implements PackageRepository {
       if (!Files.exists(srcDir)) {
         Files.createDirectories(srcDir);
       }
+      var modPathInPkg = modPath.stream().skip(2).toList();
+      MockModule parentSyntheticModule = null;
+      if (!modPathInPkg.isEmpty()) {
+        parentSyntheticModule = createSyntheticModules(modPathInPkg, pkg);
+      }
       var srcPath = modPath.stream().skip(2).collect(Collectors.joining("/"));
       var subSrcDir = srcDir.resolve(srcPath);
-      if (!Files.exists(subSrcDir)) {
-        Files.createDirectories(subSrcDir);
-      }
+      assert Files.exists(subSrcDir)
+          : String.format(
+              "Subdirectory %s does not exist in package %s. It should have been "
+                  + "created by createSyntheticModules()",
+              subSrcDir, pkg.libraryName());
       var srcFile = subSrcDir.resolve(modName.item() + ".enso");
       if (Files.exists(srcFile)) {
         throw new IllegalArgumentException("Module '" + modName + "' already exists");
       }
       VirtualFileSystem.write(srcFile, content);
       var modAbsPath = vfs.getAbsolutePath(srcFile);
-      var module = new MockModule(pkg, modName, modAbsPath, content, this);
+      boolean isSynthetic = false;
+      var module = new MockModule(pkg, modName, modAbsPath, content, this, isSynthetic);
+      if (parentSyntheticModule != null) {
+        parentSyntheticModule.addSubmodule(modName);
+      }
       loadedModules.put(modName.toString(), module);
       return module;
     } catch (IOException e) {
       LOGGER.error("Failed to create module " + modName, e);
       throw new IllegalStateException(e);
     }
+  }
+
+  /**
+   * @param modPathInPkg Module path inside package, e.g., for module name {@code local.Proj.A.B.C},
+   *     it would be {@code [A, B, C]}.
+   * @param pkg Package for which synthetic modules are created.
+   * @return Returns the last synthetic module. For example, when creating synthetic modules for
+   *     {@code local.Proj.A.B.C}, it will return synthetic module for {@code local.Proj.A.B}.
+   */
+  private MockModule createSyntheticModules(java.util.List<String> modPathInPkg, Package<Path> pkg)
+      throws IOException {
+    assert !modPathInPkg.isEmpty();
+    var curDir = pkg.sourceDir();
+    var curName = QualifiedName.fromString(pkg.libraryName().toString());
+    MockModule parentModule = null;
+    for (var pathItem : modPathInPkg) {
+      curDir = curDir.resolve(pathItem);
+      curName = curName.createChild(pathItem);
+      if (!Files.exists(curDir)) {
+        Files.createDirectory(curDir);
+        var absPath = vfs.getAbsolutePath(curDir);
+        var emptySyntheticModule = createEmptySyntheticModule(curName, pkg, absPath);
+        if (parentModule != null) {
+          parentModule.addSubmodule(curName);
+        }
+        parentModule = emptySyntheticModule;
+        loadedModules.put(curName.toString(), emptySyntheticModule);
+      }
+    }
+    assert parentModule != null;
+    return parentModule;
+  }
+
+  private MockModule createEmptySyntheticModule(
+      QualifiedName modName, Package<Path> pkg, String absolutePath) {
+    return new MockModule(pkg, modName, absolutePath, "", this, true);
   }
 
   @Override
@@ -137,7 +199,9 @@ final class MockPackageRepository implements PackageRepository {
 
   @Override
   public boolean isPackageLoaded(LibraryName libraryName) {
-    return loadedPackages.containsKey(libraryName);
+    var ret = loadedPackages.containsKey(libraryName);
+    LOGGER.trace("isPackageLoaded({}) = {}", libraryName, ret);
+    return ret;
   }
 
   @Override
@@ -200,7 +264,8 @@ final class MockPackageRepository implements PackageRepository {
       var modName = src.qualifiedName();
       var srcPath = vfs.getAbsolutePath(src.file());
       var srcContent = readFile(src.file());
-      var mod = new MockModule(virtualPkg, modName, srcPath, srcContent, this);
+      var isSynthetic = false;
+      var mod = new MockModule(virtualPkg, modName, srcPath, srcContent, this, isSynthetic);
       loadedModules.put(modName.toString(), mod);
     }
     mainProjectPkg = castObjectPkg(pkg);

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/TestMockPackageRepository.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/TestMockPackageRepository.java
@@ -1,0 +1,49 @@
+package org.enso.compiler.test.mock;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.List;
+import org.enso.pkg.QualifiedName;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class TestMockPackageRepository {
+
+  private MockPackageRepository repo;
+
+  @Before
+  public void before() {
+    repo = MockPackageRepository.create();
+  }
+
+  @Test
+  public void canCreateModule() {
+    var mod = repo.createModule(QualifiedName.fromString("local.Proj.Main"), "# Empty");
+    assertThat(mod, is(notNullValue()));
+    assertThat(mod.isSynthetic(), is(false));
+    assertThat(mod.getName().toString(), is("local.Proj.Main"));
+  }
+
+  @Test
+  public void submodulesCreateSyntheticModules() {
+    var modName = "local.Project.A.B";
+    repo.createModule(QualifiedName.fromString(modName), "# Empty");
+    var parentMod = repo.getLoadedModule("local.Project.A");
+    assertThat(parentMod.isDefined(), is(true));
+    assertThat(parentMod.get().isSynthetic(), is(true));
+  }
+
+  @Test
+  public void assignsSubmodulesAsDirectModuleRefs() {
+    var modName = "local.Project.A.B";
+    repo.createModule(QualifiedName.fromString(modName), "# Empty");
+    var parentMod = repo.getLoadedModule("local.Project.A").get();
+    var directModuleRefs = parentMod.getDirectModulesRefs();
+    assertThat(
+        "Has child module as direct module reference",
+        directModuleRefs,
+        is(List.of(QualifiedName.fromString(modName))));
+  }
+}


### PR DESCRIPTION
Extracted from #13216.

### Pull Request Description

For [MockPackageRepository](https://github.com/enso-org/enso/blob/49fffdc2475a52d343ba2a0ebae6ce8d69b955cd/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockPackageRepository.java), implements:
- Support for multiple projects, i.e., can create multiple modules from different projects and import entities from different projects.
- When a module is created, all its parent modules are created as synthetic modules with [directModuleRefs](https://github.com/enso-org/enso/blob/e9d709addd46ad44db8823a6706715e0ae2a2aa5/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java#L146) correctly set.
  - This mimics the behavior of the referential [DefaultPackageRepository](https://github.com/enso-org/enso/blob/f0cbf1a8ade9f48bd321a842ddb1075678842b96/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala).


### Important Notes

[org.enso.compiler.test.mock package](https://github.com/enso-org/enso/blob/49fffdc2475a52d343ba2a0ebae6ce8d69b955cd/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock) in `runtime-compiler/Test` contains various mocks so that the [org.enso.compiler.Compiler](https://github.com/enso-org/enso/blob/47e66da6772c9dd108506e86de31dfe718509b24/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala) can be tested without:
- The need to create modules on local file system.
- Dependency on `Truffle` file system.
- Dependency on any Standard libraries.

Ultimately, we would like to extract [org.enso.compiler.test.mock.MockPackageRepository](https://github.com/enso-org/enso/blob/49fffdc2475a52d343ba2a0ebae6ce8d69b955cd/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockPackageRepository.java) from test sources to its own project as an alternative to [org.enso.interpreter.runtime.DefaultPackageRepository](https://github.com/enso-org/enso/blob/f0cbf1a8ade9f48bd321a842ddb1075678842b96/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
