### PR TITLE
Run std lib benchmarks with `Context.Output` enabled

### DIFF
--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
@@ -287,13 +287,10 @@ public final class SpecCollector {
     out.println("    File languageHomeOverride = Utils.findLanguageHomeOverride();");
     out.println("    var fallbackLogHandler = JulHandler.get();");
     out.println("    var logHandler = new LogHandler(fallbackLogHandler);");
+    out.println("    Map<String, String> options = new java.util.HashMap<>();");
+    out.println("    options.put(\"engine.TraceCompilation\", \"true\");");
     out.println(
-        """
-                     Map<String, String> options = Map.of(
-                         "engine.TraceCompilation", "true",
-                         RuntimeOptions.LANGUAGE_HOME_OVERRIDE, languageHomeOverride.getAbsolutePath()
-                     );
-        """);
+        "    options.put(RuntimeOptions.LANGUAGE_HOME_OVERRIDE, languageHomeOverride.getAbsolutePath());");
     out.println("    var ctxFactory = ContextFactory.create();");
     out.println("    ctxFactory.enableStaticAnalysis(false);");
     out.println("    ctxFactory.enableDebugServer(false);");

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
@@ -295,6 +295,7 @@ public final class SpecCollector {
     out.println("    ctxFactory.enableStaticAnalysis(false);");
     out.println("    ctxFactory.enableDebugServer(false);");
     out.println("    ctxFactory.projectRoot(projectRootDir.getAbsolutePath());");
+    out.println("    ctxFactory.executionEnvironment(\"live\");");
     out.println("    ctxFactory.options(options);");
     out.println("    ctxFactory.logHandler(logHandler);");
     out.println("    var ctx = ctxFactory.build();");

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
@@ -290,7 +290,8 @@ public final class SpecCollector {
     out.println("    Map<String, String> options = new java.util.HashMap<>();");
     out.println("    options.put(\"engine.TraceCompilation\", \"true\");");
     out.println(
-        "    options.put(RuntimeOptions.LANGUAGE_HOME_OVERRIDE, languageHomeOverride.getAbsolutePath());");
+        "    options.put(RuntimeOptions.LANGUAGE_HOME_OVERRIDE,"
+            + " languageHomeOverride.getAbsolutePath());");
     out.println("    var ctxFactory = ContextFactory.create();");
     out.println("    ctxFactory.enableStaticAnalysis(false);");
     out.println("    ctxFactory.enableDebugServer(false);");


### PR DESCRIPTION
Closes #13371

Related to #13406

### Pull Request Description

`std-benchmarks` are run with `Runtime.Context.Output` enabled. Previously, the "design" execution environment was used.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
