### PR TITLE
Ensure module sources are initialized

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -178,16 +178,6 @@ public final class ExecutionService {
     var pending =
         submitExecution(
             () -> {
-              SourceSection src;
-              try {
-                src = call.getFunction().getSourceSection();
-              } catch (UnsupportedMessageException ex) {
-                src = null;
-              }
-              if (src == null) {
-                throw new SourceNotFoundException(call.getFunction().getName());
-              }
-
               var callbacks =
                   new ExecutionCallbacks(
                       visualizationHolder,

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -385,18 +385,15 @@ public final class Module extends EnsoObject {
   public final SourceSection createSection(int sourceStartIndex, int sourceLength) {
     Source src;
     try {
-        src = getSource();
+      src = getSource();
     } catch (IOException e) {
       TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, Module.class);
-      logger.log(
-              Level.SEVERE,
-              "Failed to retrieve sources of the module: " + e.getMessage(), e);
-        return null;
+      logger.log(Level.SEVERE, "Failed to retrieve sources of the module: " + e.getMessage(), e);
+      return null;
     }
     if (src == null) {
       return null;
     }
-    allSources.put(src, this);
     var startDelta = patchedValues == null ? 0 : patchedValues.findDelta(sourceStartIndex, false);
     var endDelta =
         patchedValues == null ? 0 : patchedValues.findDelta(sourceStartIndex + sourceLength, true);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -51,6 +51,7 @@ import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.data.TypeGraph;
 import org.enso.text.buffer.Rope;
+import org.slf4j.LoggerFactory;
 
 /** Represents a source module with a known location. */
 @ExportLibrary(InteropLibrary.class)
@@ -387,11 +388,8 @@ public final class Module extends EnsoObject {
     try {
       src = getSource();
     } catch (IOException e) {
-      TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, Module.class);
-      logger.log(Level.SEVERE, "Failed to retrieve sources of the module: " + e.getMessage(), e);
-      return null;
-    }
-    if (src == null) {
+      var logger = LoggerFactory.getLogger(Module.class);
+      logger.warn("Failed to retrieve sources of the module: {}", e.getMessage(), e);
       return null;
     }
     var startDelta = patchedValues == null ? 0 : patchedValues.findDelta(sourceStartIndex, false);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -383,7 +383,16 @@ public final class Module extends EnsoObject {
    */
   @TruffleBoundary
   public final SourceSection createSection(int sourceStartIndex, int sourceLength) {
-    var src = sources.source();
+    Source src;
+    try {
+        src = getSource();
+    } catch (IOException e) {
+      TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, Module.class);
+      logger.log(
+              Level.SEVERE,
+              "Failed to retrieve sources of the module: " + e.getMessage(), e);
+        return null;
+    }
     if (src == null) {
       return null;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleSources.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleSources.java
@@ -66,7 +66,7 @@ record ModuleSources(TruffleFile file, Rope rope, Source source) {
     if (source != null) {
       return this;
     }
-    if (rope() != null) {
+    if (rope != null) {
       Source src = Source.newBuilder(LanguageInfo.ID, rope.characters(), name.toString()).build();
       return new ModuleSources(file, rope, src);
     } else if (file != null) {


### PR DESCRIPTION
### Pull Request Description

If Module sources where loaded from a disk but not (yet) sent by a GUI we had a potential race-condition in the execution. A safety check that was retrieving sources of a method to-be-called could have module's sources not yet initialized and ignoring the fact that they had been loaded from a disk.

The most problematic situation was to reproduce the problem which only happened on
1) first load of a project
2) no caches are yet available
3) NI build

The three conditions were not yet sufficient to have the "Missing Main.main" error to happen every time. Had to introduce an artifical sleep in `textFile/open` to create the necessary race-condition to appear every time.
Native Image was technically not required but because startup was much faster it increased the chances of a race condition.

We could potentially remove the src condition check altogether, as it is now covered in other places.

Closes #13324.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
