### PR TITLE
Less heavyweight `persistance` module by bridging `System.Logger` to slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1778,11 +1778,10 @@ lazy val `persistance` = (project in file("lib/java/persistance"))
     crossPaths := false,
     Compile / javacOptions := ((Compile / javacOptions).value),
     inConfig(Compile)(truffleRunOptionsSettings),
-    libraryDependencies ++= slf4jApi ++ Seq(
+    libraryDependencies ++= Seq(
       "junit"          % "junit"           % junitVersion   % Test,
       "com.github.sbt" % "junit-interface" % junitIfVersion % Test
-    ),
-    Compile / moduleDependencies ++= slf4jApi
+    )
   )
   .dependsOn(`persistance-dsl` % Test)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1914,6 +1914,9 @@ lazy val `engine-common` = project
     Compile / internalModuleDependencies := Seq(
       (`logging-utils` / Compile / exportedModule).value,
       (`logging-config` / Compile / exportedModule).value
+    ),
+    Test / moduleDependencies ++= Seq(
+      "com.typesafe" % "config" % typesafeConfigVersion
     )
   )
   .dependsOn(`logging-config`)
@@ -3503,6 +3506,9 @@ lazy val `engine-runner` = project
       (`polyglot-api` / Compile / exportedModule).value,
       (`logging-config` / Compile / exportedModule).value,
       (`logging-utils` / Compile / exportedModule).value
+    ),
+    Test / moduleDependencies ++= Seq(
+      "com.typesafe" % "config" % typesafeConfigVersion
     ),
     run / connectInput := true
   )

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
@@ -1,0 +1,23 @@
+package org.enso.interpreter.runtime.progress;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.System.Logger.Level;
+import org.enso.logger.ObservedMessage;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class ObservedMessageTest {
+  @Test
+  public void observeAlsoWhatHappensInSystemLogger() throws Exception {
+    var slf4j = LoggerFactory.getLogger("my.test.logger");
+    var logger = System.getLogger(slf4j.getName());
+    var arr =
+        ObservedMessage.collect(
+            slf4j,
+            () -> {
+              logger.log(Level.ERROR, "OK");
+            });
+    assertEquals("One message", 1, arr.size());
+  }
+}

