### PR TITLE
Restore scrollbar in documentation editor

### DIFF
--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -1,6 +1,6 @@
 /** @file Tests for the multiline CodeMirror editor panels: documentation editor and code editor. */
 import type { Page } from '@playwright/test'
-import { test } from 'playwright/test'
+import { type Locator, test } from 'playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
 import { mockCollapsedFunctionInfo, mockMethodCallInfo } from './expressionUpdates'
@@ -11,8 +11,9 @@ async function goToGraphAndGetDocs(page: Page) {
   await actions.goToGraph(page)
   await page.getByRole('tab', { name: 'Documentation' }).click()
   const docsContent = page.getByTestId('documentation-editor-content')
+  const docsScroller = page.getByTestId('documentation-editor-scroller')
   await expect(docsContent.locator('.cm-line')).toExist()
-  return { docsContent }
+  return { docsContent, docsScroller }
 }
 
 test('Main method documentation', async ({ page }) => {
@@ -78,7 +79,8 @@ async function openCodeEditor(page: Page) {
   await expect(codeEditor).toBeVisible()
   const getCodeEditorContent = () =>
     page.evaluate(() => (window as any).__codeEditorApi.textContent())
-  return { codeEditor, getCodeEditorContent }
+  const codeScroller = codeEditor.locator('.cm-scroller')
+  return { codeEditor, getCodeEditorContent, codeScroller }
 }
 
 test('Code editor with wide content does not take space from doc editor (#12476)', async ({
@@ -194,6 +196,31 @@ test('Documentation editor: Editing with keyboard', async ({ page }) => {
   await page.keyboard.type('Second line')
   const codeAfterAddingLine = await getCodeEditorContent()
   expect(codeAfterAddingLine).toContain(`## # ${NEW_DOCS}\n   Second line`)
+})
+
+function getScrollbarState(locator: Locator) {
+  return locator.evaluate((el) => ({
+    scrollableWidth: el.scrollWidth > el.clientWidth,
+    scrollableHeight: el.scrollHeight > el.clientHeight,
+  }))
+}
+
+test('Scrollbars in editor panels', async ({ page }) => {
+  const { docsContent, docsScroller } = await goToGraphAndGetDocs(page)
+  await docsContent
+    .locator('.cm-line')
+    .getByText(/The main method/)
+    .click()
+  await page.keyboard.press(`${CONTROL_KEY}+A`)
+  const NEW_DOCS = ('very long documentation '.repeat(12) + '\n').repeat(30)
+  await docsContent.fill(NEW_DOCS)
+  await expect(docsContent).toHaveText(NEW_DOCS)
+  const docsScrollbars = await getScrollbarState(docsScroller)
+  expect(docsScrollbars).toEqual({ scrollableWidth: false, scrollableHeight: true })
+
+  const { codeEditor, codeScroller } = await openCodeEditor(page)
+  const codeScrollbars = await getScrollbarState(codeScroller)
+  expect(codeScrollbars).toEqual({ scrollableWidth: true, scrollableHeight: true })
 })
 
 test.skip('Code editor: Copy and paste (clipboard cannot be used in CI but test can be run locally)', async ({

--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -218,7 +218,7 @@ test('Scrollbars in editor panels', async ({ page }) => {
   const docsScrollbars = await getScrollbarState(docsScroller)
   expect(docsScrollbars).toEqual({ scrollableWidth: false, scrollableHeight: true })
 
-  const { codeEditor, codeScroller } = await openCodeEditor(page)
+  const { codeScroller } = await openCodeEditor(page)
   const codeScrollbars = await getScrollbarState(codeScroller)
   expect(codeScrollbars).toEqual({ scrollableWidth: true, scrollableHeight: true })
 })

--- a/app/gui/src/project-view/components/CodeMirrorRoot.vue
+++ b/app/gui/src/project-view/components/CodeMirrorRoot.vue
@@ -12,6 +12,11 @@ defineExpose({ highlightClasses })
 </template>
 
 <style scoped>
+.CodeMirrorRoot {
+  width: 100%;
+  height: 100%;
+}
+
 .CodeMirrorRoot :deep(.cm-content) {
   cursor: text;
 }

--- a/app/gui/src/project-view/components/DocumentationEditor.vue
+++ b/app/gui/src/project-view/components/DocumentationEditor.vue
@@ -88,6 +88,7 @@ provideDocumentationImages({
       v-if="editorMarkdown.ok"
       :content="editorMarkdown.value"
       contentTestId="documentation-editor-content"
+      scrollerTestId="documentation-editor-scroller"
     >
       <template #belowToolbar>
         <FunctionSignatureEditor

--- a/app/gui/src/project-view/components/MarkdownEditor.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor.vue
@@ -6,10 +6,12 @@ const {
   content,
   toolbar = true,
   contentTestId,
+  scrollerTestId,
 } = defineProps<{
   content: Y.Text | string
   toolbar?: boolean
   contentTestId?: string | undefined
+  scrollerTestId?: string | undefined
 }>()
 defineOptions({
   inheritAttrs: false,
@@ -28,6 +30,7 @@ const LazyMarkdownEditor = defineAsyncComponent(
       :content="content"
       :toolbar="toolbar"
       :contentTestId="contentTestId"
+      :scrollerTestId="scrollerTestId"
     >
       <template #belowToolbar>
         <slot name="belowToolbar" />

--- a/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
@@ -15,10 +15,11 @@ import { drawSelection, EditorView } from '@codemirror/view'
 import { type ComponentInstance, computed, useCssModule, useTemplateRef } from 'vue'
 import * as Y from 'yjs'
 
-const { content, toolbar, contentTestId } = defineProps<{
+const { content, toolbar, contentTestId, scrollerTestId } = defineProps<{
   content: Y.Text | string
   toolbar: boolean
   contentTestId?: string | undefined
+  scrollerTestId?: string | undefined
 }>()
 defineOptions({
   inheritAttrs: false,
@@ -44,6 +45,7 @@ const { editorView, readonly, setExtraExtensions } = useCodeMirror(editorRoot, {
   vueHost: () => vueHost,
   lineMode: 'multi',
   contentTestId,
+  scrollerTestId,
 })
 
 useLinkTitles(editorView, { readonly })

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -67,6 +67,8 @@ interface CodeMirrorOptions {
   vueHost?: WatchSource<VueHost | undefined>
   /** If provided, the element with class `cm-content` will also have the given `data-testid`. */
   contentTestId?: string | undefined
+  /** If provided, the element with class `cm-scroller` will also have the given `data-testid`. */
+  scrollerTestId?: string | undefined
   readonly?: boolean
   lineMode: ToValue<LineMode>
 }
@@ -80,6 +82,7 @@ export function useCodeMirror(
     extensions,
     vueHost,
     contentTestId,
+    scrollerTestId,
     readonly: isReadonly,
     lineMode,
   }: CodeMirrorOptions,
@@ -128,6 +131,7 @@ export function useCodeMirror(
   )
 
   if (contentTestId != null) view.contentDOM.dataset['testid'] = contentTestId
+  if (scrollerTestId != null) view.scrollDOM.dataset['testid'] = scrollerTestId
   onUnmounted(view.destroy.bind(view))
 
   if (vueHost) useStateEffect(view, setVueHost, vueHost)


### PR DESCRIPTION
### Pull Request Description

Fix scrollbar; has been broken since #13014. Add integration test checking scrollability of documentation editor and code editor.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
