### PR TITLE
Dump visualization text in addition to its UUID

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -3,6 +3,7 @@ package org.enso.interpreter.instrument.job
 import org.slf4j.LoggerFactory
 
 import com.oracle.truffle.api.exception.AbstractTruffleException
+import com.oracle.truffle.api.source.SourceSection
 import org.enso.interpreter.instrument.{
   InstrumentFrame,
   MethodCallsCache,
@@ -729,6 +730,7 @@ object ProgramExecutionSupport {
         if (!TypesGen.isPanicSentinel(expressionValue)) {
           val typeOfNode =
             TypeOfNode.getUncached.findTypeOrError(expressionValue)
+
           logger.warn(
             "Execution of visualization [{}] on value [{}] of [{}] failed. {} | {} | {}",
             visualizationId,
@@ -738,6 +740,23 @@ object ProgramExecutionSupport {
             expressionValue,
             error
           )
+          error match {
+            case p: AbstractTruffleException if p.getLocation() != null => {
+              p.getLocation().getEncapsulatingSourceSection() match {
+                case ss: SourceSection =>
+                  logger.warn(
+                    "Visualization {} represents '{}' at {}-{} in\n{}",
+                    visualizationId,
+                    ss.getCharacters(),
+                    ss.getCharIndex(),
+                    ss.getCharEndIndex(),
+                    ss.getSource().getCharacters()
+                  )
+                case _ =>
+              }
+            }
+            case _ =>
+          }
         }
         ctx.endpoint.sendToClient(
           Api.Response(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -745,11 +745,11 @@ object ProgramExecutionSupport {
               p.getLocation().getEncapsulatingSourceSection() match {
                 case ss: SourceSection =>
                   logger.warn(
-                    "Visualization {} represents '{}' at {}-{} in\n{}",
-                    visualizationId,
-                    ss.getCharacters(),
+                    "Error at {}-{} (e.g. `{}`) of {} with text:\n{}",
                     ss.getCharIndex(),
                     ss.getCharEndIndex(),
+                    ss.getCharacters(),
+                    visualizationId,
                     ss.getSource().getCharacters()
                   )
                 case _ =>


### PR DESCRIPTION
### Pull Request Description

While investigating #13342 I noticed log messages like
```
Execution of visualization [7b3fb3c2-6397-44b1-9518-e7414de00a44] 
on value [2213ffb9-7deb-4474-8976-7e08edc8aa5e] of [Nothing] failed. 
Compile error: Fully qualified name references a library Standard.Visualization
but an import statement for it is missing. 
```
I do not find the `7b3fb3c2-6397-44b1-9518-e7414de00a44` information very valuable. Hence I'd like to add additional log message:
```
Error at 9-22 (e.g. `Visualization`) of 7b3fb3c2-6397-44b1-9518-e7414de00a44 with text:
Standard.Visualization.Table.Visualization.prepare_visualization _ (1000) <| column4 * 3
```
helping mere humans find out what's going on.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