--- a/lib/java/persistance/src/main/java/module-info.java
+++ b/lib/java/persistance/src/main/java/module-info.java
@@ -1,5 +1,3 @@
 module org.enso.persistance {
-  requires org.slf4j;
-
   exports org.enso.persist;
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.slf4j.Logger;
 
 final class PerGenerator {
   static final byte[] HEADER = new byte[] {0x0a, 0x0d, 0x13, 0x0f};
@@ -38,7 +37,7 @@ final class PerGenerator {
 
   static byte[] writeObject(PerMap map, Object obj, Function<Object, Object> writeReplace)
       throws IOException {
-    var histogram = PerUtils.LOG.isDebugEnabled() ? new Histogram() : null;
+    var histogram = PerUtils.LOG.isLoggable(System.Logger.Level.DEBUG) ? new Histogram() : null;
 
     var out = new ByteArrayOutputStream();
     var data = new DataOutputStream(out);
@@ -228,7 +227,7 @@ final class PerGenerator {
   private static final class Histogram {
     private final Map<Class, int[]> knownTypes = new HashMap<>();
 
-    private void dump(Logger log, int length) {
+    private void dump(System.Logger log, int length) {
       var counts = knownTypes;
       var list = new ArrayList<>(counts.entrySet());
       list.sort(
@@ -236,13 +235,14 @@ final class PerGenerator {
             return a.getValue()[0] - b.getValue()[0];
           });
 
-      log.debug("==== Top Bytes & Counts of Classes =====");
+      log.log(System.Logger.Level.DEBUG, "==== Top Bytes & Counts of Classes =====");
       for (var i = 0; i < list.size(); i++) {
         if (i == 30) {
           break;
         }
         var elem = list.get(list.size() - 1 - i);
-        log.debug(
+        log.log(
+            System.Logger.Level.DEBUG,
             "  " + elem.getValue()[0] + " " + elem.getValue()[1] + " " + elem.getKey().getName());
       }
     }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
@@ -227,7 +227,7 @@ final class PerInputImpl implements Input {
       sb.append("\nare they equal: ").append(bothObjectsAreTheSame);
       var ex = new IOException(sb.toString());
       if (bothObjectsAreTheSame) {
-        PerUtils.LOG.warn(sb.toString(), ex);
+        PerUtils.LOG.log(System.Logger.Level.WARNING, sb.toString(), ex);
       } else {
         throw raise(RuntimeException.class, ex);
       }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerUtils.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerUtils.java
@@ -1,12 +1,11 @@
 package org.enso.persist;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.lang.System.Logger;
 
 final class PerUtils {
   private PerUtils() {}
 
-  static final Logger LOG = LoggerFactory.getLogger(Persistance.class.getPackageName());
+  static final Logger LOG = System.getLogger(Persistance.class.getPackageName());
 
   @SuppressWarnings("unchecked")
   static <E extends Throwable> E raise(Class<E> clazz, Throwable t) throws E {

--- a/lib/java/persistance/src/test/java/org/enso/persist/PersistanceDependenciesTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/PersistanceDependenciesTest.java
@@ -1,0 +1,51 @@
+package org.enso.persist;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class PersistanceDependenciesTest {
+  public PersistanceDependenciesTest() {}
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidFlatbuffers() throws Exception {
+    var c = Class.forName("com.google.flatbuffers.Constants");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidJackson() throws Exception {
+    var c = Class.forName("com.fasterxml.jackson.core.JsonParser");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidCirce() throws Exception {
+    var c = Class.forName("io.circe.Codec");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidApacheCommons() throws Exception {
+    var c = Class.forName("org.apache.commons.io.Charsets");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidCats() throws Exception {
+    var c = Class.forName("cats.Align");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidSlf4j() throws Exception {
+    var c = Class.forName("org.slf4j.Logger");
+    fail("No class should be found: " + c);
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void avoidSnakeyaml() throws Exception {
+    var c = Class.forName("org.yaml.snakeyaml.Yaml");
+    fail("No class should be found: " + c);
+  }
+}

--- a/lib/scala/logging-config/src/main/java/module-info.java
+++ b/lib/scala/logging-config/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import org.enso.logging.config.systemlogger.SystemLoggerViaSlf4j;
+
 module org.enso.logging.config {
   requires org.slf4j;
   requires typesafe.config;
@@ -5,4 +7,7 @@ module org.enso.logging.config {
   exports org.enso.logging.config;
 
   uses org.enso.logging.config.LoggerSetup;
+
+  provides java.lang.System.LoggerFinder with
+      SystemLoggerViaSlf4j;
 }

--- a/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
@@ -1,0 +1,74 @@
+package org.enso.logging.config.systemlogger;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Bridges logs sent to {@link System.Logger} to slf4j logger. */
+public final class SystemLoggerViaSlf4j extends System.LoggerFinder {
+  public SystemLoggerViaSlf4j() {}
+
+  @Override
+  public System.Logger getLogger(String name, Module module) {
+    var logger = LoggerFactory.getLogger(name);
+    return new Bridge(logger);
+  }
+
+  private static final class Bridge implements System.Logger {
+    private final Logger delegate;
+
+    Bridge(Logger delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String getName() {
+      return delegate.getName();
+    }
+
+    @Override
+    public boolean isLoggable(Level level) {
+      return delegate.isEnabledForLevel(at(level));
+    }
+
+    @Override
+    public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+      if (isLoggable(level)) {
+        var m = readMsg(bundle, msg);
+        delegate.atLevel(at(level)).setCause(thrown).setMessage(m).log();
+      }
+    }
+
+    @Override
+    public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+      if (isLoggable(level)) {
+        var m = readMsg(bundle, format);
+        var formatted = MessageFormat.format(m, params);
+        delegate.atLevel(at(level)).log(formatted);
+      }
+    }
+
+    private org.slf4j.event.Level at(Level l) {
+      return switch (l) {
+        case ERROR -> org.slf4j.event.Level.ERROR;
+        case WARNING -> org.slf4j.event.Level.WARN;
+        case INFO -> org.slf4j.event.Level.INFO;
+        case DEBUG -> org.slf4j.event.Level.DEBUG;
+        case TRACE -> org.slf4j.event.Level.TRACE;
+        case null -> null;
+        default -> org.slf4j.event.Level.intToLevel(l.getSeverity());
+      };
+    }
+
+    private String readMsg(ResourceBundle bundle, String textOrKey) {
+      if (textOrKey == null) {
+        return null;
+      }
+      if (bundle == null) {
+        return textOrKey;
+      }
+      return bundle.getString(textOrKey);
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description

- One of the remaining problems in #13238
- was _"logging in the HotSpot JVM isn't configured"_
- which resulted in a lot of printed log messages
- by making `persistance` use the default `System.Logger` no messages shall appear
- as the default logger is configured to not log `DEBUG` messages by default  
- moreover the use of `System.Logger` makes `persistance` _3rd party libraries free_
- while the logging behavior of `persistance` in the Enso runtime remains unchanged
- because of the bridge that delegates to _slf4j_

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
