### PR TITLE
Add project_id to the initial telemetry message from LS's boot

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -544,9 +544,9 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
       .getAttribute(osBean.getObjectName, "TotalPhysicalMemorySize")
       .asInstanceOf[Long]
     val totalMemMB = totalMem / 1024 / 1024
-    ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
     telemetryLog.trace(
-      "Initializing main module of the Language Server: edition={}, graal_version={}, enso_version={}, is_release={}, AOT={}, os_name={}, os_arch={}, os_version={}, available_cpus={}, total_memory_MB={}, available_memory_MB={}",
+      "Initializing main module of the Language Server: project_id={}, edition={}, graal_version={}, enso_version={}, is_release={}, AOT={}, os_name={}, os_arch={}, os_version={}, available_cpus={}, total_memory_MB={}, available_memory_MB={}",
+      serverConfig.projectId,
       BuildVersion.currentEdition(),
       BuildVersion.graalVersion(),
       BuildVersion.ensoVersion(),


### PR DESCRIPTION
Closes #13214

### Pull Request Description

There is an initial telemetry message when language server is booting in [MainModule.initialTelemetry](https://github.com/enso-org/enso/blob/c3e4fd98fcbb9e7bc87a073996331a577f4aae53/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala#L534). How that message looks like can be seen in the description of #12620.

This PR adds `project_id` field to that initial message.

### Important Notes

> How to answer the question "How many project is a user with `user_id` working on"?

- Group the *initial* telemetry messages by `user_id`
- Look for distinct `metadata.project_id` fields.

Note that the `project_id` is taken from `<project-path>/.enso/project.json`, which is handled by the project manager.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
