### PR TITLE
Avoid crashing when an invalid id is passed to `extractTypeAndId`

### DIFF
--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -100,7 +100,14 @@ export function extractTypeAndId<Id extends backend.AssetId>(id: Id): AssetTypeA
     }
     case undefined:
     default: {
-      throw new Error(`Invalid type '${typeRaw}'`)
+      // This is INCORRECT but avoids a crash, to allow the error to be handled gracefully.
+      // eslint-disable-next-line no-restricted-properties
+      console.error(`Invalid type '${typeRaw}' for asset id`)
+      return {
+        type: backend.AssetType.directory,
+        id: projectManager.Path(idRaw),
+        directory: directoryPath,
+      }
     }
   }
 }


### PR DESCRIPTION
### Pull Request Description
- Avoid crashing when an invalid id is passed to `extractTypeAndId`
  - This happens sometimes due to incorrect local state. Exact cause unknown.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
