### PR TITLE
Implement `AllOfTypesCheckNode.findDirectMatch` for `EnsoMultiValue`

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EnsoMultiValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/EnsoMultiValueTest.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -169,6 +170,93 @@ public class EnsoMultiValueTest {
     var foo = ctxRule.evalModule(code, "dataflow.enso", "foo");
     assertTrue("Returns a dataflow error", foo.isException());
     assertEquals("(Error: (My_Error.Error 'msg'))", foo.toString());
+  }
+
+  @Test
+  public void makeAbx13272() throws Exception {
+    var types =
+        """
+    from project.PrivateConversion import all
+    type A
+        A_Ctor x
+
+        a_method self = "A method"
+    type B
+        B_Ctor x
+
+        b_method self = "B method"
+
+    type X
+        X_Ctor x
+
+        x_method self = "X method"
+
+    make_abx -> A & B & X =
+        a = A.A_Ctor 1
+        # Relies on the hidden conversions
+        (a : A & B & X)
+    """;
+
+    var privateConversion =
+        """
+    from project.Types import all
+
+    B.from (that : A) = B.B_Ctor that
+    X.from (that : A) -> X =
+        X.X_Ctor that
+    """;
+
+    var main =
+        """
+    from project.Types import all
+
+    main =
+        abx = make_abx
+        # X is hidden in A & B
+        ab = (abx : A & B)
+        # but should still be possible to uncover it
+        x = (ab:X)
+        [abx, ab, x]
+    """;
+
+    var prjDir = dir.newFolder();
+    var sources = new HashSet<SourceModule>();
+    sources.add(new SourceModule(QualifiedName.fromString("Types"), types));
+    sources.add(new SourceModule(QualifiedName.fromString("PrivateConversion"), privateConversion));
+    sources.add(new SourceModule(QualifiedName.fromString("Main"), main));
+    ProjectUtils.createProject("Keep_Id", sources, prjDir.toPath());
+
+    ProjectUtils.testProjectRun(
+        prjDir.toPath(),
+        (tripple) -> {
+          assertTrue(tripple.hasArrayElements());
+          assertEquals(3, tripple.getArraySize());
+
+          {
+            var abx = tripple.getArrayElement(0);
+
+            assertEquals("A method", abx.invokeMember("a_method").asString());
+            assertEquals("B method", abx.invokeMember("b_method").asString());
+            assertEquals("X method", abx.invokeMember("x_method").asString());
+          }
+
+          {
+            var ab = tripple.getArrayElement(1);
+            assertEquals("A method", ab.invokeMember("a_method").asString());
+            assertEquals("B method", ab.invokeMember("b_method").asString());
+            try {
+              var res = ab.invokeMember("x_method");
+              fail("No result expected: " + res);
+            } catch (UnsupportedOperationException ex) {
+              assertNotEquals(-1, ex.getMessage().indexOf("x_method"));
+            }
+          }
+
+          {
+            var x = tripple.getArrayElement(2);
+            assertEquals("X method", x.invokeMember("x_method").asString());
+          }
+        });
   }
 
   private static void assertStartsWith(String exp, String actual) {

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -29,6 +29,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
       .newBuilder(LanguageInfo.ID)
       .allowExperimentalOptions(true)
       .allowAllAccess(true)
+      .environment("NO_COLOR", "true")
       .option(RuntimeOptions.PROJECT_ROOT, pkgPath.getAbsolutePath)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -36,6 +36,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
           .newBuilder()
           .allowExperimentalOptions(true)
           .allowAllAccess(true)
+          .environment("NO_COLOR", "true")
           .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
           .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
           .option(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -7,9 +7,7 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import java.util.List;
 import org.enso.interpreter.node.ExpressionNode;
-import org.enso.interpreter.node.expression.builtin.meta.AtomWithAHoleNode;
 import org.enso.interpreter.runtime.data.text.Text;
-import org.enso.interpreter.runtime.error.DataflowError;
 
 /**
  * Root of hierarchy of nodes checking types. This class (and its subclasses) are an implementation
@@ -102,9 +100,5 @@ abstract sealed class AbstractTypeCheckNode extends Node
     }
 
     return builder.toString();
-  }
-
-  static boolean isAllFitValue(Object v) {
-    return v instanceof DataflowError || AtomWithAHoleNode.isHole(v);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -24,8 +24,7 @@ abstract sealed class AbstractTypeCheckNode extends Node
 
   abstract Object findDirectMatch(VirtualFrame frame, Object value);
 
-  abstract Object executeConversion(
-      VirtualFrame frame, Object value, ExpressionNode valueNode);
+  abstract Object executeConversion(VirtualFrame frame, Object value, ExpressionNode valueNode);
 
   abstract String expectedTypeMessage();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -24,7 +24,7 @@ abstract sealed class AbstractTypeCheckNode extends Node
 
   abstract Object findDirectMatch(VirtualFrame frame, Object value);
 
-  abstract Object executeCheckOrConversion(
+  abstract Object executeConversion(
       VirtualFrame frame, Object value, ExpressionNode valueNode);
 
   abstract String expectedTypeMessage();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -50,13 +50,6 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
   @Override
   @ExplodeLoop
   Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
-    {
-      var result = findDirectMatch(frame, value);
-      if (result != null) {
-        return result;
-      }
-    }
-
     var values = new Object[checks.length];
     var valueTypes = new Type[checks.length];
     var at = 0;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -50,10 +50,6 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
   @Override
   @ExplodeLoop
   Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
-    if (isAllFitValue(value)) {
-      return value;
-    }
-
     {
       var result = findDirectMatch(frame, value);
       if (result != null) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -30,6 +30,20 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   Object findDirectMatch(VirtualFrame frame, Object value) {
+    if (value instanceof EnsoMultiValue multi) {
+      var dispatchTypes = new Type[checks.length];
+      var at = 0;
+      for (var n : checks) {
+        var result = n.findDirectMatch(frame, value);
+        if (result == null) {
+          return null;
+        }
+        var t = typeNode.findTypeOrNull(result);
+        dispatchTypes[at++] = t;
+      }
+      var node = EnsoMultiValue.NewNode.getUncached();
+      return node.renewMulti(multi, dispatchTypes);
+    }
     return null;
   }
 
@@ -38,6 +52,13 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
   Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
     if (isAllFitValue(value)) {
       return value;
+    }
+
+    {
+      var result = findDirectMatch(frame, value);
+      if (result != null) {
+        return result;
+      }
     }
 
     var values = new Object[checks.length];

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -49,14 +49,14 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
+  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
     var values = new Object[checks.length];
     var valueTypes = new Type[checks.length];
     var at = 0;
     var integers = 0;
     var floats = 0;
     for (var n : checks) {
-      var result = n.executeCheckOrConversion(frame, value, expr);
+      var result = n.executeConversion(frame, value, expr);
       if (result == null) {
         return null;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
@@ -31,9 +31,6 @@ non-sealed abstract class MetaTypeCheckNode extends AbstractTypeCheckNode {
 
   @Specialization
   Object verifyMetaObject(VirtualFrame frame, Object v, @Cached IsValueOfTypeNode isA) {
-    if (isAllFitValue(v)) {
-      return v;
-    }
     if (isA.execute(expectedSupplier.get(), v, true)) {
       return v;
     } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
@@ -13,24 +14,23 @@ import org.enso.interpreter.runtime.util.CachingSupplier;
  * Node for checking {@code polyglot java import} types. This class (and its subclasses)
  * are an implementation detail. The API to perform the is in {@link TypeCheckValueNode}.
  */
-non-sealed abstract class MetaTypeCheckNode extends AbstractTypeCheckNode {
+final class MetaTypeCheckNode extends AbstractTypeCheckNode {
   private final CachingSupplier<? extends Object> expectedSupplier;
   @CompilerDirectives.CompilationFinal private String expectedTypeMessage;
+  @Child private IsValueOfTypeNode isA = IsValueOfTypeNode.build();
 
   MetaTypeCheckNode(String name, CachingSupplier<? extends Object> expectedMetaSupplier) {
     super(name);
     this.expectedSupplier = expectedMetaSupplier;
   }
 
-  abstract Object executeCheckOrConversion(VirtualFrame frame, Object value);
-
   @Override
-  Object findDirectMatch(VirtualFrame frame, Object value) {
-    return executeCheckOrConversion(frame, value);
+  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode ignore) {
+      return null;
   }
 
-  @Specialization
-  Object verifyMetaObject(VirtualFrame frame, Object v, @Cached IsValueOfTypeNode isA) {
+  @Override
+  Object findDirectMatch(VirtualFrame frame, Object v) {
     if (isA.execute(expectedSupplier.get(), v, true)) {
       return v;
     } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter.node.typecheck;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
@@ -11,8 +9,8 @@ import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /**
- * Node for checking {@code polyglot java import} types. This class (and its subclasses)
- * are an implementation detail. The API to perform the is in {@link TypeCheckValueNode}.
+ * Node for checking {@code polyglot java import} types. This class (and its subclasses) are an
+ * implementation detail. The API to perform the is in {@link TypeCheckValueNode}.
  */
 final class MetaTypeCheckNode extends AbstractTypeCheckNode {
   private final CachingSupplier<? extends Object> expectedSupplier;
@@ -26,7 +24,7 @@ final class MetaTypeCheckNode extends AbstractTypeCheckNode {
 
   @Override
   Object executeConversion(VirtualFrame frame, Object value, ExpressionNode ignore) {
-      return null;
+    return null;
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -19,7 +19,7 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
   @ExplodeLoop
   final Object findDirectMatch(VirtualFrame frame, Object value) {
     for (var n : checks) {
-      java.lang.Object result = n.findDirectMatch(frame, value);
+      var result = n.findDirectMatch(frame, value);
       if (result != null) {
         return result;
       }
@@ -30,10 +30,6 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
   @Override
   @ExplodeLoop
   Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
-    java.lang.Object direct = findDirectMatch(frame, value);
-    if (direct != null) {
-      return direct;
-    }
     for (var n : checks) {
       java.lang.Object result = n.executeCheckOrConversion(frame, value, expr);
       if (result != null) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -29,9 +29,9 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeCheckOrConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
+  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
     for (var n : checks) {
-      java.lang.Object result = n.executeCheckOrConversion(frame, value, expr);
+      var result = n.executeConversion(frame, value, expr);
       if (result != null) {
         return result;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -98,9 +98,6 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
 
   @ExplodeLoop
   final Object findDirectMatch(VirtualFrame frame, Object v) {
-    if (isAllFitValue(v)) {
-      return v;
-    }
     if (v instanceof Function fn && fn.isThunk()) {
       if (lazyCheck == null) {
         CompilerDirectives.transferToInterpreter();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -43,7 +43,7 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     this.expectedType = expectedType;
   }
 
-  abstract Object executeCheckOrConversion(
+  abstract Object executeConversion(
       VirtualFrame frame, Object value, ExpressionNode valueSource);
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -61,17 +61,6 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     return construct.execute(frame, state, expectedType, unresolved);
   }
 
-  @Specialization(rewriteOn = InvalidAssumptionException.class)
-  Object doCheckNoConversionNeeded(VirtualFrame frame, Object v, ExpressionNode ignore)
-      throws InvalidAssumptionException {
-    var ret = findDirectMatch(frame, v);
-    if (ret != null) {
-      return ret;
-    } else {
-      throw new InvalidAssumptionException();
-    }
-  }
-
   @Specialization(
       limit = "10",
       guards = {"cachedType != null", "findType(typeOfNode, v, cachedType) == cachedType"})
@@ -96,8 +85,13 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
         frame == null ? null : frame.materialize(), v, expr, type);
   }
 
-  @ExplodeLoop
+  @Override
   final Object findDirectMatch(VirtualFrame frame, Object v) {
+      return directMatchImpl(v);
+  }
+
+  @ExplodeLoop
+  private final Object directMatchImpl(Object v) {
     if (v instanceof Function fn && fn.isThunk()) {
       if (lazyCheck == null) {
         CompilerDirectives.transferToInterpreter();
@@ -191,11 +185,7 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   private Object handleWithConversion(VirtualFrame frame, Object v, ApplicationNode convertNode)
       throws PanicException {
     if (convertNode == null) {
-      var ret = findDirectMatch(frame, v);
-      if (ret != null) {
-        return ret;
-      }
-      return null;
+      return directMatchImpl(v);
     } else {
       var converted = convertNode.executeGeneric(frame);
       return converted;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -95,7 +95,7 @@ public final class TypeCheckValueNode extends Node {
     if (direct != null) {
       return direct;
     }
-    var result = check.executeCheckOrConversion(frame, value, expr);
+    var result = check.executeConversion(frame, value, expr);
     if (result == null) {
       throw panicAtTheEnd(value);
     }
@@ -177,7 +177,7 @@ public final class TypeCheckValueNode extends Node {
   public static TypeCheckValueNode meta(
       String comment, Supplier<? extends Object> metaObjectSupplier) {
     var cachingSupplier = CachingSupplier.wrap(metaObjectSupplier);
-    var typeCheckNodeImpl = MetaTypeCheckNodeGen.create(comment, cachingSupplier);
+    var typeCheckNodeImpl = new MetaTypeCheckNode(comment, cachingSupplier);
     return new TypeCheckValueNode(typeCheckNodeImpl, true);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -91,6 +91,10 @@ public final class TypeCheckValueNode extends Node {
 
   private final Object handleCheckOrConversionImpl(
       VirtualFrame frame, Object value, ExpressionNode expr) {
+    var direct = check.findDirectMatch(frame, value);
+    if (direct != null) {
+      return direct;
+    }
     var result = check.executeCheckOrConversion(frame, value, expr);
     if (result == null) {
       throw panicAtTheEnd(value);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -10,11 +10,13 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.node.expression.builtin.meta.AtomWithAHoleNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 import org.enso.interpreter.runtime.warning.AppendWarningNode;
@@ -61,6 +63,9 @@ public final class TypeCheckValueNode extends Node {
    */
   public final Object handleCheckOrConversion(
       VirtualFrame frame, Object value, ExpressionNode expr) {
+    if (isAllFitValue(value)) {
+      return value;
+    }
     if (warnings.hasWarnings(value)) {
       if (append == null) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -226,5 +231,9 @@ public final class TypeCheckValueNode extends Node {
 
   final boolean isAllTypes() {
     return allTypes;
+  }
+
+  private static boolean isAllFitValue(Object v) {
+    return v instanceof DataflowError || AtomWithAHoleNode.isHole(v);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
@@ -109,6 +109,41 @@ public final class EnsoMultiValue extends EnsoObject {
       return new EnsoMultiValue(dt, et, values, firstDispatch);
     }
 
+    /**
+     * Recreates new multi value with different dispatch types.
+     *
+     * @param original original multi value to extract information from
+     * @param dispatchTypes new dispatch types - all of them must already be present in the {@code
+     *     dispatch} or {@code extra} types of the provided multi value
+     * @return
+     */
+    @NeverDefault
+    @TruffleBoundary
+    public final EnsoMultiValue renewMulti(EnsoMultiValue original, Type[] dispatchTypes) {
+      var allTypes = original.allTypes(true, AllTypesWith.getUncached());
+      var allValues = original.values.clone();
+      var extraCount = 0;
+      FOUND:
+      for (var searchFor = 0; searchFor < dispatchTypes.length; searchFor++) {
+        for (var i = 0; i < allTypes.length; i++) {
+          if (dispatchTypes[searchFor] == allTypes[i]) {
+            swap(allTypes, extraCount, i);
+            swap(allValues, extraCount, i);
+            extraCount++;
+            continue FOUND;
+          }
+        }
+        assert false
+            : "Cannot find " + dispatchTypes[searchFor] + " among " + Arrays.toString(allTypes);
+      }
+      assert extraCount == dispatchTypes.length : "All types found";
+      var dt = executeTypes(allTypes, 0, extraCount);
+      var et = executeTypes(allTypes, extraCount, allTypes.length);
+      assert !dt.hasIntersectionWith(et)
+          : "Dispatch (" + dt + ") and extra (" + et + ") should be disjoin!";
+      return new EnsoMultiValue(dt, et, allValues, 0);
+    }
+
     abstract EnsoMultiType executeTypes(Type[] types, int from, int to);
 
     @Specialization(
@@ -147,6 +182,12 @@ public final class EnsoMultiValue extends EnsoObject {
         }
       }
       return true;
+    }
+
+    private static void swap(Object[] arr, int i1, int i2) {
+      var tmp = arr[i1];
+      arr[i1] = arr[i2];
+      arr[i2] = tmp;
     }
   }
 

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
@@ -388,7 +388,11 @@ public final class ContextUtils implements TestRule, AutoCloseable {
 
     private Builder(String... permittedLanguages) {
       this.polyglotCtxBldr = defaultContextBuilder(permittedLanguages);
-      this.polyglotCtxBldr.out(stdout).err(stderr).logHandler(stdout);
+      this.polyglotCtxBldr
+          .out(stdout)
+          .err(stderr)
+          .logHandler(stdout)
+          .environment("NO_COLOR", "true");
     }
 
     private static Context.Builder defaultContextBuilder(String... permittedLanguages) {
@@ -396,6 +400,7 @@ public final class ContextUtils implements TestRule, AutoCloseable {
           .allowExperimentalOptions(true)
           .allowIO(IOAccess.ALL)
           .allowAllAccess(true)
+          .environment("NO_COLOR", "true")
           .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
           .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
           .option(RuntimeOptions.STRICT_ERRORS, "true")

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -10,10 +10,11 @@ import Standard.Base.Errors.Common.No_Such_Conversion
 import Standard.Base.Errors.Common.No_Such_Method
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
-from project.Semantic.Type_Refinement.Types import A, B, make_a_and_b
+from project.Semantic.Type_Refinement.Types import A, B, X, make_a_and_b, make_abx
 
 id_a (x : A) -> A = x
 id_b (x : B) -> B = x
+id_x (x : X) -> X = x
 
 type C
     C_Ctor x
@@ -29,6 +30,12 @@ add_specs suite_builder =
             Test.expect_panic Type_Error (just_a:B)
             Test.expect_panic No_Such_Conversion (B.from just_a)
             Test.expect_panic Type_Error (id_b just_a)
+
+        group_builder.specify "conversion A&B -> X should not be available" <|
+            ab = make_a_and_b
+            Test.expect_panic Type_Error (ab:X)
+            Test.expect_panic No_Such_Conversion (X.from ab)
+            Test.expect_panic Type_Error (id_x ab)
 
         group_builder.specify "make_a_and_b->A&B presents as both A and B" <|
             ab = make_a_and_b
@@ -352,6 +359,22 @@ add_specs suite_builder =
             r3.is_a B . should_be_true
             r3.a_method . should_equal "A method"
             r3.b_method . should_equal "B method"
+
+        group_builder.specify "narrowing A & B & X to A & B should hide X but allow to unhide it via cast" <|
+            abx = make_abx
+            abx.a_method.should_equal "A method"
+            abx.b_method.should_equal "B method"
+            abx.x_method.should_equal "X method"
+
+            ab = (abx : A & B)
+            ab.a_method.should_equal "A method"
+            ab.b_method.should_equal "B method"
+
+            # X is hidden in A & B
+            Test.expect_panic No_Such_Method (ab.x_method)
+            # but should still be possible to uncover it
+            x = (ab:X)
+            x.x_method.should_equal "X method"
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Base_Tests/src/Semantic/Type_Refinement/Hidden_Conversions.enso
+++ b/test/Base_Tests/src/Semantic/Type_Refinement/Hidden_Conversions.enso
@@ -1,7 +1,11 @@
 private
 
-from project.Semantic.Type_Refinement.Types import A, B
+from project.Semantic.Type_Refinement.Types import A, B, X
 
 ## This conversion should only be imported in `Type_Refinement.Types` and nowhere else.
 B.from (that : A) -> B =
     B.B_Ctor that
+
+## This conversion should only be imported in `Type_Refinement.Types` and nowhere else.
+X.from (that : A) -> X =
+    X.X_Ctor that

--- a/test/Base_Tests/src/Semantic/Type_Refinement/Types.enso
+++ b/test/Base_Tests/src/Semantic/Type_Refinement/Types.enso
@@ -14,7 +14,17 @@ type B
     b_id_unchecked self = self
     b_id self -> B = self
 
+type X
+    X_Ctor x
+
+    x_method self = "X method"
+
 make_a_and_b -> A & B =
     a = A.A_Ctor 1
     # Relies on the hidden conversion
     (a : A & B)
+
+make_abx -> A & B & X =
+    a = A.A_Ctor 1
+    # Relies on the hidden conversions
+    (a : A & B & X)


### PR DESCRIPTION
### Pull Request Description

Fixes #13272 by implementing `findDirectMatch` in `AllOfTypesCheckNode`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [ ] Engine [benchmarks are fine](https://github.com/enso-org/enso/actions/runs/15731302258) - not perfect, reported: #13318
- [ ] StdLibs [benchmarks are fine](https://github.com/enso-org/enso/actions/runs/15731317969)
