### PR TITLE
Update Project Session Logs view

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1402,6 +1402,11 @@ export interface ListDirectoryRequestParams {
   readonly rootPath?: Path | undefined
 }
 
+/** URL query string parameters for the "get project session logs" endpoint. */
+export interface GetProjectSessionLogsRequestParams {
+  readonly scrollId: string | null
+}
+
 /** URL query string parameters for the "upload file" endpoint. */
 export interface UploadFileRequestParams {
   readonly fileId: AssetId | null
@@ -1798,6 +1803,7 @@ export default abstract class Backend {
   /** Return Language Server logs for a project session. */
   abstract getProjectSessionLogs(
     projectSessionId: ProjectSessionId,
+    params: GetProjectSessionLogsRequestParams,
     title: string,
   ): Promise<readonly string[]>
   /** Set a project to an open state. */
@@ -1816,7 +1822,7 @@ export default abstract class Backend {
   abstract getFileContent(projectId: ProjectId, versionId?: S3ObjectVersionId): Promise<string>
   /** Begin uploading a large file. */
   abstract uploadFileStart(
-    body: UploadFileRequestParams,
+    params: UploadFileRequestParams,
     file: File,
   ): Promise<UploadLargeFileMetadata>
   /** Upload a chunk of a large file. */

--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -362,6 +362,11 @@ export interface ProjectSession {
   readonly userEmail: EmailAddress
 }
 
+export interface ProjectSessionLogs {
+  readonly scrollId: string
+  readonly hits: readonly string[]
+}
+
 export const PROJECT_PARALLEL_MODES = ['ignore', 'restart', 'parallel'] as const
 
 export const PARALLEL_MODE_TO_TEXT_ID = {
@@ -1805,7 +1810,7 @@ export default abstract class Backend {
     projectSessionId: ProjectSessionId,
     params: GetProjectSessionLogsRequestParams,
     title: string,
-  ): Promise<readonly string[]>
+  ): Promise<ProjectSessionLogs>
   /** Set a project to an open state. */
   abstract openProject(
     projectId: ProjectId,

--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -254,6 +254,8 @@
   "logs": "Logs",
   "showLogs": "Show Logs",
   "searchLogs": "Search Logs",
+  "loadMore": "Load More",
+  "noMoreEntriesToLoad": "No more entries to load!",
   "executionsCalendar": "Scheduler",
   "accept": "Accept",
   "decline": "Decline",

--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -253,6 +253,7 @@
   "drop": "Drop",
   "logs": "Logs",
   "showLogs": "Show Logs",
+  "searchLogs": "Search Logs",
   "executionsCalendar": "Scheduler",
   "accept": "Accept",
   "decline": "Decline",

--- a/app/gui/src/dashboard/components/Scroller/Scroller.tsx
+++ b/app/gui/src/dashboard/components/Scroller/Scroller.tsx
@@ -32,6 +32,10 @@ export const SCROLLER_STYLES = tv({
         shadowStart: 'from-background/80',
         shadowEnd: 'from-background/80',
       },
+      white: {
+        shadowStart: 'from-white',
+        shadowEnd: 'from-white',
+      },
     },
     orientation: {
       horizontal: {

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetDiffView.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetDiffView.tsx
@@ -47,7 +47,7 @@ export function AssetDiffView(props: AssetDiffViewProps) {
   return (
     <DiffEditor
       beforeMount={(monaco) => {
-        monaco.editor.defineTheme('myTheme', {
+        monaco.editor.defineTheme('transparentBackground', {
           base: 'vs',
           inherit: true,
           rules: [],
@@ -61,7 +61,7 @@ export function AssetDiffView(props: AssetDiffViewProps) {
       language="enso"
       options={{ readOnly: true }}
       loading={loader}
-      theme={'myTheme'}
+      theme="transparentBackground"
     />
   )
 }

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectSessions.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectSessions.tsx
@@ -1,5 +1,6 @@
 /** @file A list of previous versions of an asset. */
 import { Result } from '#/components/Result'
+import { Scroller } from '#/components/Scroller'
 import { AssetPanelPlaceholder } from '#/layouts/AssetPanel/components/AssetPanelPlaceholder'
 import type Backend from '#/services/Backend'
 import { AssetType, BackendType, type ProjectAsset } from '#/services/Backend'
@@ -54,15 +55,17 @@ function AssetProjectSessionsInternal(props: AssetProjectSessionsInternalProps) 
 
   return projectSessionsQuery.data.length === 0 ?
       <Result status="info" centered title={getText('assetProjectSessions.noSessions')} />
-    : <div className="flex w-full flex-col justify-start">
-        {projectSessionsQuery.data.map((session, i) => (
-          <ProjectSession
-            key={session.projectSessionId}
-            backend={backend}
-            project={item}
-            projectSession={session}
-            index={projectSessionsQuery.data.length - i}
-          />
-        ))}
+    : <div className="flex min-h-0 w-full flex-col justify-start">
+        <Scroller scrollbar orientation="vertical" background="white" className="h-full">
+          {projectSessionsQuery.data.map((session, i) => (
+            <ProjectSession
+              key={session.projectSessionId}
+              backend={backend}
+              project={item}
+              projectSession={session}
+              index={projectSessionsQuery.data.length - i}
+            />
+          ))}
+        </Scroller>
       </div>
 }

--- a/app/gui/src/dashboard/layouts/SearchBar.tsx
+++ b/app/gui/src/dashboard/layouts/SearchBar.tsx
@@ -2,6 +2,7 @@
 import { Input, Label, SearchField } from '#/components/aria'
 import { Icon } from '#/components/Icon'
 import type { Dispatch, SetStateAction } from 'react'
+import { twMerge } from 'tailwind-merge'
 
 /** Props for a {@link SearchBar}. */
 export interface SearchBarProps {
@@ -10,16 +11,20 @@ export interface SearchBarProps {
   readonly setQuery: Dispatch<SetStateAction<string>>
   readonly label: string
   readonly placeholder: string
+  readonly className?: string
 }
 
 /** A search bar containing a text input, and a list of suggestions. */
 export default function SearchBar(props: SearchBarProps) {
-  const { query, setQuery, label, placeholder } = props
+  const { query, setQuery, label, placeholder, className } = props
 
   return (
     <Label
       data-testid={props['data-testid']}
-      className="group relative flex h-row w-full items-center gap-asset-search-bar rounded-full border-0.5 border-primary/20 px-input-x text-primary -outline-offset-1 outline-primary transition-colors focus-within:outline focus-within:outline-2 sm:w-[512px]"
+      className={twMerge(
+        'group relative flex h-row w-full items-center gap-asset-search-bar rounded-full border-0.5 border-primary/20 px-input-x text-primary -outline-offset-1 outline-primary transition-colors focus-within:outline focus-within:outline-2 sm:w-[512px]',
+        className,
+      )}
     >
       <Icon icon="find" className="text-primary/30" />
       <SearchField

--- a/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
+++ b/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
@@ -2,14 +2,13 @@
 import { Button } from '#/components/Button'
 import { Dialog } from '#/components/Dialog'
 import { Loader } from '#/components/Loader'
-import SearchBar from '#/layouts/SearchBar'
 import type Backend from '#/services/Backend'
 import type { ProjectSessionId } from '#/services/Backend'
 import { useText } from '$/providers/react'
 import type { Monaco } from '@monaco-editor/react'
 import { Editor } from '@monaco-editor/react'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useRef } from 'react'
 
 const MONACO_OPTIONS: NonNullable<Parameters<typeof Editor>[0]['options']> = {
   wordWrap: 'on',
@@ -60,7 +59,7 @@ export default function ProjectLogsModal(props: ProjectLogsModalProps) {
 function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
   const { backend, projectSessionId, projectTitle } = props
   const { getText } = useText()
-  const [query, setQuery] = useState('')
+  const editorRef = useRef<Monaco>()
 
   const logsPages = useInfiniteQuery({
     queryKey: ['projectLogs', { projectSessionId, projectTitle }],
@@ -69,21 +68,20 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
     initialPageParam: ((): string | null => null)(),
     getNextPageParam: (page) => (page.hits.length === 0 ? null : page.scrollId),
   })
-  const matchesQuery = query === '' ? () => true : (line: string) => line.includes(query)
-  const logs =
-    logsPages.data?.pages.flatMap((page) => page.hits.filter(matchesQuery)).join('\n') ?? ''
+  const logs = logsPages.data?.pages.flatMap((page) => page.hits).join('\n') ?? ''
   const isLoading = logsPages.isLoading
 
   return (
     <div className="flex h-full flex-col gap-2">
       <Button.Group className="grow-0 items-center">
-        <SearchBar
-          data-testid="logs-search-bar"
-          label={getText('searchLogs')}
-          placeholder={getText('searchLogs')}
-          query={query}
-          setQuery={setQuery}
-          className="mr-auto"
+        <Button
+          variant="icon"
+          icon="find"
+          aria-label={getText('search')}
+          onPress={async () => {
+            const editor = editorRef.current?.editor.getEditors()[0]
+            await editor?.getAction('actions.find')?.run()
+          }}
         />
         <Button
           variant="icon"
@@ -104,6 +102,7 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
         <Loader />
       : <Editor
           beforeMount={(monaco) => {
+            editorRef.current = monaco
             monaco.editor.defineTheme('transparentBackground', {
               base: 'vs',
               inherit: true,

--- a/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
+++ b/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
@@ -90,6 +90,14 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
           aria-label={getText('reload')}
           onPress={() => logsPages.refetch()}
         />
+        <Button
+          variant="icon"
+          icon="data_download"
+          aria-label={getText('loadMore')}
+          tooltip={logsPages.hasNextPage ? null : getText('noMoreEntriesToLoad')}
+          onPress={() => logsPages.fetchNextPage()}
+          isDisabled={!logsPages.hasNextPage}
+        />
       </Button.Group>
       {isLoading ?
         <Loader />

--- a/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
+++ b/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
@@ -19,21 +19,22 @@ const MONACO_OPTIONS: NonNullable<Parameters<typeof Editor>[0]['options']> = {
 const ENSO_LOG_MONACO_LANGUAGE: Parameters<Monaco['languages']['setMonarchTokensProvider']>[1] = {
   defaultToken: '',
   tokenizer: {
-    root: [{ include: '@level' }, { include: '@timestamp' }, { include: '@namespace' }],
-    level: [
-      { include: '@traceLevel' },
-      { include: '@debugLevel' },
-      { include: '@infoLevel' },
-      { include: '@warnLevel' },
-      { include: '@errorLevel' },
+    root: [
+      { include: '@level' },
+      { include: '@timestamp' },
+      { include: '@namespace' },
+      { include: '@functionReference' },
     ],
-    traceLevel: [[/\[TRACE\]/, 'comment']],
-    debugLevel: [[/\[DEBUG\]/, 'comment']],
-    infoLevel: [[/\[INFO\]/, 'comment']],
-    warnLevel: [[/\[WARN\]/, 'comment']],
-    errorLevel: [[/\[ERROR\]/, 'comment']],
+    level: [
+      [/\[TRACE\]/, 'comment'],
+      [/\[DEBUG\]/, 'comment'],
+      [/\[INFO\]/, 'comment'],
+      [/\[WARN\]/, 'comment'],
+      [/\[ERROR\]/, 'comment'],
+    ],
     timestamp: [[/\[\d+-\d+-\d+T\d+:\d+:\d+Z\]/, 'keyword']],
     namespace: [[/\[org.[^\]]+\]/, 'type']],
+    functionReference: [[/\(org.[^\]]+\)/, 'variable']],
   },
 }
 

--- a/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
+++ b/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
@@ -1,11 +1,13 @@
 /** @file A modal for showing logs for a project. */
-import ReloadIcon from '#/assets/reload.svg'
 import { Button } from '#/components/Button'
 import { Dialog } from '#/components/Dialog'
+import { Loader } from '#/components/Loader'
+import { Scroller } from '#/components/Scroller'
+import { StatelessSpinner } from '#/components/StatelessSpinner'
 import type Backend from '#/services/Backend'
 import type { ProjectSessionId } from '#/services/Backend'
 import { useText } from '$/providers/react'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 
 /** Props for a {@link ProjectLogsModal}. */
 export interface ProjectLogsModalProps {
@@ -20,7 +22,7 @@ export default function ProjectLogsModal(props: ProjectLogsModalProps) {
 
   return (
     <Dialog title={getText('logs')} type="fullscreen">
-      {() => <ProjectLogsModalInternal {...props} />}
+      <ProjectLogsModalInternal {...props} />
     </Dialog>
   )
 }
@@ -30,30 +32,53 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
   const { backend, projectSessionId, projectTitle } = props
   const { getText } = useText()
 
-  const logsQuery = useSuspenseQuery({
+  const logsPages = useInfiniteQuery({
     queryKey: ['projectLogs', { projectSessionId, projectTitle }],
-    queryFn: async () => {
-      const logs = await backend.getProjectSessionLogs(projectSessionId, projectTitle)
-      return logs.join('\n')
-    },
+    queryFn: ({ pageParam }) =>
+      backend.getProjectSessionLogs(projectSessionId, { scrollId: pageParam }, projectTitle),
+    initialPageParam: ((): string | null => null)(),
+    getNextPageParam: (page) => (page.hits.length === 0 ? null : page.scrollId),
   })
+  const logs = logsPages.data?.pages.flatMap((page) => page.hits).join('\n')
+  const isLoading = logsPages.isLoading
+  const isFetching = logsPages.isFetching
 
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center gap-4 self-start rounded-full border-0.5 border-primary/20 px-[11px] py-2">
+    <div className="flex h-full flex-col gap-2">
+      <Button.Group className="grow-0">
         <Button
-          size="medium"
           variant="icon"
-          icon={ReloadIcon}
+          icon="refresh"
           aria-label={getText('reload')}
-          onPress={async () => {
-            await logsQuery.refetch()
-          }}
+          onPress={() => logsPages.refetch()}
         />
-      </div>
-      <pre className="relative overflow-auto whitespace-pre-wrap">
-        <code>{logsQuery.data}</code>
-      </pre>
+      </Button.Group>
+      {isLoading ?
+        <Loader />
+      : <Scroller
+          scrollbar
+          orientation="vertical"
+          className="relative min-h-0 flex-1 after:pointer-events-none after:absolute after:inset-0 after:rounded-default after:border after:border-primary/20"
+          onScroll={(event) => {
+            if (isFetching) {
+              return
+            }
+            const element = event.currentTarget
+            if (element.scrollTop + element.clientHeight >= element.scrollHeight) {
+              void logsPages.fetchNextPage()
+            }
+          }}
+        >
+          <pre className="m-4 whitespace-pre-wrap break-words">
+            <code>{logs}</code>
+          </pre>
+          {isFetching && (
+            <div className="my-2 flex h-8 w-full flex-col items-center">
+              <StatelessSpinner size={32} phase="loading-medium" />
+            </div>
+          )}
+        </Scroller>
+      }
     </div>
   )
 }

--- a/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
+++ b/app/gui/src/dashboard/modals/ProjectLogsModal.tsx
@@ -2,12 +2,40 @@
 import { Button } from '#/components/Button'
 import { Dialog } from '#/components/Dialog'
 import { Loader } from '#/components/Loader'
-import { Scroller } from '#/components/Scroller'
-import { StatelessSpinner } from '#/components/StatelessSpinner'
+import SearchBar from '#/layouts/SearchBar'
 import type Backend from '#/services/Backend'
 import type { ProjectSessionId } from '#/services/Backend'
 import { useText } from '$/providers/react'
+import type { Monaco } from '@monaco-editor/react'
+import { Editor } from '@monaco-editor/react'
 import { useInfiniteQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+const MONACO_OPTIONS: NonNullable<Parameters<typeof Editor>[0]['options']> = {
+  wordWrap: 'on',
+  readOnly: true,
+}
+
+const ENSO_LOG_MONACO_LANGUAGE: Parameters<Monaco['languages']['setMonarchTokensProvider']>[1] = {
+  defaultToken: '',
+  tokenizer: {
+    root: [{ include: '@level' }, { include: '@timestamp' }, { include: '@namespace' }],
+    level: [
+      { include: '@traceLevel' },
+      { include: '@debugLevel' },
+      { include: '@infoLevel' },
+      { include: '@warnLevel' },
+      { include: '@errorLevel' },
+    ],
+    traceLevel: [[/\[TRACE\]/, 'comment']],
+    debugLevel: [[/\[DEBUG\]/, 'comment']],
+    infoLevel: [[/\[INFO\]/, 'comment']],
+    warnLevel: [[/\[WARN\]/, 'comment']],
+    errorLevel: [[/\[ERROR\]/, 'comment']],
+    timestamp: [[/\[\d+-\d+-\d+T\d+:\d+:\d+Z\]/, 'keyword']],
+    namespace: [[/\[org.[^\]]+\]/, 'type']],
+  },
+}
 
 /** Props for a {@link ProjectLogsModal}. */
 export interface ProjectLogsModalProps {
@@ -31,6 +59,7 @@ export default function ProjectLogsModal(props: ProjectLogsModalProps) {
 function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
   const { backend, projectSessionId, projectTitle } = props
   const { getText } = useText()
+  const [query, setQuery] = useState('')
 
   const logsPages = useInfiniteQuery({
     queryKey: ['projectLogs', { projectSessionId, projectTitle }],
@@ -39,13 +68,22 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
     initialPageParam: ((): string | null => null)(),
     getNextPageParam: (page) => (page.hits.length === 0 ? null : page.scrollId),
   })
-  const logs = logsPages.data?.pages.flatMap((page) => page.hits).join('\n')
+  const matchesQuery = query === '' ? () => true : (line: string) => line.includes(query)
+  const logs =
+    logsPages.data?.pages.flatMap((page) => page.hits.filter(matchesQuery)).join('\n') ?? ''
   const isLoading = logsPages.isLoading
-  const isFetching = logsPages.isFetching
 
   return (
     <div className="flex h-full flex-col gap-2">
-      <Button.Group className="grow-0">
+      <Button.Group className="grow-0 items-center">
+        <SearchBar
+          data-testid="logs-search-bar"
+          label={getText('searchLogs')}
+          placeholder={getText('searchLogs')}
+          query={query}
+          setQuery={setQuery}
+          className="mr-auto"
+        />
         <Button
           variant="icon"
           icon="refresh"
@@ -55,29 +93,24 @@ function ProjectLogsModalInternal(props: ProjectLogsModalProps) {
       </Button.Group>
       {isLoading ?
         <Loader />
-      : <Scroller
-          scrollbar
-          orientation="vertical"
-          className="relative min-h-0 flex-1 after:pointer-events-none after:absolute after:inset-0 after:rounded-default after:border after:border-primary/20"
-          onScroll={(event) => {
-            if (isFetching) {
-              return
-            }
-            const element = event.currentTarget
-            if (element.scrollTop + element.clientHeight >= element.scrollHeight) {
-              void logsPages.fetchNextPage()
-            }
+      : <Editor
+          beforeMount={(monaco) => {
+            monaco.editor.defineTheme('transparentBackground', {
+              base: 'vs',
+              inherit: true,
+              rules: [],
+              // The name comes from a third-party API and cannot be changed.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              colors: { 'editor.background': '#00000000' },
+            })
+            monaco.languages.register({ id: 'ensolog' })
+            monaco.languages.setMonarchTokensProvider('ensolog', ENSO_LOG_MONACO_LANGUAGE)
           }}
-        >
-          <pre className="m-4 whitespace-pre-wrap break-words">
-            <code>{logs}</code>
-          </pre>
-          {isFetching && (
-            <div className="my-2 flex h-8 w-full flex-col items-center">
-              <StatelessSpinner size={32} phase="loading-medium" />
-            </div>
-          )}
-        </Scroller>
+          value={logs}
+          language="ensolog"
+          theme="transparentBackground"
+          options={MONACO_OPTIONS}
+        />
       }
     </div>
   )

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -1020,12 +1020,12 @@ export default class RemoteBackend extends Backend {
     projectSessionId: backend.ProjectSessionId,
     params: backend.GetProjectSessionLogsRequestParams,
     title: string,
-  ): Promise<string[]> {
+  ): Promise<backend.ProjectSessionLogs> {
     const queryString = new URLSearchParams({
       ...(params.scrollId != null ? { scrollId: params.scrollId } : {}),
     }).toString()
     const path = `${remoteBackendPaths.getProjectSessionLogsPath(projectSessionId)}?${queryString}`
-    const response = await this.get<string[]>(path)
+    const response = await this.get<backend.ProjectSessionLogs>(path)
     if (!response.ok) {
       return await this.throw(response, 'getProjectLogsBackendError', title)
     } else {

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -1018,9 +1018,13 @@ export default class RemoteBackend extends Backend {
    */
   override async getProjectSessionLogs(
     projectSessionId: backend.ProjectSessionId,
+    params: backend.GetProjectSessionLogsRequestParams,
     title: string,
   ): Promise<string[]> {
-    const path = remoteBackendPaths.getProjectSessionLogsPath(projectSessionId)
+    const queryString = new URLSearchParams({
+      ...(params.scrollId != null ? { scrollId: params.scrollId } : {}),
+    }).toString()
+    const path = `${remoteBackendPaths.getProjectSessionLogsPath(projectSessionId)}?${queryString}`
     const response = await this.get<string[]>(path)
     if (!response.ok) {
       return await this.throw(response, 'getProjectLogsBackendError', title)

--- a/app/gui/src/providers/httpClient.ts
+++ b/app/gui/src/providers/httpClient.ts
@@ -17,6 +17,7 @@ function createHttpClient() {
   return new HttpClient({
     'x-enso-ide-version': $config.VERSION ?? '',
     'x-enso-session-id': sessionID,
+    'x-enso-version': '2025-01-16',
   })
 }
 

--- a/app/gui/src/providers/httpClient.ts
+++ b/app/gui/src/providers/httpClient.ts
@@ -17,6 +17,10 @@ function createHttpClient() {
   return new HttpClient({
     'x-enso-ide-version': $config.VERSION ?? '',
     'x-enso-session-id': sessionID,
+    /**
+     * For compatibility with backend versioned endpoints. The new project logs endpoint
+     * checks for date strings that are at least `2025-01-16`.
+     */
     'x-enso-version': '2025-01-16',
   })
 }


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/1666
  - Update "get project session logs" to new paginated API
  - Use Monaco for viewing logs
  - Add highlighting for logs to Monaco

### Important Notes
None

### Screenshots

![image](https://github.com/user-attachments/assets/b465f007-efc3-4156-b510-fee4b19027e9)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
