### PR TITLE
Add execute_query to the Connection types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - [Support `skip_rows` and `on_empty_field` for fixed-width files.][13240]
 - [Add Google_Sheets.read][13307]
 - [Align the Generic JDBC Connection with the main Connection type][13365]
+- [Add `execute_query` to the `Connection` types.][13415]
 
 [12726]: https://github.com/enso-org/enso/pull/12726
 [12950]: https://github.com/enso-org/enso/pull/12950
@@ -69,6 +70,7 @@
 [13240]: https://github.com/enso-org/enso/pull/13240
 [13307]: https://github.com/enso-org/enso/pull/13307
 [13365]: https://github.com/enso-org/enso/pull/13365
+[13415]: https://github.com/enso-org/enso/pull/13415
 
 #### Enso Language & Runtime
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
@@ -11,6 +11,7 @@
     - databases self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_columns self statement:Standard.Base.Any.Any statement_setter:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_tables_advanced self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= include_hidden:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -10,6 +10,7 @@
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -11,6 +11,7 @@
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -345,6 +345,33 @@ type Connection
     ## PRIVATE
        ADVANCED
 
+       Executes a raw query returning a Table object, which can be used to get the
+       results of the query. This is meant for advanced users who need to call direct
+       SQL queries that are not supported by the `query` method.
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+       - write_operation: if set to `True`, the query is expected to be a
+         write operation and will only run if the output context is enabled.
+         If set to `False`, the query is expected to be a read operation and
+         will run regardless of the output context. Defaults to `True`.
+    execute_query : Text | SQL_Statement -> Rows_To_Read -> Boolean -> Table
+    execute_query self query (limit : Rows_To_Read = ..First_With_Warning 1000) write_operation:Boolean=True = case write_operation of
+        True ->
+            Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot execute the query. Press the Write button ▶ to perform the operation." panic=False
+                (self.execute_query query limit False)
+        False ->
+            statement_setter = self.dialect.get_statement_setter
+            self.jdbc_connection.with_prepared_statement query statement_setter stmt->
+                _check_statement_is_allowed self stmt
+                rs = stmt.executeQuery
+                table = result_set_to_table rs self.dialect.get_type_mapping.make_column_fetcher row_limit=(limit.rows_to_read.if_nothing -1)
+                limit.attach_warning table
+
+    ## PRIVATE
+       ADVANCED
+
        Executes a raw update query. If the query was inserting, updating or
        deleting rows, the number of affected rows is returned; otherwise it
        returns 0 for other types of queries (like creating or altering tables).

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -229,6 +229,27 @@ type Postgres_Connection
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED
+       ICON data_input
+
+       Executes a raw query returning a Table object, which can be used to get the
+       results of the query. This is meant for advanced users who need to call direct
+       SQL queries that are not supported by the `query` method.
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+       - write_operation: if set to `True`, the query is expected to be a
+         write operation and will only run if the output context is enabled.
+         If set to `False`, the query is expected to be a read operation and
+         will run regardless of the output context. Defaults to `True`.
+    @query Text_Input display=..Always
+    @limit Rows_To_Read.default_widget
+    execute_query : Text | SQL_Statement -> Rows_To_Read -> Boolean -> Table
+    execute_query self query (limit : Rows_To_Read = ..First_With_Warning 1000) write_operation:Boolean=True =
+        self.connection.execute_query query limit write_operation
+
+
+    ## ADVANCED
        GROUP Standard.Base.Output
        ICON data_output
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Metadata.Display
 import Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Widget import Single_Choice, Text_Input
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -215,6 +215,26 @@ type SQLite_Connection
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED
+       ICON data_input
+
+       Executes a raw query returning a Table object, which can be used to get the
+       results of the query. This is meant for advanced users who need to call direct
+       SQL queries that are not supported by the `query` method.
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+       - write_operation: if set to `True`, the query is expected to be a
+         write operation and will only run if the output context is enabled.
+         If set to `False`, the query is expected to be a read operation and
+         will run regardless of the output context. Defaults to `True`.
+    @query Text_Input display=..Always
+    @limit Rows_To_Read.default_widget
+    execute_query : Text | SQL_Statement -> Rows_To_Read -> Boolean -> Table
+    execute_query self query (limit : Rows_To_Read = ..First_With_Warning 1000) write_operation:Boolean=True =
+        self.connection.execute_query query limit write_operation
+
+    ## ADVANCED
        GROUP Standard.Base.Output
        ICON data_output
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Metadata.Display
 import Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Widget import Single_Choice, Text_Input
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -11,6 +11,7 @@
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Metadata.Display
 import Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Widget import Single_Choice, Text_Input
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -230,6 +230,26 @@ type SQLServer_Connection
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED
+       ICON data_input
+
+       Executes a raw query returning a Table object, which can be used to get the
+       results of the query. This is meant for advanced users who need to call direct
+       SQL queries that are not supported by the `query` method.
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+       - write_operation: if set to `True`, the query is expected to be a
+         write operation and will only run if the output context is enabled.
+         If set to `False`, the query is expected to be a read operation and
+         will run regardless of the output context. Defaults to `True`.
+    @query Text_Input display=..Always
+    @limit Rows_To_Read.default_widget
+    execute_query : Text | SQL_Statement -> Rows_To_Read -> Boolean -> Table
+    execute_query self query (limit : Rows_To_Read = ..First_With_Warning 1000) write_operation:Boolean=True =
+        self.connection.execute_query query limit write_operation
+
+    ## ADVANCED
        GROUP Standard.Base.Output
        ICON data_output
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -9,6 +9,7 @@
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -4,7 +4,7 @@ import Standard.Base.Metadata.Display
 import Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data
 from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference, as_hideable_value
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Widget import Single_Choice, Text_Input
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table
@@ -270,6 +270,26 @@ type Snowflake_Connection
     create_table : Text  -> Vector Column_Description | DB_Table | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | DB_Table | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ADVANCED
