### PR TITLE
Extract native libs from jline (Second attempt)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5611,7 +5611,6 @@ lazy val createStdLibsIndexes =
 createStdLibsIndexes := {
   updateLibraryManifests.value
   buildEngineDistributionNoIndex.value
-  val modulesToCopy    = componentModulesPaths.value
   val distributionRoot = engineDistributionRoot.value
   val log              = streams.value.log
   val cacheFactory     = streams.value.cacheStoreFactory
@@ -5659,12 +5658,37 @@ ThisBuild / createEnginePackageNoIndex := {
   createEnginePackageNoIndex.result.value
 }
 
+lazy val extractNativeLibsFromEngine =
+  taskKey[AnalysisOfExtractedNativeLibs](
+    "Task that extracts native libraries from engine dependencies"
+  )
+
+ThisBuild / extractNativeLibsFromEngine := Def
+  .task {
+    import sbt.util.CacheImplicits._
+    val componentDir = engineDistributionRoot.value / "component"
+    val cacheFactory = streams.value.cacheStoreFactory
+    val updateReport = (`engine-runner` / update).value
+    val logger       = streams.value.log
+    val prev         = extractNativeLibsFromEngine.previous
+    EngineNativeLibraryExtractor.extractNativeLibraries(
+      componentDir,
+      logger,
+      updateReport,
+      scalaBinaryVersion.value,
+      cacheFactory,
+      prev
+    )
+  }
+  .dependsOn(createEnginePackageNoIndex)
+  .value
+
 lazy val buildEngineDistributionNoIndex =
   taskKey[Unit](
     "Builds the engine distribution without generating indexes and optionally generating native image"
   )
 buildEngineDistributionNoIndex := Def.taskIf {
-  createEnginePackageNoIndex.value
+  extractNativeLibsFromEngine.value
   if (shouldBuildNativeImage.value) {
     (`engine-runner` / buildNativeImage).value
     (`engine-runner` / checkNativeImageSize).value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -250,12 +250,14 @@ object Dependencies {
 
   // === JLine ==================================================================
   val jlineVersion = "3.26.3"
+  val jlineNative = Seq(
+    "org.jline" % "jline-native" % jlineVersion
+  )
   val jline = Seq(
     "org.jline" % "jline-terminal"     % jlineVersion,
     "org.jline" % "jline-terminal-jni" % jlineVersion, // The terminal provider jna has been deprecated, check your configuration.
-    "org.jline" % "jline-reader"       % jlineVersion,
-    "org.jline" % "jline-native"       % jlineVersion
-  )
+    "org.jline" % "jline-reader"       % jlineVersion
+  ) ++ jlineNative
 
   // === Google =================================================================
   val googleApiClientVersion         = "2.7.1"

--- a/project/EngineNativeLibraryExtractor.scala
+++ b/project/EngineNativeLibraryExtractor.scala
@@ -1,0 +1,171 @@
+import sbt.*
+import sbt.util.CacheStoreFactory
+
+object EngineNativeLibraryExtractor {
+  private val JLINE_NATIVE = "jline-native"
+
+  /** Extracts native libraries from engine jars (all transitive dependencies of
+    * engine).
+    *
+    * For every JAR file for which native libraries should be extracted:
+    * <ul>
+    *   <li>Extracts the native libraries into the `componentDir` directory.</li>
+    *   <li>Copies the rest of the JAR archive into a new JAR file with the
+    *   `-thin.jar` suffix, which contains only the non-native parts of the JAR.</li>
+    *   <li>Deletes the original (fat) JAR file from the `componentDir` directory.</li>
+    * </ul>
+    * @param componentDir Component directory where all the dependencies of engine are stored.
+    * @param updateReport Update report for the "engine-runner" project.
+    *            Get it with `(engine-runner/update).value`.
+    * @param scalaBinaryVersion
+    * @param cacheFactory
+    * @param previousRun
+    * @return
+    */
+  def extractNativeLibraries(
+    componentDir: File,
+    logger: Logger,
+    updateReport: UpdateReport,
+    scalaBinaryVersion: String,
+    cacheFactory: CacheStoreFactory,
+    previousRun: Option[AnalysisOfExtractedNativeLibs]
+  ): AnalysisOfExtractedNativeLibs = {
+    val jlineNativeJars = JPMSUtils.filterModulesFromUpdate(
+      updateReport,
+      Dependencies.jlineNative,
+      logger,
+      "engine-runner",
+      scalaBinaryVersion,
+      shouldContainAll = true
+    )
+    require(
+      jlineNativeJars.size == 1,
+      s"Expected exactly one jline-native jar, found: ${jlineNativeJars}."
+    )
+    val jlineNativeJar = jlineNativeJars.head
+    var analysis = previousRun
+      .getOrElse(AnalysisOfExtractedNativeLibs(Map.empty))
+    if (!componentDir.exists()) {
+      logger.error(
+        s"Component directory [$componentDir] does not exist yet. " +
+        "It must have been created with createEnginePackageNoIndex task."
+      )
+      throw new IllegalStateException("Component directory does not exist.")
+    }
+    logger.debug(
+      s"[EngineNativeLibraryExtractor] Extracting native libraries. " +
+      s"jlineNativeJar: $jlineNativeJar, analysis; $analysis"
+    )
+
+    getFromCache(jlineNativeJar, analysis) match {
+      case Some(cachedLibs) =>
+        logger.debug(
+          "jline-native libraries already extracted, skipping extraction."
+        )
+      case None =>
+        val outJarName = jlineNativeJar.getName.replace(
+          ".jar",
+          "-thin.jar"
+        )
+        val outJar = componentDir / outJarName
+        val extractedLibs = extractJLineNative(
+          jlineNativeJar,
+          outJar,
+          componentDir,
+          logger,
+          cacheFactory,
+          analysis
+        )
+        analysis = analysis.appended(
+          AnalysisOfExtractedNativeLibs(
+            from        = jlineNativeJar,
+            dynamicLibs = extractedLibs,
+            thinTarget  = Some(outJar)
+          )
+        )
+        // Delete the old fat jar.
+        // It is possible that it does not exist, in that case, just ignore the error.
+        deleteFromComponentDir(
+          componentDir,
+          jlineNativeJar
+        )
+    }
+    analysis
+  }
+
+  private def getFromCache(
+    jar: File,
+    prevRun: AnalysisOfExtractedNativeLibs
+  ): Option[List[File]] = {
+    prevRun.forJar(jar) match {
+      case None => None
+      case Some(summary) =>
+        if (summary.isOutdated) {
+          None
+        } else {
+          Some(summary.dynamicLibs)
+        }
+    }
+  }
+
+  private def extractJLineNative(
+    jLineJar: File,
+    outThinJar: File,
+    componentDir: File,
+    logger: Logger,
+    cacheFactory: CacheStoreFactory,
+    previousRun: AnalysisOfExtractedNativeLibs
+  ): List[File] = {
+    val (expectedLibEntry, renameTo) =
+      if (Platform.isLinux && Platform.isAmd64) {
+        ("Linux/x86_64/libjlinenative.so", "libjlinenative.so")
+      } else if (Platform.isLinux && Platform.isArm64) {
+        ("Linux/arm64/libjlinenative.so", "libjlinenative.so")
+      } else if (Platform.isWindows && Platform.isAmd64) {
+        ("Windows/x86_64/jlinenative.dll", "jlinenative.dll")
+      } else if (Platform.isMacOS && Platform.isAmd64) {
+        ("Mac/x86_64/libjlinenative.jnilib", "libjlinenative.dylib")
+      } else if (Platform.isMacOS && Platform.isArm64) {
+        ("Mac/arm64/libjlinenative.jnilib", "libjlinenative.dylib")
+      } else {
+        throw new RuntimeException(
+          s"Unsupported platform for JLine native library: ${StdBits.plainOsName()}"
+        )
+      }
+
+    val prefix = "org.jline.nativ"
+
+    def renameFunc(name: String): Option[String] = {
+      val strippedEntryName = name.substring(prefix.length + 1)
+      if (strippedEntryName == expectedLibEntry) {
+        Some(renameTo)
+      } else {
+        None
+      }
+    }
+
+    JARUtils
+      .extractFilesFromJar(
+        inputJarPath      = jLineJar.toPath,
+        outputJarPath     = Some(outThinJar.toPath),
+        extractPrefix     = None,
+        extractedFilesDir = componentDir.toPath,
+        renameFunc        = renameFunc,
+        logger            = logger,
+        cacheStoreFactory = cacheFactory,
+        previousRun       = previousRun.forJar(jLineJar),
+        copyMetaInf       = true
+      )
+      .get
+  }
+
+  /** @param jarDependency JAR file that resides somewhere in `$HOME/.cache/coursier`
+    */
+  private def deleteFromComponentDir(
+    componentDir: File,
+    jarDependency: File
+  ): Unit = {
+    val path = componentDir.toPath.resolve(jarDependency.getName)
+    IO.delete(path.toFile)
+  }
+}

--- a/project/EngineNativeLibraryExtractor.scala
+++ b/project/EngineNativeLibraryExtractor.scala
@@ -83,13 +83,13 @@ object EngineNativeLibraryExtractor {
             thinTarget  = Some(outJar)
           )
         )
-        // Delete the old fat jar.
-        // It is possible that it does not exist, in that case, just ignore the error.
-        deleteFromComponentDir(
-          componentDir,
-          jlineNativeJar
-        )
     }
+    // Delete the old fat jar.
+    // It is possible that it does not exist, in that case, just ignore the error.
+    deleteFromComponentDir(
+      componentDir,
+      jlineNativeJar
+    )
     analysis
   }
 

