### PR TITLE
Add `ErrorBoundary` to sidebar panels

### DIFF
--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetProperties.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetProperties.tsx
@@ -2,6 +2,7 @@
 import PenIcon from '#/assets/pen.svg'
 import { Heading } from '#/components/aria'
 import { Button, CopyButton } from '#/components/Button'
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Form } from '#/components/Form'
 import { ResizableContentEditableInput } from '#/components/Inputs/ResizableInput'
 import { Result } from '#/components/Result'
@@ -64,13 +65,15 @@ export function AssetProperties() {
   }
 
   return (
-    <AssetPropertiesInternal
-      key={focusedAsset.id}
-      backend={remoteBackend}
-      item={focusedAsset}
-      isReadonly={isReadonly}
-      category={category}
-    />
+    <ErrorBoundary>
+      <AssetPropertiesInternal
+        key={focusedAsset.id}
+        backend={remoteBackend}
+        item={focusedAsset}
+        isReadonly={isReadonly}
+        category={category}
+      />
+    </ErrorBoundary>
   )
 }
 

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersions.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersions.tsx
@@ -4,6 +4,7 @@ import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
 
 import { uniqueString } from 'enso-common/src/utilities/uniqueString'
 
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Result } from '#/components/Result'
 import { copyAssetsMutationOptions } from '#/hooks/backendBatchedHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
@@ -52,7 +53,11 @@ export function AssetVersions() {
     return <Result status="info" centered title={getText('assetVersions.invalidAssetType')} />
   }
 
-  return <AssetVersionsInternal backend={remoteBackend} item={focusedAsset} />
+  return (
+    <ErrorBoundary>
+      <AssetVersionsInternal backend={remoteBackend} item={focusedAsset} />
+    </ErrorBoundary>
+  )
 }
 
 /** Props for an {@link AssetVersionsInternal}. */

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectExecutionsCalendar.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectExecutionsCalendar.tsx
@@ -14,6 +14,7 @@ import {
 } from '#/components/aria'
 import { Button } from '#/components/Button'
 import { Dialog } from '#/components/Dialog'
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Form } from '#/components/Form'
 import { Text } from '#/components/Text'
 import { listProjectExecutionsQueryOptions } from '#/hooks/backendHooks'
@@ -80,7 +81,11 @@ export function ProjectExecutionsCalendar() {
       <AssetPanelPlaceholder title={getText('assetProjectExecutionsCalendar.notProjectAsset')} />
     )
   }
-  return <ProjectExecutionsCalendarInternal backend={remoteBackend} item={focusedAsset} />
+  return (
+    <ErrorBoundary>
+      <ProjectExecutionsCalendarInternal backend={remoteBackend} item={focusedAsset} />
+    </ErrorBoundary>
+  )
 }
 
 /** Props for a {@link ProjectExecutionsCalendarInternal}. */

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectSessions.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/ProjectSessions.tsx
@@ -1,4 +1,5 @@
 /** @file A list of previous versions of an asset. */
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Result } from '#/components/Result'
 import { AssetPanelPlaceholder } from '#/layouts/AssetPanel/components/AssetPanelPlaceholder'
 import type Backend from '#/services/Backend'
@@ -30,7 +31,11 @@ export function ProjectSessions() {
     return <AssetPanelPlaceholder title={getText('assetProjectSessions.notProjectAsset')} />
   }
 
-  return <AssetProjectSessionsInternal backend={remoteBackend} item={focusedAsset} />
+  return (
+    <ErrorBoundary>
+      <AssetProjectSessionsInternal backend={remoteBackend} item={focusedAsset} />
+    </ErrorBoundary>
+  )
 }
 
 /** Props for a {@link AssetProjectSessionsInternal}. */


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/2048
  - Add `ErrorBoundary` around sidebar panels so an error in the sidebar does not crash the entire app

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
