### PR TITLE
Fix "Free plan" users going to cloud category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   Browser.][13266]
 - [Allow marking grouped component arguments as required or providing a default
   value.][13254]
+- [Fixed a bug, where "Free plan" user was redirected to Cloud directory,
+  resulting in an Error page without option of returning back to Local.][13366]
 
 [12774]: https://github.com/enso-org/enso/pull/12774
 [12778]: https://github.com/enso-org/enso/pull/12778
@@ -39,6 +41,7 @@
 [13161]: https://github.com/enso-org/enso/pull/13161
 [13266]: https://github.com/enso-org/enso/pull/13266
 [13254]: https://github.com/enso-org/enso/pull/13254
+[13366]: https://github.com/enso-org/enso/pull/13366
 
 #### Enso Standard Library
 

--- a/app/gui/src/dashboard/layouts/Drive.tsx
+++ b/app/gui/src/dashboard/layouts/Drive.tsx
@@ -68,7 +68,6 @@ function Drive(props: DriveProps) {
               <Button
                 size="medium"
                 variant="primary"
-                className="mx-auto"
                 onPress={() => {
                   setCategory('local')
                 }}

--- a/app/gui/src/dashboard/layouts/Drive.tsx
+++ b/app/gui/src/dashboard/layouts/Drive.tsx
@@ -64,8 +64,18 @@ function Drive(props: DriveProps) {
               {getText('upgrade')}
             </Button>
 
-            {!supportLocalBackend && (
+            {supportLocalBackend ?
               <Button
+                size="medium"
+                variant="primary"
+                className="mx-auto"
+                onPress={() => {
+                  setCategory('local')
+                }}
+              >
+                {getText('switchToLocal')}
+              </Button>
+            : <Button
                 data-testid="download-free-edition"
                 size="medium"
                 variant="accent"
@@ -80,7 +90,7 @@ function Drive(props: DriveProps) {
               >
                 {getText('downloadFreeEdition')}
               </Button>
-            )}
+            }
           </Button.Group>
         </result.Result>
       )

--- a/app/gui/src/dashboard/layouts/Drive/Categories/CategoriesProvider.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/CategoriesProvider.tsx
@@ -7,9 +7,9 @@
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useOffline } from '#/hooks/offlineHooks'
 import { useSearchParamsState } from '#/hooks/searchParamsStateHooks'
-import { useBackends } from '$/providers/react'
+import { useBackends, useFullUserSession } from '$/providers/react'
 import type { ReactNode } from 'react'
-import type { Category, CategoryId } from './Category'
+import { isCloudCategory, type Category, type CategoryId } from './Category'
 import {
   CategoriesContext,
   categoryIdStore,
@@ -33,23 +33,24 @@ export function CategoriesProvider(props: CategoriesProviderProps): React.JSX.El
 
   const { cloudCategories, localCategories, findCategoryById } = useCategories()
   const { backendForType, localBackend } = useBackends()
+  const { user } = useFullUserSession()
   const { isOffline } = useOffline()
 
   const [categoryId, privateSetCategoryId, privateResetCategoryId] =
     useSearchParamsState<CategoryId>(
       'driveCategory',
       () => {
-        const savedId = categoryIdStore.getState().categoryId
-
-        if (savedId != null && findCategoryById(savedId) != null) {
-          return savedId
+        const readSavedCategory = () => {
+          const id = categoryIdStore.getState().categoryId
+          if (id == null) return null
+          const category = findCategoryById(id)
+          if (category == null) return null
+          const unavailable = (!user.isEnabled || isOffline) && isCloudCategory(category)
+          if (unavailable) return null
+          return id
         }
 
-        if (isOffline && localBackend != null) {
-          return 'local'
-        }
-
-        return localBackend != null ? 'local' : 'cloud'
+        return readSavedCategory() ?? (localBackend != null ? 'local' : 'cloud')
       },
       // This is safe, because we enshure the type inside the function
       // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
### Pull Request Description

Fixes #13339

* When reading saved category, we ignore it if requires access to Cloud and the user doesn't have it.
* If the user strays to cloud category anyway, they are presented the button allowing going back to local

![image](https://github.com/user-attachments/assets/087c3e2c-dce8-42ff-8625-c1f452d7c36b)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
