### PR TITLE
Bump compilation timeout for NI on CI

### DIFF
--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -206,6 +206,9 @@ object NativeImage {
         "-H:+UnlockExperimentalVMOptions"
       )
 
+      val compilationTimeoutOpt =
+        if (isCi) Seq("-H:CompilationExpirationPeriod=500") else Seq.empty
+
       var args: Seq[String] =
         excludeConfigsOpt ++
         Seq("-cp", cpStr) ++
@@ -220,6 +223,7 @@ object NativeImage {
         additionalOptions ++
         additionalOpts.value ++
         deadlockWatchdogOpts ++
+        compilationTimeoutOpt ++
         Seq("-o", targetLoc.toString)
 
       args = mainClass match {


### PR DESCRIPTION
### Pull Request Description

MacOS appears to occasionally timeout despite the fact that it would probably finish.
This is a temporary workaround until we get dual JVM mode and our NI can be smaller.
