### PR TITLE
Remove Enso Devtools from built app; show override status even if Devtools is hidden

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -616,7 +616,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "t0LacG+6Y3sh8Y9kRThzg2d+viLv86e7ACVSHudAhlA=",
+        "bzlTransitiveDigest": "FBJ8rEFIAaJxNKbI8PBvdmePmLfLri38dvzRcNI+6RE=",
         "usagesDigest": "3QyfiyrJKYb+RnTA85xhz1ecQjw78S7PpkjVgmLoLxA=",
         "recordedFileInputs": {
           "@@//app/rust-ffi/Cargo.toml": "b17bf21f56720ffba5031fdf70296acb53ff018adcf17a8cdcec86b46103d1d8",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -616,7 +616,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "FBJ8rEFIAaJxNKbI8PBvdmePmLfLri38dvzRcNI+6RE=",
+        "bzlTransitiveDigest": "t0LacG+6Y3sh8Y9kRThzg2d+viLv86e7ACVSHudAhlA=",
         "usagesDigest": "3QyfiyrJKYb+RnTA85xhz1ecQjw78S7PpkjVgmLoLxA=",
         "recordedFileInputs": {
           "@@//app/rust-ffi/Cargo.toml": "b17bf21f56720ffba5031fdf70296acb53ff018adcf17a8cdcec86b46103d1d8",

--- a/app/gui/env.d.ts
+++ b/app/gui/env.d.ts
@@ -146,7 +146,6 @@ declare global {
     readonly fileBrowserApi?: FileBrowserApi
     readonly versionInfo?: VersionInfo
     readonly mapBoxApiToken?: () => string
-    toggleDevtools: () => void
     /**
      * If set to `true`, animations will be disabled.
      * Used by playwright tests to speed up execution.

--- a/app/gui/src/components/ProtectedLayout.vue
+++ b/app/gui/src/components/ProtectedLayout.vue
@@ -19,9 +19,7 @@ const route = useRoute()
 const router = useRouter()
 const queryClient = useQueryClient()
 const text = useText()
-const EnsoDevtools = reactComponent(
-  process.env.NODE_ENV === 'development' ? EnsoDevToolsReact : () => null,
-)
+const EnsoDevtools = reactComponent(EnsoDevToolsReact)
 
 const routeGuardResult = computed(() => auth.routeGuard(route))
 watch(

--- a/app/gui/src/components/ProtectedLayout.vue
+++ b/app/gui/src/components/ProtectedLayout.vue
@@ -19,7 +19,9 @@ const route = useRoute()
 const router = useRouter()
 const queryClient = useQueryClient()
 const text = useText()
-const EnsoDevtools = reactComponent(EnsoDevToolsReact)
+const EnsoDevtools = reactComponent(
+  process.env.NODE_ENV === 'development' ? EnsoDevToolsReact : () => null,
+)
 
 const routeGuardResult = computed(() => auth.routeGuard(route))
 watch(
@@ -47,16 +49,16 @@ const displayDevTools = computed(() => auth.session?.type === UserSessionType.fu
 
 <template>
   <div v-if="auth.session == null" data-testid="before-auth-layout" aria-hidden>
-    <!-- This div is used as a flag to indicate that the user is not logged in.
-        also it guarantees that the top-level suspense boundary is already resolved -->
+    <!-- This div is used as a flag to indicate that the user is not logged in
+        and guarantees that the top-level suspense boundary is already resolved -->
   </div>
   <div
     v-if="auth.session?.type === UserSessionType.full"
     data-testid="after-auth-layout"
     aria-hidden
   >
-    <!--This div is used as a flag to indicate that the dashboard has been loaded and the user is authenticated. */}
-        also it guarantees that the top-level suspense boundary is already resolved -->
+    <!--This div is used as a flag to indicate that the dashboard has been loaded and the user is authenticated
+        and guarantees that the top-level suspense boundary is already resolved -->
   </div>
 
   <Dialog

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtools.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtools.tsx
@@ -1,50 +1,24 @@
-/**
- * @file
- *
- * A component that provides a UI for toggling paywall features.
- */
+/** @file UI for editing application state. */
 import * as React from 'react'
+import { useShowEnsoDevtools } from './EnsoDevtoolsProvider'
 
-import * as authProvider from '$/providers/react/auth'
-import { useEffect } from 'react'
-import { ensoDevtoolsStore, useShowEnsoDevtools } from './EnsoDevtoolsProvider'
+const EnsoDevtoolsImpl =
+  process.env.NODE_ENV === 'development' ?
+    React.lazy(() => import('./EnsoDevtoolsImpl').then((mod) => ({ default: mod.EnsoDevtools })))
+  : () => null
+const EnsoDevStatus =
+  process.env.NODE_ENV === 'development' ?
+    React.lazy(() => import('./EnsoDevtoolsImpl').then((mod) => ({ default: mod.EnsoDevStatus })))
+  : () => null
 
-const EnsoDevtoolsImpl = React.lazy(() =>
-  import('./EnsoDevtoolsImpl').then((mod) => ({ default: mod.EnsoDevtools })),
-)
-const EnsoDevStatus = React.lazy(() =>
-  import('./EnsoDevtoolsImpl').then((mod) => ({ default: mod.EnsoDevStatus })),
-)
-
-/** A component that provides a UI for toggling paywall features. */
+/** UI for editing application state */
 export function EnsoDevtools() {
-  const { isEnsoTeamMember } = authProvider.useUser()
-
   const showEnsoDevtools = useShowEnsoDevtools()
-
-  useEffect(() => {
-    if (isEnsoTeamMember) {
-      addToggleDevtoolsToWindow()
-    }
-  }, [isEnsoTeamMember])
-
-  if (!showEnsoDevtools) {
-    return null
-  }
 
   return (
     <>
-      <EnsoDevtoolsImpl />
+      {showEnsoDevtools && <EnsoDevtoolsImpl />}
       <EnsoDevStatus />
     </>
   )
-}
-
-/**
- * Adds the `toggleDevtools` function to the window object.
- */
-function addToggleDevtoolsToWindow() {
-  if (typeof window !== 'undefined') {
-    window.toggleDevtools = ensoDevtoolsStore.getState().toggleDevtools
-  }
 }

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsImpl.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsImpl.tsx
@@ -114,7 +114,20 @@ export function EnsoDevStatus() {
       }
     }
   })()
