### PR TITLE
Update Table Java Problems to be Long based

### DIFF
--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeIntegerColumnMaterializer.java
@@ -94,7 +94,7 @@ public class SnowflakeIntegerColumnMaterializer implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return currentSize;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -94,7 +94,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return size;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -255,7 +255,7 @@ public interface Builder {
   /**
    * @return the number of appended elements
    */
-  int getCurrentSize();
+  long getCurrentSize();
 
   /**
    * @return a storage containing all the items appended so far

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -185,7 +185,7 @@ public final class InferredBuilder implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return currentSize;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredIntegerBuilder.java
@@ -78,7 +78,7 @@ public final class InferredIntegerBuilder implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return bigIntegerBuilder != null
         ? bigIntegerBuilder.getCurrentSize()
         : longBuilder.getCurrentSize();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/MixedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/MixedBuilder.java
@@ -8,7 +8,7 @@ import org.enso.table.data.column.storage.type.StorageType;
 final class MixedBuilder extends ObjectBuilder implements BuilderWithRetyping {
   /** Creates a new builder with the given size. Copies the data from the given source Builder. */
   static MixedBuilder fromBuilder(Builder source, int capacity) {
-    var sourceCurrentSize = source.getCurrentSize();
+    var sourceCurrentSize = Builder.checkSize(source.getCurrentSize());
 
     var dataSize = Math.max(capacity, sourceCurrentSize);
     var builder = new MixedBuilder(dataSize);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NullBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NullBuilder.java
@@ -35,7 +35,7 @@ final class NullBuilder implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return length;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -18,7 +18,7 @@ abstract class NumericBuilder implements Builder {
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return currentSize;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/TypedBuilder.java
@@ -75,7 +75,7 @@ abstract class TypedBuilder<T> implements BuilderWithRetyping, BuilderForType<T>
   }
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return currentSize;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
@@ -180,7 +180,7 @@ public final class IsInOperation {
         Builder.getForBoolean(storage.getSize()),
         (builder, index, value) -> {
           if (value instanceof Double || value instanceof Float) {
-            problemAggregator.reportFloatingPointEquality((int)index);
+            problemAggregator.reportFloatingPointEquality(index);
           }
 
           if (contains.test(result.uniqueValues, value)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/BinaryOperator.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/BinaryOperator.java
@@ -148,7 +148,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         Double doDouble(
             double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b == 0.0) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
           }
           return a % b;
         }
@@ -156,7 +156,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         @Override
         Long doLong(long a, long b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b == 0) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
             return null;
           }
 
@@ -167,7 +167,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         BigInteger doBigInteger(
             BigInteger a, BigInteger b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b.equals(BigInteger.ZERO)) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
             return null;
           }
 
@@ -178,7 +178,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         BigDecimal doBigDecimal(
             BigDecimal a, BigDecimal b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b.equals(BigDecimal.ZERO)) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
             return null;
           }
 
@@ -192,7 +192,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         Double doDouble(
             double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b == 0.0) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
           }
           return a / b;
         }
