### PR TITLE
No shutdown timeout in std-benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4187,6 +4187,10 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       // There is no Truffle compiler available for annotation processors. Suppress the warning.
       "-J-Dpolyglot.engine.WarnInterpreterOnly=false"
     ),
+    Compile / javaOptions ++= Seq(
+      // Force killing of alive threads once a benchmark is finished.
+      "-Djmh.shutdownTimeout=0"
+    ),
     Compile / moduleDependencies := {
       (`runtime-benchmarks` / Compile / moduleDependencies).value
     },


### PR DESCRIPTION
Related to #13402

### Pull Request Description

Set [jmh.shutdownTimeout](https://github.com/openjdk/jmh/blob/2a316030b509aa9874dd6ab04e21962ac92cd634/jmh-core/src/main/java/org/openjdk/jmh/runner/ForkedMain.java#L172) to 0 (the default is 30 seconds). By default, JMH launches the benchmark in a subprocess. Once benchmark is finished, JMH waits for all the alive threads to stop. If that is not happening, it waits for up to 30 seconds. This causes timeouts in "Standard Libraries Benchamrks" CI job. For example in https://github.com/enso-org/enso/actions/runs/15889786034/job/44809992109#step:10:1707. 

Note that [DataQualityMetrics](https://github.com/enso-org/enso/blob/5c925feea6df60ba0b1c648da9b04a063a7db9ae/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java#L41-L42) initializes a thread pool that is never shut down, introduced in #13365.

This is a quick fix that will allow us to run stdlib benchmarks again. The proper fix is to start `DataQualityMetrics` only if `Runtime.Context.Output` is disabled.



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
