### PR TITLE
Rename "Group Components" to "User Defined Components"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [New Right Panel Tab with Markdown Description Editor][13347]
 - [Fixed a bug, where "Free plan" user was redirected to Cloud directory,
   resulting in an Error page without option of returning back to Local.][13366]
+- ["Grouped Components" are renamed to "User Defined Components"][13389]
 
 [12774]: https://github.com/enso-org/enso/pull/12774
 [12778]: https://github.com/enso-org/enso/pull/12778
@@ -44,6 +45,7 @@
 [13254]: https://github.com/enso-org/enso/pull/13254
 [13347]: https://github.com/enso-org/enso/pull/13347
 [13366]: https://github.com/enso-org/enso/pull/13366
+[13389]: https://github.com/enso-org/enso/pull/13389
 
 #### Enso Standard Library
 

--- a/app/gui/integration-test/project-view/actions.ts
+++ b/app/gui/integration-test/project-view/actions.ts
@@ -40,7 +40,7 @@ export async function expectNodePositionsInitialized(page: Page, yPos: number) {
   )
 }
 
-/** Exit the currently opened graph (of collapsed function). */
+/** Exit the currently opened graph (of User Defined Component). */
 export async function exitFunction(page: Page, x = 300, y = 300) {
   await locate.graphEditor(page).dblclick({ position: { x, y } })
 }

--- a/app/gui/integration-test/project-view/collapsingAndEntering.spec.ts
+++ b/app/gui/integration-test/project-view/collapsingAndEntering.spec.ts
@@ -1,7 +1,7 @@
 import { test, type Page } from '@playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
-import { mockCollapsedFunctionInfo } from './expressionUpdates'
+import { mockUserDefinedFunctionInfo } from './expressionUpdates'
 import { CONTROL_KEY, DELETE_KEY } from './keyboard'
 import * as locate from './locate'
 import { edgesFromNode, edgesToNode } from './locate'