@@ -213,7 +213,7 @@ public abstract class BinaryOperator<T> extends BinaryOperationNumeric<T, T> {
         BigDecimal doBigDecimal(
             BigDecimal a, BigDecimal b, long ix, MapOperationProblemAggregator problemAggregator) {
           if (b.equals(BigDecimal.ZERO)) {
-            problemAggregator.reportDivisionByZero((int) ix);
+            problemAggregator.reportDivisionByZero(ix);
             return null;
           }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/NumericComparators.java
@@ -39,7 +39,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
         @Override
         boolean doDouble(
             double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
-          problemAggregator.reportFloatingPointEquality((int) ix);
+          problemAggregator.reportFloatingPointEquality(ix);
           return a == b;
         }
 
@@ -64,7 +64,7 @@ abstract class NumericComparators<T> extends BinaryOperationNumeric<T, Boolean> 
         @Override
         boolean doDouble(
             double a, double b, long ix, MapOperationProblemAggregator problemAggregator) {
-          problemAggregator.reportFloatingPointEquality((int) ix);
+          problemAggregator.reportFloatingPointEquality(ix);
           return a != b;
         }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/NumericUnaryOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/NumericUnaryOperation.java
@@ -83,7 +83,7 @@ public abstract class NumericUnaryOperation implements UnaryOperation {
           default -> {
             builder.appendNulls(1);
             problemAggregator.reportIllegalArgumentError(
-                "Unsupported type for signum operation: " + item, Math.toIntExact(i));
+                "Unsupported type for signum operation: " + item, i);
           }
         }
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/RoundOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/RoundOperation.java
@@ -61,7 +61,7 @@ public class RoundOperation<T, R> extends UnaryOperationNumeric<T, R> {
       boolean special = Double.isNaN(value) || Double.isInfinite(value);
       if (special) {
         String message = "Value is " + value;
-        problemAggregator.reportArithmeticError(message, (int) index);
+        problemAggregator.reportArithmeticError(message, index);
         return null;
       }
 
@@ -75,7 +75,7 @@ public class RoundOperation<T, R> extends UnaryOperationNumeric<T, R> {
       boolean special = Double.isNaN(value) || Double.isInfinite(value);
       if (special) {
         String message = "Value is " + value;
-        problemAggregator.reportArithmeticError(message, (int) index);
+        problemAggregator.reportArithmeticError(message, index);
         return null;
       }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/RoundOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/RoundOperation.java
@@ -43,7 +43,7 @@ public class RoundOperation<T, R> extends UnaryOperationNumeric<T, R> {
     return (index, value, problemAggregator) -> {
       if (value < ROUND_MIN_LONG || value > ROUND_MAX_LONG) {
         String message = ROUND_LONG_ERROR + value;
-        problemAggregator.reportIllegalArgumentError(message, (int) index);
+        problemAggregator.reportIllegalArgumentError(message, index);
         return null;
       }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/SignumOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/SignumOperation.java
@@ -89,7 +89,7 @@ public final class SignumOperation implements UnaryOperation {
           default -> {
             builder.appendNulls(1);
             problemAggregator.reportIllegalArgumentError(
-                "Unsupported type for signum operation: " + item, Math.toIntExact(i));
+                "Unsupported type for signum operation: " + item, i);
           }
         }
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
@@ -92,7 +92,7 @@ public abstract class MultiValueKeyBase {
         if (NumericConverter.isFloatLike(this.get(columnIx))) {
           problemAggregator.reportColumnAggregatedProblem(
               new FloatingPointGrouping(
-                  columnNameMapping.getColumnName(columnIx), Math.toIntExact(rowIndex)));
+                  columnNameMapping.getColumnName(columnIx), rowIndex));
         }
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
@@ -91,8 +91,7 @@ public abstract class MultiValueKeyBase {
       for (int columnIx = 0; columnIx < storages.length; columnIx++) {
         if (NumericConverter.isFloatLike(this.get(columnIx))) {
           problemAggregator.reportColumnAggregatedProblem(
-              new FloatingPointGrouping(
-                  columnNameMapping.getColumnName(columnIx), rowIndex));
+              new FloatingPointGrouping(columnNameMapping.getColumnName(columnIx), rowIndex));
         }
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticError.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticError.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class ArithmeticError extends ColumnAggregatedProblem {
   private final String message;
 
-  public ArithmeticError(String locationName, String message, Integer row) {
+  public ArithmeticError(String locationName, String message, Long row) {
     super(locationName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticError.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticError.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class ArithmeticError extends ColumnAggregatedProblem {
   private final String message;
 
-  public ArithmeticError(String locationName, String message, Long row) {
+  public ArithmeticError(String locationName, String message, long row) {
     super(locationName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/ColumnAggregatedProblem.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/ColumnAggregatedProblem.java
@@ -7,9 +7,9 @@ import org.enso.table.problems.Problem;
 
 public abstract class ColumnAggregatedProblem implements Problem {
   private final String locationName;
-  protected final List<Integer> rows;
+  protected final List<Long> rows;
 
-  protected ColumnAggregatedProblem(String locationName, Integer row) {
+  protected ColumnAggregatedProblem(String locationName, Long row) {
     this.locationName = locationName;
     this.rows = new ArrayList<>();
     this.rows.add(row);
@@ -19,8 +19,8 @@ public abstract class ColumnAggregatedProblem implements Problem {
     return locationName;
   }
 
-  public int[] getRows() {
-    return rows.stream().mapToInt(Integer::intValue).toArray();
+  public List<Long> getRows() {
+    return rows;
   }
 
   public int count() {

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/FloatingPointGrouping.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/FloatingPointGrouping.java
@@ -1,7 +1,7 @@
 package org.enso.table.data.table.problems;
 
 public class FloatingPointGrouping extends ColumnAggregatedProblem {
-  public FloatingPointGrouping(String columnName, int row) {
+  public FloatingPointGrouping(String columnName, long row) {
     super(columnName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNaN.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNaN.java
@@ -2,7 +2,7 @@ package org.enso.table.data.table.problems;
 
 public class IgnoredNaN extends ColumnAggregatedProblem {
 
-  public IgnoredNaN(String locationName, Integer row) {
+  public IgnoredNaN(String locationName, Long row) {
     super(locationName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNaN.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNaN.java
@@ -2,7 +2,7 @@ package org.enso.table.data.table.problems;
 
 public class IgnoredNaN extends ColumnAggregatedProblem {
 
-  public IgnoredNaN(String locationName, Long row) {
+  public IgnoredNaN(String locationName, long row) {
     super(locationName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNothing.java
@@ -2,7 +2,7 @@ package org.enso.table.data.table.problems;
 
 public class IgnoredNothing extends ColumnAggregatedProblem {
 
-  public IgnoredNothing(String locationName, Integer row) {
+  public IgnoredNothing(String locationName, Long row) {
     super(locationName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IgnoredNothing.java
@@ -2,7 +2,7 @@ package org.enso.table.data.table.problems;
 
 public class IgnoredNothing extends ColumnAggregatedProblem {
 
-  public IgnoredNothing(String locationName, Long row) {
+  public IgnoredNothing(String locationName, long row) {
     super(locationName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IllegalArgumentError.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IllegalArgumentError.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class IllegalArgumentError extends ColumnAggregatedProblem {
   private final String message;
 
-  public IllegalArgumentError(String locationName, String message, Integer row) {
+  public IllegalArgumentError(String locationName, String message, Long row) {
     super(locationName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/IllegalArgumentError.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/IllegalArgumentError.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class IllegalArgumentError extends ColumnAggregatedProblem {
   private final String message;
 
-  public IllegalArgumentError(String locationName, String message, Long row) {
+  public IllegalArgumentError(String locationName, String message, long row) {
     super(locationName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/InvalidAggregation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/InvalidAggregation.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class InvalidAggregation extends ColumnAggregatedProblem {
   private final String message;
 
-  public InvalidAggregation(String columnName, int row, String message) {
+  public InvalidAggregation(String columnName, long row, String message) {
     super(columnName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
@@ -25,7 +25,7 @@ public class MapOperationProblemAggregator extends ColumnAggregatedProblemAggreg
     reportColumnAggregatedProblem(new FloatingPointGrouping(location, row));
   }
 
-  public void reportArithmeticError(String message, Integer row) {
+  public void reportArithmeticError(String message, Long row) {
     reportColumnAggregatedProblem(new ArithmeticError(location, message, row));
   }
 
@@ -49,7 +49,7 @@ public class MapOperationProblemAggregator extends ColumnAggregatedProblemAggreg
     }
   }
 
-  public void reportDivisionByZero(Integer row) {
+  public void reportDivisionByZero(Long row) {
     reportArithmeticError("Division by zero", row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
@@ -25,11 +25,11 @@ public class MapOperationProblemAggregator extends ColumnAggregatedProblemAggreg
     reportColumnAggregatedProblem(new FloatingPointGrouping(location, row));
   }
 
-  public void reportArithmeticError(String message, Long row) {
+  public void reportArithmeticError(String message, long row) {
     reportColumnAggregatedProblem(new ArithmeticError(location, message, row));
   }
 
-  public void reportIllegalArgumentError(String message, Integer row) {
+  public void reportIllegalArgumentError(String message, long row) {
     reportColumnAggregatedProblem(new IllegalArgumentError(location, message, row));
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
@@ -21,7 +21,7 @@ public class MapOperationProblemAggregator extends ColumnAggregatedProblemAggreg
     this.location = location;
   }
 
-  public void reportFloatingPointEquality(int row) {
+  public void reportFloatingPointEquality(long row) {
     reportColumnAggregatedProblem(new FloatingPointGrouping(location, row));
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/MapOperationProblemAggregator.java
@@ -41,15 +41,7 @@ public class MapOperationProblemAggregator extends ColumnAggregatedProblemAggreg
     }
   }
 
-  public void reportOverflow(StorageType<?> targetType, String op) {
-    overflowCount++;
-    if (overflowTargetType == null) {
-      overflowTargetType = targetType;
-      overflowExample = new Object[] {op};
-    }
-  }
-
-  public void reportDivisionByZero(Long row) {
+  public void reportDivisionByZero(long row) {
     reportArithmeticError("Division by zero", row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/UnquotedCharactersInOutput.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/UnquotedCharactersInOutput.java
@@ -1,7 +1,7 @@
 package org.enso.table.data.table.problems;
 
 public class UnquotedCharactersInOutput extends ColumnAggregatedProblem {
-  public UnquotedCharactersInOutput(String columnName, int row) {
+  public UnquotedCharactersInOutput(String columnName, long row) {
     super(columnName, row);
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/UnquotedDelimiter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/UnquotedDelimiter.java
@@ -3,7 +3,7 @@ package org.enso.table.data.table.problems;
 public class UnquotedDelimiter extends ColumnAggregatedProblem {
   private final String message;
 
-  public UnquotedDelimiter(String columnName, int row, String message) {
+  public UnquotedDelimiter(String columnName, long row, String message) {
     super(columnName, row);
     this.message = message;
   }

--- a/std-bits/table/src/main/java/org/enso/table/operations/AddRunning.java
+++ b/std-bits/table/src/main/java/org/enso/table/operations/AddRunning.java
@@ -203,13 +203,13 @@ public class AddRunning {
       Object value = sourceColumn.getStorage().getItemBoxed(i);
       if (value == null) {
         columnAggregatedProblemAggregator.reportColumnAggregatedProblem(
-            new IgnoredNothing(sourceColumn.getName(), i));
+            new IgnoredNothing(sourceColumn.getName(), (long) i));
       }
       T dValue = typeHandler.tryConvertingToType(value);
       T dNextValue;
       if (dValue != null && dValue.equals(Double.NaN)) {
         columnAggregatedProblemAggregator.reportColumnAggregatedProblem(
-            new IgnoredNaN(sourceColumn.getName(), i));
+            new IgnoredNaN(sourceColumn.getName(), (long) i));
         dNextValue = it.currentValue();
       } else {
         dNextValue = it.next(dValue);

--- a/std-bits/table/src/main/java/org/enso/table/parsing/problems/InvalidFormat.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/problems/InvalidFormat.java
@@ -6,4 +6,4 @@ import org.graalvm.polyglot.Value;
 
 /** Indicates that a text value did not match the format expected of a datatype. */
 public record InvalidFormat(
-    String column, Value expectedEnsoValueType, int count, List<String> cells) implements Problem {}
+    String column, Value expectedEnsoValueType, long count, List<String> cells) implements Problem {}

--- a/std-bits/table/src/main/java/org/enso/table/parsing/problems/InvalidFormat.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/problems/InvalidFormat.java
@@ -6,4 +6,5 @@ import org.graalvm.polyglot.Value;
 
 /** Indicates that a text value did not match the format expected of a datatype. */
 public record InvalidFormat(
-    String column, Value expectedEnsoValueType, long count, List<String> cells) implements Problem {}
+    String column, Value expectedEnsoValueType, long count, List<String> cells)
+    implements Problem {}

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -30,8 +30,10 @@ type Data
         t3_with_nulls = Table.new [["A", [1, Nothing, 3]], ["B", [4, Nothing, Nothing]], ["C", [7, Nothing, Nothing]]]
         t4_with_space = Table.new [["A", ['hello', '   leading space', 'trailing space    ']], ["B", ['a', 'b', 'c']], ["C", [7, 8, 9]]]
         t5_with_non_trivial_ws = Table.new [["A", ['hello', 'extra \r space', 'world']], ["B", ['a', 'b', 'c']], ["C", [7, 8, 9]]]
-        [t, t2, t3_with_nulls, t4_with_space, t5_with_non_trivial_ws]
 
+        result = [t, t2, t3_with_nulls, t4_with_space, t5_with_non_trivial_ws]
+        result.map .column_info
+        result
 
 type Foo
     Value x
@@ -192,6 +194,8 @@ add_specs suite_builder =
         
         group_builder.specify "should set required numeric formatting to true if one or more entry is greater than/ less than +/999999" <|
             num_table = Table.new [["A", [1, 2, 3]], ["B", [12345678, 5,6]], ["C", [-12345678, -5,6]]]
+            ## Read the column_info as that will force materialization of the metrics
+            num_table.column_info
             vis = Visualization.prepare_visualization num_table 1000
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             json = make_json header=["A", "B", "C"] data=[[1, 2, 3], [12345678, 5,6], [-12345678, -5,6]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True is_ssrm=False get_child_node="get_row" range=["1 - 3","5 - 12345678","-12345678 - 6"] number_of_distinct=[3,3,3] number_of_nothing=[0,0,0] requires_number_format=[False, True, True] is_using_multi_filter=[True, True, True] use_bottom_status_bar=True enable_create_node=True


### PR DESCRIPTION
### Pull Request Description

- Changes `Builder.getCurrentSize` to be long.
- Update all the problems to take long and build a Long list.
- Small fix for Viz test issues.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
  -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - 