### PR TITLE
startup benchmarks with Native Image

### DIFF
--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -264,6 +264,10 @@ impl BuildConfigurationResolved {
             config.check_enso_benchmarks = false;
         }
 
+        if Self::should_run_enso_jmh_benchmarks(&config) {
+            config.build_native_runner = true;
+        }
+
         if config.test_java_generated_from_rust {
             config.generate_java_from_rust = true;
         }
@@ -274,6 +278,13 @@ impl BuildConfigurationResolved {
     fn should_run_enso_benchmarks(config: &BuildConfigurationFlags) -> bool {
         match &config.execute_benchmarks {
             Some(benchmark) => benchmark.bench_type == BenchmarkType::Enso,
+            None => false,
+        }
+    }
+
+    fn should_run_enso_jmh_benchmarks(config: &BuildConfigurationFlags) -> bool {
+        match &config.execute_benchmarks {
+            Some(benchmark) => benchmark.bench_type == BenchmarkType::EnsoJMH,
             None => false,
         }
     }

--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -104,6 +104,9 @@ pub enum Tests {
 pub enum EngineLauncher {
     /// The binary inside the engine distribution will be built as an optimized native image
     Native,
+    /// The binary inside the engine distribution will be built as an optimized native image
+    /// without language server.
+    NativeWithoutLS,
     /// The binary inside the engine distribution will be built as native image with assertions
     /// enabled but no debug information
     TestNative,
@@ -127,6 +130,7 @@ impl Display for EngineLauncher {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let str = match self {
             EngineLauncher::Native => "native".to_string(),
+            EngineLauncher::NativeWithoutLS => "native,-ls".to_string(),
             EngineLauncher::TestNative => "native,test".to_string(),
             EngineLauncher::TestDebugNative => "native,test,debug".to_string(),
             EngineLauncher::Shell => "shell".to_string(),

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -200,7 +200,11 @@ impl RunContext {
             sbt.call_arg("syntax-rust-definition/Runtime/managedClasspath").await?;
         }
         if self.config.build_native_runner {
-            env::ENSO_LAUNCHER.set(&engine::EngineLauncher::TestNative)?;
+            if self.config.execute_benchmarks.is_some() {
+                env::ENSO_LAUNCHER.set(&engine::EngineLauncher::NativeWithoutLS)?;
+            } else {
+                env::ENSO_LAUNCHER.set(&engine::EngineLauncher::TestNative)?;
+            }
         }
         prepare_simple_library_server.await??;
 

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -8,14 +8,23 @@ polyglot java import java.io.File as Java_File
 type Data
     Value ~enso_bin:File ~empty_world:File ~hello_world:File ~import_world:File
 
-    bench_empty self =
-        self.startup [ "--run", self.empty_world.to_text ]
+    bench_empty self in_jvm:Boolean =
+        cmd = ["--run", self.empty_world.to_text]
+        case in_jvm of
+            True -> self.startup (["--jvm"] + cmd)
+            False -> self.startup cmd
 
-    bench_hello self =
-        self.startup [ "--run", self.hello_world.to_text ]
+    bench_hello self in_jvm:Boolean =
+        cmd = ["--run", self.hello_world.to_text]
+        case in_jvm of
+            True -> self.startup (["--jvm"] + cmd)
+            False -> self.startup cmd
 
-    bench_import self =
-        self.startup [ "--run", self.import_world.to_text ]
+    bench_import self in_jvm:Boolean =
+        cmd = ["--run", self.import_world.to_text]
+        case in_jvm of
+            True -> self.startup (["--jvm"] + cmd)
+            False -> self.startup cmd
 
     startup self  args =
         exe = self.enso_bin
@@ -35,19 +44,29 @@ type Data
 collect_benches = Bench.build builder->
     options = Bench.options . set_warmup (Bench.phase_conf 2 5) . set_measure (Bench.phase_conf 3 5)
 
-
     data =
         Data.Value enso_bin (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
 
-    builder.group "Startup" options group_builder->
-        group_builder.specify "empty_startup" data.bench_empty
-        group_builder.specify "hello_world_startup" data.bench_hello
-        group_builder.specify "import_world_startup" data.bench_import
+    if runs_in_aot.not then
+        Panic.throw "This benchmark must be run in AOT (The engine distribution must be build with NI)"
+
+    [["Native_Image_Startup", False], ["JVM_Startup", True]].each \entry->
+        group_name = entry.at 0
+        in_jvm = (entry.at 1):Boolean
+        builder.group group_name options group_builder->
+            group_builder.specify "empty_startup" (data.bench_empty in_jvm)
+            group_builder.specify "hello_world_startup" (data.bench_hello in_jvm)
+            group_builder.specify "import_world_startup" (data.bench_import in_jvm)
+
 
 find_sibling name =
     f = enso_project.root / "src" / "Startup" / name
     if f.is_regular_file.not then Panic.throw "Cannot find "+f.to_text
     f
+
+runs_in_aot =
+    prop = Java_System.getProperty "org.graalvm.nativeimage.imagecode"
+    prop == "runtime"
 
 enso_bin =
     find_prefix dir prefix =

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -9,27 +9,21 @@ type Data
     Value ~enso_bin:File ~empty_world:File ~hello_world:File ~import_world:File
 
     bench_empty self in_jvm:Boolean =
-        cmd = ["--run", self.empty_world.to_text]
-        case in_jvm of
-            True -> self.startup (["--jvm"] + cmd)
-            False -> self.startup cmd
+        self.startup [ "--run", self.empty_world.to_text ] in_jvm
 
     bench_hello self in_jvm:Boolean =
-        cmd = ["--run", self.hello_world.to_text]
-        case in_jvm of
-            True -> self.startup (["--jvm"] + cmd)
-            False -> self.startup cmd
+        self.startup [ "--run", self.hello_world.to_text ] in_jvm
 
     bench_import self in_jvm:Boolean =
-        cmd = ["--run", self.import_world.to_text]
-        case in_jvm of
-            True -> self.startup (["--jvm"] + cmd)
-            False -> self.startup cmd
+        self.startup [ "--run", self.import_world.to_text ] in_jvm
 
-    startup self  args =
+    startup self args in_jvm:Boolean =
         ensure_runs_in_aot
         exe = self.enso_bin
-        result = Process.run exe.path args
+        all_args = case in_jvm of
+            True -> ["--jvm"] + args
+            False -> args
+        result = Process.run exe.path all_args
         case result.exit_code of
             Exit_Code.Failure code ->
                 IO.println "Exit code: "+code.to_text

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -18,7 +18,6 @@ type Data
         self.startup [ "--run", self.import_world.to_text ] in_jvm
 
     startup self args in_jvm:Boolean =
-        ensure_runs_in_aot
         exe = self.enso_bin
         all_args = case in_jvm of
             True -> ["--jvm"] + args
@@ -55,14 +54,6 @@ find_sibling name =
     f = enso_project.root / "src" / "Startup" / name
     if f.is_regular_file.not then Panic.throw "Cannot find "+f.to_text
     f
-
-ensure_runs_in_aot =
-    if runs_in_aot.not then
-        Panic.throw "This benchmark must be run in AOT (The engine distribution must be build with NI)"
-
-runs_in_aot =
-    prop = Java_System.getProperty "org.graalvm.nativeimage.imagecode"
-    prop == "runtime"
 
 enso_bin =
     find_prefix dir prefix =

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -49,8 +49,8 @@ collect_benches = Bench.build builder->
         Data.Value enso_bin (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
 
     [["Native_Image_Startup", False], ["Startup", True]].each \entry->
-        group_name = entry.at 0
-        in_jvm = (entry.at 1):Boolean
+        group_name = entry.first
+        in_jvm = (entry.second):Boolean
         builder.group group_name options group_builder->
             group_builder.specify "empty_startup" (data.bench_empty in_jvm)
             group_builder.specify "hello_world_startup" (data.bench_hello in_jvm)

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -48,7 +48,7 @@ collect_benches = Bench.build builder->
     data =
         Data.Value enso_bin (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
 
-    [["Native_Image_Startup", False], ["JVM_Startup", True]].each \entry->
+    [["Native_Image_Startup", False], ["Startup", True]].each \entry->
         group_name = entry.at 0
         in_jvm = (entry.at 1):Boolean
         builder.group group_name options group_builder->

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -27,6 +27,7 @@ type Data
             False -> self.startup cmd
 
     startup self  args =
+        ensure_runs_in_aot
         exe = self.enso_bin
         result = Process.run exe.path args
         case result.exit_code of
@@ -47,9 +48,6 @@ collect_benches = Bench.build builder->
     data =
         Data.Value enso_bin (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
 
-    if runs_in_aot.not then
-        Panic.throw "This benchmark must be run in AOT (The engine distribution must be build with NI)"
-
     [["Native_Image_Startup", False], ["JVM_Startup", True]].each \entry->
         group_name = entry.at 0
         in_jvm = (entry.at 1):Boolean
@@ -63,6 +61,10 @@ find_sibling name =
     f = enso_project.root / "src" / "Startup" / name
     if f.is_regular_file.not then Panic.throw "Cannot find "+f.to_text
     f
+
+ensure_runs_in_aot =
+    if runs_in_aot.not then
+        Panic.throw "This benchmark must be run in AOT (The engine distribution must be build with NI)"
 
 runs_in_aot =
     prop = Java_System.getProperty "org.graalvm.nativeimage.imagecode"


### PR DESCRIPTION
Closes #13291

### Pull Request Description

Introduce `Native_Image_Startup` benchmarks. The old `Startup` benchmarks are kept intact to preserve history. 

### Important Notes

[Benchmark Standard Libraries GH workflow](https://github.com/enso-org/enso/actions/runs/15873473973/workflow) now builds NI with `ENSO_LAUNCHER=native`. See changes to [engine.rs](https://github.com/enso-org/enso/pull/13360/files#diff-ddb74013689698a7a9da05e81c3edcfb0ddd7fa8015f03546ea5476d3260acdf).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
