### PR TITLE
Intersection type work on Columns

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -37,7 +37,7 @@ const label = computed(() => {
 </script>
 
 <template>
-  <div v-if="label" data-testid="component-editor-label">
+  <div v-if="label" data-testid="component-editor-label" class="no-wrap">
     <span v-if="additionalTypes?.kind === 'single'" v-text="`${label} & ${additionalTypes.type}`" />
     <template v-else-if="additionalTypes?.kind === 'multiple'">
       <span v-text="`${label} & `" />
@@ -66,5 +66,9 @@ const label = computed(() => {
   background-color: rgba(0, 0, 0, 0.1);
   padding: 1px 2px;
   border-radius: 2px;
+}
+
+.no-wrap {
+  white-space: nowrap;
 }
 </style>

--- a/app/gui/src/project-view/components/ComponentBrowser/input.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/input.ts
@@ -177,10 +177,10 @@ export function useComponentBrowserInput(
     requiredImport: ProjectPath | undefined
   } {
     if (sourceNodeIdentifier.value && sourceNodeType.value?.type === 'known') {
-      const sourceType = sourceNodeType.value.typeInfo.primaryType
+      const sourceTypes = sourceNodeType.value.typeInfo.visibleTypes
       if (
         entryHasOwner(entry) &&
-        !sourceType.equals(entry.memberOf) &&
+        !sourceTypes.find((type) => type.equals(entry.memberOf)) &&
         !sourceNodeType.value.ancestors.find((ancestor) => ancestor.equals(entry.memberOf)) &&
         !entry.memberOf.equals(ANY_TYPE)
       ) {

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Column.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Column.md
@@ -4,8 +4,8 @@
     - dialect_name self -> Standard.Base.Data.Text.Text
     - is_database_column object:Standard.Base.Any.Any -> Standard.Base.Data.Boolean.Boolean
     - let self name:Standard.Base.Data.Text.Text callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
-    - pretty self -> Standard.Base.Any.Any
-    - read self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Table.Column.Column
+    - pretty self -> Standard.Base.Data.Text.Text
+    - read self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - to_sql self -> Standard.Database.SQL_Statement.SQL_Statement
     - to_text self -> Standard.Base.Data.Text.Text
 - Standard.Table.Column.Column.from that:Standard.Database.DB_Column.DB_Column -> Standard.Table.Column.Column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -37,7 +37,7 @@ type DB_Column
 
        It can perform some additional operations, like refining the type,
        so it should always be preferred over calling `DB_Column.Value` directly.
-    private new internal_name:Text connection:(Connection | Any) sql_type_reference:SQL_Type_Reference expression:SQL_IR_Expression context:SQL_IR_Source -> Column =
+    private new internal_name:Text connection:(Connection | Any) sql_type_reference:SQL_Type_Reference expression:SQL_IR_Expression context:SQL_IR_Source =
         DB_Column_Refinements.refine_column <|
             DB_Column.Value internal_name connection sql_type_reference expression context
 
@@ -53,7 +53,7 @@ type DB_Column
        Arguments:
        - max_rows: specifies the maximum number of rows to read.
     @max_rows Rows_To_Read.default_widget
-    read self (max_rows : Rows_To_Read = ..First_With_Warning 1000) -> Column =
+    read self (max_rows : Rows_To_Read = ..First_With_Warning 1000) -> Column | Any =
         ## This method clashes with one defined on `Column` to redefine it as a public method.
            (On base Column it is purposefully hidden).
         self.to_table.read max_rows . at 0
@@ -63,8 +63,7 @@ type DB_Column
     to_sql self -> SQL_Statement = (self:Column).to_table.to_sql
 
     ## PRIVATE
-    pretty : Text
-    pretty self =
+    pretty self -> Text =
         "DB_Column " + (self:Column).name.pretty
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -40,65 +40,61 @@ import project.SQL_Type.SQL_Type
 from project.Errors import Implicit_DB_Table_Read, Integrity_Error, Unsupported_Database_Operation
 
 type DB_Column_Implementation
-    name (this_column : Column & DB_Column) -> Text = this_column.internal_name
+    name (this_column : Column & DB_Column) = this_column.internal_name
 
-    dialect_name (this_column : Column & DB_Column) -> Text = this_column.connection.dialect.name
+    dialect_name (this_column : Column & DB_Column) = this_column.connection.dialect.name
 
-    display (this_column : Column & DB_Column) show_rows=10 format_terminal=False =
+    display (this_column : Column & DB_Column) show_rows:Integer format_terminal:Boolean =
         this_column.to_table.display show_rows format_terminal
-
-    print (this_column : Column & DB_Column) show_rows=10 =
-        IO.println (this_column.display show_rows format_terminal=True)
-        IO.println ''
 
     to_js_object_implementation (this_column : Column & DB_Column) = this_column.to_sql.to_js_object
 
-    to_table (this_column : Column & DB_Column) -> DB_Table =
+    to_table (this_column : Column & DB_Column) =
         DB_Table.new this_column.name this_column.connection [Internal_Column.from this_column] this_column.context
 
-    info (this_column : Column & DB_Column) -> Table = this_column.to_table.column_info
+    info (this_column : Column & DB_Column) = this_column.to_table.column_info
 
-    read (this_column : Column & DB_Column) (max_rows : Rows_To_Read = ..First_With_Warning 1000) -> Column =
+    read (this_column : Column & DB_Column) (max_rows : Rows_To_Read) =
         this_column.to_table.read max_rows . at 0
 
-    to_vector (this_column : Column & DB_Column) -> Vector Any =
+    to_vector (this_column : Column & DB_Column) =
         Warning.attach (Implicit_DB_Table_Read.Warning "DB_Column.to_vector") <|
             this_column.read DB_Column_Implementation.default_row_limit_for_read . to_vector
 
-    at (this_column : Column & DB_Column) index:Integer=0 -> (Any | Nothing) ! Index_Out_Of_Bounds =
+    at (this_column : Column & DB_Column) index:Integer =
         this_column.get index (Error.throw (Index_Out_Of_Bounds.Error index this_column.length))
 
-    get (this_column : Column & DB_Column) index:Integer=0 ~default:Any=Nothing -> Any | Nothing =
+    get (this_column : Column & DB_Column) index:Integer ~default:Any =
         if index < 0 then Error.throw (Unsupported_Database_Operation.Error "Reading backwards from end") else
             this_column.read (..First index+1) . get index default
 
-    first (this_column : Column & DB_Column) -> Any ! Index_Out_Of_Bounds = this_column.at 0
+    first (this_column : Column & DB_Column) = this_column.at 0
 
-    value_type (this_column : Column & DB_Column) -> Value_Type =
+    value_type (this_column : Column & DB_Column) =
         mapping = this_column.connection.dialect.get_type_mapping
         mapping.sql_type_to_value_type this_column.sql_type_reference.get
 
     inferred_precise_value_type (this_column : Column & DB_Column) =
         this_column.value_type
 
-    should_be_selected_by_type (this_column : Column & DB_Column) (value_type : Value_Type) -> Boolean =
+    should_be_selected_by_type (this_column : Column & DB_Column) (value_type : Value_Type) =
         type_mapping = this_column.connection.dialect.get_type_mapping
         type_mapping.is_same_type this_column.value_type value_type
 
-    to_sql (this_column : Column & DB_Column) -> SQL_Statement = this_column.to_table.to_sql
+    to_sql (this_column : Column & DB_Column) = this_column.to_table.to_sql
 
-    length (this_column : Column & DB_Column) -> Integer = this_column.to_table.row_count
+    length (this_column : Column & DB_Column) = this_column.to_table.row_count
 
-    count_nothing (this_column : Column & DB_Column) -> Integer =
+    count_nothing (this_column : Column & DB_Column) =
         this_column.to_table.filter 0 Filter_Condition.Is_Nothing . row_count
 
-    count (this_column : Column & DB_Column) -> Integer =
+    count (this_column : Column & DB_Column) =
         this_column.to_table.filter 0 Filter_Condition.Not_Nothing . row_count
 
     equals (this_column : Column & DB_Column) (other : Column | Any) =
         make_equality_check_with_floating_point_handling this_column other "=="
 
-    equals_ignore_case (this_column : Column & DB_Column) (other : Column | Any) locale:Locale=Locale.default =
+    equals_ignore_case (this_column : Column & DB_Column) (other : Column | Any) locale:Locale =
         Value_Type.expect_text this_column <|
             Value_Type.expect_text other <|
                 Helpers.assume_default_locale locale <|
@@ -196,7 +192,7 @@ type DB_Column_Implementation
 
     const (this_column : Column & DB_Column) value = this_column.to_table.make_constant_column value
 
-    round (this_column : Column & DB_Column) decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) =
+    round (this_column : Column & DB_Column) decimal_places:Integer (rounding_mode : Rounding_Mode) =
         Rounding_Helpers.check_decimal_places decimal_places <| Value_Type.expect_numeric this_column <|
             if should_use_builtin_round this_column decimal_places rounding_mode then round_builtin this_column decimal_places rounding_mode else
                 short_circuit_special_floating_point this_column <|
@@ -280,7 +276,7 @@ type DB_Column_Implementation
         new_name = (naming_helper this_column).function_name "is_present" [this_column]
         this_column.is_nothing.not . rename new_name
 
-    is_blank (this_column : Column & DB_Column) treat_nans_as_blank=False =
+    is_blank (this_column : Column & DB_Column) treat_nans_as_blank:Boolean =
         new_name = (naming_helper this_column).function_name "is_blank" [this_column]
         self_type = this_column.value_type
         is_blank = case self_type.is_text of
@@ -304,29 +300,29 @@ type DB_Column_Implementation
                 result = this_column.is_empty.iif default this_column
                 result.rename this_column.name
 
-    offset (this_column : Column & DB_Column) n=-1:Integer fill_with:Fill_With=..Nothing =
+    offset (this_column : Column & DB_Column) n:Integer fill_with:Fill_With =
         _ = [this_column, n, fill_with]
         Error.throw (Unsupported_Database_Operation.Error "offset")
 
     rename (this_column : Column & DB_Column) name:Text = (naming_helper this_column).ensure_name_is_valid name <|
         DB_Column.new name this_column.connection this_column.sql_type_reference this_column.expression this_column.context
 
-    sort (this_column : Column & DB_Column) order:Sort_Direction missing_last:Boolean=True by=Nothing =
+    sort (this_column : Column & DB_Column) order:Sort_Direction missing_last:Boolean by =
         if Nothing != by then
             Error.throw (Unsupported_Database_Operation.Error "Using `by` argument in `sort`")
         if missing_last != True then
             Error.throw (Unsupported_Database_Operation.Error "Using `missing_last` argument in `sort`")
         this_column.to_table.sort [..Index 0 order] . at 0
 
-    take (this_column : Column & DB_Column) (range : Index_Sub_Range | Range | Integer = ..First) = this_column.to_table.take range . at 0
+    take (this_column : Column & DB_Column) (range : Index_Sub_Range | Range | Integer) = this_column.to_table.take range . at 0
 
-    drop (this_column : Column & DB_Column) (range : Index_Sub_Range | Range | Integer = ..First) = this_column.to_table.drop range . at 0
+    drop (this_column : Column & DB_Column) (range : Index_Sub_Range | Range | Integer) = this_column.to_table.drop range . at 0
 
-    starts_with (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default =
+    starts_with (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity =
         new_name = (naming_helper this_column).function_name "starts_with" [this_column, other]
         make_text_case_op this_column "STARTS_WITH" other case_sensitivity new_name
 
-    ends_with (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default =
+    ends_with (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity =
         new_name = (naming_helper this_column).function_name "ends_with" [this_column, other]
         make_text_case_op this_column "ENDS_WITH" other case_sensitivity new_name
 
@@ -347,7 +343,7 @@ type DB_Column_Implementation
             new_name = (naming_helper this_column).function_name "text_right" [this_column, n]
             make_binary_op this_column "RIGHT" n2 new_name
 
-    contains (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default =
+    contains (this_column : Column & DB_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity =
         new_name = (naming_helper this_column).function_name "contains" [this_column, other]
         make_text_case_op this_column "CONTAINS" other case_sensitivity new_name
 
@@ -369,7 +365,7 @@ type DB_Column_Implementation
                 Error.throw (Unsupported_Database_Operation.Error ("regex_match"))
 
 
-    trim (this_column : Column & DB_Column) where:Location=..Both (what : Column | Text = '') =
+    trim (this_column : Column & DB_Column) where:Location=..Both (what : Column | Text) =
         Value_Type.expect_text this_column <| Value_Type.expect_text what <|
             new_name = (naming_helper this_column).function_name "trim" [this_column]
             operator = case where of
@@ -380,7 +376,7 @@ type DB_Column_Implementation
                 Error.throw (Unsupported_Database_Operation.Error ("`trim "+where.to_text+"`"))
 
     @new_text (Text_Input display=..Always)
-    text_replace (this_column : Column & DB_Column) (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Default only_first:Boolean=False =
+    text_replace (this_column : Column & DB_Column) (term : Text | Regex | Column) (new_text : Text | Column) case_sensitivity:Case_Sensitivity only_first:Boolean =
         Value_Type.expect_text this_column <| case_sensitivity.disallow_non_default_locale <|
             input_type = if term.is_error then term else Meta.type_of term
             params = Replace_Params.Value input_type case_sensitivity only_first
@@ -421,7 +417,7 @@ type DB_Column_Implementation
     date_part (this_column : Column & DB_Column) (period : Date_Period | Time_Period) =
         Date_Time_Helpers.make_date_part_function this_column period (column->op_name-> make_unary_op column op_name) (naming_helper this_column)
 
-    date_diff (this_column : Column & DB_Column) (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = Date_Period.Day) =
+    date_diff (this_column : Column & DB_Column) (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period) =
         Value_Type.expect_type this_column .is_date_or_time "date/time" <|
             my_type = this_column.inferred_precise_value_type
             Value_Type.expect_type end (== my_type) my_type.to_display_text <|
@@ -431,7 +427,7 @@ type DB_Column_Implementation
                     metadata = this_column.connection.dialect.prepare_metadata_for_period aligned_period my_type
                     make_op this_column "date_diff" [end] new_name metadata
 
-    date_add (this_column : Column & DB_Column) (amount : Column | Integer) (period : Date_Period | Time_Period = default_date_period this_column) =
+    date_add (this_column : Column & DB_Column) (amount : Column | Integer) (period : Date_Period | Time_Period) =
         Value_Type.expect_type this_column .is_date_or_time "date/time" <|
             my_type = this_column.inferred_precise_value_type
             Helpers.expect_dialect_specific_integer_type this_column amount <|
@@ -469,7 +465,7 @@ type DB_Column_Implementation
                 DB_Column.new new_name this_column.connection new_type_ref new_expr this_column.context
 
     @format (make_format_chooser include_number=False)
-    parse (this_column : Column & DB_Column) (type : Value_Type | Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning =
+    parse (this_column : Column & DB_Column) (type : Value_Type | Auto) (format : Text | Data_Formatter) on_problems:Problem_Behavior =
         if type == Auto then Error.throw (Unsupported_Database_Operation.Error "`Auto` parse type") else
             if format != "" then Error.throw (Unsupported_Database_Operation.Error "Custom formatting") else
                 if this_column.value_type.is_same_type type then this_column else
@@ -481,23 +477,23 @@ type DB_Column_Implementation
 
 
     @format (this_column-> Widget_Helpers.make_format_chooser_for_type this_column.value_type)
-    format (this_column : Column & DB_Column) (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default =
+    format (this_column : Column & DB_Column) (format : Text | Date_Time_Formatter | Column) locale:Locale =
         _ = [this_column, format, locale]
         Error.throw <| Unsupported_Database_Operation.Error "format"
 
-    cast (this_column : Column & DB_Column) value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning =
+    cast (this_column : Column & DB_Column) value_type:Value_Type on_problems:Problem_Behavior =
         check_cast_compatibility this_column.value_type value_type <|
             internal_do_cast this_column value_type on_problems
 
-    auto_cast (this_column : Column & DB_Column) shrink_types:Boolean=False =
+    auto_cast (this_column : Column & DB_Column) shrink_types:Boolean =
         _ = [this_column, shrink_types]
         Error.throw <| Unsupported_Database_Operation.Error "auto_cast"
 
-    map (this_column : Column & DB_Column) (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) =
+    map (this_column : Column & DB_Column) (function : Any -> Any) skip_nothing:Boolean (expected_value_type : Value_Type | Auto) =
         _ = [this_column, function, skip_nothing, expected_value_type]
         Error.throw <| Unsupported_Database_Operation.Error "map"
 
-    zip (this_column : Column & DB_Column) (right : Column | Table = Missing_Argument.throw "right") (keep_unmatched : Boolean | Report_Unmatched = Report_Unmatched) (right_prefix : Text = "Right ") on_problems:Problem_Behavior=..Report_Warning -> Table =
+    zip (this_column : Column & DB_Column) (right : Column | Table) (keep_unmatched : Boolean | Report_Unmatched) (right_prefix : Text) on_problems:Problem_Behavior =
         _ = [this_column, right, keep_unmatched, right_prefix, on_problems]
         Error.throw <| Unsupported_Database_Operation.Error "zip"
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -19,7 +19,6 @@ import Standard.Table.Internal.Value_Type_Helpers
 import Standard.Table.Internal.Widget_Helpers
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Auto, Column, Data_Formatter, Previous_Value, Table, Value_Type
-from Standard.Table.Column import default_date_period
 from Standard.Table.Errors import Inexact_Type_Coercion, Invalid_Value_Type
 from Standard.Table.Internal.Cast_Helpers import check_cast_compatibility
 from Standard.Table.Internal.Column_Type_Helpers import get_underlying_from_column

--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Column.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Column.md
@@ -15,89 +15,89 @@
     - >= self other:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> Standard.Table.Column.Column
     - ^ self other:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> Standard.Table.Column.Column
     - at self index:Standard.Base.Data.Numbers.Integer= -> (Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)!Standard.Base.Errors.Common.Index_Out_Of_Bounds
-    - auto_cast self shrink_types:Standard.Base.Data.Boolean.Boolean= -> Standard.Table.Column.Column
-    - auto_value_type self shrink_types:Standard.Base.Data.Boolean.Boolean= -> Standard.Table.Column.Column
-    - between self lower:(Standard.Table.Column.Column|Standard.Base.Any.Any) upper:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> Standard.Table.Column.Column
-    - cast self value_type:Standard.Table.Value_Type.Value_Type on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Table.Column.Column!(Standard.Base.Errors.Illegal_Argument.Illegal_Argument|Standard.Table.Errors.Inexact_Type_Coercion|Standard.Table.Errors.Conversion_Failure)
-    - ceil self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - coalesce self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> Standard.Table.Column.Column
+    - auto_cast self shrink_types:Standard.Base.Data.Boolean.Boolean= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - auto_value_type self shrink_types:Standard.Base.Data.Boolean.Boolean= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - between self lower:(Standard.Table.Column.Column|Standard.Base.Any.Any) upper:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - cast self value_type:Standard.Table.Value_Type.Value_Type on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!(Standard.Base.Errors.Illegal_Argument.Illegal_Argument|Standard.Table.Errors.Inexact_Type_Coercion|Standard.Table.Errors.Conversion_Failure)
+    - ceil self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - coalesce self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - compute self statistic:Standard.Base.Data.Statistics.Statistic= -> Standard.Base.Any.Any
     - compute_bulk self statistics:(Standard.Base.Data.Vector.Vector Standard.Base.Data.Statistics.Statistic)= -> Standard.Table.Table.Table
-    - const self value:Standard.Base.Any.Any -> Standard.Table.Column.Column
-    - contains self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> Standard.Table.Column.Column
+    - const self value:Standard.Base.Any.Any -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - contains self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - count self -> Standard.Base.Data.Numbers.Integer
     - count_nothing self -> Standard.Base.Data.Numbers.Integer
-    - date_add self amount:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> Standard.Table.Column.Column!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
-    - date_diff self end:(Standard.Table.Column.Column|Standard.Base.Data.Time.Date.Date|Standard.Base.Data.Time.Date_Time.Date_Time|Standard.Base.Data.Time.Time_Of_Day.Time_Of_Day) period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> Standard.Table.Column.Column!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
-    - date_part self period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> Standard.Table.Column.Column!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
-    - day self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - day_of_week self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - day_of_year self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - date_add self amount:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
+    - date_diff self end:(Standard.Table.Column.Column|Standard.Base.Data.Time.Date.Date|Standard.Base.Data.Time.Date_Time.Date_Time|Standard.Base.Data.Time.Time_Of_Day.Time_Of_Day) period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
+    - date_part self period:(Standard.Base.Data.Time.Date_Period.Date_Period|Standard.Base.Data.Time.Time_Period.Time_Period)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!(Standard.Table.Errors.Invalid_Value_Type|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
+    - day self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - day_of_week self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - day_of_year self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - display self show_rows:Standard.Base.Data.Numbers.Integer= format_terminal:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Data.Text.Text
-    - drop self range:(Standard.Base.Data.Index_Sub_Range.Index_Sub_Range|Standard.Base.Data.Range.Range|Standard.Base.Data.Numbers.Integer)= -> Standard.Table.Column.Column
-    - duplicate_count self -> Standard.Table.Column.Column
-    - ends_with self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> Standard.Table.Column.Column
-    - equals_ignore_case self other:(Standard.Table.Column.Column|Standard.Base.Any.Any) locale:Standard.Base.Data.Locale.Locale= -> Standard.Table.Column.Column
-    - fill_empty self default:(Standard.Table.Column.Column|Standard.Table.Constants.Previous_Value|Standard.Base.Any.Any) -> Standard.Table.Column.Column
-    - fill_nothing self default:(Standard.Table.Column.Column|Standard.Table.Constants.Previous_Value|Standard.Base.Any.Any) -> Standard.Table.Column.Column
+    - drop self range:(Standard.Base.Data.Index_Sub_Range.Index_Sub_Range|Standard.Base.Data.Range.Range|Standard.Base.Data.Numbers.Integer)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - duplicate_count self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - ends_with self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - equals_ignore_case self other:(Standard.Table.Column.Column|Standard.Base.Any.Any) locale:Standard.Base.Data.Locale.Locale= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - fill_empty self default:(Standard.Table.Column.Column|Standard.Table.Constants.Previous_Value|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - fill_nothing self default:(Standard.Table.Column.Column|Standard.Table.Constants.Previous_Value|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - first self -> Standard.Base.Any.Any!Standard.Base.Errors.Common.Index_Out_Of_Bounds
-    - floor self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - format self format:(Standard.Base.Data.Text.Text|Standard.Base.Data.Time.Date_Time_Formatter.Date_Time_Formatter|Standard.Table.Column.Column)= locale:Standard.Base.Data.Locale.Locale= -> Standard.Table.Column.Column!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-    - from_repeated_item name:Standard.Base.Data.Text.Text item:Standard.Base.Any.Any repeats:Standard.Base.Data.Numbers.Integer -> Standard.Table.Column.Column
-    - from_vector name:Standard.Base.Data.Text.Text items:Standard.Base.Data.Vector.Vector value_type:(Standard.Table.Value_Type.Auto|Standard.Table.Value_Type.Value_Type)= -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - floor self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - format self format:(Standard.Base.Data.Text.Text|Standard.Base.Data.Time.Date_Time_Formatter.Date_Time_Formatter|Standard.Table.Column.Column)= locale:Standard.Base.Data.Locale.Locale= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+    - from_repeated_item name:Standard.Base.Data.Text.Text item:Standard.Base.Any.Any repeats:Standard.Base.Data.Numbers.Integer -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - from_vector name:Standard.Base.Data.Text.Text items:Standard.Base.Data.Vector.Vector value_type:(Standard.Table.Value_Type.Auto|Standard.Table.Value_Type.Value_Type)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - get self index:Standard.Base.Data.Numbers.Integer= ~default:Standard.Base.Any.Any= -> (Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)
-    - hour self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - iif self when_true:(Standard.Table.Column.Column|Standard.Base.Any.Any) when_false:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> Standard.Table.Column.Column
+    - hour self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - iif self when_true:(Standard.Table.Column.Column|Standard.Base.Any.Any) when_false:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - inferred_precise_value_type self -> Standard.Table.Value_Type.Value_Type
     - info self -> Standard.Table.Table.Table
-    - is_blank self treat_nans_as_blank:Standard.Base.Data.Boolean.Boolean= -> Standard.Table.Column.Column
+    - is_blank self treat_nans_as_blank:Standard.Base.Data.Boolean.Boolean= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - is_column object:Standard.Base.Any.Any -> Standard.Base.Data.Boolean.Boolean
-    - is_empty self -> Standard.Table.Column.Column
-    - is_finite self -> Standard.Table.Column.Column
-    - is_in self vector:(Standard.Base.Data.Vector.Vector|Standard.Table.Column.Column|Standard.Base.Data.Array.Array) -> Standard.Table.Column.Column
-    - is_infinite self -> Standard.Table.Column.Column
-    - is_nan self -> Standard.Table.Column.Column
-    - is_nothing self -> Standard.Table.Column.Column
-    - is_present self -> Standard.Table.Column.Column
+    - is_empty self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_finite self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_in self vector:(Standard.Base.Data.Vector.Vector|Standard.Table.Column.Column|Standard.Base.Data.Array.Array) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_infinite self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_nan self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_nothing self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - is_present self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - last self -> Standard.Base.Any.Any!Standard.Base.Errors.Common.Index_Out_Of_Bounds
     - length self -> Standard.Base.Data.Numbers.Integer
-    - like self pattern:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) -> Standard.Table.Column.Column
-    - map self function:Standard.Base.Any.Any skip_nothing:Standard.Base.Data.Boolean.Boolean= expected_value_type:(Standard.Table.Value_Type.Value_Type|Standard.Table.Value_Type.Auto)= -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - max self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> Standard.Table.Column.Column
-    - min self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> Standard.Table.Column.Column
-    - minute self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
-    - month self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - like self pattern:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - map self function:Standard.Base.Any.Any skip_nothing:Standard.Base.Data.Boolean.Boolean= expected_value_type:(Standard.Table.Value_Type.Value_Type|Standard.Table.Value_Type.Auto)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - max self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - min self values:(Standard.Base.Any.Any|Standard.Base.Any.Any) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - minute self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
+    - month self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - name self -> Standard.Base.Data.Text.Text
-    - not self -> Standard.Table.Column.Column
-    - offset self n:Standard.Base.Any.Any= fill_with:Standard.Table.Fill_With.Fill_With= -> Standard.Table.Column.Column
-    - parse self type:(Standard.Table.Value_Type.Value_Type|Standard.Table.Value_Type.Auto)= format:(Standard.Base.Data.Text.Text|Standard.Table.Data_Formatter.Data_Formatter)= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Table.Column.Column
+    - not self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - offset self n:Standard.Base.Data.Numbers.Integer= fill_with:Standard.Table.Fill_With.Fill_With= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - parse self type:(Standard.Table.Value_Type.Value_Type|Standard.Table.Value_Type.Auto)= format:(Standard.Base.Data.Text.Text|Standard.Table.Data_Formatter.Data_Formatter)= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - pretty self -> Standard.Base.Data.Text.Text
     - print self show_rows:Standard.Base.Data.Numbers.Integer= -> Standard.Base.Nothing.Nothing
-    - read self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Table.Column.Column
-    - regex_match self pattern:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Data.Text.Regex.Regex) -> Standard.Table.Column.Column
-    - rename self name:Standard.Base.Data.Text.Text -> Standard.Table.Column.Column!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-    - reverse self -> Standard.Table.Column.Column
-    - round self decimal_places:Standard.Base.Data.Numbers.Integer= rounding_mode:Standard.Base.Data.Numeric.Rounding_Mode.Rounding_Mode= -> Standard.Table.Column.Column!(Standard.Base.Errors.Illegal_Argument.Illegal_Argument|Standard.Table.Errors.Invalid_Value_Type)
-    - running self statistic:Standard.Base.Data.Statistics.Statistic= name:Standard.Base.Data.Text.Text= -> Standard.Table.Column.Column
-    - second self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - read self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - regex_match self pattern:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Data.Text.Regex.Regex) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - rename self name:Standard.Base.Data.Text.Text -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+    - reverse self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - round self decimal_places:Standard.Base.Data.Numbers.Integer= rounding_mode:Standard.Base.Data.Numeric.Rounding_Mode.Rounding_Mode= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!(Standard.Base.Errors.Illegal_Argument.Illegal_Argument|Standard.Table.Errors.Invalid_Value_Type)
+    - running self statistic:Standard.Base.Data.Statistics.Statistic= name:Standard.Base.Data.Text.Text= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - second self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - should_be_selected_by_type self value_type:Standard.Table.Value_Type.Value_Type -> Standard.Base.Data.Boolean.Boolean
     - slice self start:Standard.Base.Any.Any end:Standard.Base.Any.Any -> Standard.Base.Any.Any
-    - sort self order:Standard.Base.Data.Sort_Direction.Sort_Direction= missing_last:Standard.Base.Data.Boolean.Boolean= by:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= -> Standard.Table.Column.Column
-    - starts_with self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> Standard.Table.Column.Column
-    - take self range:(Standard.Base.Data.Index_Sub_Range.Index_Sub_Range|Standard.Base.Data.Range.Range|Standard.Base.Data.Numbers.Integer)= -> Standard.Table.Column.Column
-    - text_cleanse self remove:(Standard.Base.Data.Vector.Vector Standard.Base.Data.Text.Regex.Named_Pattern.Named_Pattern) -> Standard.Table.Column.Column
-    - text_left self n:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) -> Standard.Table.Column.Column
-    - text_length self -> Standard.Table.Column.Column
-    - text_replace self term:(Standard.Base.Data.Text.Text|Standard.Base.Data.Text.Regex.Regex|Standard.Table.Column.Column)= new_text:(Standard.Base.Data.Text.Text|Standard.Table.Column.Column)= case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= only_first:Standard.Base.Data.Boolean.Boolean= -> Standard.Table.Column.Column
-    - text_right self n:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) -> Standard.Table.Column.Column
+    - sort self order:Standard.Base.Data.Sort_Direction.Sort_Direction= missing_last:Standard.Base.Data.Boolean.Boolean= by:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - starts_with self other:(Standard.Table.Column.Column|Standard.Base.Data.Text.Text|Standard.Base.Any.Any) case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - take self range:(Standard.Base.Data.Index_Sub_Range.Index_Sub_Range|Standard.Base.Data.Range.Range|Standard.Base.Data.Numbers.Integer)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - text_cleanse self remove:(Standard.Base.Data.Vector.Vector Standard.Base.Data.Text.Regex.Named_Pattern.Named_Pattern) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - text_left self n:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - text_length self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - text_replace self term:(Standard.Base.Data.Text.Text|Standard.Base.Data.Text.Regex.Regex|Standard.Table.Column.Column)= new_text:(Standard.Base.Data.Text.Text|Standard.Table.Column.Column)= case_sensitivity:Standard.Base.Data.Text.Case_Sensitivity.Case_Sensitivity= only_first:Standard.Base.Data.Boolean.Boolean= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - text_right self n:(Standard.Table.Column.Column|Standard.Base.Data.Numbers.Integer) -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
     - to_js_object self -> Standard.Base.Data.Json.JS_Object
     - to_table self -> (Standard.Table.Table.Table|Standard.Base.Any.Any)
     - to_text self -> Standard.Base.Data.Text.Text
     - to_vector self -> Standard.Base.Data.Vector.Vector
-    - trim self where:Standard.Base.Data.Text.Location.Location= what:(Standard.Base.Data.Text.Text|Standard.Table.Column.Column)= -> Standard.Table.Column.Column
-    - truncate self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - trim self where:Standard.Base.Data.Text.Location.Location= what:(Standard.Base.Data.Text.Text|Standard.Table.Column.Column)= -> (Standard.Table.Column.Column|Standard.Base.Any.Any)
+    - truncate self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - value_type self -> Standard.Table.Value_Type.Value_Type
-    - year self -> Standard.Table.Column.Column!Standard.Table.Errors.Invalid_Value_Type
+    - year self -> (Standard.Table.Column.Column|Standard.Base.Any.Any)!Standard.Table.Errors.Invalid_Value_Type
     - zip self right:(Standard.Table.Column.Column|Standard.Table.Table.Table)= keep_unmatched:(Standard.Base.Data.Boolean.Boolean|Standard.Base.Data.Vector.Report_Unmatched)= right_prefix:Standard.Base.Data.Text.Text= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Table.Table.Table
     - || self other:(Standard.Table.Column.Column|Standard.Base.Any.Any) -> Standard.Table.Column.Column
 - default_date_period column:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2209,7 +2209,7 @@ type Column
        - - ..Closest_Value - If n is negative the first value gets used, if n is negative the last value gets used.
        - - ..Wrap_Around - In this mode values that slide off the top or bottom reappear at the other end. So no values get lost they are just rotated.
     @n (self-> Numeric_Input minimum=0-self.length maximum=self.length)
-    offset self n=-1:Integer fill_with:Fill_With=..Nothing -> Column =
+    offset self n:Integer=-1 fill_with:Fill_With=..Nothing -> Column =
         self.implementation.offset self n fill_with
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -50,7 +50,7 @@ type Column
 
              example_from_vector =
                  Column.from_vector "My Column" [1, 2, 3, 4, 5]
-    from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) -> Column | Any! Invalid_Value_Type =
+    from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) -> Column | Any ! Invalid_Value_Type =
         In_Memory_Column.from_vector name items value_type
 
     ## PRIVATE
@@ -61,7 +61,7 @@ type Column
        - name: The name of the column to create.
        - item: The element to repeat in the column.
        - repeats: The number of times to repeat the element.
-    from_repeated_item name:Text item:Any repeats:Integer -> Column | Any=
+    from_repeated_item name:Text item:Any repeats:Integer -> Column | Any =
         In_Memory_Column.from_repeated_item name item repeats
 
     ## PRIVATE
@@ -155,7 +155,7 @@ type Column
        Returns a column with results of comparing this column's elements against
        `other`.
     @locale Locale.default_widget
-    equals_ignore_case self (other : Column | Any) locale:Locale=Locale.default -> Column | Any=
+    equals_ignore_case self (other : Column | Any) locale:Locale=Locale.default -> Column | Any =
         self.implementation.equals_ignore_case self other locale
 
     ## ALIAS not equals
@@ -323,7 +323,7 @@ type Column
 
        Returns a column with boolean values indicating whether values of this
        column fit between the lower and upper bounds (both ends inclusive).
-    between self (lower : Column | Any) (upper : Column | Any) -> Column | Any=
+    between self (lower : Column | Any) (upper : Column | Any) -> Column | Any =
         self.implementation.between self lower upper
 
     ## ALIAS add, concatenate, plus
@@ -629,7 +629,7 @@ type Column
              import Standard.Examples
 
              example_not = Examples.bool_column_1.not
-    not self -> Column | Any=
+    not self -> Column | Any =
         self.implementation.not self
 
     ## ALIAS if
@@ -649,7 +649,7 @@ type Column
              import Standard.Examples
 
              example_if = Examples.bool_column_1.iif 1 0
-    iif self (when_true : Column | Any) (when_false : Column | Any) -> Column | Any=
+    iif self (when_true : Column | Any) (when_false : Column | Any) -> Column | Any =
         self.implementation.iif self when_true when_false
 
     ## PRIVATE
@@ -667,7 +667,7 @@ type Column
          Create a column of the value 42
 
          column.const 42
-    const self value:Any -> Column | Any=
+    const self value:Any -> Column | Any =
         self.to_table.make_constant_column value
 
     ## GROUP Standard.Base.Math
@@ -731,7 +731,7 @@ type Column
          Round a column of `Float` values`.
 
              Column.from_vector "foo" [1.2, 2.3, 3.6] . round == (Column.from_vector "foo" [1, 2, 4])
-    round self decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) -> Column | Any! Illegal_Argument | Invalid_Value_Type =
+    round self decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) -> Column | Any ! Illegal_Argument | Invalid_Value_Type =
         self.implementation.round self decimal_places rounding_mode
 
     ## ALIAS int
@@ -757,7 +757,7 @@ type Column
             date_times = Column.from_vector "foo" [Date_Time.new 2020 10 24 1 2 3, Date_Time.new 2020 10 24 1 2 3]
             dates = Column.from_vector "foo" [Date.new 2020 10 24, Date.new 2020 10 24]
             col.truncate == dates
-    truncate self -> Column | Any! Invalid_Value_Type =
+    truncate self -> Column | Any ! Invalid_Value_Type =
         self.implementation.truncate self
 
     ## GROUP Standard.Base.Rounding
@@ -775,7 +775,7 @@ type Column
          Take the ceiling of a column of `Float` values.
 
              Column.from_vector "foo" [1.25, 2.33, 3.57] . ceil == (Column.from_vector "foo" [2, 3, 4])
-    ceil self -> Column | Any! Invalid_Value_Type =
+    ceil self -> Column | Any ! Invalid_Value_Type =
         self.implementation.ceil self
 
     ## GROUP Standard.Base.Rounding
@@ -793,7 +793,7 @@ type Column
          Take the floor of a column of `Float` values.
 
              Column.from_vector "foo" [1.25, 2.33, 3.57] . floor == (Column.from_vector "foo" [1, 2, 3])
-    floor self -> Column | Any! Invalid_Value_Type =
+    floor self -> Column | Any ! Invalid_Value_Type =
         self.implementation.floor self
 
     ## GROUP Standard.Base.Logical
@@ -810,7 +810,7 @@ type Column
              import Standard.Examples
 
              example_coalesce = Examples.decimal_column.coalesce Examples.integer_column
-    coalesce self (values : Any | Vector Any) -> Column | Any=
+    coalesce self (values : Any | Vector Any) -> Column | Any =
         self.implementation.coalesce self values
 
     ## GROUP Standard.Base.Math
@@ -831,7 +831,7 @@ type Column
              import Standard.Examples
 
              example_min = Examples.decimal_column.min Examples.integer_column
-    min self (values : Any | Vector Any) -> Column | Any=
+    min self (values : Any | Vector Any) -> Column | Any =
         self.implementation.min self values
 
     ## GROUP Standard.Base.Math
@@ -852,7 +852,7 @@ type Column
              import Standard.Examples
 
              example_max = Examples.decimal_column.max Examples.integer_column
-    max self (values : Any | Vector Any) -> Column | Any=
+    max self (values : Any | Vector Any) -> Column | Any =
         self.implementation.max self values
 
     ## GROUP Standard.Base.Logical
@@ -866,14 +866,14 @@ type Column
              import Standard.Examples
 
              example_is_nothing = Examples.decimal_column.is_nothing
-    is_nothing self -> Column | Any=
+    is_nothing self -> Column | Any =
         self.implementation.is_nothing_implementation self
 
     ## GROUP Standard.Base.Math
        ICON math
        Returns a column of booleans, with `True` items at the positions where
        this column contains a NaN. This is only applicable to double columns.
-    is_nan self -> Column | Any=
+    is_nan self -> Column | Any =
         self.implementation.is_nan self
 
     ## GROUP Standard.Base.Math
@@ -881,7 +881,7 @@ type Column
        Returns a column of booleans, with `True` items at the positions where
        this column contains a +Inf/-Inf. This is only applicable to double
        columns.
-    is_infinite self -> Column | Any=
+    is_infinite self -> Column | Any =
         self.implementation.is_infinite self
 
     ## GROUP Standard.Base.Math
@@ -889,13 +889,13 @@ type Column
        Returns a column of booleans, with `True` items at the positions where
        this column contains a non-infinite, non-NaN floating point value. This
        is only applicable to double columns.
-    is_finite self -> Column | Any=
+    is_finite self -> Column | Any =
         self.implementation.is_finite self
 
     ## PRIVATE
        Returns a column of booleans, with `True` items at the positions where
        this column contains an empty string or `Nothing`.
-    is_empty self -> Column | Any=
+    is_empty self -> Column | Any =
         self.implementation.is_empty self
 
     ## GROUP Standard.Base.Logical
@@ -909,7 +909,7 @@ type Column
              import Standard.Examples
 
              example_is_present = Examples.decimal_column.is_present
-    is_present self -> Column | Any=
+    is_present self -> Column | Any =
         self.implementation.is_present self
 
     ## PRIVATE
@@ -922,7 +922,7 @@ type Column
 
        ? Blank values
          Blank values are `Nothing`, `""` and depending on setting `Number.nan`.
-    is_blank self treat_nans_as_blank:Boolean=False -> Column | Any=
+    is_blank self treat_nans_as_blank:Boolean=False -> Column | Any =
         self.implementation.is_blank self treat_nans_as_blank
 
     ## ALIAS fill missing, if_nothing
@@ -947,7 +947,7 @@ type Column
 
              example_fill_nothing = Examples.decimal_column.fill_nothing 20.5
     @default (self-> Widget_Helpers.make_fill_default_value_selector value_types=self.value_type)
-    fill_nothing self (default : Column | Previous_Value | Any) -> Column | Any=
+    fill_nothing self (default : Column | Previous_Value | Any) -> Column | Any =
         self.implementation.fill_nothing self default
 
     ## ALIAS fill empty, if_empty
@@ -971,7 +971,7 @@ type Column
 
              example_fill_empty = Examples.text_column_1.fill_empty "hello"
     @default (self-> Widget_Helpers.make_fill_default_value_selector value_types=Value_Type.Char add_nothing=True)
-    fill_empty self (default : Column | Previous_Value | Any) -> Column | Any=
+    fill_empty self (default : Column | Previous_Value | Any) -> Column | Any =
         self.implementation.fill_empty self default
 
     ## GROUP Standard.Base.Text
@@ -1007,7 +1007,7 @@ type Column
              import Standard.Examples
 
              example_starts_with = Examples.text_column_1.starts_with "hell" Case_Sensitivity.Insensitive
-    starts_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
+    starts_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any =
         self.implementation.starts_with self other case_sensitivity
 
     ## GROUP Standard.Base.Text
@@ -1036,7 +1036,7 @@ type Column
              import Standard.Examples
 
              example_ends_with = Examples.text_column_1.ends_with "hell"
-    ends_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
+    ends_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any =
         self.implementation.ends_with self other case_sensitivity
 
     ## GROUP Standard.Base.Text
@@ -1053,7 +1053,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_length
-    text_length self -> Column | Any=
+    text_length self -> Column | Any =
         self.implementation.text_length self
 
     ## GROUP Standard.Base.Text
@@ -1070,7 +1070,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_left 5
-    text_left self (n : Column | Integer) -> Column | Any=
+    text_left self (n : Column | Integer) -> Column | Any =
         self.implementation.text_left self n
 
     ## GROUP Standard.Base.Text
@@ -1087,7 +1087,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_right 5
-    text_right self (n : Column | Integer) -> Column | Any=
+    text_right self (n : Column | Integer) -> Column | Any =
         self.implementation.text_right self n
 
     ## GROUP Standard.Base.Logical
@@ -1116,7 +1116,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.contains "hell"
-    contains self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
+    contains self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any =
         self.implementation.contains self other case_sensitivity
 
     ## GROUP Standard.Base.Logical
@@ -1136,7 +1136,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.like "F%."
-    like self (pattern : Column | Text | Any) -> Column | Any=
+    like self (pattern : Column | Text | Any) -> Column | Any =
         self.implementation.like self pattern
 
     ## GROUP Standard.Base.Logical
@@ -1154,7 +1154,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.regex_match (regex "A.*M")
-    regex_match self (pattern : Column | Text | Regex) -> Column | Any=
+    regex_match self (pattern : Column | Text | Regex) -> Column | Any =
         self.implementation.regex_match self pattern
 
     ## GROUP Standard.Base.Text
@@ -1167,7 +1167,7 @@ type Column
          function trims both ends of the input.
        - what: A `Text` (or text `Column`) containing characters that should be
          removed. By default, all whitespace is removed.
-    trim self where:Location=..Both (what : Text | Column = '') -> Column | Any=
+    trim self where:Location=..Both (what : Text | Column = '') -> Column | Any =
         self.implementation.trim self where what
 
     ## ALIAS regex, substitute
@@ -1245,7 +1245,7 @@ type Column
              column.text_replace '"(.*?)"'.to_regex '($1)'
     @term make_regex_text_widget
     @new_text (Text_Input display=..Always)
-    text_replace self (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False -> Column | Any=
+    text_replace self (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False -> Column | Any =
         self.implementation.text_replace self term new_text case_sensitivity only_first
 
     ## GROUP Standard.Base.Text
@@ -1275,7 +1275,7 @@ type Column
 
              column.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
-    text_cleanse self (remove : Vector Named_Pattern) -> Column | Any=
+    text_cleanse self (remove : Vector Named_Pattern) -> Column | Any =
         self.implementation.text_cleanse self remove
 
     ## GROUP Standard.Base.DateTime
@@ -1284,7 +1284,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    year self -> Column | Any! Invalid_Value_Type =
+    year self -> Column | Any ! Invalid_Value_Type =
         self.implementation.year self
 
     ## GROUP Standard.Base.DateTime
@@ -1293,7 +1293,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    month self -> Column | Any! Invalid_Value_Type =
+    month self -> Column | Any ! Invalid_Value_Type =
         self.implementation.month self
 
     ## GROUP Standard.Base.DateTime
@@ -1303,7 +1303,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day self -> Column | Any! Invalid_Value_Type =
+    day self -> Column | Any ! Invalid_Value_Type =
         self.implementation.day self
 
     ## GROUP Standard.Base.DateTime
@@ -1313,7 +1313,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day_of_year self -> Column | Any! Invalid_Value_Type =
+    day_of_year self -> Column | Any ! Invalid_Value_Type =
         self.implementation.day_of_year self
 
     ## ALIAS weekday
@@ -1324,7 +1324,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day_of_week self -> Column | Any! Invalid_Value_Type =
+    day_of_week self -> Column | Any ! Invalid_Value_Type =
         self.implementation.day_of_week self
 
     ## GROUP Standard.Base.DateTime
@@ -1333,7 +1333,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    hour self -> Column | Any! Invalid_Value_Type =
+    hour self -> Column | Any ! Invalid_Value_Type =
         self.implementation.hour self
 
     ## GROUP Standard.Base.DateTime
@@ -1342,7 +1342,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    minute self -> Column | Any! Invalid_Value_Type =
+    minute self -> Column | Any ! Invalid_Value_Type =
         self.implementation.minute self
 
     ## GROUP Standard.Base.DateTime
@@ -1351,7 +1351,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    second self -> Column | Any! Invalid_Value_Type =
+    second self -> Column | Any ! Invalid_Value_Type =
         self.implementation.second self
 
     ## GROUP Standard.Base.DateTime
@@ -1360,7 +1360,7 @@ type Column
 
        Returns a column of `Integer` type.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_part self (period : Date_Period | Time_Period = ..Day) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
+    date_part self (period : Date_Period | Time_Period = ..Day) -> Column | Any ! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_part self period
 
     ## GROUP Standard.Base.DateTime
@@ -1388,7 +1388,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_diff self (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = ..Day) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
+    date_diff self (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = ..Day) -> Column | Any ! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_diff self end period
 
     ## GROUP Standard.Base.DateTime
@@ -1411,7 +1411,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_add self (amount : Column | Integer) (period : Date_Period | Time_Period = default_date_period self) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
+    date_add self (amount : Column | Integer) (period : Date_Period | Time_Period = default_date_period self) -> Column | Any ! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_add self amount period
 
     ## GROUP Standard.Base.Logical
@@ -1430,7 +1430,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.is_in [1, 2, 5]
-    is_in self (vector : Vector | Column | Array) -> Column | Any=
+    is_in self (vector : Vector | Column | Array) -> Column | Any =
         self.implementation.is_in self vector
 
     ## GROUP Standard.Base.Conversions
@@ -1516,7 +1516,7 @@ type Column
              example_contains = Examples.text_column_1.parse Boolean 'Yes|No'
     @type Widget_Helpers.parse_type_selector
     @format (make_format_chooser include_number=False)
-    parse self (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning -> Column | Any=
+    parse self (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning -> Column | Any =
         self.implementation.parse self type format on_problems
 
     ## GROUP Standard.Base.Conversions
@@ -1599,7 +1599,7 @@ type Column
              # ==> ["100 000 000,00", "2 222,00", "3,00"]
     @locale Locale.default_widget
     @format (self-> Widget_Helpers.make_format_chooser_for_type self.value_type)
-    format self (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default -> Column | Any! Illegal_Argument =
+    format self (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default -> Column | Any ! Illegal_Argument =
         self.implementation.format self format locale
 
     ## GROUP Standard.Base.Conversions
@@ -1650,7 +1650,7 @@ type Column
          The `parse` method should be used to convert text values into other
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
-    cast self value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning -> Column | Any! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure =
+    cast self value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning -> Column | Any ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure =
         self.implementation.cast self value_type on_problems
 
     ## ALIAS auto_value_type
@@ -1684,7 +1684,7 @@ type Column
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    auto_cast self shrink_types:Boolean=False -> Column | Any=
+    auto_cast self shrink_types:Boolean=False -> Column | Any =
         self.implementation.auto_cast self shrink_types
 
     ## PRIVATE
@@ -1721,7 +1721,7 @@ type Column
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    auto_value_type self shrink_types:Boolean=False -> Column | Any=
+    auto_value_type self shrink_types:Boolean=False -> Column | Any =
         Warning.attach (Deprecated.Warning "Standard.Table.Column.Column" "auto_value_type" "Deprecated: `auto_value_type` has been replaced by `auto_cast`.") <|
             self.auto_cast shrink_types
 
@@ -1754,7 +1754,7 @@ type Column
              import Standard.Examples
 
              example_map = Examples.integer_column.map (x -> x * x)
-    map self (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) -> Column | Any! Invalid_Value_Type =
+    map self (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) -> Column | Any ! Invalid_Value_Type =
         self.implementation.map self function skip_nothing expected_value_type
 
     ## ALIAS join by row position
@@ -1820,7 +1820,7 @@ type Column
              import Standard.Examples
 
              example_rename = Examples.integer_column.rename "My Numbers"
-    rename self name:Text -> Column | Any! Illegal_Argument =
+    rename self name:Text -> Column | Any ! Illegal_Argument =
         self.implementation.rename self name
 
     ## GROUP Standard.Base.Metadata
@@ -1926,7 +1926,7 @@ type Column
          By default, it will return all rows for in-memory columns, but in
          Database it will read up to 1000 rows and warn if there are more.
     @max_rows Rows_To_Read.default_widget
-    read self (max_rows : Rows_To_Read = default_row_limit_for_read self) -> Column | Any=
+    read self (max_rows : Rows_To_Read = default_row_limit_for_read self) -> Column | Any =
         self.implementation.read self max_rows
 
     ## GROUP Standard.Base.Conversions
@@ -2041,7 +2041,7 @@ type Column
              example_sort =
                  my_compare a b = Ordering.compare a.abs b.abs
                  Examples.decimal_column.sort by=my_compare
-    sort self order:Sort_Direction=..Ascending missing_last:Boolean=True (by : (Any -> Any -> Ordering) | Nothing = Nothing) -> Column | Any=
+    sort self order:Sort_Direction=..Ascending missing_last:Boolean=True (by : (Any -> Any -> Ordering) | Nothing = Nothing) -> Column | Any =
         self.implementation.sort self order missing_last by
 
     ## ALIAS first, head, keep, last, limit, sample, slice, tail, top
@@ -2075,7 +2075,7 @@ type Column
              ## The take returns "Charlie"
              last_row = column.take (..Last 1)
     @range (self-> Index_Sub_Range.default_widget self.length)
-    take self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any=
+    take self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any =
         self.implementation.take self range
 
     ## ALIAS remove, skip
@@ -2087,7 +2087,7 @@ type Column
        Arguments:
        - range: The selection of rows from the table to remove.
     @range (self-> Index_Sub_Range.default_widget self.length)
-    drop self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any=
+    drop self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any =
         self.implementation.drop self range
 
     ## PRIVATE
@@ -2139,7 +2139,7 @@ type Column
              import Standard.Examples
 
              example_reverse = Examples.integer_column.reverse
-    reverse self -> Column | Any=
+    reverse self -> Column | Any =
         self.implementation.reverse self
 
     ## GROUP Standard.Base.Metadata
@@ -2153,7 +2153,7 @@ type Column
              import Standard.Examples
 
              example_duplicate_count = Examples.integer_column.duplicate_count
-    duplicate_count self -> Column | Any=
+    duplicate_count self -> Column | Any =
         self.implementation.duplicate_count self
 
     ## PRIVATE
@@ -2192,7 +2192,7 @@ type Column
        Arguments:
        - statistic: Statistic to calculate.
        - name: Name of the new column.
-    running self statistic:Statistic=..Count (name : Text = statistic.to_text+" "+self.name) -> Column | Any=
+    running self statistic:Statistic=..Count (name : Text = statistic.to_text+" "+self.name) -> Column | Any =
         self.implementation.running self statistic name
 
     ## ALIAS displace, lag, lead, shift, slide
@@ -2209,7 +2209,7 @@ type Column
        - - ..Closest_Value - If n is negative the first value gets used, if n is negative the last value gets used.
        - - ..Wrap_Around - In this mode values that slide off the top or bottom reappear at the other end. So no values get lost they are just rotated.
     @n (self-> Numeric_Input minimum=0-self.length maximum=self.length)
-    offset self n:Integer=-1 fill_with:Fill_With=..Nothing -> Column | Any=
+    offset self n:Integer=-1 fill_with:Fill_With=..Nothing -> Column | Any =
         self.implementation.offset self n fill_with
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -50,7 +50,7 @@ type Column
 
              example_from_vector =
                  Column.from_vector "My Column" [1, 2, 3, 4, 5]
-    from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) -> Column ! Invalid_Value_Type =
+    from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) -> Column | Any! Invalid_Value_Type =
         In_Memory_Column.from_vector name items value_type
 
     ## PRIVATE
@@ -61,7 +61,7 @@ type Column
        - name: The name of the column to create.
        - item: The element to repeat in the column.
        - repeats: The number of times to repeat the element.
-    from_repeated_item name:Text item:Any repeats:Integer -> Column =
+    from_repeated_item name:Text item:Any repeats:Integer -> Column | Any=
         In_Memory_Column.from_repeated_item name item repeats
 
     ## PRIVATE
@@ -155,7 +155,7 @@ type Column
        Returns a column with results of comparing this column's elements against
        `other`.
     @locale Locale.default_widget
-    equals_ignore_case self (other : Column | Any) locale:Locale=Locale.default -> Column =
+    equals_ignore_case self (other : Column | Any) locale:Locale=Locale.default -> Column | Any=
         self.implementation.equals_ignore_case self other locale
 
     ## ALIAS not equals
@@ -323,7 +323,7 @@ type Column
 
        Returns a column with boolean values indicating whether values of this
        column fit between the lower and upper bounds (both ends inclusive).
-    between self (lower : Column | Any) (upper : Column | Any) -> Column =
+    between self (lower : Column | Any) (upper : Column | Any) -> Column | Any=
         self.implementation.between self lower upper
 
     ## ALIAS add, concatenate, plus
@@ -629,7 +629,7 @@ type Column
              import Standard.Examples
 
              example_not = Examples.bool_column_1.not
-    not self -> Column =
+    not self -> Column | Any=
         self.implementation.not self
 
     ## ALIAS if
@@ -649,7 +649,7 @@ type Column
              import Standard.Examples
 
              example_if = Examples.bool_column_1.iif 1 0
-    iif self (when_true : Column | Any) (when_false : Column | Any) -> Column =
+    iif self (when_true : Column | Any) (when_false : Column | Any) -> Column | Any=
         self.implementation.iif self when_true when_false
 
     ## PRIVATE
@@ -667,7 +667,7 @@ type Column
          Create a column of the value 42
 
          column.const 42
-    const self value:Any -> Column =
+    const self value:Any -> Column | Any=
         self.to_table.make_constant_column value
 
     ## GROUP Standard.Base.Math
@@ -731,7 +731,7 @@ type Column
          Round a column of `Float` values`.
 
              Column.from_vector "foo" [1.2, 2.3, 3.6] . round == (Column.from_vector "foo" [1, 2, 4])
-    round self decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) -> Column ! Illegal_Argument | Invalid_Value_Type =
+    round self decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) -> Column | Any! Illegal_Argument | Invalid_Value_Type =
         self.implementation.round self decimal_places rounding_mode
 
     ## ALIAS int
@@ -757,7 +757,7 @@ type Column
             date_times = Column.from_vector "foo" [Date_Time.new 2020 10 24 1 2 3, Date_Time.new 2020 10 24 1 2 3]
             dates = Column.from_vector "foo" [Date.new 2020 10 24, Date.new 2020 10 24]
             col.truncate == dates
-    truncate self -> Column ! Invalid_Value_Type =
+    truncate self -> Column | Any! Invalid_Value_Type =
         self.implementation.truncate self
 
     ## GROUP Standard.Base.Rounding
@@ -775,7 +775,7 @@ type Column
          Take the ceiling of a column of `Float` values.
 
              Column.from_vector "foo" [1.25, 2.33, 3.57] . ceil == (Column.from_vector "foo" [2, 3, 4])
-    ceil self -> Column ! Invalid_Value_Type =
+    ceil self -> Column | Any! Invalid_Value_Type =
         self.implementation.ceil self
 
     ## GROUP Standard.Base.Rounding
@@ -793,7 +793,7 @@ type Column
          Take the floor of a column of `Float` values.
 
              Column.from_vector "foo" [1.25, 2.33, 3.57] . floor == (Column.from_vector "foo" [1, 2, 3])
-    floor self -> Column ! Invalid_Value_Type =
+    floor self -> Column | Any! Invalid_Value_Type =
         self.implementation.floor self
 
     ## GROUP Standard.Base.Logical
@@ -810,7 +810,7 @@ type Column
              import Standard.Examples
 
              example_coalesce = Examples.decimal_column.coalesce Examples.integer_column
-    coalesce self (values : Any | Vector Any) -> Column =
+    coalesce self (values : Any | Vector Any) -> Column | Any=
         self.implementation.coalesce self values
 
     ## GROUP Standard.Base.Math
@@ -831,7 +831,7 @@ type Column
              import Standard.Examples
 
              example_min = Examples.decimal_column.min Examples.integer_column
-    min self (values : Any | Vector Any) -> Column =
+    min self (values : Any | Vector Any) -> Column | Any=
         self.implementation.min self values
 
     ## GROUP Standard.Base.Math
@@ -852,7 +852,7 @@ type Column
              import Standard.Examples
 
              example_max = Examples.decimal_column.max Examples.integer_column
-    max self (values : Any | Vector Any) -> Column =
+    max self (values : Any | Vector Any) -> Column | Any=
         self.implementation.max self values
 
     ## GROUP Standard.Base.Logical
@@ -866,14 +866,14 @@ type Column
              import Standard.Examples
 
              example_is_nothing = Examples.decimal_column.is_nothing
-    is_nothing self -> Column =
+    is_nothing self -> Column | Any=
         self.implementation.is_nothing_implementation self
 
     ## GROUP Standard.Base.Math
        ICON math
        Returns a column of booleans, with `True` items at the positions where
        this column contains a NaN. This is only applicable to double columns.
-    is_nan self -> Column =
+    is_nan self -> Column | Any=
         self.implementation.is_nan self
 
     ## GROUP Standard.Base.Math
@@ -881,7 +881,7 @@ type Column
        Returns a column of booleans, with `True` items at the positions where
        this column contains a +Inf/-Inf. This is only applicable to double
        columns.
-    is_infinite self -> Column =
+    is_infinite self -> Column | Any=
         self.implementation.is_infinite self
 
     ## GROUP Standard.Base.Math
@@ -889,13 +889,13 @@ type Column
        Returns a column of booleans, with `True` items at the positions where
        this column contains a non-infinite, non-NaN floating point value. This
        is only applicable to double columns.
-    is_finite self -> Column =
+    is_finite self -> Column | Any=
         self.implementation.is_finite self
 
     ## PRIVATE
        Returns a column of booleans, with `True` items at the positions where
        this column contains an empty string or `Nothing`.
-    is_empty self -> Column =
+    is_empty self -> Column | Any=
         self.implementation.is_empty self
 
     ## GROUP Standard.Base.Logical
@@ -909,7 +909,7 @@ type Column
              import Standard.Examples
 
              example_is_present = Examples.decimal_column.is_present
-    is_present self -> Column =
+    is_present self -> Column | Any=
         self.implementation.is_present self
 
     ## PRIVATE
@@ -922,7 +922,7 @@ type Column
 
        ? Blank values
          Blank values are `Nothing`, `""` and depending on setting `Number.nan`.
-    is_blank self treat_nans_as_blank:Boolean=False -> Column =
+    is_blank self treat_nans_as_blank:Boolean=False -> Column | Any=
         self.implementation.is_blank self treat_nans_as_blank
 
     ## ALIAS fill missing, if_nothing
@@ -947,7 +947,7 @@ type Column
 
              example_fill_nothing = Examples.decimal_column.fill_nothing 20.5
     @default (self-> Widget_Helpers.make_fill_default_value_selector value_types=self.value_type)
-    fill_nothing self (default : Column | Previous_Value | Any) -> Column =
+    fill_nothing self (default : Column | Previous_Value | Any) -> Column | Any=
         self.implementation.fill_nothing self default
 
     ## ALIAS fill empty, if_empty
@@ -971,7 +971,7 @@ type Column
 
              example_fill_empty = Examples.text_column_1.fill_empty "hello"
     @default (self-> Widget_Helpers.make_fill_default_value_selector value_types=Value_Type.Char add_nothing=True)
-    fill_empty self (default : Column | Previous_Value | Any) -> Column =
+    fill_empty self (default : Column | Previous_Value | Any) -> Column | Any=
         self.implementation.fill_empty self default
 
     ## GROUP Standard.Base.Text
@@ -1007,7 +1007,7 @@ type Column
              import Standard.Examples
 
              example_starts_with = Examples.text_column_1.starts_with "hell" Case_Sensitivity.Insensitive
-    starts_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column =
+    starts_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
         self.implementation.starts_with self other case_sensitivity
 
     ## GROUP Standard.Base.Text
@@ -1036,7 +1036,7 @@ type Column
              import Standard.Examples
 
              example_ends_with = Examples.text_column_1.ends_with "hell"
-    ends_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column =
+    ends_with self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
         self.implementation.ends_with self other case_sensitivity
 
     ## GROUP Standard.Base.Text
@@ -1053,7 +1053,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_length
-    text_length self -> Column =
+    text_length self -> Column | Any=
         self.implementation.text_length self
 
     ## GROUP Standard.Base.Text
@@ -1070,7 +1070,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_left 5
-    text_left self (n : Column | Integer) -> Column =
+    text_left self (n : Column | Integer) -> Column | Any=
         self.implementation.text_left self n
 
     ## GROUP Standard.Base.Text
@@ -1087,7 +1087,7 @@ type Column
 
              example_text_length =
                 Examples.text_column_1.text_right 5
-    text_right self (n : Column | Integer) -> Column =
+    text_right self (n : Column | Integer) -> Column | Any=
         self.implementation.text_right self n
 
     ## GROUP Standard.Base.Logical
@@ -1116,7 +1116,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.contains "hell"
-    contains self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column =
+    contains self (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column | Any=
         self.implementation.contains self other case_sensitivity
 
     ## GROUP Standard.Base.Logical
@@ -1136,7 +1136,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.like "F%."
-    like self (pattern : Column | Text | Any) -> Column =
+    like self (pattern : Column | Text | Any) -> Column | Any=
         self.implementation.like self pattern
 
     ## GROUP Standard.Base.Logical
@@ -1154,7 +1154,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.regex_match (regex "A.*M")
-    regex_match self (pattern : Column | Text | Regex) -> Column =
+    regex_match self (pattern : Column | Text | Regex) -> Column | Any=
         self.implementation.regex_match self pattern
 
     ## GROUP Standard.Base.Text
@@ -1167,7 +1167,7 @@ type Column
          function trims both ends of the input.
        - what: A `Text` (or text `Column`) containing characters that should be
          removed. By default, all whitespace is removed.
-    trim self where:Location=..Both (what : Text | Column = '') -> Column =
+    trim self where:Location=..Both (what : Text | Column = '') -> Column | Any=
         self.implementation.trim self where what
 
     ## ALIAS regex, substitute
@@ -1245,7 +1245,7 @@ type Column
              column.text_replace '"(.*?)"'.to_regex '($1)'
     @term make_regex_text_widget
     @new_text (Text_Input display=..Always)
-    text_replace self (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False -> Column =
+    text_replace self (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False -> Column | Any=
         self.implementation.text_replace self term new_text case_sensitivity only_first
 
     ## GROUP Standard.Base.Text
@@ -1275,7 +1275,7 @@ type Column
 
              column.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
-    text_cleanse self (remove : Vector Named_Pattern) -> Column =
+    text_cleanse self (remove : Vector Named_Pattern) -> Column | Any=
         self.implementation.text_cleanse self remove
 
     ## GROUP Standard.Base.DateTime
@@ -1284,7 +1284,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    year self -> Column ! Invalid_Value_Type =
+    year self -> Column | Any! Invalid_Value_Type =
         self.implementation.year self
 
     ## GROUP Standard.Base.DateTime
@@ -1293,7 +1293,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    month self -> Column ! Invalid_Value_Type =
+    month self -> Column | Any! Invalid_Value_Type =
         self.implementation.month self
 
     ## GROUP Standard.Base.DateTime
@@ -1303,7 +1303,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day self -> Column ! Invalid_Value_Type =
+    day self -> Column | Any! Invalid_Value_Type =
         self.implementation.day self
 
     ## GROUP Standard.Base.DateTime
@@ -1313,7 +1313,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day_of_year self -> Column ! Invalid_Value_Type =
+    day_of_year self -> Column | Any! Invalid_Value_Type =
         self.implementation.day_of_year self
 
     ## ALIAS weekday
@@ -1324,7 +1324,7 @@ type Column
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
        Returns a column of `Integer` type.
-    day_of_week self -> Column ! Invalid_Value_Type =
+    day_of_week self -> Column | Any! Invalid_Value_Type =
         self.implementation.day_of_week self
 
     ## GROUP Standard.Base.DateTime
@@ -1333,7 +1333,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    hour self -> Column ! Invalid_Value_Type =
+    hour self -> Column | Any! Invalid_Value_Type =
         self.implementation.hour self
 
     ## GROUP Standard.Base.DateTime
@@ -1342,7 +1342,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    minute self -> Column ! Invalid_Value_Type =
+    minute self -> Column | Any! Invalid_Value_Type =
         self.implementation.minute self
 
     ## GROUP Standard.Base.DateTime
@@ -1351,7 +1351,7 @@ type Column
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
        Returns a column of `Integer` type.
-    second self -> Column ! Invalid_Value_Type =
+    second self -> Column | Any! Invalid_Value_Type =
         self.implementation.second self
 
     ## GROUP Standard.Base.DateTime
@@ -1360,7 +1360,7 @@ type Column
 
        Returns a column of `Integer` type.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_part self (period : Date_Period | Time_Period = ..Day) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_part self (period : Date_Period | Time_Period = ..Day) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_part self period
 
     ## GROUP Standard.Base.DateTime
@@ -1388,7 +1388,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_diff self (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = ..Day) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_diff self (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = ..Day) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_diff self end period
 
     ## GROUP Standard.Base.DateTime
@@ -1411,7 +1411,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_add self (amount : Column | Integer) (period : Date_Period | Time_Period = default_date_period self) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_add self (amount : Column | Integer) (period : Date_Period | Time_Period = default_date_period self) -> Column | Any! Invalid_Value_Type | Illegal_Argument =
         self.implementation.date_add self amount period
 
     ## GROUP Standard.Base.Logical
@@ -1430,7 +1430,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.is_in [1, 2, 5]
-    is_in self (vector : Vector | Column | Array) -> Column =
+    is_in self (vector : Vector | Column | Array) -> Column | Any=
         self.implementation.is_in self vector
 
     ## GROUP Standard.Base.Conversions
@@ -1516,7 +1516,7 @@ type Column
              example_contains = Examples.text_column_1.parse Boolean 'Yes|No'
     @type Widget_Helpers.parse_type_selector
     @format (make_format_chooser include_number=False)
-    parse self (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning -> Column =
+    parse self (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning -> Column | Any=
         self.implementation.parse self type format on_problems
 
     ## GROUP Standard.Base.Conversions
@@ -1599,7 +1599,7 @@ type Column
              # ==> ["100 000 000,00", "2 222,00", "3,00"]
     @locale Locale.default_widget
     @format (self-> Widget_Helpers.make_format_chooser_for_type self.value_type)
-    format self (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default -> Column ! Illegal_Argument =
+    format self (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default -> Column | Any! Illegal_Argument =
         self.implementation.format self format locale
 
     ## GROUP Standard.Base.Conversions
@@ -1650,7 +1650,7 @@ type Column
          The `parse` method should be used to convert text values into other
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
-    cast self value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning -> Column ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure =
+    cast self value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning -> Column | Any! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure =
         self.implementation.cast self value_type on_problems
 
     ## ALIAS auto_value_type
@@ -1684,7 +1684,7 @@ type Column
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    auto_cast self shrink_types:Boolean=False -> Column =
+    auto_cast self shrink_types:Boolean=False -> Column | Any=
         self.implementation.auto_cast self shrink_types
 
     ## PRIVATE
@@ -1721,7 +1721,7 @@ type Column
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    auto_value_type self shrink_types:Boolean=False -> Column =
+    auto_value_type self shrink_types:Boolean=False -> Column | Any=
         Warning.attach (Deprecated.Warning "Standard.Table.Column.Column" "auto_value_type" "Deprecated: `auto_value_type` has been replaced by `auto_cast`.") <|
             self.auto_cast shrink_types
 
@@ -1754,7 +1754,7 @@ type Column
              import Standard.Examples
 
              example_map = Examples.integer_column.map (x -> x * x)
-    map self (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) -> Column ! Invalid_Value_Type =
+    map self (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) -> Column | Any! Invalid_Value_Type =
         self.implementation.map self function skip_nothing expected_value_type
 
     ## ALIAS join by row position
@@ -1820,7 +1820,7 @@ type Column
              import Standard.Examples
 
              example_rename = Examples.integer_column.rename "My Numbers"
-    rename self name:Text -> Column ! Illegal_Argument =
+    rename self name:Text -> Column | Any! Illegal_Argument =
         self.implementation.rename self name
 
     ## GROUP Standard.Base.Metadata
@@ -1926,7 +1926,7 @@ type Column
          By default, it will return all rows for in-memory columns, but in
          Database it will read up to 1000 rows and warn if there are more.
     @max_rows Rows_To_Read.default_widget
-    read self (max_rows : Rows_To_Read = default_row_limit_for_read self) -> Column =
+    read self (max_rows : Rows_To_Read = default_row_limit_for_read self) -> Column | Any=
         self.implementation.read self max_rows
 
     ## GROUP Standard.Base.Conversions
@@ -2041,7 +2041,7 @@ type Column
              example_sort =
                  my_compare a b = Ordering.compare a.abs b.abs
                  Examples.decimal_column.sort by=my_compare
-    sort self order:Sort_Direction=..Ascending missing_last:Boolean=True (by : (Any -> Any -> Ordering) | Nothing = Nothing) -> Column =
+    sort self order:Sort_Direction=..Ascending missing_last:Boolean=True (by : (Any -> Any -> Ordering) | Nothing = Nothing) -> Column | Any=
         self.implementation.sort self order missing_last by
 
     ## ALIAS first, head, keep, last, limit, sample, slice, tail, top
@@ -2075,7 +2075,7 @@ type Column
              ## The take returns "Charlie"
              last_row = column.take (..Last 1)
     @range (self-> Index_Sub_Range.default_widget self.length)
-    take self (range : Index_Sub_Range | Range | Integer = ..First) -> Column =
+    take self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any=
         self.implementation.take self range
 
     ## ALIAS remove, skip
@@ -2087,7 +2087,7 @@ type Column
        Arguments:
        - range: The selection of rows from the table to remove.
     @range (self-> Index_Sub_Range.default_widget self.length)
-    drop self (range : Index_Sub_Range | Range | Integer = ..First) -> Column =
+    drop self (range : Index_Sub_Range | Range | Integer = ..First) -> Column | Any=
         self.implementation.drop self range
 
     ## PRIVATE
@@ -2139,7 +2139,7 @@ type Column
              import Standard.Examples
 
              example_reverse = Examples.integer_column.reverse
-    reverse self -> Column =
+    reverse self -> Column | Any=
         self.implementation.reverse self
 
     ## GROUP Standard.Base.Metadata
@@ -2153,7 +2153,7 @@ type Column
              import Standard.Examples
 
              example_duplicate_count = Examples.integer_column.duplicate_count
-    duplicate_count self -> Column =
+    duplicate_count self -> Column | Any=
         self.implementation.duplicate_count self
 
     ## PRIVATE
@@ -2192,7 +2192,7 @@ type Column
        Arguments:
        - statistic: Statistic to calculate.
        - name: Name of the new column.
-    running self statistic:Statistic=..Count (name : Text = statistic.to_text+" "+self.name) -> Column =
+    running self statistic:Statistic=..Count (name : Text = statistic.to_text+" "+self.name) -> Column | Any=
         self.implementation.running self statistic name
 
     ## ALIAS displace, lag, lead, shift, slide
@@ -2209,7 +2209,7 @@ type Column
        - - ..Closest_Value - If n is negative the first value gets used, if n is negative the last value gets used.
        - - ..Wrap_Around - In this mode values that slide off the top or bottom reappear at the other end. So no values get lost they are just rotated.
     @n (self-> Numeric_Input minimum=0-self.length maximum=self.length)
-    offset self n:Integer=-1 fill_with:Fill_With=..Nothing -> Column =
+    offset self n:Integer=-1 fill_with:Fill_With=..Nothing -> Column | Any=
         self.implementation.offset self n fill_with
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Internal.Polyglot_Helpers
+import Standard.Base.Runtime.Context
 
 import project.Column.Column
 import project.Internal.In_Memory_Column_Implementation.In_Memory_Column_Implementation
@@ -18,6 +19,7 @@ from project.Internal.Storage import enso_to_java
 
 polyglot java import org.enso.table.data.column.operation.cast.CastOperation
 polyglot java import org.enso.table.data.table.Column as Java_Column
+polyglot java import org.enso.table.data.column.DataQualityMetrics
 polyglot java import org.enso.table.error.ValueTypeMismatchException
 
 ## A column whose data is stored in memory.
@@ -56,6 +58,9 @@ type In_Memory_Column
     ## PRIVATE
        Creates a new column given a Java Column object.
     private from_java_column java_column:Java_Column =
+        ## Trigger data quality metrics computation (conditionally on Output context).
+        if Context.Output.is_enabled.not then DataQualityMetrics.triggerColumn java_column
+
         column = In_Memory_Column.Value java_column
         In_Memory_Column_Refinements.refine_column column
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
@@ -17,9 +17,9 @@ from project.Errors import Conversion_Failure, Invalid_Column_Names, Invalid_Val
 from project.Internal.Column_Type_Helpers import column_from_implementation
 from project.Internal.Storage import enso_to_java
 
+polyglot java import org.enso.table.data.column.DataQualityMetrics
 polyglot java import org.enso.table.data.column.operation.cast.CastOperation
 polyglot java import org.enso.table.data.table.Column as Java_Column
-polyglot java import org.enso.table.data.column.DataQualityMetrics
 polyglot java import org.enso.table.error.ValueTypeMismatchException
 
 ## A column whose data is stored in memory.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
@@ -55,13 +55,13 @@ type In_Memory_Column
 
     ## PRIVATE
        Creates a new column given a Java Column object.
-    private from_java_column java_column:Java_Column -> Column =
+    private from_java_column java_column:Java_Column =
         column = In_Memory_Column.Value java_column
         In_Memory_Column_Refinements.refine_column column
 
     ## PRIVATE
        Implementation fro `Column.from_vector`.
-    private from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) -> Column ! Invalid_Value_Type =
+    private from_vector name:Text items:Vector (value_type : Auto | Value_Type = Auto) =
         ## If the type does not accept date-time-like values, we can skip the
            additional logic for polyglot conversions that would normally be used,
            which is quite costly - so if we can guarantee it is unnecessary,

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Table.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Data.Vector.No_Wrap
 import Standard.Base.Errors.Deprecated.Deprecated
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Runtime.Context
 from Standard.Base.Widget_Helpers import make_delimiter_selector
 
 import project.Column.Column
@@ -20,7 +21,6 @@ polyglot java import org.enso.table.data.table.Table as Java_Table
 
 # A table whose data is stored in memory.
 type In_Memory_Table
-
     ## PRIVATE
        Internal constructor that should not be used directly.
        Please use `from_java_table` if needed.
@@ -78,6 +78,9 @@ type In_Memory_Table
 ## PRIVATE
    Helper method for internal use to make a Table from a Java Table.
 from_java_table java_table -> Table & In_Memory_Table =
+    ## Trigger data quality metrics computation (conditionally on Output context).
+    if Context.Output.is_enabled.not then DataQualityMetrics.triggerTable java_table
+
     Table_Refinements.refine_table <|
         In_Memory_Table.Value java_table
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Table.enso
@@ -17,6 +17,7 @@ import project.Internal.Type_Refinements.Table_Refinements
 import project.Internal.In_Memory_Table_Implementation.In_Memory_Table_Implementation
 from project.Internal.Table_Type_Helpers import table_from_implementation
 
+polyglot java import org.enso.table.data.column.DataQualityMetrics
 polyglot java import org.enso.table.data.table.Table as Java_Table
 
 # A table whose data is stored in memory.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -82,7 +82,7 @@ type In_Memory_Column_Implementation
             a == b
         _call_comparator this_column other new_name (Comparators.eq this_column.java_column (_java_other other)) fallback
 
-    equals_ignore_case (this_column : Column & In_Memory_Column) (other : Column | Any) locale:Locale=
+    equals_ignore_case (this_column : Column & In_Memory_Column) (other : Column | Any) locale:Locale =
         ## TODO currently this always runs the fallback which is slow due to the
            cost of Java-to-Enso calls. We want to have a vectorized
            implementation, but we need to extend the architecture to allow
@@ -689,7 +689,7 @@ type In_Memory_Column_Implementation
 
     to_text_implementation (this_column : Column & In_Memory_Column) = "(In-Memory Column "+this_column.name.to_text+")"
 
-    pretty_implementation (this_column : Column & In_Memory_Column =
+    pretty_implementation (this_column : Column & In_Memory_Column) =
         (this_column:In_Memory_Column).pretty
 
     ## PRIVATE
@@ -727,7 +727,7 @@ type In_Memory_Column_Implementation
      It should never raise dataflow errors.
    - operands: The vector of operands to apply to the function after `column`.
    - new_name: The name of the column created as the result of this operation.
-private _run_vectorized_many_op column:Column name:Text fallback_fn:(Any -> Any -> Any) operands new_name:(Text | Nothing)=Nothing=
+private _run_vectorized_many_op column:Column name:Text fallback_fn:(Any -> Any -> Any) operands new_name:(Text | Nothing)=Nothing =
     effective_operands = Vector.unify_vector_or_element operands
     all_operands = [column]+effective_operands
     effective_new_name = new_name.if_nothing (naming_helper.function_name name all_operands)
@@ -833,13 +833,13 @@ private _call_binary_operator left:In_Memory_Column other new_name ~operation =
         In_Memory_Column.from_java_column java_column
 
 ## PRIVATE
-private _apply_case_sensitive_text_operation left:Column (other : Column | Text | Any) case_sensitivity:Case_Sensitivity operation fallback_fn new_name:Text=
+private _apply_case_sensitive_text_operation left:Column (other : Column | Text | Any) case_sensitivity:Case_Sensitivity operation fallback_fn new_name:Text =
     java_other = (if other.is_a Column then (other:In_Memory_Column).java_column else other)
     use_fallback = case case_sensitivity of
         Case_Sensitivity.Insensitive _ -> True
         _ -> operation.canApply (left:In_Memory_Column).java_column java_other . not
     case use_fallback of
-        True -> `_apply_binary_map` left fallback_fn other new_name=new_name skip_nulls=True expected_result_type=Value_Type.Boolean
+        True -> _apply_binary_map left fallback_fn other new_name=new_name skip_nulls=True expected_result_type=Value_Type.Boolean
         _ ->
             Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->
                 java_column = operation.apply (left:In_Memory_Column).java_column java_other new_name java_problem_aggregator

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -71,10 +71,10 @@ polyglot java import org.enso.table.operations.OrderBuilder
 polyglot java import org.enso.table.parsing.problems.ParseProblemAggregator
 
 type In_Memory_Column_Implementation
-    display (this_column : Column & In_Memory_Column) show_rows:Integer=10 format_terminal:Boolean=False -> Text =
+    display (this_column : Column & In_Memory_Column) show_rows:Integer format_terminal:Boolean =
         this_column.to_table.display show_rows format_terminal
 
-    equals (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    equals (this_column : Column & In_Memory_Column) (other : Column | Any) =
         new_name = naming_helper.binary_operation_name "==" this_column other
         fallback problem_builder a b =
             if (a.is_a Float) || (b.is_a Float) then
@@ -82,7 +82,7 @@ type In_Memory_Column_Implementation
             a == b
         _call_comparator this_column other new_name (Comparators.eq this_column.java_column (_java_other other)) fallback
 
-    equals_ignore_case (this_column : Column & In_Memory_Column) (other : Column | Any) locale:Locale=Locale.default -> Column =
+    equals_ignore_case (this_column : Column & In_Memory_Column) (other : Column | Any) locale:Locale=
         ## TODO currently this always runs the fallback which is slow due to the
            cost of Java-to-Enso calls. We want to have a vectorized
            implementation, but we need to extend the architecture to allow
@@ -95,7 +95,7 @@ type In_Memory_Column_Implementation
                 new_name = naming_helper.function_name "equals_ignore_case" [this_column, other]
                 _apply_binary_map this_column fallback other new_name expected_result_type=Value_Type.Boolean
 
-    not_equals (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    not_equals (this_column : Column & In_Memory_Column) (other : Column | Any) =
         new_name = naming_helper.binary_operation_name "!=" this_column other
         fallback problem_builder a b =
             if (a.is_a Float) || (b.is_a Float) then
@@ -103,35 +103,35 @@ type In_Memory_Column_Implementation
             a != b
         _call_comparator this_column other new_name (Comparators.notEq this_column.java_column (_java_other other)) fallback
 
-    greater_than_eq (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
+    greater_than_eq (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a >= b
         _call_comparator this_column other new_name (Comparators.greaterThanEq this_column.java_column (_java_other other)) fallback
 
-    less_than_eq (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
+    less_than_eq (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a <= b
         _call_comparator this_column other new_name (Comparators.lessThanEq this_column.java_column (_java_other other)) fallback
 
-    greater_than (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
+    greater_than (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a > b
         _call_comparator this_column other new_name (Comparators.greaterThan this_column.java_column (_java_other other)) fallback
 
-    less_than (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
+    less_than (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<" this_column other
         fallback problem_builder a b =
             _ = problem_builder
             a < b
         _call_comparator this_column other new_name (Comparators.lessThan this_column.java_column (_java_other other)) fallback
 
-    between (this_column : Column & In_Memory_Column) (lower : Column | Any) (upper : Column | Any) -> Column = Value_Type.expect_comparable this_column lower <| Value_Type.expect_comparable this_column upper <|
+    between (this_column : Column & In_Memory_Column) (lower : Column | Any) (upper : Column | Any) = Value_Type.expect_comparable this_column lower <| Value_Type.expect_comparable this_column upper <|
         new_name = naming_helper.concat <|
             [naming_helper.to_expression_text this_column, "between", naming_helper.to_expression_text lower, "and", naming_helper.to_expression_text upper]
         lower_check = (this_column >= lower)
@@ -139,14 +139,14 @@ type In_Memory_Column_Implementation
         result = lower_check && upper_check
         result.rename new_name
 
-    add (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    add (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.resolve_addition_kind this_column other . if_not_error <|
             operation = BinaryOperator.add (this_column:In_Memory_Column).java_column (_java_other other)
             if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported add operation.")
             new_name = naming_helper.binary_operation_name "+" this_column other
             _call_binary_operator this_column other new_name operation
 
-    minus (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    minus (this_column : Column & In_Memory_Column) (other : Column | Any) =
         kind = Value_Type_Helpers.resolve_subtraction_kind this_column other
         kind.if_not_error <|
             new_name = naming_helper.binary_operation_name "-" this_column other
@@ -159,50 +159,50 @@ type In_Memory_Column_Implementation
                     if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported minus operation.")
                     _call_binary_operator this_column other new_name operation
 
-    multiply (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    multiply (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.check_binary_numeric_op this_column other <|
             operation = BinaryOperator.multiply (this_column:In_Memory_Column).java_column (_java_other other)
             if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported multiply operation.")
             new_name = naming_helper.binary_operation_name "*" this_column other
             _call_binary_operator this_column other new_name operation
 
-    divide (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    divide (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.check_binary_numeric_op this_column other <|
             operation = BinaryOperator.divide (this_column:In_Memory_Column).java_column (_java_other other)
             if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported divide operation.")
             new_name = naming_helper.binary_operation_name "/" this_column other
             _call_binary_operator this_column other new_name operation
 
-    modulus (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    modulus (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.check_binary_numeric_op this_column other <|
             operation = BinaryOperator.modulus (this_column:In_Memory_Column).java_column (_java_other other)
             if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported modulo operation.")
             new_name = naming_helper.binary_operation_name "%" this_column other
             _call_binary_operator this_column other new_name operation
 
-    power (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column = Illegal_Argument.handle_java_exception <|
+    power (this_column : Column & In_Memory_Column) (other : Column | Any) = Illegal_Argument.handle_java_exception <|
         Value_Type_Helpers.check_binary_numeric_op this_column other <|
             operation = BinaryOperator.power (this_column:In_Memory_Column).java_column (_java_other other)
             if operation.is_nothing then Error.throw (Illegal_State.Error "Unsupported power operation.")
             new_name = naming_helper.binary_operation_name "^" this_column other
             _call_binary_operator this_column other new_name operation
 
-    and (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    and (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.check_binary_boolean_op this_column other <|
             new_name = naming_helper.binary_operation_name "&&" this_column other
             _call_binary_operator this_column other new_name LogicalOperations.AND
 
-    or (this_column : Column & In_Memory_Column) (other : Column | Any) -> Column =
+    or (this_column : Column & In_Memory_Column) (other : Column | Any) =
         Value_Type_Helpers.check_binary_boolean_op this_column other <|
             new_name = naming_helper.binary_operation_name "||" this_column other
             _call_binary_operator this_column other new_name LogicalOperations.OR
 
-    not (this_column : Column & In_Memory_Column) -> Column =
+    not (this_column : Column & In_Memory_Column) =
         Value_Type.expect_boolean this_column <|
             new_name = naming_helper.concat ["not", naming_helper.to_expression_text this_column]
             apply_unary_operation this_column NotOperation.INSTANCE new_name
 
-    iif this_column (when_true : Column | Any) (when_false : Column | Any) -> Column = Value_Type.expect_boolean this_column <|
+    iif this_column (when_true : Column | Any) (when_false : Column | Any) = Value_Type.expect_boolean this_column <|
         common_type = Value_Type_Helpers.find_common_type_for_arguments [when_true, when_false] . if_nothing Value_Type.Mixed
         storage_type = Storage.from_value_type_strict common_type
         storage_type.if_not_error <|
@@ -219,13 +219,13 @@ type In_Memory_Column_Implementation
 
     const (this_column : Column & In_Memory_Column) value = this_column.to_table.make_constant_column value
 
-    round (this_column : Column & In_Memory_Column) decimal_places:Integer=0 (rounding_mode : Rounding_Mode = ..Half_Up) -> Column ! Illegal_Argument | Invalid_Value_Type =
+    round (this_column : Column & In_Memory_Column) decimal_places:Integer (rounding_mode : Rounding_Mode) =
         Value_Type.expect_numeric this_column <| Illegal_Argument.handle_java_exception <| Rounding_Helpers.check_decimal_places decimal_places <|
             new_name = naming_helper.function_name "round" [this_column]
             round_operation = RoundOperation.create (this_column:In_Memory_Column).java_column decimal_places (rounding_mode == Rounding_Mode.Bankers)
             apply_unary_operation this_column round_operation new_name
 
-    truncate (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type =
+    truncate (this_column : Column & In_Memory_Column) =
         new_name = naming_helper.function_name "truncate" [this_column]
         precise_value_type = this_column.inferred_precise_value_type
         case precise_value_type.is_numeric of
@@ -240,7 +240,7 @@ type In_Memory_Column_Implementation
                     apply_unary_operation this_column DateTruncateOperation.TRUNCATE_INSTANCE
                 False -> Error.throw <| Invalid_Value_Type.Column "Numeric or Date_Time" this_column.value_type this_column.name
 
-    ceil (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_numeric this_column <|
+    ceil (this_column : Column & In_Memory_Column) = Value_Type.expect_numeric this_column <|
         case this_column.inferred_precise_value_type.is_integer of
             True ->
                 new_name = naming_helper.function_name "ceil" [this_column]
@@ -248,7 +248,7 @@ type In_Memory_Column_Implementation
             False ->
                 apply_unary_operation this_column UnaryRoundOperation.CEIL_INSTANCE
 
-    floor (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_numeric this_column <|
+    floor (this_column : Column & In_Memory_Column) = Value_Type.expect_numeric this_column <|
         case this_column.inferred_precise_value_type.is_integer of
             True ->
                 new_name = naming_helper.function_name "floor" [this_column]
@@ -256,30 +256,30 @@ type In_Memory_Column_Implementation
             False ->
                 apply_unary_operation this_column UnaryRoundOperation.FLOOR_INSTANCE
 
-    coalesce (this_column : Column & In_Memory_Column) (values : Any | Vector Any) -> Column =
+    coalesce (this_column : Column & In_Memory_Column) (values : Any | Vector Any) =
         vec = Vector.unify_vector_or_element values
         new_name = naming_helper.function_name "coalesce" [this_column]+vec
         result = if vec.is_empty then this_column else
             vec.fold this_column acc-> v-> acc.fill_nothing v
         result.rename new_name
 
-    min (this_column : Column & In_Memory_Column) (values : Any | Vector Any) -> Column = Value_Type_Helpers.check_multi_argument_comparable_op this_column values <|
+    min (this_column : Column & In_Memory_Column) (values : Any | Vector Any) = Value_Type_Helpers.check_multi_argument_comparable_op this_column values <|
         fallback a b = if a.is_nothing then b else
             if b.is_nothing then a else
                 if b < a then b else a
         _run_vectorized_many_op this_column "min" fallback values
 
-    max (this_column : Column & In_Memory_Column) (values : Any | Vector Any) -> Column = Value_Type_Helpers.check_multi_argument_comparable_op this_column values <|
+    max (this_column : Column & In_Memory_Column) (values : Any | Vector Any) = Value_Type_Helpers.check_multi_argument_comparable_op this_column values <|
         fallback a b = if a.is_nothing then b else
             if b.is_nothing then a else
                 if b > a then b else a
         _run_vectorized_many_op this_column "max" fallback values
 
-    is_nothing_implementation (this_column : Column & In_Memory_Column) -> Column =
+    is_nothing_implementation (this_column : Column & In_Memory_Column) =
         new_name = naming_helper.concat [naming_helper.to_expression_text this_column, "is Nothing"]
         apply_unary_operation this_column IsNothingOperation.INSTANCE new_name
 
-    is_nan (this_column : Column & In_Memory_Column) -> Column = Value_Type.expect_numeric this_column <|
+    is_nan (this_column : Column & In_Memory_Column) = Value_Type.expect_numeric this_column <|
         In_Memory_Column_Implementation.internal_is_nan this_column
 
     internal_is_nan (this_column : Column & In_Memory_Column) =
@@ -289,21 +289,21 @@ type In_Memory_Column_Implementation
             _           -> False
         apply_unary_operation this_column DoubleIsOperation.IS_NAN new_name if_unsupported=(_apply_unary_map this_column new_name fallback Value_Type.Boolean)
 
-    is_infinite (this_column : Column & In_Memory_Column) -> Column = Value_Type.expect_numeric this_column <|
+    is_infinite (this_column : Column & In_Memory_Column) = Value_Type.expect_numeric this_column <|
         new_name = naming_helper.function_name "is_infinite" [this_column]
         fallback x = case x of
             _ : Float   -> x.is_infinite
             _           -> False
         apply_unary_operation this_column DoubleIsOperation.IS_INFINITE new_name if_unsupported=(_apply_unary_map this_column new_name fallback Value_Type.Boolean)
 
-    is_finite (this_column : Column & In_Memory_Column) -> Column = Value_Type.expect_numeric this_column <|
+    is_finite (this_column : Column & In_Memory_Column) = Value_Type.expect_numeric this_column <|
         new_name = naming_helper.function_name "is_finite" [this_column]
         fallback x = case x of
             _ : Float   -> x.is_finite
             _           -> True
         apply_unary_operation this_column DoubleIsOperation.IS_FINITE new_name if_unsupported=(_apply_unary_map this_column new_name fallback Value_Type.Boolean)
 
-    is_empty (this_column : Column & In_Memory_Column) -> Column = Value_Type.expect_text this_column <|
+    is_empty (this_column : Column & In_Memory_Column) = Value_Type.expect_text this_column <|
         In_Memory_Column_Implementation.internal_is_empty this_column
 
     internal_is_empty (this_column : Column & In_Memory_Column) =
@@ -314,11 +314,11 @@ type In_Memory_Column_Implementation
             _        -> False
         apply_unary_operation this_column IsEmptyOperation.INSTANCE new_name if_unsupported=(_apply_unary_map this_column new_name fallback Value_Type.Boolean nothing_unchanged=False)
 
-    is_present (this_column : Column & In_Memory_Column) -> Column =
+    is_present (this_column : Column & In_Memory_Column) =
         new_name = naming_helper.function_name "is_present" [this_column]
         this_column.is_nothing.not.rename new_name
 
-    is_blank (this_column : Column & In_Memory_Column) treat_nans_as_blank:Boolean=False -> Column =
+    is_blank (this_column : Column & In_Memory_Column) treat_nans_as_blank:Boolean =
         new_name = naming_helper.function_name "is_blank" [this_column]
         result = case this_column.value_type of
             Value_Type.Char _ _ -> this_column.is_empty
@@ -329,7 +329,7 @@ type In_Memory_Column_Implementation
             _ -> this_column.is_nothing
         result.rename new_name
 
-    fill_nothing (this_column : Column & In_Memory_Column) (default : Column | Previous_Value | Any) -> Column = case default of
+    fill_nothing (this_column : Column & In_Memory_Column) (default : Column | Previous_Value | Any) = case default of
         Previous_Value -> apply_unary_operation this_column FillFromPreviousOperation.INSTANCE
         _ ->
             common_type = Value_Type_Helpers.find_common_type_for_arguments [this_column, default]
@@ -339,7 +339,7 @@ type In_Memory_Column_Implementation
                 operation = FillMissingOperation.create java_column storage_type
                 _call_binary_operator this_column default this_column.name operation
 
-    fill_empty (this_column : Column & In_Memory_Column) (default : Column | Previous_Value | Any) -> Column = Value_Type.expect_text this_column <|
+    fill_empty (this_column : Column & In_Memory_Column) (default : Column | Previous_Value | Any) = Value_Type.expect_text this_column <|
         case default of
             Previous_Value -> apply_unary_operation this_column FillFromPreviousOperation.FILL_EMPTY
             _ ->
@@ -347,40 +347,40 @@ type In_Memory_Column_Implementation
                     result = this_column.is_empty.iif default this_column
                     result.rename this_column.name
 
-    starts_with (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
+    starts_with (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
         new_name = naming_helper.function_name "starts_with" [this_column, other]
         _apply_case_sensitive_text_operation this_column other case_sensitivity TextPredicates.STARTS_WITH (a -> b -> a.starts_with b case_sensitivity) new_name
 
-    ends_with (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
+    ends_with (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
         new_name = naming_helper.function_name "ends_with" [this_column, other]
         _apply_case_sensitive_text_operation this_column other case_sensitivity TextPredicates.ENDS_WITH (a -> b -> a.ends_with b case_sensitivity) new_name
 
-    text_length (this_column : Column & In_Memory_Column) -> Column =
+    text_length (this_column : Column & In_Memory_Column) =
         Value_Type.expect_text this_column <|
             apply_unary_operation this_column TextLengthOperation.INSTANCE
 
-    text_left (this_column : Column & In_Memory_Column) (n : Column | Integer) -> Column =
+    text_left (this_column : Column & In_Memory_Column) (n : Column | Integer) =
         Value_Type.expect_text this_column <| Value_Type.expect_integer n <|
             new_name = naming_helper.function_name "text_left" [this_column, n]
             _apply_case_sensitive_text_operation this_column n ..Default TextPartOperation.LEFT (a -> b -> a.take b) new_name
 
-    text_right (this_column : Column & In_Memory_Column) (n : Column | Integer) -> Column =
+    text_right (this_column : Column & In_Memory_Column) (n : Column | Integer) =
         Value_Type.expect_text this_column <| Value_Type.expect_integer n <|
             new_name = naming_helper.function_name "text_right" [this_column, n]
             _apply_case_sensitive_text_operation this_column n ..Default TextPartOperation.RIGHT (a -> b -> a.take (..Last b)) new_name
 
-    contains (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity=..Default -> Column = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
+    contains (this_column : Column & In_Memory_Column) (other : Column | Text | Any) case_sensitivity:Case_Sensitivity = Value_Type.expect_text this_column <| Value_Type.expect_text other <|
         new_name = naming_helper.function_name "contains" [this_column, other]
         _apply_case_sensitive_text_operation this_column other case_sensitivity TextPredicates.CONTAINS (a -> b -> a.contains b case_sensitivity) new_name
 
-    like (this_column : Column & In_Memory_Column) (pattern : Column | Text | Any) -> Column = Value_Type.expect_text this_column <| Value_Type.expect_text pattern <|
+    like (this_column : Column & In_Memory_Column) (pattern : Column | Text | Any) = Value_Type.expect_text this_column <| Value_Type.expect_text pattern <|
         new_name = naming_helper.binary_operation_name "like" this_column pattern
         fallback x y =
             _ = [x, y]
             Error.throw (Illegal_Argument.Error "LIKE operation is not supported for the given types.")
         _apply_case_sensitive_text_operation this_column pattern ..Default TextPredicates.LIKE fallback new_name
 
-    regex_match (this_column : Column & In_Memory_Column) (pattern : Column | Text | Regex) -> Column =
+    regex_match (this_column : Column & In_Memory_Column) (pattern : Column | Text | Regex) =
         string_pattern = case pattern of
             Regex.Value _ _ -> pattern.pattern
             _ -> pattern
@@ -391,7 +391,7 @@ type In_Memory_Column_Implementation
                 Error.throw (Illegal_Argument.Error "regex_match is not supported for the given types.")
             _apply_case_sensitive_text_operation this_column string_pattern ..Default TextPredicates.REGEX_MATCH fallback new_name
 
-    trim (this_column : Column & In_Memory_Column) where:Location=..Both (what : Text | Column = '') -> Column = Value_Type.expect_text this_column <|
+    trim (this_column : Column & In_Memory_Column) where:Location (what : Text | Column) = Value_Type.expect_text this_column <|
         parsed_what = if what.is_a Column && what.value_type == Value_Type.Null then "" else what
 
         new_name = naming_helper.function_name "trim" [this_column]
@@ -405,7 +405,7 @@ type In_Memory_Column_Implementation
                         if w.is_nothing || w.is_empty then t.trim where else t.trim where w
                     _apply_binary_map this_column fn parsed_what new_name skip_nulls=False expected_result_type=Value_Type.Char
 
-    text_replace (this_column : Column & In_Memory_Column) (term : Text | Regex | Column = "") (new_text : Text | Column = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False -> Column = Value_Type.expect_text this_column <|
+    text_replace (this_column : Column & In_Memory_Column) (term : Text | Regex | Column) (new_text : Text | Column) case_sensitivity:Case_Sensitivity only_first:Boolean = Value_Type.expect_text this_column <|
         parsed_term = if term.is_a Column && term.value_type == Value_Type.Null then "" else term
         parsed_new = if new_text.is_a Column && new_text.value_type == Value_Type.Null then "" else new_text
 
@@ -447,34 +447,34 @@ type In_Memory_Column_Implementation
 
                     In_Memory_Column.from_storage new_name builder.seal
 
-    text_cleanse (this_column : Column & In_Memory_Column) (remove : Vector Named_Pattern) -> Column =
+    text_cleanse (this_column : Column & In_Memory_Column) (remove : Vector Named_Pattern) =
       remove.map (Text_Cleanse.Value _) . fold this_column (current-> tc-> tc.apply current)
 
-    year (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_date this_column <|
+    year (this_column : Column & In_Memory_Column) = Value_Type.expect_has_date this_column <|
         apply_unary_operation this_column DatePartOperation.YEAR_INSTANCE
 
-    month (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_date this_column <|
+    month (this_column : Column & In_Memory_Column) = Value_Type.expect_has_date this_column <|
         apply_unary_operation this_column DatePartOperation.MONTH_INSTANCE
 
-    day (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_date this_column <|
+    day (this_column : Column & In_Memory_Column) = Value_Type.expect_has_date this_column <|
         apply_unary_operation this_column DatePartOperation.DAY_INSTANCE
 
-    day_of_year (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_date this_column <|
+    day_of_year (this_column : Column & In_Memory_Column) = Value_Type.expect_has_date this_column <|
         apply_unary_operation this_column DatePartOperation.DAY_OF_YEAR_INSTANCE
 
-    day_of_week (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_date this_column <|
+    day_of_week (this_column : Column & In_Memory_Column) = Value_Type.expect_has_date this_column <|
         apply_unary_operation this_column DatePartOperation.DAY_OF_WEEK_INSTANCE
 
-    hour (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_time this_column <|
+    hour (this_column : Column & In_Memory_Column) = Value_Type.expect_has_time this_column <|
         apply_unary_operation this_column DatePartOperation.HOUR_INSTANCE
 
-    minute (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_time this_column <|
+    minute (this_column : Column & In_Memory_Column) = Value_Type.expect_has_time this_column <|
         apply_unary_operation this_column DatePartOperation.MINUTE_INSTANCE
 
-    second (this_column : Column & In_Memory_Column) -> Column ! Invalid_Value_Type = Value_Type.expect_has_time this_column <|
+    second (this_column : Column & In_Memory_Column) = Value_Type.expect_has_time this_column <|
         apply_unary_operation this_column DatePartOperation.SECOND_INSTANCE
 
-    date_part (this_column : Column & In_Memory_Column) (period : Date_Period | Time_Period = ..Day) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_part (this_column : Column & In_Memory_Column) (period : Date_Period | Time_Period) =
         date_part_operation col name =
             operation = case name of
                 DatePartOperation.YEAR -> DatePartOperation.YEAR_INSTANCE
@@ -491,7 +491,7 @@ type In_Memory_Column_Implementation
             apply_unary_operation col operation
         Date_Time_Helpers.make_date_part_function this_column period date_part_operation naming_helper
 
-    date_diff (this_column : Column & In_Memory_Column) (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period = ..Day) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_diff (this_column : Column & In_Memory_Column) (end : Column | Date | Date_Time | Time_Of_Day) (period : Date_Period | Time_Period) =
         Value_Type.expect_type this_column .is_date_or_time "date/time" <|
             my_type = this_column.inferred_precise_value_type
             Value_Type.expect_type end (== my_type) my_type.to_display_text <|
@@ -508,7 +508,7 @@ type In_Memory_Column_Implementation
                             start-> end-> Time_Utils.unit_time_difference java_unit start end
                     _apply_binary_map this_column fn end new_name
 
-    date_add (this_column : Column & In_Memory_Column) (amount : Column | Integer) (period : Date_Period | Time_Period) -> Column ! Invalid_Value_Type | Illegal_Argument =
+    date_add (this_column : Column & In_Memory_Column) (amount : Column | Integer) (period : Date_Period | Time_Period) =
         Value_Type.expect_type this_column .is_date_or_time "date/time" <|
             my_type = this_column.inferred_precise_value_type
             Value_Type.expect_integer amount <|
@@ -524,7 +524,7 @@ type In_Memory_Column_Implementation
                         java_unit.addTo date amount
                     _apply_binary_map this_column fn amount new_name
 
-    is_in (this_column : Column & In_Memory_Column) (vector : Vector | Column | Array) -> Column =
+    is_in (this_column : Column & In_Memory_Column) (vector : Vector | Column | Array) =
         as_vector = case vector of
             _ : Vector -> vector
             _ : Array -> Vector.from_polyglot_array vector
@@ -542,7 +542,7 @@ type In_Memory_Column_Implementation
                 set = Hashset.from_vector as_vector error_on_duplicates=False
                 _apply_unary_map this_column new_name set.contains_relational Value_Type.Boolean nothing_unchanged=False
 
-    parse (this_column : Column & In_Memory_Column) (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter = "") on_problems:Problem_Behavior=..Report_Warning -> Column =
+    parse (this_column : Column & In_Memory_Column) (type : Value_Type | Auto = Auto) (format : Text | Data_Formatter) on_problems:Problem_Behavior =
         if type != Auto && this_column.value_type.is_same_type type then this_column else
             Value_Type.expect_text this_column <|
                 formatter = case format of
@@ -555,7 +555,7 @@ type In_Memory_Column_Implementation
                     parser.parseColumn this_column.java_column parse_problem_aggregator
                 In_Memory_Column.from_storage this_column.name new_storage
 
-    format (this_column : Column & In_Memory_Column) (format : Text | Date_Time_Formatter | Column = "") locale:Locale=Locale.default -> Column ! Illegal_Argument = case format of
+    format (this_column : Column & In_Memory_Column) (format : Text | Date_Time_Formatter | Column) locale:Locale = case format of
         format_column : Column -> Value_Type.expect_text format_column <|
             if format_column.length != this_column.length then Error.throw (Illegal_Argument.Error ("Column lengths differ: " + this_column.length.to_text + " != " + format_column.length.to_text)) else
                 formatter = make_value_formatter_for_value_type this_column.value_type locale
@@ -568,47 +568,47 @@ type In_Memory_Column_Implementation
                 formatter = make_value_formatter_for_value_type this_column.value_type locale format
                 _apply_unary_map this_column this_column.name formatter Value_Type.Char on_problems=..Report_Error
 
-    cast (this_column : Column & In_Memory_Column) value_type:Value_Type on_problems:Problem_Behavior=..Report_Warning -> Column ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure =
+    cast (this_column : Column & In_Memory_Column) value_type:Value_Type on_problems:Problem_Behavior =
         Cast_Helpers.check_cast_compatibility this_column.value_type value_type <|
             target_storage_type = Storage.from_value_type value_type on_problems
             Java_Problems.with_problem_aggregator on_problems java_problem_aggregator->
                 new_column = CastOperation.apply this_column.java_column target_storage_type java_problem_aggregator
                 In_Memory_Column.from_java_column new_column
 
-    auto_cast (this_column : Column & In_Memory_Column) shrink_types:Boolean=False -> Column =
+    auto_cast (this_column : Column & In_Memory_Column) shrink_types:Boolean =
         new_value_type = Storage.to_value_type <|
             CastOperation.inferPreciseType this_column.java_column (PreciseTypeOptions.forAutoCast shrink_types)
 
         # We run with Report_Error because we do not expect any problems.
         this_column.cast new_value_type on_problems=Problem_Behavior.Report_Error
 
-    map (this_column : Column & In_Memory_Column) (function : Any -> Any) skip_nothing:Boolean=True (expected_value_type : Value_Type | Auto = Auto) -> Column ! Invalid_Value_Type =
+    map (this_column : Column & In_Memory_Column) (function : Any -> Any) skip_nothing:Boolean (expected_value_type : Value_Type | Auto) =
         new_fn = if skip_nothing then (x-> if x.is_nothing then Nothing else function x) else function
         new_st = this_column.to_vector.map on_problems=No_Wrap.Value new_fn
         Column.from_vector this_column.name new_st value_type=expected_value_type
 
-    zip (this_column : Column & In_Memory_Column) (right : Column | Table = Missing_Argument.throw "right") (keep_unmatched : Boolean | Report_Unmatched = Report_Unmatched) (right_prefix : Text = "Right ") on_problems:Problem_Behavior=..Report_Warning -> Table =
+    zip (this_column : Column & In_Memory_Column) (right : Column | Table) (keep_unmatched : Boolean | Report_Unmatched ) (right_prefix : Text) on_problems:Problem_Behavior =
         right_table = case right of
             _ : Table -> right
             _ : Column -> right.to_table
         this_column.to_table.zip right_table keep_unmatched right_prefix on_problems
 
-    rename (this_column : Column & In_Memory_Column) name:Text -> Column ! Illegal_Argument = naming_helper.ensure_name_is_valid name <|
+    rename (this_column : Column & In_Memory_Column) name:Text = naming_helper.ensure_name_is_valid name <|
         Illegal_Argument.handle_java_exception <|
             In_Memory_Column.from_java_column (this_column.java_column.rename name)
 
-    name (this_column : Column & In_Memory_Column) -> Text = this_column.java_column.getName
+    name (this_column : Column & In_Memory_Column) = this_column.java_column.getName
 
-    length (this_column : Column & In_Memory_Column) -> Integer = this_column.java_column . getSize
+    length (this_column : Column & In_Memory_Column) = this_column.java_column . getSize
 
-    count_nothing (this_column : Column & In_Memory_Column) -> Integer = CountNothing.apply this_column.java_column
+    count_nothing (this_column : Column & In_Memory_Column) = CountNothing.apply this_column.java_column
 
-    count (this_column : Column & In_Memory_Column) -> Integer = this_column.length - this_column.count_nothing
+    count (this_column : Column & In_Memory_Column) = this_column.length - this_column.count_nothing
 
-    at (this_column : Column & In_Memory_Column) index:Integer=0 -> Any | Nothing ! Index_Out_Of_Bounds =
+    at (this_column : Column & In_Memory_Column) index:Integer =
         this_column.get index (Error.throw (Index_Out_Of_Bounds.Error index this_column.length))
 
-    get (this_column : Column & In_Memory_Column) index:Integer=0 ~default=Nothing -> Any | Nothing =
+    get (this_column : Column & In_Memory_Column) index:Integer ~default =
         length = this_column.length
         if index < 0 && index >= -length then this_column.get (length + index) default else
             valid_index = (index >= 0) && (index < length)
@@ -616,38 +616,38 @@ type In_Memory_Column_Implementation
                 java_column = this_column.java_column
                 java_to_enso <| java_column.getItem index
 
-    read (this_column : Column & In_Memory_Column) (max_rows : Rows_To_Read = ..All_Rows) -> Column =
+    read (this_column : Column & In_Memory_Column) (max_rows : Rows_To_Read) =
         if max_rows.is_nothing then this_column else
             this_column.to_table.read max_rows . at 0
 
-    to_vector (this_column : Column & In_Memory_Column) -> Vector =
+    to_vector (this_column : Column & In_Memory_Column) =
         column_as_list = this_column.java_column.asList
         Vector.from_polyglot_array column_as_list . map java_to_enso
 
-    value_type (this_column : Column & In_Memory_Column) -> Value_Type =
+    value_type (this_column : Column & In_Memory_Column) =
         storage_type = this_column.java_column.getType
         Storage.to_value_type storage_type
 
-    inferred_precise_value_type this_column -> Value_Type =
+    inferred_precise_value_type (this_column : Column & In_Memory_Column) =
         storage_type = CastOperation.inferPreciseType (this_column:In_Memory_Column).java_column
         Storage.to_value_type storage_type
 
-    should_be_selected_by_type (this_column : Column & In_Memory_Column) (value_type : Value_Type) -> Boolean =
+    should_be_selected_by_type (this_column : Column & In_Memory_Column) (value_type : Value_Type) =
         this_column.value_type.is_same_type value_type
 
-    to_js_object_implementation this_column -> JS_Object =
+    to_js_object_implementation (this_column : Column & In_Memory_Column) =
         name = this_column.name
         column_list = (this_column:In_Memory_Column).java_column.asList
         storage_json = Vector.from_polyglot_array column_list
         JS_Object.from_pairs [["name", name], ["data", storage_json]]
 
-    to_table (this_column : Column & In_Memory_Column) -> Table =
+    to_table (this_column : Column & In_Memory_Column) =
         java_table = Java_Table.new this_column.java_column
         from_java_table java_table
 
-    info (this_column : Column & In_Memory_Column) -> Table = this_column.to_table.column_info
+    info (this_column : Column & In_Memory_Column) = this_column.to_table.column_info
 
-    sort (this_column : Column & In_Memory_Column) order:Sort_Direction=..Ascending missing_last:Boolean=True (by : (Any -> Any -> Ordering) | Nothing = Nothing) -> Column = case by of
+    sort (this_column : Column & In_Memory_Column) order:Sort_Direction missing_last:Boolean (by : (Any -> Any -> Ordering) | Nothing) = case by of
         Nothing ->
             order_bool = case order of
                 Sort_Direction.Ascending -> True
@@ -665,10 +665,10 @@ type In_Memory_Column_Implementation
             sorted = this_column.to_vector.sort order by=wrapped
             Column.from_vector this_column.name sorted
 
-    take (this_column : Column & In_Memory_Column) (range : Index_Sub_Range | Range | Integer = ..First) -> Column =
+    take (this_column : Column & In_Memory_Column) (range : Index_Sub_Range | Range | Integer) =
         take_helper this_column.length (this_column.at _) this_column.slice (slice_ranges this_column) range
 
-    drop (this_column : Column & In_Memory_Column) (range : Index_Sub_Range | Range | Integer = ..First) -> Column =
+    drop (this_column : Column & In_Memory_Column) (range : Index_Sub_Range | Range | Integer) =
         drop_helper this_column.length (this_column.at _) this_column.slice (slice_ranges this_column) range
 
     slice (this_column : Column & In_Memory_Column) start end =
@@ -677,19 +677,19 @@ type In_Memory_Column_Implementation
         limit = ((end - offset).min (length - offset)).max 0
         In_Memory_Column.from_java_column (this_column.java_column.slice offset limit)
 
-    first (this_column : Column & In_Memory_Column) -> Any ! Index_Out_Of_Bounds = this_column.at 0
+    first (this_column : Column & In_Memory_Column) = this_column.at 0
 
-    last (this_column : Column & In_Memory_Column) -> Any ! Index_Out_Of_Bounds = this_column.at (this_column.length - 1)
+    last (this_column : Column & In_Memory_Column) = this_column.at (this_column.length - 1)
 
-    reverse (this_column : Column & In_Memory_Column) -> Column =
+    reverse (this_column : Column & In_Memory_Column) =
         In_Memory_Column.from_java_column this_column.java_column.reverse
 
-    duplicate_count (this_column : Column & In_Memory_Column) -> Column =
+    duplicate_count (this_column : Column & In_Memory_Column) =
         apply_unary_operation this_column DuplicateCountOperation.INSTANCE
 
-    to_text_implementation (this_column : Column & In_Memory_Column) -> Text = "(In-Memory Column "+this_column.name.to_text+")"
+    to_text_implementation (this_column : Column & In_Memory_Column) = "(In-Memory Column "+this_column.name.to_text+")"
 
-    pretty_implementation (this_column : Column & In_Memory_Column) -> Text =
+    pretty_implementation (this_column : Column & In_Memory_Column =
         (this_column:In_Memory_Column).pretty
 
     ## PRIVATE
@@ -698,19 +698,19 @@ type In_Memory_Column_Implementation
         _ = this_column
         naming_helper
 
-    compute (this_column : Column & In_Memory_Column) statistic:Statistic=..Count -> Any =
+    compute (this_column : Column & In_Memory_Column) statistic:Statistic =
         Statistic.compute_bulk this_column.to_vector [statistic] . first
 
-    compute_bulk (this_column : Column & In_Memory_Column) (statistics : Vector Statistic = [Statistic.Count, Statistic.Sum]) -> Table =
+    compute_bulk (this_column : Column & In_Memory_Column) (statistics : Vector Statistic) =
         values = Statistic.compute_bulk this_column.to_vector statistics
         names = statistics.map _.to_text
         Table.from_rows names [values]
 
-    running (this_column : Column & In_Memory_Column) statistic:Statistic=..Count (name : Text = statistic.to_text+" "+this_column.name) -> Column =
+    running (this_column : Column & In_Memory_Column) statistic:Statistic (name : Text) =
         data = Statistic.running this_column.to_vector statistic
         Column.from_vector name data
 
-    offset (this_column : Column & In_Memory_Column) n=-1:Integer fill_with:Fill_With=..Nothing -> Column =
+    offset (this_column : Column & In_Memory_Column) n:Integer fill_with:Fill_With =
         Offset_Helper.column_offset_impl this_column n fill_with
 
     default_row_limit_for_read = ..All_Rows
@@ -727,7 +727,7 @@ type In_Memory_Column_Implementation
      It should never raise dataflow errors.
    - operands: The vector of operands to apply to the function after `column`.
    - new_name: The name of the column created as the result of this operation.
-private _run_vectorized_many_op column:Column name:Text fallback_fn:(Any -> Any -> Any) operands new_name:(Text | Nothing)=Nothing -> Column =
+private _run_vectorized_many_op column:Column name:Text fallback_fn:(Any -> Any -> Any) operands new_name:(Text | Nothing)=Nothing=
     effective_operands = Vector.unify_vector_or_element operands
     all_operands = [column]+effective_operands
     effective_new_name = new_name.if_nothing (naming_helper.function_name name all_operands)
@@ -833,7 +833,7 @@ private _call_binary_operator left:In_Memory_Column other new_name ~operation =
         In_Memory_Column.from_java_column java_column
 
 ## PRIVATE
-private _apply_case_sensitive_text_operation left:Column (other : Column | Text | Any) case_sensitivity:Case_Sensitivity operation fallback_fn new_name:Text -> Column =
+private _apply_case_sensitive_text_operation left:Column (other : Column | Text | Any) case_sensitivity:Case_Sensitivity operation fallback_fn new_name:Text=
     java_other = (if other.is_a Column then (other:In_Memory_Column).java_column else other)
     use_fallback = case case_sensitivity of
         Case_Sensitivity.Insensitive _ -> True

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -31,7 +31,7 @@ import project.Rows_To_Read.Rows_To_Read
 import project.Table.Table
 import project.Value_Type.Auto
 import project.Value_Type.Value_Type
-from project.Errors import Conversion_Failure, Inexact_Type_Coercion, Invalid_Value_Type
+from project.Errors import Invalid_Value_Type
 from project.Internal.Column_Format import all
 from project.Internal.Column_Type_Helpers import get_underlying_from_column
 from project.Internal.Java_Exports import make_string_builder

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -585,7 +585,7 @@ type In_Memory_Column_Implementation
     map (this_column : Column & In_Memory_Column) (function : Any -> Any) skip_nothing:Boolean (expected_value_type : Value_Type | Auto) =
         new_fn = if skip_nothing then (x-> if x.is_nothing then Nothing else function x) else function
         new_st = this_column.to_vector.map on_problems=No_Wrap.Value new_fn
-        Column.from_vector this_column.name new_st value_type=expected_value_type
+        In_Memory_Column.from_vector this_column.name new_st value_type=expected_value_type
 
     zip (this_column : Column & In_Memory_Column) (right : Column | Table) (keep_unmatched : Boolean | Report_Unmatched ) (right_prefix : Text) on_problems:Problem_Behavior =
         right_table = case right of
@@ -663,7 +663,7 @@ type In_Memory_Column_Implementation
                     Nothing -> if missing_last then Ordering.Less else Ordering.Greater
                     _ -> by a b
             sorted = this_column.to_vector.sort order by=wrapped
-            Column.from_vector this_column.name sorted
+            In_Memory_Column.from_vector this_column.name sorted
 
     take (this_column : Column & In_Memory_Column) (range : Index_Sub_Range | Range | Integer) =
         take_helper this_column.length (this_column.at _) this_column.slice (slice_ranges this_column) range
@@ -708,7 +708,7 @@ type In_Memory_Column_Implementation
 
     running (this_column : Column & In_Memory_Column) statistic:Statistic (name : Text) =
         data = Statistic.running this_column.to_vector statistic
-        Column.from_vector name data
+        In_Memory_Column.from_vector name data
 
     offset (this_column : Column & In_Memory_Column) n:Integer fill_with:Fill_With =
         Offset_Helper.column_offset_impl this_column n fill_with
@@ -839,7 +839,7 @@ private _apply_case_sensitive_text_operation left:Column (other : Column | Text 
         Case_Sensitivity.Insensitive _ -> True
         _ -> operation.canApply (left:In_Memory_Column).java_column java_other . not
     case use_fallback of
-        True -> _apply_binary_map left fallback_fn other new_name=new_name skip_nulls=True expected_result_type=Value_Type.Boolean
+        True -> `_apply_binary_map` left fallback_fn other new_name=new_name skip_nulls=True expected_result_type=Value_Type.Boolean
         _ ->
             Java_Problems.with_map_operation_problem_aggregator new_name Problem_Behavior.Report_Warning java_problem_aggregator->
                 java_column = operation.apply (left:In_Memory_Column).java_column java_other new_name java_problem_aggregator

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
@@ -681,19 +681,19 @@ type In_Memory_Table_Implementation
     to_xml (this_table : Table & In_Memory_Table) (element_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex = this_table.column_names) (attribute_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex = []) (value_column : Text | Integer | Nothing = Nothing) root_name:Text="Table" row_name:Text="Row" on_problems:Problem_Behavior=..Report_Warning -> XML_Document =
         columns_helper = this_table.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
+
         resolved_element_columns = columns_helper.select_columns_helper element_columns Case_Sensitivity.Default False problem_builder
-        java_element_columns = resolved_element_columns.map c->(c:In_Memory_Column).java_column
-
         resolved_attribute_columns = columns_helper.select_columns_helper attribute_columns Case_Sensitivity.Default False problem_builder
-        java_attribute_column = resolved_attribute_columns.map c->(c:In_Memory_Column).java_column
-
         resolved_value_column = if value_column.is_nothing then Nothing else (this_table.at value_column)
-        java_value_column = if value_column.is_nothing then Nothing else (resolved_value_column:In_Memory_Column).java_column
+        used_names = resolved_element_columns.map .name + resolved_attribute_columns.map .name + (if Nothing == resolved_value_column then [] else [resolved_value_column.name])
 
-        unused_columns = columns_helper.internal_columns.filter (Filter_Condition.Is_In resolved_element_columns+resolved_attribute_columns+[resolved_value_column] ..Remove) . map .name
+        unused_columns = columns_helper.internal_columns.filter (c-> used_names.contains c.name . not) . map .name
         if unused_columns.length > 0 then problem_builder.report_other_warning (Unexpected_Extra_Columns.Warning unused_columns)
 
         problem_builder.attach_problems_before on_problems <|
+            java_element_columns = resolved_element_columns.map c->(c:In_Memory_Column).java_column
+            java_attribute_column = resolved_attribute_columns.map c->(c:In_Memory_Column).java_column
+            java_value_column = if value_column.is_nothing then Nothing else (resolved_value_column:In_Memory_Column).java_column
             XML_Document.new (Java_TableToXml.to_xml this_table.row_count java_element_columns java_attribute_column java_value_column root_name row_name)
 
     columns_helper (this_table : Table & In_Memory_Table) =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Type_Refinements/In_Memory_Column_Refinements.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Type_Refinements/In_Memory_Column_Refinements.enso
@@ -17,17 +17,8 @@ refine_column (column : Column & In_Memory_Column) =
         Value_Type.Byte -> _refine_numeric_column column
         Value_Type.Float _ -> _refine_numeric_column column
         Value_Type.Decimal _ _ -> _refine_numeric_column column
-        _ ->
-            ## We treat a column as single value if it contains a single not-nothing value.
-            first_value = if is_single_value column then column.at 0 else Nothing
-            case first_value of
-                _ : Text -> (column : Column & In_Memory_Column & Text)
-                _ : Boolean -> (column : Column & In_Memory_Column & Boolean)
-                _ : Date -> (column : Column & In_Memory_Column & Date)
-                _ : Time_Of_Day -> (column : Column & In_Memory_Column & Time_Of_Day)
-                _ : Date_Time -> (column : Column & In_Memory_Column & Date_Time)
-                # Other types are not supported.
-                _ -> (column : Column & In_Memory_Column)
+        _ -> _refine_other_column column
+
 
 private _refine_numeric_column (column : Column & In_Memory_Column) -> Column & In_Memory_Column & Numeric_Column = case column.length of
     1 -> case column.at 0 of
@@ -36,6 +27,18 @@ private _refine_numeric_column (column : Column & In_Memory_Column) -> Column & 
         _ : Decimal -> column : Column & In_Memory_Column & Numeric_Column & Decimal
         _ -> column : Column & In_Memory_Column & Numeric_Column
     _ -> column : Column & In_Memory_Column & Numeric_Column
+
+private _refine_other_column (column : Column & In_Memory_Column) -> Column & In_Memory_Column =
+    ## We treat a column as single value if it contains a single not-nothing value.
+    first_value = if is_single_value column then column.at 0 else Nothing
+    case first_value of
+        _ : Text -> (column : Column & In_Memory_Column & Text)
+        _ : Boolean -> (column : Column & In_Memory_Column & Boolean)
+        _ : Date -> (column : Column & In_Memory_Column & Date)
+        _ : Time_Of_Day -> (column : Column & In_Memory_Column & Time_Of_Day)
+        _ : Date_Time -> (column : Column & In_Memory_Column & Date_Time)
+        # Other types are not supported.
+        _ -> (column : Column & In_Memory_Column)
 
 is_single_value column:Column -> Boolean =
     (column.length == 1) && (column.at 0 . is_nothing . not)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Type_Refinements/In_Memory_Column_Refinements.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Type_Refinements/In_Memory_Column_Refinements.enso
@@ -10,42 +10,32 @@ import project.Value_Type.Value_Type
 from project.Internal.Type_Refinements.Single_Value_Column_Conversions import all
 from project.Internal.Type_Refinements.Typed_Column_Conversions import all
 
-refine_column (column : In_Memory_Column) =
-    ## We treat a column as single value if it contains a single not-nothing value.
-    if is_single_value column then _refine_single_value_column column else _refine_column column
-
-private _refine_column column =
+refine_column (column : Column & In_Memory_Column) =
     inferred_value_type = (column:Column).inferred_precise_value_type
     case inferred_value_type of
-        Value_Type.Integer _ -> (column : Column & In_Memory_Column & Numeric_Column)
-        Value_Type.Byte -> (column : Column & In_Memory_Column & Numeric_Column)
-        Value_Type.Float _ -> (column : Column & In_Memory_Column & Numeric_Column)
-        Value_Type.Decimal _ _ -> (column : Column & In_Memory_Column & Numeric_Column)
-        _ -> (column : Column & In_Memory_Column)
+        Value_Type.Integer _ -> _refine_numeric_column column
+        Value_Type.Byte -> _refine_numeric_column column
+        Value_Type.Float _ -> _refine_numeric_column column
+        Value_Type.Decimal _ _ -> _refine_numeric_column column
+        _ ->
+            ## We treat a column as single value if it contains a single not-nothing value.
+            first_value = if is_single_value column then column.at 0 else Nothing
+            case first_value of
+                _ : Text -> (column : Column & In_Memory_Column & Text)
+                _ : Boolean -> (column : Column & In_Memory_Column & Boolean)
+                _ : Date -> (column : Column & In_Memory_Column & Date)
+                _ : Time_Of_Day -> (column : Column & In_Memory_Column & Time_Of_Day)
+                _ : Date_Time -> (column : Column & In_Memory_Column & Date_Time)
+                # Other types are not supported.
+                _ -> (column : Column & In_Memory_Column)
 
-private _refine_single_value_column column =
-    inferred_value_type = (column:Column).inferred_precise_value_type
-    case inferred_value_type of
-        Value_Type.Integer _ ->
-            # `inferred_precise_value_type` will return Integer if the column was Float (or Mixed) but contained integral values - e.g. [2.0]
-            # We inspect the actual value to correctly deal with both Float and Mixed base type.
-            value = (column:Column).at 0
-            case value of
-                # If the value was really a float, we preserve that.
-                _ : Float -> (column : Column & In_Memory_Column & Numeric_Column & Float)
-                # Otherwise we treat it as an integer.
-                _ -> (column : Column & In_Memory_Column & Numeric_Column & Integer)
-        Value_Type.Float _ -> (column : Column & In_Memory_Column & Numeric_Column & Float)
-        Value_Type.Char _ _ -> (column : Column & In_Memory_Column & Text)
-        Value_Type.Boolean -> (column : Column & In_Memory_Column & Boolean)
-        Value_Type.Date -> (column : Column & In_Memory_Column & Date)
-        Value_Type.Time -> (column : Column & In_Memory_Column & Time_Of_Day)
-        Value_Type.Date_Time True -> (column : Column & In_Memory_Column & Date_Time)
-        Value_Type.Decimal _ _ ->
-            is_integer = Value_Type_Helpers.is_decimal_integer inferred_value_type
-            if is_integer then (column : Column & In_Memory_Column & Numeric_Column & Integer) else (column : Column & In_Memory_Column & Numeric_Column & Decimal)
-        # Other types (e.g. Mixed) are not supported.
-        _ -> (column : Column & In_Memory_Column)
+private _refine_numeric_column (column : Column & In_Memory_Column) -> Column & In_Memory_Column & Numeric_Column = case column.length of
+    1 -> case column.at 0 of
+        _ : Integer -> column : Column & In_Memory_Column & Numeric_Column & Integer
+        _ : Float -> column : Column & In_Memory_Column & Numeric_Column & Float
+        _ : Decimal -> column : Column & In_Memory_Column & Numeric_Column & Decimal
+        _ -> column : Column & In_Memory_Column & Numeric_Column
+    _ -> column : Column & In_Memory_Column & Numeric_Column
 
 is_single_value column:Column -> Boolean =
     (column.length == 1) && (column.at 0 . is_nothing . not)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Numeric_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Numeric_Column.enso
@@ -6,7 +6,7 @@ import project.Column.Column
 type Numeric_Column
     private Value column operations_implementation
 
-    ## GROUP Standard.Base.Operators
+    ## GROUP Standard.Base.Math
        ICON operators
        Computes the absolute value of each element in the column.
 
@@ -19,7 +19,7 @@ type Numeric_Column
     abs self -> Column & Numeric_Column =
         self.operations_implementation.abs self.column
 
-    ## GROUP Standard.Base.Operators
+    ## GROUP Standard.Base.Math
        ICON operators
        Computes the sign of each element in the column.
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
@@ -30,6 +30,7 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.data.table.Column;
+import org.enso.table.data.table.Table;
 import org.enso.table.util.LeastRecentlyUsedCache;
 
 public abstract class DataQualityMetrics {
@@ -71,6 +72,29 @@ public abstract class DataQualityMetrics {
       _cachedMetrics = new LeastRecentlyUsedCache<>(1000);
     }
     return _cachedMetrics;
+  }
+
+  /**
+   * Triggers the computation of data quality metrics for the given table.
+   * This method is a no-op if the metrics have already been computed.
+   *
+   * @param table the table to trigger metrics for
+   */
+  public static void triggerTable(Table table) {
+    for (var column : table.getColumns()) {
+      DataQualityMetrics.triggerColumn(column);
+    }
+  }
+
+  /**
+   * Triggers the computation of data quality metrics for the given column.
+   * This method is a no-op if the metrics have already been computed.
+   *
+   * @param column the column to trigger metrics for
+   */
+  public static void triggerColumn(Column column) {
+    var storage = column.getStorage();
+    get(storage);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
@@ -75,8 +75,8 @@ public abstract class DataQualityMetrics {
   }
 
   /**
-   * Triggers the computation of data quality metrics for the given table.
-   * This method is a no-op if the metrics have already been computed.
+   * Triggers the computation of data quality metrics for the given table. This method is a no-op if
+   * the metrics have already been computed.
    *
    * @param table the table to trigger metrics for
    */
@@ -87,8 +87,8 @@ public abstract class DataQualityMetrics {
   }
 
   /**
-   * Triggers the computation of data quality metrics for the given column.
-   * This method is a no-op if the metrics have already been computed.
+   * Triggers the computation of data quality metrics for the given column. This method is a no-op
+   * if the metrics have already been computed.
    *
    * @param column the column to trigger metrics for
    */

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
@@ -2,7 +2,6 @@ package org.enso.table.data.table;
 
 import java.util.List;
 import org.enso.base.polyglot.Polyglot_Utils;
-import org.enso.table.data.column.DataQualityMetrics;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.masks.IndexMapper;
 import org.enso.table.data.column.operation.masks.MaskOperation;
@@ -30,9 +29,6 @@ public final class Column {
     ensureNameIsValid(name);
     this.name = name;
     this.storage = storage;
-
-    // Trigger the computation of data quality metrics
-    DataQualityMetrics.get(storage);
   }
 
   public static boolean isColumnNameValid(String name) {


### PR DESCRIPTION
### Pull Request Description

- GUI change to not inject type conversion if a visible type.
- Don't allow wrapping in type line of component browser.
- Remove return type checking and default arguments from `In_Memory_Column_Implementation` and `DB_Column_Implementation`.
- Add or `| Any` to the public column API. Type restriction will be just done in `refine_column`.
- Conditionally run Data Quality Metrics based on Output context.
- Changed groups of `abs` and `signum` to `Math`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
