### PR TITLE
Remove Radek from CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,23 +42,23 @@ tsconfig.json
 /app/ydoc-server-polyglot/ @Frizi @farmaazon @vitvakatu @kazcw @AdRiley
 /app/ydoc-shared/ @Frizi @farmaazon @vitvakatu @kazcw @AdRiley
 # The data-link schema is owned by the libraries team
-/app/gui/src/dashboard/data/datalinkSchema.json @radeusgd @jdunkerley @GregoryTravis @AdRiley
-/app/gui/src/dashboard/data/__tests__ @radeusgd @jdunkerley @GregoryTravis @AdRiley @PabloBuchu @indiv0 @somebody1234
+/app/gui/src/dashboard/data/datalinkSchema.json @jdunkerley @GregoryTravis @AdRiley
+/app/gui/src/dashboard/data/__tests__ @jdunkerley @GregoryTravis @AdRiley @PabloBuchu @indiv0 @somebody1234
 
 # Engine (old)
 # This section should be removed once the engine moves to /app/engine
 /build.sbt @4e6 @jaroslavtulach @hubertp @Akirathan
-/distribution/ @4e6 @jdunkerley @radeusgd @GregoryTravis @AdRiley
+/distribution/ @4e6 @jdunkerley @hubertp @GregoryTravis @AdRiley
 /engine/ @4e6 @jaroslavtulach @hubertp @Akirathan
 /project/ @4e6 @jaroslavtulach @hubertp @Akirathan
-/tools/ @4e6 @jaroslavtulach @radeusgd @hubertp
+/tools/ @4e6 @jaroslavtulach @hubertp
 
 # Enso Libraries
 # This section should be amended once the engine moves to /app/engine
-/distribution/lib/ @jdunkerley @radeusgd @GregoryTravis @AdRiley
-/std-bits/ @jdunkerley @radeusgd @GregoryTravis @AdRiley
-/test/ @jdunkerley @radeusgd @GregoryTravis @AdRiley
-/tools/http-test-helper/ @radeusgd @jdunkerley @GregoryTravis @AdRiley
+/distribution/lib/ @jdunkerley @hubertp @GregoryTravis @AdRiley
+/std-bits/ @jdunkerley @hubertp @GregoryTravis @AdRiley
+/test/ @jdunkerley @hubertp @GregoryTravis @AdRiley
+/tools/http-test-helper/ @hubertp @jdunkerley @GregoryTravis @AdRiley
 
 # Licenses
 /distribution/engine/
@@ -67,4 +67,4 @@ tsconfig.json
 /tools/legal-review/
 
 # The default project template is owned by the libraries team
-/lib/scala/pkg/src/main/resources/default/src/ @radeusgd @jdunkerley @GregoryTravis @AdRiley
+/lib/scala/pkg/src/main/resources/default/src/ @hubertp @jdunkerley @GregoryTravis @AdRiley


### PR DESCRIPTION
### Pull Request Description

- Remove Radek as code owner.
- Added Hubert to lib space.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
