### PR TITLE
Evaluate visualization arguments in the `Main` module

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -43,7 +43,7 @@ export function useWidgetFunctionCallInfo(
   },
   project: {
     useVisualizationData(config: Ref<Opt<NodeVisualizationConfiguration>>): Ref<Result<any> | null>
-    moduleProjectPath: ProjectPath
+    moduleProjectPath: Result<ProjectPath> | undefined
   },
   projectNames: ProjectNameStore,
 ) {
@@ -112,7 +112,10 @@ export function useWidgetFunctionCallInfo(
       Ast.TextLiteral.new(JSON.stringify(args)).code(),
     ]
 
-    const modulePath = project.moduleProjectPath.value
+    let modulePath: ProjectPath = WIDGETS_ENSO_PATH
+    if (project.moduleProjectPath?.ok) {
+      modulePath = project.moduleProjectPath.value
+    }
     const moduleFqn = projectNames.serializeProjectPathForBackend(modulePath)
 
     const expressionId = widgetQuerySubjectExpressionId.value

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -112,7 +112,7 @@ export function useWidgetFunctionCallInfo(
       Ast.TextLiteral.new(JSON.stringify(args)).code(),
     ]
 
-    const modulePath = project.moduleProjectPath
+    let modulePath = project.moduleProjectPath.value
     const moduleFqn = projectNames.serializeProjectPathForBackend(modulePath)
 
     const expressionId = widgetQuerySubjectExpressionId.value

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -132,7 +132,7 @@ export function useWidgetFunctionCallInfo(
       // we assume that this is a static function call and create the subject by using resolved type name.
       return {
         expressionId: toValue(input).value.externalId,
-        visualizationModule: WIDGETS_ENSO_MODULE,
+        visualizationModule: moduleFqn,
         expression: `_ -> ${WIDGETS_ENSO_MODULE}.${GET_WIDGETS_METHOD} ${projectNames.printProjectPath(info.suggestion.memberOf)}`,
         positionalArgumentsExpressions,
       }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -112,7 +112,7 @@ export function useWidgetFunctionCallInfo(
       Ast.TextLiteral.new(JSON.stringify(args)).code(),
     ]
 
-    let modulePath = project.moduleProjectPath.value
+    const modulePath = project.moduleProjectPath.value
     const moduleFqn = projectNames.serializeProjectPathForBackend(modulePath)
 
     const expressionId = widgetQuerySubjectExpressionId.value

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -115,7 +115,7 @@ export function useWidgetFunctionCallInfo(
     if (expressionId != null) {
       return {
         expressionId,
-        visualizationModule: WIDGETS_ENSO_MODULE,
+        visualizationModule: "local.NewProject1.Main",
         expression: {
           module: WIDGETS_ENSO_PATH,
           definedOnType: WIDGETS_ENSO_PATH,

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -43,6 +43,7 @@ export function useWidgetFunctionCallInfo(
   },
   project: {
     useVisualizationData(config: Ref<Opt<NodeVisualizationConfiguration>>): Ref<Result<any> | null>
+    moduleProjectPath: ProjectPath
   },
   projectNames: ProjectNameStore,
 ) {
@@ -111,10 +112,7 @@ export function useWidgetFunctionCallInfo(
       Ast.TextLiteral.new(JSON.stringify(args)).code(),
     ]
 
-    const modulePath: ProjectPath = ProjectPath.create(
-      'local.NewProject1' as QualifiedName,
-      'Main' as QualifiedName,
-    )
+    const modulePath = project.moduleProjectPath
     const moduleFqn = projectNames.serializeProjectPathForBackend(modulePath)
 
     const expressionId = widgetQuerySubjectExpressionId.value

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -111,11 +111,17 @@ export function useWidgetFunctionCallInfo(
       Ast.TextLiteral.new(JSON.stringify(args)).code(),
     ]
 
+    const modulePath: ProjectPath = ProjectPath.create(
+      'local.NewProject1' as QualifiedName,
+      'Main' as QualifiedName,
+    )
+    const moduleFqn = projectNames.serializeProjectPathForBackend(modulePath)
+
     const expressionId = widgetQuerySubjectExpressionId.value
     if (expressionId != null) {
       return {
         expressionId,
-        visualizationModule: "local.NewProject1.Main",
+        visualizationModule: moduleFqn,
         expression: {
           module: WIDGETS_ENSO_PATH,
           definedOnType: WIDGETS_ENSO_PATH,

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -8,8 +8,6 @@ from Standard.Table import all
 
 from Standard.Database import all
 
-from Standard.Geo import all
-
 ## PRIVATE
    Basic preprocessor for widgets metadata visualization.
 

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -306,7 +306,7 @@ public final class ExecutionService {
    * @return a result of evaluation
    */
   public Object evaluateExpression(Module module, String expression) {
-    LOGGER.debug("evaluateExpression in {} code: {}", module.getName(), expression);
+    LOGGER.trace("evaluateExpression in {} code: {}", module.getName(), expression);
     var future =
         submitExecution(
             () -> {

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -71,6 +71,7 @@ import org.slf4j.LoggerFactory;
  * language.
  */
 public final class ExecutionService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionService.class);
   private static final String MAIN_METHOD = "main";
   private final EnsoContext context;
   private final Optional<IdExecutionService> idExecutionInstrument;
@@ -136,10 +137,9 @@ public final class ExecutionService {
     if (connectedLockManager != null) {
       connectedLockManager.connect(endpoint);
     } else {
-      LoggerFactory.getLogger(ExecutionService.class)
-          .warn(
-              "ConnectedLockManager was not initialized, even though a Language Server connection"
-                  + " has been established. This may result in synchronization errors.");
+      LOGGER.warn(
+          "ConnectedLockManager was not initialized, even though a Language Server connection"
+              + " has been established. This may result in synchronization errors.");
     }
   }
 
@@ -306,6 +306,7 @@ public final class ExecutionService {
    * @return a result of evaluation
    */
   public Object evaluateExpression(Module module, String expression) {
+    LOGGER.info("evaluateExpression in {} code: {}", module.getName(), expression);
     var future =
         submitExecution(
             () -> {

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -306,7 +306,7 @@ public final class ExecutionService {
    * @return a result of evaluation
    */
   public Object evaluateExpression(Module module, String expression) {
-    LOGGER.info("evaluateExpression in {} code: {}", module.getName(), expression);
+    LOGGER.debug("evaluateExpression in {} code: {}", module.getName(), expression);
     var future =
         submitExecution(
             () -> {

--- a/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Base.Metadata.Widget
 import Standard.Base.Metadata.Display
 
 from Standard.Table import Table
+from Standard.Geo import all
 
 import Standard.Visualization.Widgets
 
@@ -58,6 +59,11 @@ add_specs suite_builder =
                 e.label
 
             labels . should_equal ['Equals', 'Equals (Ignore Case)', 'Between']
+
+        group_builder.specify "works for `geo_distance`" <|
+            choices = [Choice.Option "<Number Value>" "0", Choice.Option "<Expression>" "(expr '[A]')"]
+            expect = [["lat1", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            Widgets.get_widget_json mock_table .geo_distance ["lat1"] . should_equal expect
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

- Fix for #11021 
- the `visualizationModule` is the module to evaluate arguments at, not the module with the visualization!

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
- [x] Some unit tests was written
