### PR TITLE
Enable test that executes two JavaScripts in parallel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3075,6 +3075,7 @@ lazy val `runtime-integration-tests` =
             "ALL-UNNAMED",
             testInstrumentsModName,
             (`runtime-instrument-common` / javaModuleName).value,
+            (`runtime-utils` / javaModuleName).value,
             (`text-buffer` / javaModuleName).value,
             (`semver` / javaModuleName).value,
             "truffle.tck.tests",

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -15,6 +15,7 @@ import java.io.StringWriter;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import org.enso.common.MethodNames;
+import org.enso.runtime.utils.ThreadUtils;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
@@ -25,7 +26,8 @@ import org.junit.Test;
 
 public class ForeignMethodInvokeTest {
   @ClassRule
-  public static final ContextUtils ctxRule = ContextUtils.newBuilder("enso", "js").build();
+  public static final ContextUtils ctxRule =
+      ContextUtils.newBuilder("enso", "js").alwaysExecuteInContext(false).build();
 
   @Test
   public void testForeignFunctionParseFailure() throws Exception {
@@ -96,8 +98,30 @@ public class ForeignMethodInvokeTest {
     assertEquals(12, res2.getArrayElement(2).asInt());
   }
 
-  @Test
+  private static final long TIMEOUT = 30000;
+
+  @Test(timeout = TIMEOUT)
   public void testParallelInteropWithJavaScript() throws Exception {
+    var orig = Thread.currentThread();
+    var pool = Executors.newSingleThreadExecutor();
+    var watchDog =
+        pool.submit(
+            () -> {
+              Thread.sleep(TIMEOUT / 3 * 2);
+              var dump = ThreadUtils.dumpAllStacktraces("[testParallelInteropWithJavaScript] ");
+              System.err.println(dump);
+              orig.interrupt();
+              return dump;
+            });
+    try {
+      handleParallelInteropWithJavaScript();
+    } finally {
+      watchDog.cancel(false);
+      pool.shutdown();
+    }
+  }
+
+  private void handleParallelInteropWithJavaScript() throws Exception {
     var source =
         """
         from Standard.Base import all

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -108,7 +108,9 @@ public class ForeignMethodInvokeTest {
         pool.submit(
             () -> {
               Thread.sleep(TIMEOUT / 3 * 2);
-              var dump = ThreadUtils.dumpAllStacktraces("[testParallelInteropWithJavaScript] ");
+              var dump =
+                  ThreadUtils.dumpAllStacktraces(
+                      "[paralleljs] ", "Time out in a testParallelInteropWithJavaScript");
               System.err.println(dump);
               orig.interrupt();
               return dump;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import org.enso.common.MethodNames;
 import org.enso.test.utils.ContextUtils;
@@ -20,7 +21,6 @@ import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ForeignMethodInvokeTest {
@@ -96,7 +96,6 @@ public class ForeignMethodInvokeTest {
     assertEquals(12, res2.getArrayElement(2).asInt());
   }
 
-  @Ignore
   @Test
   public void testParallelInteropWithJavaScript() throws Exception {
     var source =
@@ -115,23 +114,38 @@ public class ForeignMethodInvokeTest {
     var module = ctxRule.eval("enso", source);
     var third = module.invokeMember("eval_expression", new AsString("third"));
 
-    var future =
-        Executors.newSingleThreadExecutor()
-            .submit(
-                () -> {
-                  return third.execute(12);
-                });
-    var res = third.execute(13);
-    assertTrue("It is an array", res.hasArrayElements());
-    assertEquals(3, res.getArraySize());
-    assertEquals(1, res.getArrayElement(0).asInt());
-    assertEquals(2, res.getArrayElement(1).asInt());
-    assertEquals(13, res.getArrayElement(2).asInt());
+    var pool =
+        Executors.newSingleThreadExecutor(
+            (r) -> {
+              return new Thread(r, "testParallelInteropWithJavaScript 2nd");
+            });
 
-    var res2 = future.get();
+    // action12 and action13 will be invoke in parallel...
+    Callable<Value> action12 =
+        () -> {
+          return third.execute(12);
+        };
+    Callable<Value> action13 =
+        () -> {
+          return third.execute(13);
+        };
+    try {
+      var futureResult12 = pool.submit(action12);
+      var result13 = action13.call();
 
-    assertTrue("It is an array2", res2.hasArrayElements());
-    assertEquals(12, res2.getArrayElement(2).asInt());
+      assertTrue("It is an array", result13.hasArrayElements());
+      assertEquals(3, result13.getArraySize());
+      assertEquals(1, result13.getArrayElement(0).asInt());
+      assertEquals(2, result13.getArrayElement(1).asInt());
+      assertEquals(13, result13.getArrayElement(2).asInt());
+
+      var result12 = futureResult12.get();
+
+      assertTrue("It is an array2", result12.hasArrayElements());
+      assertEquals(12, result12.getArrayElement(2).asInt());
+    } finally {
+      pool.shutdownNow();
+    }
   }
 
   @Test

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -108,6 +108,7 @@ final class EpbContext {
       try {
         return polyfillInitialized.get();
       } catch (InterruptedException | ExecutionException ex) {
+        // log and try again
         this.log.log(Level.INFO, null, ex);
       }
     }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -126,14 +126,18 @@ final class EpbContext {
             var obj = ctx.evalPublic(node, src);
             return Value.asValue(obj);
           } catch (IOException ex) {
-            throw new IllegalStateException(ex);
+            throw raise(RuntimeException.class, ex);
           }
         };
     return () -> {
-      WebEnvironment.initialize(eval, exec);
-      var parserPolyfill = new ParserPolyfill();
-      parserPolyfill.initialize(eval);
-      whenDone.complete(null);
+      try {
+        WebEnvironment.initialize(eval, exec);
+        var parserPolyfill = new ParserPolyfill();
+        parserPolyfill.initialize(eval);
+        whenDone.complete(null);
+      } catch (Exception ex) {
+        whenDone.completeExceptionally(ex);
+      }
     };
   }
 
@@ -155,5 +159,10 @@ final class EpbContext {
     log(Level.FINE, dump);
     log(Level.INFO, "Waiting " + ms + " ms");
     return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Exception> E raise(Class<E> clazz, Throwable t) throws E {
+    throw (E) t;
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -9,6 +9,9 @@ import com.oracle.truffle.api.source.Source;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -32,7 +35,7 @@ final class EpbContext {
   private @CompilationFinal TruffleContext innerContext;
   private final TruffleLogger log;
   private final Random delayer = new Random();
-  private boolean polyfillInitialized;
+  private Future<Void> polyfillInitialized;
 
   /**
    * Creates a new instance of this context.
@@ -89,44 +92,67 @@ final class EpbContext {
     this.log.log(level, msg, args);
   }
 
-  final void initializePolyfill(Node node, TruffleContext ctx) {
-    if (!polyfillInitialized) {
-      var parserPolyfill = new ParserPolyfill();
-      polyfillInitialized = true;
-      var ensoLanguage = getEnv().getInternalLanguages().get("enso");
-      var exec = getEnv().lookup(ensoLanguage, ScheduledExecutorService.class);
-      assert exec != null : "Need executor from " + ensoLanguage;
-      Function<URL, Value> eval =
-          (url) -> {
-            try {
-              var src = Source.newBuilder("js", url).build();
-              var obj = ctx.evalPublic(node, src);
-              return Value.asValue(obj);
-            } catch (IOException ex) {
-              throw new IllegalStateException(ex);
-            }
-          };
-      WebEnvironment.initialize(eval, exec);
-      parserPolyfill.initialize(eval);
+  final Void initializePolyfill(Node node, TruffleContext ctx) {
+    Runnable toInit = null;
+    synchronized (this) {
+      if (polyfillInitialized == null) {
+        var cf = new CompletableFuture<Void>();
+        toInit = createPolyfillSetup(cf, node, ctx);
+        polyfillInitialized = cf;
+      }
     }
+    if (toInit != null) {
+      toInit.run();
+    }
+    for (; ; ) {
+      try {
+        return polyfillInitialized.get();
+      } catch (InterruptedException | ExecutionException ex) {
+        this.log.log(Level.INFO, null, ex);
+      }
+    }
+  }
+
+  private Runnable createPolyfillSetup(
+      CompletableFuture<Void> whenDone, Node node, TruffleContext ctx) {
+    var ensoLanguage = getEnv().getInternalLanguages().get("enso");
+    var exec = getEnv().lookup(ensoLanguage, ScheduledExecutorService.class);
+    assert exec != null : "Need executor from " + ensoLanguage;
+    Function<URL, Value> eval =
+        (url) -> {
+          try {
+            var src = Source.newBuilder("js", url).build();
+            var obj = ctx.evalPublic(node, src);
+            return Value.asValue(obj);
+          } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+          }
+        };
+    return () -> {
+      WebEnvironment.initialize(eval, exec);
+      var parserPolyfill = new ParserPolyfill();
+      parserPolyfill.initialize(eval);
+      whenDone.complete(null);
+    };
   }
 
   final void handleMultiAccess(String msg) {
     try {
       var ms = delayer.nextInt(10, 1000);
       // dump stack when assertions on
-      assert dumpStack(ms);
+      assert dumpStack(msg, ms);
       Thread.sleep(ms);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
     }
   }
 
-  private boolean dumpStack(int ms) {
-    var msg =
-        ThreadUtils.dumpAllStacktraces(
-            "Polyglot access failed. Waiting " + ms + " ms. Thread dump:");
+  private boolean dumpStack(String msg, int ms) {
+    var prefix = "[PolyglotAccess:" + Thread.currentThread().getName() + "]";
+    var dump = ThreadUtils.dumpAllStacktraces(prefix);
     log(Level.WARNING, msg);
+    log(Level.FINE, dump);
+    log(Level.INFO, "Waiting " + ms + " ms");
     return true;
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -154,7 +154,7 @@ final class EpbContext {
 
   private boolean dumpStack(String msg, int ms) {
     var prefix = "[PolyglotAccess:" + Thread.currentThread().getName() + "]";
-    var dump = ThreadUtils.dumpAllStacktraces(prefix);
+    var dump = ThreadUtils.dumpAllStacktraces("[epb] ", prefix);
     log(Level.WARNING, msg);
     log(Level.FINE, dump);
     log(Level.INFO, "Waiting " + ms + " ms");

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/ForeignMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/ForeignMethodCallNode.java
@@ -1,23 +1,29 @@
 package org.enso.interpreter.node.expression.foreign;
 
-import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.profiles.BranchProfile;
+import com.oracle.truffle.api.source.Source;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.error.DataflowError;
 
 /** Performs a call into a given foreign call target. */
-public class ForeignMethodCallNode extends ExpressionNode {
+public final class ForeignMethodCallNode extends ExpressionNode {
+  private final Source src;
+  private final String[] names;
   private @Children ExpressionNode[] arguments;
   private @Child DirectCallNode callNode;
   private @Child HostValueToEnsoNode coerceNode;
   private final BranchProfile[] errorProfiles;
 
-  ForeignMethodCallNode(ExpressionNode[] arguments, CallTarget foreignCt) {
+  ForeignMethodCallNode(Source src, String[] names, ExpressionNode[] arguments) {
+    this.src = src;
+    this.names = names;
     this.arguments = arguments;
-    this.callNode = DirectCallNode.create(foreignCt);
+    this.callNode = null;
     this.coerceNode = HostValueToEnsoNode.build();
 
     this.errorProfiles = new BranchProfile[arguments.length];
@@ -33,13 +39,20 @@ public class ForeignMethodCallNode extends ExpressionNode {
    * @param foreignCt the foreign call target to call
    * @return the result of calling the foreign call target with the executed arguments
    */
-  public static ForeignMethodCallNode build(ExpressionNode[] arguments, CallTarget foreignCt) {
-    return new ForeignMethodCallNode(arguments, foreignCt);
+  public static ForeignMethodCallNode buildDeferred(
+      Source src, String[] names, ExpressionNode[] arguments) {
+    return new ForeignMethodCallNode(src, names, arguments);
   }
 
   @Override
   @ExplodeLoop
   public Object executeGeneric(VirtualFrame frame) {
+    if (callNode == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var ctx = EnsoContext.get(this);
+      var foreignCt = ctx.parseInternal(src, names);
+      callNode = insert(DirectCallNode.create(foreignCt));
+    }
     Object[] args = new Object[arguments.length];
     for (int i = 0; i < arguments.length; i++) {
       args[i] = arguments[i].executeGeneric(frame);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/ForeignMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/ForeignMethodCallNode.java
@@ -33,14 +33,18 @@ public final class ForeignMethodCallNode extends ExpressionNode {
   }
 
   /**
-   * Creates a new instance of this node
+   * Creates a new instance of this node that will parse and execute provided source. The parsing
+   * will happen when {@link #executeGeneric(com.oracle.truffle.api.frame.VirtualFrame)} is executed
+   * for the first time. The length of {@code names} and {@code arguments} arrays must be the same.
    *
+   * @param src source code to parse
+   * @param names names of arguments the source can refer to
    * @param arguments expressions resulting in the computation of function arguments
-   * @param foreignCt the foreign call target to call
-   * @return the result of calling the foreign call target with the executed arguments
+   * @return new node to perform the evaluation and execution
    */
   public static ForeignMethodCallNode buildDeferred(
       Source src, String[] names, ExpressionNode[] arguments) {
+    assert names.length == arguments.length;
     return new ForeignMethodCallNode(src, names, arguments);
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2233,14 +2233,17 @@ class IrToTruffle(
       val name = scopeName.replace('.', '_') + "." + language
       val b    = Source.newBuilder("epb", language + ":" + line + "#" + code, name)
       b.uri(source.getURI())
-      val src       = b.build()
-      val foreignCt = context.parseInternal(src, argumentNames: _*)
+      val src = b.build()
       val argumentReaders = argumentSlotIdxs
         .map(slotIdx =>
           ReadLocalVariableNode.build(new FramePointer(0, slotIdx))
         )
         .toArray[RuntimeExpression]
-      ForeignMethodCallNode.build(argumentReaders, foreignCt)
+      ForeignMethodCallNode.buildDeferred(
+        src,
+        argumentNames.toArray,
+        argumentReaders
+      )
     }
 
     /** Generates code for an Enso function body.

--- a/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
+++ b/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
@@ -7,17 +7,18 @@ public class ThreadUtils {
   private ThreadUtils() {}
 
   public static String dumpAllStacktraces(String prefix) {
-    var sb = new StringBuilder(prefix);
+    var sb = new StringBuilder();
     sb.append(System.lineSeparator());
     Thread.getAllStackTraces()
         .entrySet()
         .forEach(
             entry -> {
-              sb.append(entry.getKey().getName()).append(System.lineSeparator());
+              sb.append(prefix).append(entry.getKey().getName()).append(System.lineSeparator());
               Arrays.stream(entry.getValue())
                   .forEach(
                       e ->
-                          sb.append("    ")
+                          sb.append(prefix)
+                              .append("    at ")
                               .append(e.getClassName())
                               .append(".")
                               .append(e.getMethodName())

--- a/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
+++ b/lib/java/runtime-utils/src/main/java/org/enso/runtime/utils/ThreadUtils.java
@@ -6,8 +6,13 @@ public class ThreadUtils {
 
   private ThreadUtils() {}
 
-  public static String dumpAllStacktraces(String prefix) {
+  public static String dumpAllStacktraces(String header) {
+    return dumpAllStacktraces("", header);
+  }
+
+  public static String dumpAllStacktraces(String prefix, String header) {
     var sb = new StringBuilder();
+    sb.append(header);
     sb.append(System.lineSeparator());
     Thread.getAllStackTraces()
         .entrySet()

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
@@ -434,8 +434,9 @@ public final class ContextUtils implements TestRule, AutoCloseable {
      *
      * @param b true for automatically wrapping the test code in the context. If false, the context
      *     entering must be done manually.
+     * @return this builder
      */
-    private Builder alwaysExecuteInContext(boolean b) {
+    public Builder alwaysExecuteInContext(boolean b) {
       this.alwaysExecuteInContext = b;
       return this;
     }


### PR DESCRIPTION
### Pull Request Description

- enabling forgotten `@Ignore` test: ca2af1a76310fcb2938d85fd60d60dee1fdf5718
- the test relies on `threadAccessDeniedHandler` which is available since #12855 
- let 190c011a087f811890a61b0ed6e780d4279aa6ca defer `parseInternal` call for later
- let d8b5cd5503e493594258a58cdcd5951992174063 make sure the polyfill is initialized only once

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
