### PR TITLE
Filewatcher does not starve CPU

### DIFF
--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -95,7 +95,8 @@ final class DefaultWatcher implements Watcher {
           return;
         }
         var dir = (Path) key.watchable();
-        assert watchedDirs.containsKey(dir) : "Directory " + dir + " is not registered in watchedDirs";
+        assert watchedDirs.containsKey(dir)
+            : "Directory " + dir + " is not registered in watchedDirs";
         for (var event : key.pollEvents()) {
           dispatchEvent(event, dir);
         }

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -94,13 +94,8 @@ final class DefaultWatcher implements Watcher {
           // the watch service is closed. We don't even have to log it.
           return;
         }
-        var matchingEntry =
-            watchedDirs.entrySet().stream()
-                .filter(entry -> entry.getValue().equals(key))
-                .findFirst();
-        assert matchingEntry.isPresent();
-        var entry = matchingEntry.get();
-        var dir = entry.getKey();
+        var dir = (Path) key.watchable();
+        assert watchedDirs.containsKey(dir) : "Directory " + dir + " is not registered in watchedDirs";
         for (var event : key.pollEvents()) {
           dispatchEvent(event, dir);
         }

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -84,10 +84,14 @@ final class DefaultWatcher implements Watcher {
         try {
           // Wait for the next key
           key = watchService.take();
-        } catch (InterruptedException | ClosedWatchServiceException e) {
-          LOGGER.debug("Watcher service interrupted or closed: {}", e.getMessage());
+        } catch (InterruptedException e) {
+          LOGGER.debug("Watcher service interrupted: {}", e.getMessage());
           var err = new Watcher.WatcherError(e);
           exceptionCallback.accept(err);
+          continue;
+        } catch (ClosedWatchServiceException e) {
+          // ClosedWatchServiceException is a "standard" exception thrown when
+          // the watch service is closed. We don't even have to log it.
           return;
         }
         var matchingEntry =

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -5,10 +5,12 @@ import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -44,17 +46,19 @@ final class DefaultWatcher implements Watcher {
     }
     LOGGER.debug("Starting watcher for root directory {}", root.toAbsolutePath());
     try {
-      var watchKey =
-          root.register(
-              watchService,
-              StandardWatchEventKinds.ENTRY_MODIFY,
-              StandardWatchEventKinds.ENTRY_CREATE,
-              StandardWatchEventKinds.ENTRY_DELETE,
-              StandardWatchEventKinds.OVERFLOW);
-      watchedDirs.put(root, watchKey);
+      Files.walkFileTree(
+          root,
+          new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+              registerWatchService(dir);
+              return FileVisitResult.CONTINUE;
+            }
+          });
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
+    assert watchedDirs.containsKey(root);
     executor.execute(this::eventLoop);
   }
 

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -1,6 +1,8 @@
 package org.enso.filewatcher;
 
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
@@ -72,18 +74,29 @@ final class DefaultWatcher implements Watcher {
   private void eventLoop() {
     try {
       while (!closed) {
-        var iterator = watchedDirs.entrySet().iterator();
-        while (iterator.hasNext()) {
-          var entry = iterator.next();
-          var dir = entry.getKey();
-          var watchKey = entry.getValue();
-          for (var event : watchKey.pollEvents()) {
-            dispatchEvent(event, dir);
-          }
-          var valid = watchKey.reset();
-          if (!valid) {
-            iterator.remove();
-          }
+        WatchKey key;
+        try {
+          // Wait for the next key
+          key = watchService.take();
+        } catch (InterruptedException | ClosedWatchServiceException e) {
+          LOGGER.debug("Watcher service interrupted or closed: {}", e.getMessage());
+          var err = new Watcher.WatcherError(e);
+          exceptionCallback.accept(err);
+          return;
+        }
+        var matchingEntry =
+            watchedDirs.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(key))
+                .findFirst();
+        assert matchingEntry.isPresent();
+        var entry = matchingEntry.get();
+        var dir = entry.getKey();
+        for (var event : key.pollEvents()) {
+          dispatchEvent(event, dir);
+        }
+        var valid = key.reset();
+        if (!valid) {
+          watchedDirs.remove(dir);
         }
       }
     } catch (Throwable e) {

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -149,27 +149,27 @@ final class DefaultWatcher implements Watcher {
     exceptionCallback.accept(watcherError);
   }
 
-  private void registerWatchService(Path path) {
-    LOGGER.debug("Registering watch service for subdir {}", path);
+  private void registerWatchService(Path dir) {
+    LOGGER.debug("Registering watch service for subdir {}", dir);
     try {
       var watchKey =
-          path.register(
+          dir.register(
               watchService,
               StandardWatchEventKinds.ENTRY_CREATE,
               StandardWatchEventKinds.ENTRY_MODIFY,
               StandardWatchEventKinds.ENTRY_DELETE,
               StandardWatchEventKinds.OVERFLOW);
-      watchedDirs.put(path, watchKey);
+      watchedDirs.put(dir, watchKey);
     } catch (IOException e) {
       exceptionCallback.accept(new Watcher.WatcherError(e));
     }
   }
 
-  private void cancelWatch(Path path) {
-    LOGGER.debug("Cancelling watch for subdir {}", path);
-    var watchKey = watchedDirs.get(path);
-    assert watchKey != null : "No watch key found for path: " + path;
+  private void cancelWatch(Path dir) {
+    LOGGER.debug("Cancelling watch for subdir {}", dir);
+    var watchKey = watchedDirs.get(dir);
+    assert watchKey != null : "No watch key found for dir: " + dir;
     watchKey.cancel();
-    watchedDirs.remove(path);
+    watchedDirs.remove(dir);
   }
 }

--- a/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
+++ b/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java
@@ -56,7 +56,9 @@ final class DefaultWatcher implements Watcher {
             }
           });
     } catch (IOException e) {
-      throw new IllegalStateException(e);
+      LOGGER.error("Failed to start file watch service in root directory " + root, e);
+      exceptionCallback.accept(new Watcher.WatcherError(e));
+      return;
     }
     assert watchedDirs.containsKey(root);
     executor.execute(this::eventLoop);

--- a/lib/scala/filewatcher/src/test/java/org/enso/filewatcher/FileWatcherTest.java
+++ b/lib/scala/filewatcher/src/test/java/org/enso/filewatcher/FileWatcherTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,9 +34,11 @@ public class FileWatcherTest {
   private ExecutorService executor;
   private BlockingQueue<WatcherEvent> eventQueue = new LinkedBlockingDeque<>();
   private Watcher watcher;
+  private boolean isClosingWatcher;
 
   @Before
   public void before() throws IOException {
+    isClosingWatcher = false;
     executor = Executors.newSingleThreadExecutor();
     tmpDir = tmpFolder.newFolder();
     eventQueue = new LinkedBlockingDeque<>();
@@ -49,6 +52,7 @@ public class FileWatcherTest {
   public void after() throws Exception {
     assertThat(
         "No further events should be in the queue: " + eventQueue, eventQueue.isEmpty(), is(true));
+    isClosingWatcher = true;
     eventQueue.clear();
     executor.shutdown();
     watcher.close();
@@ -63,8 +67,14 @@ public class FileWatcherTest {
   }
 
   private void exceptionCallback(Watcher.WatcherError error) {
-    throw new AssertionError(
-        "Unexpected Watcher error: " + error.throwable().getMessage(), error.throwable());
+    // ClosedWatchServiceException is expected when closing the watcher
+    if (!isClosingWatcher || !(error.throwable() instanceof ClosedWatchServiceException)) {
+      var errMsg =
+          String.format(
+              "Unexpected Watcher error: %s '%s'",
+              error.throwable(), error.throwable().getMessage());
+      throw new AssertionError(errMsg);
+    }
   }
 
   @Test

--- a/lib/scala/filewatcher/src/test/java/org/enso/filewatcher/FileWatcherTest.java
+++ b/lib/scala/filewatcher/src/test/java/org/enso/filewatcher/FileWatcherTest.java
@@ -31,6 +31,9 @@ public class FileWatcherTest {
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private File tmpDir;
+  private Path fileInTmpDir;
+  private Path nestedDir;
+  private Path fileInNestedDir;
   private ExecutorService executor;
   private BlockingQueue<WatcherEvent> eventQueue = new LinkedBlockingDeque<>();
   private Watcher watcher;
@@ -41,6 +44,12 @@ public class FileWatcherTest {
     isClosingWatcher = false;
     executor = Executors.newSingleThreadExecutor();
     tmpDir = tmpFolder.newFolder();
+    fileInTmpDir = tmpDir.toPath().resolve("file.txt");
+    Files.writeString(fileInTmpDir, "Initial content");
+    nestedDir = tmpDir.toPath().resolve("nested-dir");
+    Files.createDirectory(nestedDir);
+    fileInNestedDir = nestedDir.resolve("nested-file.txt");
+    Files.writeString(fileInNestedDir, "Initial content in nested file");
     eventQueue = new LinkedBlockingDeque<>();
     watcher =
         new DefaultWatcherFactory()
@@ -75,6 +84,18 @@ public class FileWatcherTest {
               error.throwable(), error.throwable().getMessage());
       throw new AssertionError(errMsg);
     }
+  }
+
+  @Test
+  public void tracksModificationToExistingFile() throws IOException {
+    atomicAppend(fileInTmpDir, "Appended content");
+    assertNextEventIs(modifyEvent(fileInTmpDir));
+  }
+
+  @Test
+  public void tracksModificationToExistingNestedFile() throws IOException {
+    atomicAppend(fileInNestedDir, "Appended content in nested file");
+    assertNextEventIs(modifyEvent(fileInNestedDir));
   }
 
   @Test


### PR DESCRIPTION
Fixes #13301

### Pull Request Description

My local experiment (now uploaded in https://github.com/Akirathan/filewatcher-experiment) revealed that the main culrpit of the filewatcher thread consuming 100% CPU was in its [eventLoop](https://github.com/enso-org/enso/blob/bd68702c0f49db31cce11621f882146feb33f979/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java#L80-L112) that didn't do any waiting. Now, there is a call to [WatchService.take](https://github.com/enso-org/enso/blob/bd68702c0f49db31cce11621f882146feb33f979/lib/scala/filewatcher/src/main/java/org/enso/filewatcher/DefaultWatcher.java#L85-L86) which waits for first available WatchKey.

idle activity on develop:
![image](https://github.com/user-attachments/assets/a9e1cc04-b928-40d6-a00a-bcf620da8dc9)

idle on this PR:
![image](https://github.com/user-attachments/assets/b103eb4a-01d8-4c75-a06b-75e97d49e402)


### Important Notes

With the `DefaultWatcher` copied from develop, the previous CPU time [reported](https://github.com/Akirathan/filewatcher-experiment/blob/master/output.log#L149)  was 6000ms - which is 100%. Now, it consumes the same amount of CPU as methvin-watcher.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
