### PR TITLE
More robust formatting during logging

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
@@ -20,4 +20,19 @@ public class ObservedMessageTest {
             });
     assertEquals("One message", 1, arr.size());
   }
+
+  @Test
+  public void messageWithoutAnyArgumentsInSystemLogger() throws Exception {
+    var slf4j = LoggerFactory.getLogger("my.test.logger");
+    var logger = System.getLogger(slf4j.getName());
+    var msg = "strange / message with {} various elements";
+    var arr =
+        ObservedMessage.collect(
+            slf4j,
+            () -> {
+              logger.log(Level.WARNING, msg, (Object[]) null);
+            });
+    assertEquals("One message", 1, arr.size());
+    assertEquals("The right message", msg, arr.get(0).getFormattedMessage());
+  }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/progress/ObservedMessageTest.java
@@ -35,4 +35,24 @@ public class ObservedMessageTest {
     assertEquals("One message", 1, arr.size());
     assertEquals("The right message", msg, arr.get(0).getFormattedMessage());
   }
+
+  @Test
+  public void messageWithWrongArgsInSystemLogger() throws Exception {
+    var slf4j = LoggerFactory.getLogger("my.test.logger");
+    var logger = System.getLogger(slf4j.getName());
+    var msg = "strange / message with {0:number} various elements";
+    var arr =
+        ObservedMessage.collect(
+            slf4j,
+            () -> {
+              logger.log(Level.INFO, msg, "not a number");
+            });
+    assertEquals("Two messages", 2, arr.size());
+    assertEquals(
+        "First of all parsing problem is returned",
+        org.slf4j.event.Level.WARN,
+        arr.get(0).getLevel());
+    assertEquals("Then the original message is logged", msg, arr.get(1).getFormattedMessage());
+    assertEquals("With its level", org.slf4j.event.Level.INFO, arr.get(1).getLevel());
+  }
 }

--- a/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
@@ -44,7 +44,7 @@ public final class SystemLoggerViaSlf4j extends System.LoggerFinder {
     public void log(Level level, ResourceBundle bundle, String format, Object... params) {
       if (isLoggable(level)) {
         var m = readMsg(bundle, format);
-        var formatted = MessageFormat.format(m, params);
+        var formatted = params != null && params.length > 0 ? MessageFormat.format(m, params) : m;
         delegate.atLevel(at(level)).log(formatted);
       }
     }

--- a/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logging/config/systemlogger/SystemLoggerViaSlf4j.java
@@ -41,11 +41,17 @@ public final class SystemLoggerViaSlf4j extends System.LoggerFinder {
     }
 
     @Override
-    public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+    public void log(Level level, ResourceBundle bundle, String formatOrMessage, Object... params) {
       if (isLoggable(level)) {
-        var m = readMsg(bundle, format);
-        var formatted = params != null && params.length > 0 ? MessageFormat.format(m, params) : m;
-        delegate.atLevel(at(level)).log(formatted);
+        var msg = readMsg(bundle, formatOrMessage);
+        if (params != null && params.length > 0) {
+          try {
+            msg = MessageFormat.format(msg, params);
+          } catch (IllegalArgumentException ex) {
+            delegate.warn(msg, ex);
+          }
+        }
+        delegate.atLevel(at(level)).log(msg);
       }
     }
 


### PR DESCRIPTION
### Pull Request Description

Enhances #13356 by handling of cases when formatting isn't requested. Eliminates for example following exception:
```
️Execution finished with an error: can't parse argument number: GET /tableau/macos-x64/hyperd HTTP/1.1: null
 at <java> java.base/java.text.MessageFormat.setFormatFromPattern(MessageFormat.java:1644)
 ️at <java> java.base/java.text.MessageFormat.applyPatternImpl(MessageFormat.java:660)
 ️at <java> java.base/java.text.MessageFormat.<init>(MessageFormat.java:516)
 ️at <java> java.base/java.text.MessageFormat.format(MessageFormat.java:1058)
 ️at <java> org.enso.logging.config/systemlogger.SystemLoggerViaSlf4j$Bridge.log(SystemLoggerViaSlf4j.java:47)
 ```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