@@ -14,13 +14,13 @@ const COLLAPSE_SHORTCUT = `${CONTROL_KEY}+G`
 
 test('Entering nodes', async ({ page }) => {
   await actions.goToGraph(page)
-  await mockCollapsedFunctionInfo(page, 'final', 'func1')
+  await mockUserDefinedFunctionInfo(page, 'final', 'func1')
   await expectInsideMain(page)
   await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project'])
 
   await locate.graphNodeByBinding(page, 'final').dblclick()
   await expectInsideFunc1(page)
-  await mockCollapsedFunctionInfo(page, 'f2', 'func2')
+  await mockUserDefinedFunctionInfo(page, 'f2', 'func2')
   await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project', 'func1'])
 
   await locate.graphNodeByBinding(page, 'f2').dblclick()
@@ -30,7 +30,7 @@ test('Entering nodes', async ({ page }) => {
 
 test('Entering component shows error when function cannot be found (#12533)', async ({ page }) => {
   await actions.goToGraph(page)
-  await mockCollapsedFunctionInfo(page, 'final', 'no_such_func')
+  await mockUserDefinedFunctionInfo(page, 'final', 'no_such_func')
   await expectInsideMain(page)
   await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project'])
   await locate.graphNodeByBinding(page, 'final').dblclick()
@@ -76,7 +76,7 @@ test('Using breadcrumbs to navigate', async ({ page }) => {
 test('Collapsing nodes', async ({ page }) => {
   await actions.goToGraph(page)
   const initialNodesCount = await locate.graphNode(page).count()
-  await mockCollapsedFunctionInfo(page, 'final', 'func1')
+  await mockUserDefinedFunctionInfo(page, 'final', 'func1')
 
   // Widgets may "steal" clicks, so we always click at icon.
   await locate
@@ -94,11 +94,11 @@ test('Collapsing nodes', async ({ page }) => {
 
   await page.getByTestId('action:components.collapse').click()
   await expect(locate.graphNode(page)).toHaveCount(initialNodesCount - 2)
-  await mockCollapsedFunctionInfo(page, 'prod', 'collapsed')
+  await mockUserDefinedFunctionInfo(page, 'prod', 'user_defined_component')
   await mockSuggestion(page, {
     type: 'method',
     module: 'local.Mock_Project',
-    name: 'collapsed',
+    name: 'user_defined_component',
     isStatic: true,
     arguments: [{ name: 'five', reprType: 'Any', isSuspended: false, hasDefault: false }],
     selfType: 'local.Mock_Project',
@@ -108,7 +108,7 @@ test('Collapsing nodes', async ({ page }) => {
   const collapsedNode = locate.graphNodeByBinding(page, 'prod')
   await expect(collapsedNode.locator('.WidgetApplication.prefix > .WidgetPort')).toExist()
   await expect(collapsedNode.locator('.WidgetApplication.prefix > .WidgetPort')).toHaveText(
-    'Main.collapsed',
+    'Main.user_defined_component',
   )
   await expect(collapsedNode.locator('.WidgetTopLevelArgument')).toHaveText('five')
 
@@ -129,14 +129,18 @@ test('Collapsing nodes', async ({ page }) => {
   await expect(locate.inputNode(page)).toHaveCount(1)
 
   const secondCollapsedNode = locate.graphNodeByBinding(page, 'ten')
-  await expect(secondCollapsedNode.locator('.WidgetToken')).toHaveText(['Main', '.', 'collapsed1'])
-  await mockCollapsedFunctionInfo(page, 'ten', 'collapsed1')
+  await expect(secondCollapsedNode.locator('.WidgetToken')).toHaveText([
+    'Main',
+    '.',
+    'user_defined_component1',
+  ])
+  await mockUserDefinedFunctionInfo(page, 'ten', 'user_defined_component1')
   await secondCollapsedNode.dblclick()
   await expect(locate.graphNode(page)).toHaveCount(2)
   await expect(locate.graphNodeByBinding(page, 'ten')).toExist()
 })
 
-test('Display message when collapsed component ceases to exist', async ({ page }) => {
+test('Display message when User Defined Component ceases to exist', async ({ page }) => {
   await actions.goToGraph(page)
 
   const initialNodesCount = await locate.graphNode(page).count()
@@ -150,7 +154,7 @@ test('Display message when collapsed component ceases to exist', async ({ page }
     .click({ modifiers: ['Shift'] })
   await page.getByTestId('action:components.collapse').click()
   await expect(locate.graphNode(page)).toHaveCount(initialNodesCount - 1)
-  await mockCollapsedFunctionInfo(page, 'prod', 'collapsed')
+  await mockUserDefinedFunctionInfo(page, 'prod', 'user_defined_component')
 
   const collapsedNode = locate.graphNodeByBinding(page, 'prod')
   await locate.graphNodeIcon(collapsedNode).dblclick()
@@ -221,7 +225,7 @@ test('Output node is not collapsed', async ({ page }) => {
   await expect(locate.graphNodeByBinding(page, 'r').locator('.WidgetToken')).toHaveText([
     'Main',
     '.',
-    'collapsed',
+    'user_defined_component',
     'a',
   ])
   await expect(locate.inputNode(page)).toHaveCount(1)
@@ -241,15 +245,15 @@ test('Input node is not collapsed', async ({ page }) => {
   await expect(locate.graphNodeByBinding(page, 'r').locator('.WidgetToken')).toHaveText([
     'Main',
     '.',
-    'collapsed',
+    'user_defined_component',
     'a',
   ])
   await expect(locate.outputNode(page)).toHaveCount(1)
 })
 
-test('Collapsed call shows argument placeholders', async ({ page }) => {
+test('User Defined Component call shows argument placeholders', async ({ page }) => {
   await actions.goToGraph(page)
-  await mockCollapsedFunctionInfo(page, 'final', 'func1', [0])
+  await mockUserDefinedFunctionInfo(page, 'final', 'func1', [0])
   await mockSuggestion(page, {
     type: 'method',
     module: 'local.Mock_Project.Main',
@@ -315,10 +319,10 @@ async function expectInsideFunc2(page: Page) {
 }
 
 async function enterToFunc2(page: Page) {
-  await mockCollapsedFunctionInfo(page, 'final', 'func1')
+  await mockUserDefinedFunctionInfo(page, 'final', 'func1')
   await locate.graphNodeByBinding(page, 'final').dblclick()
   await expectInsideFunc1(page)
-  await mockCollapsedFunctionInfo(page, 'f2', 'func2')
+  await mockUserDefinedFunctionInfo(page, 'f2', 'func2')
   await locate.graphNodeByBinding(page, 'f2').dblclick()
   await expectInsideFunc2(page)
 }

--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test'
 import { type Locator, test } from 'playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
-import { mockCollapsedFunctionInfo, mockMethodCallInfo } from './expressionUpdates'
+import { mockMethodCallInfo, mockUserDefinedFunctionInfo } from './expressionUpdates'
 import { CONTROL_KEY, DELETE_KEY } from './keyboard'
 import * as locate from './locate'
 
@@ -128,13 +128,13 @@ test('Component help', async ({ page }) => {
 test('Documentation reflects entered function', async ({ page }) => {
   const { docsContent } = await goToGraphAndGetDocs(page)
 
-  // Enter the collapsed function
-  await mockCollapsedFunctionInfo(page, 'final', 'func1')
+  // Enter the User Defined Function function
+  await mockUserDefinedFunctionInfo(page, 'final', 'func1')
   await locate.graphNodeByBinding(page, 'final').dblclick()
   await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project', 'func1'])
 
-  // Editor should contain collapsed function's docs
-  await expect(docsContent).toHaveText('A collapsed function')
+  // Editor should contain function's docs
+  await expect(docsContent).toHaveText('A User Defined Function')
 })
 
 test('Link in documentation is rendered and interactive', async ({ page, context }) => {

--- a/app/gui/integration-test/project-view/expressionUpdates.ts
+++ b/app/gui/integration-test/project-view/expressionUpdates.ts
@@ -3,8 +3,8 @@ import type { ExpressionUpdate, MethodCall } from 'ydoc-shared/languageServerTyp
 
 export type ExpressionLocator = string | { binding: string; expr: string }
 
-/** Provide method call info for collapsed function call. */
-export async function mockCollapsedFunctionInfo(
+/** Provide method call info for User Defined Function call. */
+export async function mockUserDefinedFunctionInfo(
   page: Page,
   expression: ExpressionLocator,
   functionName: string,

--- a/app/gui/src/App.vue
+++ b/app/gui/src/App.vue
@@ -129,6 +129,8 @@ if (projectViewOnly) {
   height: 100%;
   display: flex;
   flex-direction: column;
+  /* This is to ensure the tooltips and floating elements will be over all other app elements */
+  isolation: isolate;
 }
 
 #floatingLayer {

--- a/app/gui/src/dashboard/App.tsx
+++ b/app/gui/src/dashboard/App.tsx
@@ -2,38 +2,12 @@
  * @file File containing the {@link App} React component, which is the entrypoint into our React
  * application.
  *
- * # Providers
- *
  * The {@link App} component is responsible for defining the global context used by child
  * components. For example, it defines a {@link toastify.ToastContainer}, which is used to display temporary
  * notifications to the user. These global components are defined at the top of the {@link App} so
  * that they are available to all of the child components.
  *
- * The {@link App} also defines various providers (e.g., {@link authProvider.AuthProvider}).
- * Providers are a React-specific concept that allows components to access global state without
- * having to pass it down through the component tree. For example, the
- * {@link authProvider.AuthProvider} wraps the entire application, and provides the context
- * necessary for child components to use the {@link authProvider.useAuth} hook. The
- * {@link authProvider.useAuth} hook lets child components access the user's authentication session
- * (i.e., email, username, etc.) and it also provides methods for signing the user in, etc.
- *
- * Providers consist of a provider component that wraps the application, a context object defined
- * by the provider component, and a hook that can be used by child components to access the context.
- * All of the providers are initialized here, at the {@link App} component to ensure that they are
- * available to all of the child components.
- *
- * # Routes and Authentication
- *
- * The {@link AppRouter} component defines the layout of the application, in terms of navigation. It
- * consists of a list of {@link router.Route}s, as well as the HTTP pathnames that the
- * {@link router.Route}s can be accessed by.
- *
- * The {@link router.Route}s are grouped by authorization level. Some routes are
- * accessed by unauthenticated (i.e., not signed in) users. Some routes are accessed by partially
- * authenticated users (c.f. {@link authProvider.PartialUserSession}). That is, users who have
- * signed up but who have not completed email verification or set a username. The remaining
- * {@link router.Route}s require fully authenticated users (c.f.
- * {@link authProvider.FullUserSession}).
+ * The {@link App} also defines various providers.
  */
 import * as React from 'react'
 

--- a/app/gui/src/project-view/components/GraphEditor.vue
+++ b/app/gui/src/project-view/components/GraphEditor.vue
@@ -545,7 +545,9 @@ function collapseNodes(nodes: Node[]) {
   try {
     const info = prepareCollapsedInfo(selected, graphStore.db)
     if (!info.ok) {
-      toasts.userActionFailed.show(`Unable to group nodes: ${info.error.payload}.`)
+      toasts.userActionFailed.show(
+        `Unable to create User Defined Component: ${info.error.payload}.`,
+      )
       return
     }
     const currentMethodName = unwrapOr(graphStore.currentMethod.pointer, undefined)?.name
@@ -554,7 +556,7 @@ function collapseNodes(nodes: Node[]) {
     }
     const topLevel = graphStore.moduleRoot
     if (!topLevel) {
-      bail('BUG: no top level, collapsing not possible.')
+      bail('BUG: no top level, creating User Defined Component not possible.')
     }
     const selectedNodeRects = iter.filterDefined(iter.map(selected, graphStore.visibleArea))
     graphStore.edit((edit) => {
@@ -576,7 +578,7 @@ function collapseNodes(nodes: Node[]) {
       }
     })
   } catch (err) {
-    console.error('Error while collapsing, this is not normal.', err)
+    console.error('Error while creating User Defined Component, this is not normal.', err)
   }
 }
 

--- a/app/gui/src/project-view/components/GraphEditor/__tests__/collapsing.test.ts
+++ b/app/gui/src/project-view/components/GraphEditor/__tests__/collapsing.test.ts
@@ -1,4 +1,8 @@
-import { performCollapseImpl, prepareCollapsedInfo } from '@/components/GraphEditor/collapsing'
+import {
+  COLLAPSED_FUNCTION_NAME,
+  performCollapseImpl,
+  prepareCollapsedInfo,
+} from '@/components/GraphEditor/collapsing'
 import { GraphDb, type NodeId } from '@/stores/graph/graphDatabase'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
@@ -191,14 +195,14 @@ test.each(testCases)('Collapsing nodes, $description', (testCase) => {
 
 test('Collapsing nodes in collapsed function', () => {
   const initialCode = `
-collapsed1 input =
+user_defined_component1 input =
     four = 4
     sum = input + four
     sum
 
 main =
     input = 14
-    sum = Main.collapsed1 input`
+    sum = Main.user_defined_component1 input`
 
   const graphDb = GraphDb.Mock()
   setupGraphDb(initialCode, graphDb)
@@ -257,7 +261,7 @@ test('Perform collapse', () => {
   expect(root.code()).toBe(
     [
       '## ICON group',
-      'collapsed keep1 =',
+      `${COLLAPSED_FUNCTION_NAME} keep1 =`,
       '    extract1 = keep1',
       '    extract2 = extract1 + 1',
       '    target = extract2',
@@ -266,7 +270,7 @@ test('Perform collapse', () => {
       'main =',
       '    keep1 = 1',
       '    keep2 = 2',
-      '    target = Main.collapsed keep1',
+      `    target = Main.${COLLAPSED_FUNCTION_NAME} keep1`,
     ].join('\n'),
   )
   const after = findExpressions(root, {
@@ -276,7 +280,7 @@ test('Perform collapse', () => {
     target: Ast.ExpressionStatement,
     'keep1 = 1': Ast.Assignment,
     'keep2 = 2': Ast.Assignment,
-    'target = Main.collapsed keep1': Ast.Assignment,
+    [`target = Main.${COLLAPSED_FUNCTION_NAME} keep1`]: Ast.Assignment,
   })
   expect(collapsedNodeIds).toStrictEqual(
     [after['target = extract2'], after['extract2 = extract1 + 1'], after['extract1 = keep1']].map(
@@ -284,5 +288,7 @@ test('Perform collapse', () => {
     ),
   )
   expect(outputAstId).toBe(after['target'].expression.id)
-  expect(collapsedCallRoot).toBe(after['target = Main.collapsed keep1'].expression.id)
+  expect(collapsedCallRoot).toBe(
+    after[`target = Main.${COLLAPSED_FUNCTION_NAME} keep1`]!.expression.id,
+  )
 })

--- a/app/gui/src/project-view/components/GraphEditor/collapsing.ts
+++ b/app/gui/src/project-view/components/GraphEditor/collapsing.ts
@@ -145,7 +145,7 @@ function findSafeMethodName(topLevel: Ast.BodyBlock, baseName: Identifier): Iden
 
 // We support working inside `Main` module of the project at the moment.
 const MODULE_NAME = 'Main' as Identifier
-const COLLAPSED_FUNCTION_NAME = 'collapsed' as Identifier
+const COLLAPSED_FUNCTION_NAME = 'user_defined_component' as Identifier
 
 interface CollapsingResult {
   /** The ID of the node refactored to the collapsed function call. */

--- a/app/gui/src/project-view/components/GraphEditor/collapsing.ts
+++ b/app/gui/src/project-view/components/GraphEditor/collapsing.ts
@@ -10,7 +10,7 @@ import * as set from 'lib0/set'
 
 // === Types ===
 
-/** Information about code transformations needed to collapse the nodes. */
+/** Information about code transformations needed to group nodes to User Defined Component. */
 interface CollapsedInfo {
   extracted: ExtractedInfo
   refactored: RefactoredInfo
@@ -145,7 +145,8 @@ function findSafeMethodName(topLevel: Ast.BodyBlock, baseName: Identifier): Iden
 
 // We support working inside `Main` module of the project at the moment.
 const MODULE_NAME = 'Main' as Identifier
-const COLLAPSED_FUNCTION_NAME = 'user_defined_component' as Identifier
+/** Default name for the collapsed component */
+export const COLLAPSED_FUNCTION_NAME = 'user_defined_component' as Identifier
 
 interface CollapsingResult {
   /** The ID of the node refactored to the collapsed function call. */

--- a/app/gui/src/project-view/mock/engine.ts
+++ b/app/gui/src/project-view/mock/engine.ts
@@ -48,7 +48,7 @@ const mainFile = `\
 ## Module documentation
 from Standard.Base import all
 
-## A collapsed function
+## A User Defined Function
 func1 arg =
     f2 = Main.func2 arg
     result = f2 - 5

--- a/app/gui/src/project-view/providers/action.ts
+++ b/app/gui/src/project-view/providers/action.ts
@@ -47,7 +47,7 @@ const displayableActions = {
 
   'components.collapse': {
     icon: 'group',
-    description: 'Group Selected Components',
+    description: 'Create User Defined Component from Selected Components',
     shortcut: graphBindings.bindings['components.collapse'],
   },
   'components.copy': {
@@ -70,7 +70,7 @@ const displayableActions = {
 
   'component.enterNode': {
     icon: 'open',
-    description: 'Open Grouped Components',
+    description: 'Open User Defined Component',
   },
   'component.startEditing': {
     icon: 'edit',

--- a/app/ide-desktop/client/tests/localWorkflow.spec.ts
+++ b/app/ide-desktop/client/tests/localWorkflow.spec.ts
@@ -46,24 +46,29 @@ test('Local Workflow', async ({ page, app, projectsDir }) => {
   await expect(addedNode.locator('.TableVisualization')).toBeVisible()
   await expect(addedNode.locator('.TableVisualization')).toContainText('1')
 
-  // Select and collapse nodes
+  // Select nodes and create User Defined Component nodes
   await page.keyboard.press(`${CONTROL_KEY}+A`)
-  await page.getByRole('button', { name: 'Group Selected Components' }).click()
+  await page
+    .getByRole('button', { name: 'Create User Defined Component from Selected Components' })
+    .click()
   await expect(page.locator('.GraphNode')).toHaveCount(1)
-  await expect(page.locator('.GraphNode')).toHaveText(/Main.collapsed/)
+  await expect(page.locator('.GraphNode')).toHaveText(/Main.user_defined_component/)
   await page.locator('.GraphNode').click()
   await page.getByRole('button', { name: 'Visualization' }).click()
   await expect(page.locator('.TableVisualization')).toBeVisible()
   await expect(page.locator('.TableVisualization')).toContainText('1')
 
-  // Enter collapsed function
+  // Enter User Defined Component
   // First wait until node is computed. Visualization may be cached, so we look at icon.
   await expect(page.locator('.GraphNode .WidgetIcon svg use')).toHaveAttribute('href', /#group/)
   await page.locator('.GraphNode').dblclick()
   await expect(page.locator('.GraphNode')).toHaveCount(3)
-  await expect(page.locator('.NavBreadcrumb')).toHaveText(['New Project 1', 'collapsed'])
+  await expect(page.locator('.NavBreadcrumb')).toHaveText([
+    'New Project 1',
+    'user_defined_component',
+  ])
 
-  // Rename collapsed function
+  // Rename User Defined component
   await page.getByRole('tab', { name: 'Documentation' }).click()
   await page
     .locator('.FunctionSignatureEditor')

--- a/app/ydoc-shared/src/ast/mutableModule.ts
+++ b/app/ydoc-shared/src/ast/mutableModule.ts
@@ -243,7 +243,6 @@ export class MutableModule implements Module {
 
   /** TODO: Add docs */
   applyUpdate(update: Uint8Array, origin: Origin): ModuleUpdate | undefined {
-    console.debug('applying update to module')
     let summary: ModuleUpdate | undefined
     const observer = (events: Y.YEvent<any>[]) => {
       summary = this.observeEvents(events, origin)
@@ -251,7 +250,6 @@ export class MutableModule implements Module {
     this.nodes.observeDeep(observer)
     Y.applyUpdate(this.ydoc, update, origin)
     this.nodes.unobserveDeep(observer)
-    console.debug('applying update to module - returning', summary)
     return summary
   }
 


### PR DESCRIPTION
### Pull Request Description

Fixes #13303 

![image](https://github.com/user-attachments/assets/c56559bc-98dd-449b-ab1b-f505411bde85)

![image](https://github.com/user-attachments/assets/92e0ed6a-fbcd-4dd6-b469-3b6ba2e3d69c)

![image](https://github.com/user-attachments/assets/e6e75b4b-d102-4907-8234-396b9406d1c8)

All other places mentioned in PR are still to be.

### Important Notes

* Decided to not rename "collapsed" in our code, mainly because "collapsing" looks much better than "createUserDefinedCompnent".
* Also fixed tooltips being under the tabs + remove some outdated documentation.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