+       ICON data_input
+
+       Executes a raw query returning a Table object, which can be used to get the
+       results of the query. This is meant for advanced users who need to call direct
+       SQL queries that are not supported by the `query` method.
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+       - write_operation: if set to `True`, the query is expected to be a
+         write operation and will only run if the output context is enabled.
+         If set to `False`, the query is expected to be a read operation and
+         will run regardless of the output context. Defaults to `True`.
+    @query Text_Input display=..Always
+    @limit Rows_To_Read.default_widget
+    execute_query : Text | SQL_Statement -> Rows_To_Read -> Boolean -> Table
+    execute_query self query (limit : Rows_To_Read = ..First_With_Warning 1000) write_operation:Boolean=True =
+        self.connection.execute_query query limit write_operation
 
     ## ADVANCED
        GROUP Standard.Base.Output

--- a/test/Table_Tests/src/Database/Common/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Common_Spec.enso
@@ -216,7 +216,7 @@ add_commmon_specs (suite_builder : Suite_Builder) (prefix : Text) (create_connec
 
         group_builder.specify "should allow direct read by execute_query" <|
             name = data.t1.name
-            tmp = data.connection.execute_query ("SELECT * FROM \"" + name + "\"")
+            tmp = data.connection.execute_query ('SELECT * FROM "' + name + '"')
             tmp.read . should_equal data.t1.read
 
         group_builder.specify "should allow to access a Table by an SQL query" <|

--- a/test/Table_Tests/src/Database/Common/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Common_Spec.enso
@@ -214,6 +214,11 @@ add_commmon_specs (suite_builder : Suite_Builder) (prefix : Text) (create_connec
             tmp = data.connection.query (SQL_Query.Table_Name name)
             tmp.read . should_equal data.t1.read
 
+        group_builder.specify "should allow direct read by execute_query" <|
+            name = data.t1.name
+            tmp = data.connection.execute_query ("SELECT * FROM \"" + name + "\"")
+            tmp.read . should_equal data.t1.read
+
         group_builder.specify "should allow to access a Table by an SQL query" <|
             name = data.t1.name
             t2 = data.connection.query (SQL_Query.Raw_SQL ('SELECT "a", "b" FROM "' + name + '" WHERE "a" >= 3'))


### PR DESCRIPTION
### Pull Request Description

To enable bulk loading to Snowflake.
- Add `execute_query` to `Connection` and derived types.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
