### PR TITLE
IGV that works with GraalVM 24.0.1 is out

### DIFF
--- a/tools/enso4igv/IGV.md
+++ b/tools/enso4igv/IGV.md
@@ -19,9 +19,9 @@ major operating systems.
 
 Visit [GraalVM's IGV page](https://www.graalvm.org/22.1/tools/igv/) to read and
 download _IGV_. Or follow
-[this link](https://lafo.ssw.uni-linz.ac.at/pub/idealgraphvisualizer/idealgraphvisualizer-1.20-ea624c6066a.zip)
+[this link](https://lafo.ssw.uni-linz.ac.at/pub/idealgraphvisualizer/idealgraphvisualizer-1.22-6cb0d3acbb1.zip)
 to get ZIP with the most up to date version of _Ideal Graph Visualizer_ (as of
-June 2024). Then:
+June 2025, known to work with GraalVM 24.0.1). Then:
 
 ```bash
 $ unzip idealgraphvisualizer-*.zip
@@ -135,6 +135,12 @@ nodes_ refer to what lines in the our _Enso_ program. Click _Navigate to Source_
 icon in the _Stack View_ to get from graph node to source. Select a drop down
 widget in the editor toolbar to show you what compiler nodes as associated with
 currently selected line.
+
+## Syntax Coloring
+
+To enable syntax coloring you may need to download and install text mate
+module into IGV. Download [its NBM file](https://repo1.maven.org/maven2/org/netbeans/api/org-netbeans-modules-textmate-lexer/RELEASE260/org-netbeans-modules-textmate-lexer-RELEASE260.nbm)
+and install in _Plugins_ dialog.
 
 ## Building
 

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -103,6 +103,7 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-textmate-lexer</artifactId>
             <version>${netbeans.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>

--- a/tools/enso4igv/src/main/nbm/manifest.mf
+++ b/tools/enso4igv/src/main/nbm/manifest.mf
@@ -3,4 +3,8 @@ OpenIDE-Module-Install: org/enso/tools/enso4igv/Installer.class
 OpenIDE-Module-Layer: org/enso/tools/enso4igv/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/enso/tools/enso4igv/Bundle.properties
 Multi-Release: true
-OpenIDE-Module-Recommends: cnb.org.netbeans.modules.java.kit, cnb.org.netbeans.modules.debugger.jpda.truffle, cnd.org.netbeans.modules.terminal, cnd.org.netbeans.modules.git
+OpenIDE-Module-Recommends: cnb.org.netbeans.modules.java.kit,
+ cnb.org.netbeans.modules.debugger.jpda.truffle,
+ cnd.org.netbeans.modules.terminal,
+ cnd.org.netbeans.modules.git
+ cnd.org.netbeans.modules.textmate.lexer


### PR DESCRIPTION
### Pull Request Description

New version of IGV has been released in https://github.com/oracle/graal/pull/11421 - updating our instructions and dependencies.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually tested by the crew