### PR TITLE
Fix offline login

### DIFF
--- a/app/gui/src/providers/auth.ts
+++ b/app/gui/src/providers/auth.ts
@@ -273,8 +273,7 @@ function createAuthStore(
   return proxyRefs({
     refetchSession,
     session: effectiveUserData,
-    waitForSession: () =>
-      sessionData.waitForSession().then(() => queryClient.ensureQueryData(usersMeQueryOptions)),
+    waitForSession: () => sessionData.waitForSession().then(() => usersMeQuery.suspense()),
     setUsername,
     isUserMarkedForDeletion,
     isUserDeleted,

--- a/app/gui/src/providers/session.ts
+++ b/app/gui/src/providers/session.ts
@@ -22,9 +22,6 @@ export function createSessionQuery(authService: cognito.ISessionProvider) {
   return vueQuery.queryOptions({
     queryKey: ['userSession'],
     queryFn: async () => authService.userSession().catch(() => null),
-    meta: {
-      persist: false,
-    },
   })
 }
 
@@ -297,7 +294,7 @@ export function createSessionStore(
   return proxyRefs({
     signUp,
     session: session.data,
-    waitForSession: () => queryClient.ensureQueryData(sessionQueryOptions),
+    waitForSession: session.suspense,
     isLoggingOut,
     confirmSignUp,
     signInWithPassword,


### PR DESCRIPTION
### Pull Request Description

Fixes a bug reported by James

When moving auth providers to Vue, I had wrong assumptions about why we actually cache things in tanstack query. So now: 
* session id is now cached, and used in offline mode
* in online mode, the navigation guard of ProtectedLayout will wait for suspense, so we won't read cached data (probably accidentally, because we don't wait for [cache restore](https://github.com/TanStack/query/issues/6148#issuecomment-1761263234) - but this is how it worked in react).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