--- a/project/EngineNativeLibraryExtractor.scala
+++ b/project/EngineNativeLibraryExtractor.scala
@@ -68,6 +68,11 @@ object EngineNativeLibraryExtractor {
           "-thin.jar"
         )
         val outJar = componentDir / outJarName
+        if (outJar.exists()) {
+          // Extraction is not cache, but the output jar exist. We must first delete it.
+          // This can happen if sbt was restarted and the outputJar was not deleted.
+          IO.delete(outJar)
+        }
         val extractedLibs = extractJLineNative(
           jlineNativeJar,
           outJar,

--- a/project/JARUtils.scala
+++ b/project/JARUtils.scala
@@ -25,6 +25,11 @@ object JARUtils {
     * @param logger SBT's logger
     * @param cacheStoreFactory SBT's cache sotre factory
     * @param previousRun summary of previous extraction data, if available
+    * @param copyMetaInf If true and `outputJarPath` is not None, copies entries from `META-INF` directory
+    *           as well as `.class` entries from `inputJarPath` to `outputJarPath`. More specifically,
+    *           for every JAR entry from `inputJarPath`, it holds that, if `renameFunc` returns None, and
+    *           the entry ends with `.class` or starts with `META-INF/`, then the entry is copied
+    *           to `outputJarPath`.
     * @return list of extracted native libraries
     */
   def extractFilesFromJar(
@@ -35,7 +40,8 @@ object JARUtils {
     renameFunc: String => Option[String],
     logger: sbt.util.Logger,
     cacheStoreFactory: CacheStoreFactory,
-    previousRun: Option[ExtractedNativeLibSummary]
+    previousRun: Option[ExtractedNativeLibSummary],
+    copyMetaInf: Boolean = false
   ): Try[List[File]] = {
     val dependencyStore = cacheStoreFactory.make("extract-jar-files")
     val inputJarFile    = inputJarPath.toFile
@@ -45,9 +51,11 @@ object JARUtils {
     )
     var shouldExtract = false
     Tracked.diffInputs(dependencyStore, FileInfo.hash)(cachedFiles) { report =>
-      shouldExtract =
-        report.modified.nonEmpty || report.removed.nonEmpty || report.added.nonEmpty || outputJarPath
-          .exists(!_.toFile.exists())
+      val inputChanged =
+        report.modified.nonEmpty || report.removed.nonEmpty || report.added.nonEmpty
+      val outExists = outputJarPath
+        .exists(_.toFile.exists())
+      shouldExtract = inputChanged || !outExists
     }
 
     if (!shouldExtract) {
@@ -103,7 +111,15 @@ object JARUtils {
                         })
                       }
                     case None =>
-                      if (entry.getName.endsWith(".class")) {
+                      val entryName = entry.getName
+                      val shouldCopy = if (copyMetaInf) {
+                        entryName.startsWith("META-INF") || entryName.endsWith(
+                          ".class"
+                        )
+                      } else {
+                        entryName.endsWith(".class")
+                      }
+                      if (shouldCopy) {
                         outputJar.putNextEntry(new JarEntry(entry.getName))
                         Using(inputJar.getInputStream(entry)) { is =>
                           is.transferTo(outputJar)

--- a/test/Base_Tests/data/native_libs.json
+++ b/test/Base_Tests/data/native_libs.json
@@ -80,20 +80,6 @@
     "META-INF/resources/windows/amd64/lib-graalpython/python-native.dll",
     "META-INF/resources/windows/amd64/lib-graalpython/pythonjni.dll"
   ],
-  "component/jline-native-3.26.3.jar": [
-    "org/jline/nativ/FreeBSD/x86/libjlinenative.so",
-    "org/jline/nativ/FreeBSD/x86_64/libjlinenative.so",
-    "org/jline/nativ/Linux/arm/libjlinenative.so",
-    "org/jline/nativ/Linux/arm64/libjlinenative.so",
-    "org/jline/nativ/Linux/armv6/libjlinenative.so",
-    "org/jline/nativ/Linux/armv7/libjlinenative.so",
-    "org/jline/nativ/Linux/ppc64/libjlinenative.so",
-    "org/jline/nativ/Linux/x86/libjlinenative.so",
-    "org/jline/nativ/Linux/x86_64/libjlinenative.so",
-    "org/jline/nativ/Windows/arm64/jlinenative.dll",
-    "org/jline/nativ/Windows/x86/jlinenative.dll",
-    "org/jline/nativ/Windows/x86_64/jlinenative.dll"
-  ],
   "component/truffle-nfi-libffi-24.2.0.jar": [
     "META-INF/resources/nfi-native/libnfi/linux/amd64/bin/libtrufflenfi.so",
     "META-INF/resources/nfi-native/libnfi/linux/aarch64/bin/libtrufflenfi.so",


### PR DESCRIPTION
Follow-up of #13359

Closes #12449

### Pull Request Description

Brings back extraction of native libraries from `jline-native`. This time, I have made extensive local tests to ensure caching is not broken. The test is in [this gist](https://gist.github.com/Akirathan/431e4d60f5266a3ae271e6530a7ef7e2#file-cache_test-py).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