-  const isOverridden = planName != null || showDeveloperIds
+  const isOverridden =
+    planName != null ||
+    animationsDisabled ||
+    versionCheckerEnabled ||
+    !enableAssetsTableBackgroundRefresh ||
+    assetsTableBackgroundRefreshInterval !== DEFAULT_ASSETS_TABLE_REFRESH_INTERVAL_MS ||
+    !enableCloudExecution ||
+    !enableScheduledExecution ||
+    !enableHybridExecution ||
+    showDeveloperIds ||
+    overrideProfilePicture ||
+    multiplyUserList ||
+    enableMultitabs ||
+    enableAdvancedProjectExecutionOptions
 
   const styles = POPOVER_STYLES({ size: 'auto-xxsmall' })
 

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsImpl.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsImpl.tsx
@@ -28,8 +28,10 @@ import { useSetPlanOverride, useUserSession } from '$/providers/react/auth'
 import { useFeatureFlags, useSetFeatureFlag } from '$/providers/react/featureFlags'
 import { useQueryClient } from '@tanstack/react-query'
 import { IS_DEV_MODE } from 'enso-common/src/detect'
+import { motion } from 'framer-motion'
 import * as React from 'react'
 import { toast } from 'react-toastify'
+import { twJoin } from 'tailwind-merge'
 import invariant from 'tiny-invariant'
 import { Icon } from '../Icon'
 import {
@@ -38,6 +40,7 @@ import {
   usePaywallDevtools,
   useSetAnimationsDisabled,
   useSetEnableVersionChecker,
+  useShowEnsoDevtools,
   useToggleEnsoDevtools,
 } from './EnsoDevtoolsProvider'
 
@@ -71,6 +74,7 @@ function DeveloperOverrideEntry(props: DeveloperOverrideEntryProps) {
 export function EnsoDevStatus() {
   const queryClient = useQueryClient()
   const { getText } = useText()
+  const showEnsoDevtools = useShowEnsoDevtools()
   const planOverride = usePlanOverride()
   const setPlanOverride = useSetPlanOverride()
   const animationsDisabled = useAnimationsDisabled()
@@ -120,9 +124,10 @@ export function EnsoDevStatus() {
 
   return (
     <Portal>
-      <div
+      <motion.div
+        layout
         className={styles.base({
-          className: 'absolute bottom-[4.25rem] left-3',
+          className: twJoin('absolute left-3', showEnsoDevtools ? 'bottom-[4.25rem]' : 'bottom-3'),
         })}
       >
         <div className={styles.dialog()}>
@@ -251,7 +256,7 @@ export function EnsoDevStatus() {
             </DeveloperOverrideEntry>
           )}
         </div>
-      </div>
+      </motion.div>
     </Portal>
   )
 }

--- a/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
+++ b/app/gui/src/dashboard/components/Devtools/EnsoDevtoolsProvider.tsx
@@ -20,7 +20,6 @@ interface EnsoDevtoolsStore {
   readonly showEnsoDevtools: boolean
   readonly toggleEnsoDevtools: () => void
   readonly setShowDevtools: (showDevtools: boolean) => void
-  readonly toggleDevtools: () => void
   readonly showVersionChecker: boolean | null
   readonly paywallFeatures: Record<PaywallFeatureName, PaywallDevtoolsFeatureConfiguration>
   readonly setPaywallFeature: (feature: PaywallFeatureName, isForceEnabled: boolean | null) => void
@@ -39,21 +38,6 @@ export const ensoDevtoolsStore = zustand.createStore<EnsoDevtoolsStore>()(
       },
       setShowDevtools: (showDevtools) => {
         set({ showDevtools, showEnsoDevtools: showDevtools })
-      },
-      toggleDevtools: () => {
-        set(({ showDevtools, showEnsoDevtools }) => {
-          if (showEnsoDevtools === false) {
-            return {
-              showDevtools: true,
-              showEnsoDevtools: true,
-            }
-          }
-
-          return {
-            showDevtools: !showDevtools,
-            showEnsoDevtools: !showDevtools,
-          }
-        })
       },
       showVersionChecker: false,
       paywallFeatures: unsafeFromEntries(

--- a/app/ide-desktop/client/src/globals.d.ts
+++ b/app/ide-desktop/client/src/globals.d.ts
@@ -170,7 +170,6 @@ declare global {
     readonly projectManagementApi?: ProjectManagementApi
     readonly versionInfo?: VersionInfo
     readonly mapBoxApiToken: () => string
-    toggleDevtools: () => void
   }
 
   namespace NodeJS {


### PR DESCRIPTION
### Pull Request Description
- Remove Enso Devtools from release
- Show override status even if the Devtools toggle button itself is hidden

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
