### PR TITLE
Add various NI reflection and JNI configs to fix connection to Azure storage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3640,11 +3640,14 @@ lazy val `engine-runner` = project
           sys.env.get("CI").isDefined && Platform.isMacOS && Platform.isArm64
         val maxLimit           = if (macArmOnCI) Some(14336) else Some(15608)
         val areStdlibsIncluded = !GraalVM.EnsoLauncher.fast
+        val azureFeature =
+          "org.enso.microsoft.nativeimage.AzureNativeImageFeature"
         val databaseFeature =
           "org.enso.database.nativeimage.SqliteJdbcPatchedFeature"
         val features = Seq(
           "org.enso.interpreter.runtime.nativeimage.NativeLibraryFeature"
-        ) ++ (if (areStdlibsIncluded) Seq(databaseFeature) else Seq())
+        ) ++ (if (areStdlibsIncluded) Seq(databaseFeature, azureFeature)
+              else Seq())
         NativeImage
           .buildNativeImage(
             "enso",

--- a/build.sbt
+++ b/build.sbt
@@ -5334,11 +5334,12 @@ lazy val `std-microsoft` = project
           ignoreDependencies = Some((fileName: String) => {
             val nameCheck = fileName.startsWith(
               "netty-transport-native"
-            ) || fileName.startsWith("netty-tcnative-boringssl-static") ||
-              fileName.startsWith("netty-resolver-dns-native")
+            ) || fileName.startsWith("netty-resolver-dns-native")
 
             (fileName.startsWith("netty-resolver-dns-classes-macos") && StdBits
               .plainOsName() != "macos") ||
+            (fileName.startsWith("netty-tcnative-boringssl-static")) ||
+            (fileName.startsWith("netty-transport-native-epoll")) ||
             nameCheck &&
             StdBits
               .allSupportedOs()
@@ -5348,16 +5349,29 @@ lazy val `std-microsoft` = project
               !sanitizedName.contains(thisPlatform)
             }
           }),
-          logger            = streams.value.log,
+          logger            = logger,
           cacheStoreFactory = cacheStoreFactory,
           previousRun       = prev
         )
       val jnaJar = (`jna-wrapper` / Compile / exportedModuleBin).value
+      val tcnativeJars = JPMSUtils.filterModulesFromUpdate(
+        updateReport = (Compile / update).value,
+        modules = Seq(
+          "io.netty" % "netty-tcnative-boringssl-static" % "2.0.70.Final"
+        ),
+        log                = logger,
+        projName           = moduleName.value,
+        scalaBinaryVersion = scalaBinaryVersion.value,
+        shouldContainAll   = true
+      )
       StdBits
         .extractNativeLibsFromMicrosoft(
           microsoftPolyglotRoot = `std-microsoft-polyglot-root`,
           microsoftNativeLibs   = `std-microsoft-native-libs`,
           jnaJar                = jnaJar,
+          tcNativeJars          = tcnativeJars,
+          updateReport          = (Compile / update).value,
+          scalaBinaryVersion    = scalaBinaryVersion.value,
           logger                = streams.value.log,
           moduleName            = moduleName.value,
           cacheStoreFactory     = cacheStoreFactory,

--- a/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reachability-metadata.json
+++ b/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reachability-metadata.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://www.graalvm.org/docs/reference-manual/native-image/assets/reachability-metadata-schema-v1.1.0.json",
   "reflection": [
     {
       "type": "scala.Symbol",

--- a/project/StdBits.scala
+++ b/project/StdBits.scala
@@ -234,7 +234,7 @@ object StdBits {
   }
 
   /** Extracts native libraries from `std-microsoft`.
-    * In particular from JNA.
+    * In particular from JNA and netty-tcnative-boringssl.
     *
     * The list of the native libraries is listed in
     * <a href="https://github.com/enso-org/enso/blob/7e0c6373b55bdf976562bce899f2fe6af7c258c0/test/Base_Tests/data/native_libs.json#L2-L25">
@@ -247,6 +247,9 @@ object StdBits {
     microsoftPolyglotRoot: File,
     microsoftNativeLibs: File,
     jnaJar: File,
+    tcNativeJars: Seq[File],
+    updateReport: UpdateReport,
+    scalaBinaryVersion: String,
     logger: ManagedLogger,
     moduleName: String,
     cacheStoreFactory: CacheStoreFactory,
@@ -295,7 +298,7 @@ object StdBits {
     val outputJna =
       (microsoftPolyglotRoot / s"jna-wrapper-thin.jar").toPath
 
-    val extractedLibs = JARUtils.extractFilesFromJar(
+    val extractedJnaLibs = JARUtils.extractFilesFromJar(
       jnaJar.toPath,
       None,
       Some(outputJna),
@@ -305,11 +308,144 @@ object StdBits {
       cacheStoreFactory,
       previousRun.flatMap(_.forJar(jnaJar))
     )
+    val extractedJnaAnalysis = AnalysisOfExtractedNativeLibs(
+      jnaJar,
+      extractedJnaLibs.getOrElse(Nil),
+      Some(outputJna.toFile)
+    )
+    logger.debug("extractedJnaAnalysis: " + extractedJnaAnalysis)
+
+    // tcNativeJar has name like:
+    // "netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar"
+    // It contains just a single native library
+    val tcNativeJar = tcNativeJars.filter { jar =>
+      jar.getName.contains(arch()) &&
+      jar.getName.contains(osName())
+    }
+    if (tcNativeJar.size != 1) {
+      throw new IllegalStateException(
+        s"Expected exactly one tc native jar for ${osName()}-${arch()}, but found: ${tcNativeJar.mkString(", ")}"
+      )
+    }
+    logger.debug(
+      s"Found tc native jar: ${tcNativeJar.head}"
+    )
+    val tcNativeJarOut =
+      microsoftPolyglotRoot / tcNativeJar.head.getName
+        .replace(".jar", "-thin.jar")
+    val extractedTcNativeLibs = JARUtils.extractFilesFromJar(
+      inputJarPath      = tcNativeJar.head.toPath,
+      extractPrefix     = None,
+      outputJarPath     = Some(tcNativeJarOut.toPath),
+      extractedFilesDir = microsoftNativeLibs.toPath,
+      renameFunc = (entryName: String) => {
+        if (entryName.endsWith(tcNativeBoringSslLibName())) {
+          Some(tcNativeBoringSslLibName())
+        } else {
+          None
+        }
+      },
+      logger            = logger,
+      cacheStoreFactory = cacheStoreFactory,
+      previousRun       = previousRun.flatMap(_.forJar(tcNativeJar.head))
+    )
+
+    val extractedTcNativeAnalysis = AnalysisOfExtractedNativeLibs(
+      tcNativeJar.head,
+      extractedTcNativeLibs.getOrElse(Nil),
+      Some(tcNativeJarOut)
+    )
+    logger.debug("extractedTcNativeAnalysis: " + extractedTcNativeAnalysis)
+
+    if (Platform.isLinux) {
+      val extractedEpollAnalysis = extractNativeEpoll(
+        updateReport,
+        logger,
+        moduleName,
+        scalaBinaryVersion,
+        cacheStoreFactory,
+        microsoftPolyglotRoot,
+        microsoftNativeLibs,
+        previousRun
+      )
+      logger.debug("extractedEpollAnalysis: " + extractedEpollAnalysis)
+      extractedJnaAnalysis
+        .appended(extractedTcNativeAnalysis)
+        .appended(extractedEpollAnalysis)
+    } else {
+      extractedJnaAnalysis
+        .appended(extractedTcNativeAnalysis)
+    }
+  }
+
+  private def tcNativeBoringSslLibName(): String = {
+    if (Platform.isWindows) {
+      "netty_tcnative_windows_x86_64.dll"
+    } else if (Platform.isLinux) {
+      "libnetty_tcnative_linux_x86_64.so"
+    } else if (Platform.isMacOS && Platform.isAmd64) {
+      "libnetty_tcnative_osx_x86_64.jnilib"
+    } else if (Platform.isMacOS && Platform.isArm64) {
+      "libnetty_tcnative_osx_aarch_64.jnilib"
+    } else {
+      throw new IllegalStateException(
+        s"Unsupported OS: " + osName() + "-" + arch()
+      )
+    }
+  }
+
+  /** native-epoll jar is present only on Linux.
+    */
+  private def extractNativeEpoll(
+    updateReport: UpdateReport,
+    logger: ManagedLogger,
+    moduleName: String,
+    scalaBinaryVersion: String,
+    cacheStoreFactory: CacheStoreFactory,
+    microsoftPolyglotRoot: File,
+    microsoftNativeLibs: File,
+    previousRun: Option[AnalysisOfExtractedNativeLibs]
+  ): AnalysisOfExtractedNativeLibs = {
+    val epollJars = JPMSUtils.filterModulesFromUpdate(
+      updateReport = updateReport,
+      modules = Seq(
+        "io.netty" % "netty-transport-native-epoll" % "4.1.118.Final"
+      ),
+      log                = logger,
+      projName           = moduleName,
+      scalaBinaryVersion = scalaBinaryVersion,
+      shouldContainAll   = true
+    )
+    if (epollJars.size != 1) {
+      throw new IllegalStateException(
+        s"Expected exactly one netty-transport-native-epoll jar, but found: ${epollJars.mkString(", ")}"
+      )
+    }
+    val epollJar     = epollJars.head
+    val epollLibName = "libnetty_transport_native_epoll_x86_64.so"
+    val epollOutJar =
+      microsoftPolyglotRoot / epollJar.getName.replace(".jar", "-thin.jar")
+    val extractedEpollLib = JARUtils.extractFilesFromJar(
+      inputJarPath      = epollJar.toPath,
+      extractPrefix     = None,
+      outputJarPath     = Some(epollOutJar.toPath),
+      extractedFilesDir = microsoftNativeLibs.toPath,
+      renameFunc = (entryName: String) => {
+        if (entryName.endsWith(epollLibName)) {
+          Some(epollLibName)
+        } else {
+          None
+        }
+      },
+      logger            = logger,
+      cacheStoreFactory = cacheStoreFactory,
+      previousRun       = previousRun.flatMap(_.forJar(epollJar))
+    )
 
     AnalysisOfExtractedNativeLibs(
-      jnaJar,
-      extractedLibs.getOrElse(Nil),
-      Some(outputJna.toFile)
+      epollJar,
+      extractedEpollLib.getOrElse(Nil),
+      Some(epollOutJar)
     )
   }
 

--- a/std-bits/microsoft/src/main/java/org/enso/microsoft/nativeimage/AzureNativeImageFeature.java
+++ b/std-bits/microsoft/src/main/java/org/enso/microsoft/nativeimage/AzureNativeImageFeature.java
@@ -1,0 +1,112 @@
+package org.enso.microsoft.nativeimage;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarFile;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+/**
+ * Explicitly registers all the classes that implement {@link com.azure.xml.XmlSerializable}
+ * interface for reflection. This is needed for {@code azure-core} that (de)serializes objects into
+ * XML via reflection.
+ *
+ * <p>Traverses all the {@code azure-*.jar} files on classpath.
+ *
+ * <p>Note that there are various {@code reflection-config.json} files in azure modules, but they do
+ * not list any classes that implement {@code XmlSerializable} interface.
+ */
+public class AzureNativeImageFeature implements Feature {
+
+  private static final String XML_SERIALIZABLE_CLASS_NAME = "com.azure.xml.XmlSerializable";
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    System.out.println("[AzureNativeImageFeature] Registering classes for reflection...");
+    var xmlSerializableClass = access.findClassByName(XML_SERIALIZABLE_CLASS_NAME);
+    if (xmlSerializableClass == null) {
+      throw new IllegalStateException(
+          "XmlSerializable class not found: " + XML_SERIALIZABLE_CLASS_NAME);
+    }
+    var httpExceptionClass =
+        access.findClassByName("com.azure.core.exception.HttpResponseException");
+    if (httpExceptionClass == null) {
+      throw new IllegalStateException(
+          "HttpResponseException class not found: com.azure.core.exception.HttpResponseException");
+    }
+
+    var classesForReflection = new ArrayList<Class<?>>();
+    for (var path : access.getApplicationClassPath()) {
+      var fileName = path.getFileName().toString();
+      if (fileName.startsWith("azure") && fileName.endsWith(".jar")) {
+        var xmlClasses = findImplementationClasses(access, path, xmlSerializableClass);
+        System.out.println(
+            "[AzureNativeImageFeature] Found "
+                + xmlClasses.size()
+                + " classes implementing XmlSerializable in "
+                + fileName);
+        var respExClasses = findImplementationClasses(access, path, httpExceptionClass);
+        System.out.println(
+            "[AzureNativeImageFeature] Found "
+                + respExClasses.size()
+                + " classes implementing HttpResponseException in "
+                + fileName);
+        classesForReflection.addAll(xmlClasses);
+        classesForReflection.addAll(respExClasses);
+      }
+    }
+    System.out.println(
+        "Registering " + classesForReflection.size() + " classes for runtime reflection.");
+    registerForReflection(xmlSerializableClass);
+    registerForReflection(httpExceptionClass);
+    for (var klazz : classesForReflection) {
+      // TODO: Register only `toXml` and `fromXml` methods.
+      registerForReflection(klazz);
+    }
+  }
+
+  private static void registerForReflection(Class<?> clazz) {
+    RuntimeReflection.register(clazz);
+    RuntimeReflection.register(clazz.getConstructors());
+    RuntimeReflection.register(clazz.getMethods());
+    RuntimeReflection.register(clazz.getFields());
+    RuntimeReflection.registerAllConstructors(clazz);
+    RuntimeReflection.registerAllMethods(clazz);
+    RuntimeReflection.registerAllFields(clazz);
+    if (clazz.isInterface()) {
+      RuntimeProxyCreation.register(clazz);
+    }
+  }
+
+  private static List<Class<?>> findImplementationClasses(
+      BeforeAnalysisAccess access, Path jarPath, Class<?> baseClass) {
+    List<Class<?>> xmlSerializableClasses = new ArrayList<>();
+    try (var jarFile = new JarFile(jarPath.toFile())) {
+      var entries = jarFile.entries();
+      while (entries.hasMoreElements()) {
+        var entry = entries.nextElement();
+        var entryName = entry.getName();
+        if (entryName.endsWith(".class")) {
+          var className = entryName.replace('/', '.').replace(".class", "");
+          var klazz = access.findClassByName(className);
+          if (klazz != null && implementsBaseClass(baseClass, klazz)) {
+            xmlSerializableClasses.add(klazz);
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read classes from azure-core jar: " + jarPath, e);
+    }
+    return xmlSerializableClasses;
+  }
+
+  private static boolean implementsBaseClass(Class<?> baseClass, Class<?> clazz) {
+    return baseClass.isAssignableFrom(clazz)
+        && !clazz.isInterface()
+        && !Modifier.isAbstract(clazz.getModifiers());
+  }
+}

--- a/std-bits/microsoft/src/main/java/org/enso/microsoft/nativeimage/AzureNativeImageFeature.java
+++ b/std-bits/microsoft/src/main/java/org/enso/microsoft/nativeimage/AzureNativeImageFeature.java
@@ -1,5 +1,6 @@
 package org.enso.microsoft.nativeimage;
 
+import com.azure.core.implementation.ReflectionSerializable;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
@@ -11,11 +12,8 @@ import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 /**
- * Explicitly registers all the classes that implement {@link com.azure.xml.XmlSerializable}
- * interface for reflection. This is needed for {@code azure-core} that (de)serializes objects into
- * XML via reflection.
- *
- * <p>Traverses all the {@code azure-*.jar} files on classpath.
+ * Manually registers some classes and methods for reflection from {@code azure-*.jar} files on
+ * classpath that are not registered by default in {@code reflection-config.json} files.
  *
  * <p>Note that there are various {@code reflection-config.json} files in azure modules, but they do
  * not list any classes that implement {@code XmlSerializable} interface.
@@ -24,8 +22,17 @@ public class AzureNativeImageFeature implements Feature {
 
   private static final String XML_SERIALIZABLE_CLASS_NAME = "com.azure.xml.XmlSerializable";
 
+  private int registeredClasses;
+  private int registeredMethods;
+  private int registeredFields;
+  private int registeredConstructors;
+
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
+    registeredClasses = 0;
+    registeredMethods = 0;
+    registeredFields = 0;
+    registeredConstructors = 0;
     System.out.println("[AzureNativeImageFeature] Registering classes for reflection...");
     var xmlSerializableClass = access.findClassByName(XML_SERIALIZABLE_CLASS_NAME);
     if (xmlSerializableClass == null) {
@@ -39,41 +46,83 @@ public class AzureNativeImageFeature implements Feature {
           "HttpResponseException class not found: com.azure.core.exception.HttpResponseException");
     }
 
-    var classesForReflection = new ArrayList<Class<?>>();
     for (var path : access.getApplicationClassPath()) {
       var fileName = path.getFileName().toString();
       if (fileName.startsWith("azure") && fileName.endsWith(".jar")) {
         var xmlClasses = findImplementationClasses(access, path, xmlSerializableClass);
-        System.out.println(
-            "[AzureNativeImageFeature] Found "
-                + xmlClasses.size()
-                + " classes implementing XmlSerializable in "
-                + fileName);
+        if (!xmlClasses.isEmpty()) {
+          System.out.println(
+              "[AzureNativeImageFeature] Found "
+                  + xmlClasses.size()
+                  + " classes implementing "
+                  + xmlSerializableClass.getName()
+                  + " in "
+                  + fileName);
+          for (var xmlClass : xmlClasses) {
+            registerXmlClassForReflection(xmlClass);
+          }
+        }
+
         var respExClasses = findImplementationClasses(access, path, httpExceptionClass);
-        System.out.println(
-            "[AzureNativeImageFeature] Found "
-                + respExClasses.size()
-                + " classes implementing HttpResponseException in "
-                + fileName);
-        classesForReflection.addAll(xmlClasses);
-        classesForReflection.addAll(respExClasses);
+        if (!respExClasses.isEmpty()) {
+          System.out.println(
+              "[AzureNativeImageFeature] Found "
+                  + respExClasses.size()
+                  + " classes implementing "
+                  + httpExceptionClass.getName()
+                  + " in "
+                  + fileName);
+          for (var respExClass : respExClasses) {
+            registerForReflection(respExClass);
+          }
+        }
       }
     }
-    System.out.println(
-        "Registering " + classesForReflection.size() + " classes for runtime reflection.");
     registerForReflection(xmlSerializableClass);
     registerForReflection(httpExceptionClass);
-    for (var klazz : classesForReflection) {
-      // TODO: Register only `toXml` and `fromXml` methods.
-      registerForReflection(klazz);
+    System.out.printf(
+        "[AzureNativeImageFeature] Registered %d classes, %d methods, %d fields, and %d"
+            + " constructors for reflection.%n",
+        registeredClasses, registeredMethods, registeredFields, registeredConstructors);
+  }
+
+  private void registerXmlClassForReflection(Class<?> clazz) {
+    RuntimeReflection.register(clazz);
+    registeredClasses++;
+    registerXmlMethodsForReflection(clazz);
+  }
+
+  /**
+   * Checks for the {@code toXml} and {@code fromXml} methods are inspired by {@link
+   * ReflectionSerializable#supportsXmlSerializable(Class)}.
+   */
+  private void registerXmlMethodsForReflection(Class<?> clazz) {
+    for (var method : clazz.getDeclaredMethods()) {
+      if (method.getName().equals("fromXml")) {
+        RuntimeReflection.register(method);
+        registeredMethods++;
+      } else if (method.getName().equals("toXml")) {
+        RuntimeReflection.register(method);
+        registeredMethods++;
+      }
     }
   }
 
-  private static void registerForReflection(Class<?> clazz) {
+  private void registerForReflection(Class<?> clazz) {
     RuntimeReflection.register(clazz);
-    RuntimeReflection.register(clazz.getConstructors());
-    RuntimeReflection.register(clazz.getMethods());
-    RuntimeReflection.register(clazz.getFields());
+    registeredClasses++;
+    var ctors = clazz.getConstructors();
+    RuntimeReflection.register(ctors);
+    registeredConstructors += ctors.length;
+
+    var methods = clazz.getMethods();
+    RuntimeReflection.register(methods);
+    registeredMethods += methods.length;
+
+    var fields = clazz.getFields();
+    RuntimeReflection.register(fields);
+    registeredFields += fields.length;
+
     RuntimeReflection.registerAllConstructors(clazz);
     RuntimeReflection.registerAllMethods(clazz);
     RuntimeReflection.registerAllFields(clazz);

--- a/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reachability-metadata.json
+++ b/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reachability-metadata.json
@@ -39,6 +39,47 @@
       "type": "[B"
     },
     {
+      "type": "[Ljava.lang.String;"
+    },
+    {
+      "type": "io.netty.handler.ssl.OpenSslClientSessionCache"
+    },
+    {
+      "type": "io.netty.handler.ssl.OpenSslSessionCache",
+      "methods": [
+        {
+          "name": "getSession",
+          "parameterTypes": [
+            "long",
+            "byte[]"
+          ]
+        },
+        {
+          "name": "sessionCreated",
+          "parameterTypes": [
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.handler.ssl.ReferenceCountedOpenSslClientContext$ExtendedTrustManagerVerifyCallback"
+    },
+    {
+      "type": "io.netty.handler.ssl.ReferenceCountedOpenSslContext$AbstractCertificateVerifier",
+      "methods": [
+        {
+          "name": "verify",
+          "parameterTypes": [
+            "long",
+            "byte[][]",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
       "type": "io.netty.internal.tcnative.Buffer"
     },
     {
@@ -131,6 +172,26 @@
       ]
     },
     {
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "getClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ClassLoader",
+      "methods": [
+        {
+          "name": "loadClass",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
       "type": "java.lang.Exception"
     },
     {
@@ -156,6 +217,9 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "type": "jdk.internal.loader.ClassLoaders$AppClassLoader"
     }
   ]
 }

--- a/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reachability-metadata.json
+++ b/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reachability-metadata.json
@@ -1,0 +1,161 @@
+{
+  "reflection": [
+    {
+      "type": "io.netty.internal.tcnative.CertificateCallback"
+    },
+    {
+      "type": "io.netty.internal.tcnative.CertificateCallbackTask"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodTask"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLTask"
+    },
+    {
+      "type": "java.lang.Exception"
+    },
+    {
+      "type": "java.lang.IllegalArgumentException"
+    },
+    {
+      "type": "java.lang.NullPointerException"
+    },
+    {
+      "type": "java.lang.OutOfMemoryError"
+    },
+    {
+      "type": "java.lang.String"
+    }
+  ],
+  "jni": [
+    {
+      "type": "[B"
+    },
+    {
+      "type": "io.netty.internal.tcnative.Buffer"
+    },
+    {
+      "type": "io.netty.internal.tcnative.CertificateCallbackTask",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "byte[]",
+            "byte[][]",
+            "io.netty.internal.tcnative.CertificateCallback"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.internal.tcnative.CertificateVerifierTask",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "byte[][]",
+            "java.lang.String",
+            "io.netty.internal.tcnative.CertificateVerifier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.internal.tcnative.Library"
+    },
+    {
+      "type": "io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSL"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLContext"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "byte[]",
+            "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "int",
+            "byte[]",
+            "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
+      "fields": [
+        {
+          "name": "resultBytes"
+        }
+      ]
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLSession"
+    },
+    {
+      "type": "io.netty.internal.tcnative.SSLTask",
+      "fields": [
+        {
+          "name": "complete"
+        },
+        {
+          "name": "returnValue"
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Exception"
+    },
+    {
+      "type": "java.lang.IllegalArgumentException"
+    },
+    {
+      "type": "java.lang.NullPointerException"
+    },
+    {
+      "type": "java.lang.OutOfMemoryError"
+    },
+    {
+      "type": "java.lang.String",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]"
+          ]
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reflect-config.json
+++ b/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reflect-config.json
@@ -61,5 +61,509 @@
   },
   {
     "name" : "org.enso.microsoft.azure.AzureCredential.BlobStorageSASToken"
+  },
+  {
+    "name": "com.azure.identity.implementation.RegionalAuthority",
+    "methods": [
+      {
+        "name" : "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.azure.core.exception.ClientAuthenticationException"
+  },
+  {
+    "name": "com.azure.core.http.HttpHeaderName",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.azure.core.http.netty.NettyAsyncHttpClientProvider"
+  },
+  {
+    "name": "com.azure.core.http.netty.implementation.AzureSdkHandler",
+    "methods": [
+      {
+        "name": "channelRead",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Object"]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "write",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Object", "io.netty.channel.ChannelPromise"]
+      }
+    ]
+  },
+  {
+    "name": "com.azure.core.http.rest.ResponseBase",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.azure.core.http.HttpRequest",
+          "int",
+          "com.azure.core.http.HttpHeaders",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.azure.core.util.Header",
+    "fields": [
+      {
+        "name": "cachedStringValue"
+      }
+    ]
+  },
+  {
+    "name": "com.azure.core.util.QueryParameter",
+    "fields": [
+      {
+        "name": "cachedStringValue"
+      }
+    ]
+  },
+  {
+    "name": "com.azure.storage.blob.implementation.models.ContainersGetPropertiesHeaders",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.azure.core.http.HttpHeaders"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.azure.storage.blob.implementation.models.ContainersListBlobFlatSegmentHeaders",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.azure.core.http.HttpHeaders"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.azure.storage.blob.implementation.models.ListBlobsFlatSegmentResponse",
+    "methods": [
+      {
+        "name": "fromXml",
+        "parameterTypes": [
+          "com.azure.xml.XmlReader"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.azure.storage.blob.models.AccessTier",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.EmitterProcessor",
+    "fields": [
+      {
+        "name": "error"
+      },
+      {
+        "name": "s"
+      },
+      {
+        "name": "subscribers"
+      },
+      {
+        "name": "upstreamDisposable"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxConcatMap$ConcatMapImmediate",
+    "fields": [
+      {
+        "name": "error"
+      },
+      {
+        "name": "guard"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxDoFinally$DoFinallySubscriber",
+    "fields": [
+      {
+        "name": "once"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxFirstWithSignal$RaceCoordinator",
+    "fields": [
+      {
+        "name": "winner"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxPublish$PubSubInner",
+    "fields": [
+      {
+        "name": "requested"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxPublish$PublishSubscriber",
+    "fields": [
+      {
+        "name": "connected"
+      },
+      {
+        "name": "error"
+      },
+      {
+        "name": "s"
+      },
+      {
+        "name": "subscribers"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber",
+    "fields": [
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.LambdaMonoSubscriber",
+    "fields": [
+      {
+        "name": "subscription"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.MonoCreate$DefaultMonoSink",
+    "fields": [
+      {
+        "name": "disposable"
+      },
+      {
+        "name": "requestConsumer"
+      },
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.MonoFlatMap$FlatMapInner",
+    "fields": [
+      {
+        "name": "s"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.MonoFlatMap$FlatMapMain",
+    "fields": [
+      {
+        "name": "s"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.MonoFlatMapMany$FlatMapManyMain",
+    "fields": [
+      {
+        "name": "inner"
+      },
+      {
+        "name": "requested"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.MonoUsing$MonoUsingSubscriber",
+    "fields": [
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.Operators$DeferredSubscription",
+    "fields": [
+      {
+        "name": "requested"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.Operators$MonoInnerProducerBase",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.Operators$MonoSubscriber",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.Operators$MultiSubscriptionSubscriber",
+    "fields": [
+      {
+        "name": "missedProduced"
+      },
+      {
+        "name": "missedRequested"
+      },
+      {
+        "name": "missedSubscription"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.Operators$ScalarSubscription",
+    "fields": [
+      {
+        "name": "once"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.SinkEmptyMulticast",
+    "fields": [
+      {
+        "name": "subscribers"
+      }
+    ]
+  },
+  {
+    "name": "reactor.core.publisher.SinksSpecs$AbstractSerializedSink",
+    "fields": [
+      {
+        "name": "lockedAt"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.channel.ChannelOperations",
+    "fields": [
+      {
+        "name": "outboundSubscription"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.channel.ChannelOperationsHandler",
+    "methods": [
+      {
+        "name": "channelInactive",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "channelActive",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Object"]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Object"]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Throwable"]
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.channel.FluxReceive",
+    "fields": [
+      {
+        "name": "receiverCancel"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.http.Cookies",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.http.HttpOperations",
+    "fields": [
+      {
+        "name": "statusAndHeadersSent"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.internal.shaded.reactor.pool.AbstractPool$AbstractPooledRef",
+    "fields": [
+      {
+        "name": "state"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.internal.shaded.reactor.pool.AllocationStrategies$SizeBasedAllocationStrategy",
+    "fields": [
+      {
+        "name": "permits"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.internal.shaded.reactor.pool.SimpleDequePool",
+    "fields": [
+      {
+        "name": "acquired"
+      },
+      {
+        "name": "idleResources"
+      },
+      {
+        "name": "idleSize"
+      },
+      {
+        "name": "pending"
+      },
+      {
+        "name": "pendingSize"
+      },
+      {
+        "name": "wip"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.internal.shaded.reactor.pool.SimpleDequePool$QueuePoolRecyclerInner",
+    "fields": [
+      {
+        "name": "once"
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer"
+  },
+  {
+    "name": "reactor.netty.tcp.SslProvider$SslReadHandler",
+    "methods": [
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "channelActive",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext"]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": ["io.netty.channel.ChannelHandlerContext", "java.lang.Object"]
+      }
+    ]
+  },
+  {
+    "name": "reactor.netty.transport.TransportConfig$TransportChannelInitializer"
+  },
+  {
+    "name": "reactor.netty.transport.TransportConnector$MonoChannelPromise",
+    "fields": [
+      {
+        "name": "result"
+      }
+    ]
+  },
+  {
+    "name": "reactor.util.concurrent.SpscArrayQueueConsumer",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "name": "reactor.util.concurrent.SpscArrayQueueProducer",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "name": "reactor.util.concurrent.SpscLinkedArrayQueue",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      },
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.epoll.LinuxSocket",
+    "methods": [
+      {
+        "name": "setIpBindAddressNoPort",
+        "parameterTypes": ["boolean"]
+      },
+      {
+        "name": "setIpBindAddressNoPort",
+        "parameterTypes": ["int", "int"]
+      }
+    ]
   }
 ]

--- a/test/Base_Tests/data/native_libs.json
+++ b/test/Base_Tests/data/native_libs.json
@@ -87,9 +87,6 @@
     "META-INF/resources/nfi-native/libnfi/darwin/aarch64/bin/libtrufflenfi.dylib",
     "META-INF/resources/nfi-native/libnfi/windows/amd64/bin/trufflenfi.dll"
   ],
-  "lib/Standard/Microsoft/0.0.0-dev/polyglot/java/netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar": [
-    "META-INF/native/libnetty_tcnative_linux_x86_64.so"
-  ],
   "lib/Standard/Microsoft/0.0.0-dev/polyglot/java/netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar": [
     "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
   ]

--- a/test/Base_Tests/data/native_libs.json
+++ b/test/Base_Tests/data/native_libs.json
@@ -86,8 +86,5 @@
     "META-INF/resources/nfi-native/libnfi/darwin/amd64/bin/libtrufflenfi.dylib",
     "META-INF/resources/nfi-native/libnfi/darwin/aarch64/bin/libtrufflenfi.dylib",
     "META-INF/resources/nfi-native/libnfi/windows/amd64/bin/trufflenfi.dll"
-  ],
-  "lib/Standard/Microsoft/0.0.0-dev/polyglot/java/netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar": [
-    "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
   ]
 }

--- a/test/Microsoft_Tests/src/Azure_Storage_Spec.enso
+++ b/test/Microsoft_Tests/src/Azure_Storage_Spec.enso
@@ -1,0 +1,23 @@
+from Standard.Base import all
+from Standard.Test import all
+from Standard.Microsoft import all
+
+add_specs suite_builder =
+    suite_builder.group "Azure_Storage" group_builder->
+        group_builder.specify "Connect to dummy blob storage should fail with authentication error" <|
+            dummy_token = "sv=2024-11-04&ss=bfqt&srt=sco&sp=rwdlacupiytfx&se=2025-08-30T19:03:22Z&st=2025-06-24T11:03:22Z&spr=https&sig=z1Gm3CUR896qh1eBfebjkMhsTD4Mw8cB9c3W40kl5z9rzC"
+            storage_ident = "ensostorage"
+            container_ident = "test-container"
+            caught = Panic.catch Any (Azure_Storage.list_blob storage_ident container=container_ident cred=(..SAS_Token dummy_token)) handler=\panic -> panic
+            actual_exception_msg = caught.payload.to_text
+            clue = "Expected Authentication error, but actual panic was: " + caught.to_text
+            expected_msg = "AuthenticationFailed"
+            Test.with_clue clue <|
+                actual_exception_msg.contains expected_msg . should_be_true
+
+
+main filter=Nothing =
+    suite = Test.build suite_builder->
+        add_specs suite_builder
+    suite.run_with_filter filter
+

--- a/test/Microsoft_Tests/src/Main.enso
+++ b/test/Microsoft_Tests/src/Main.enso
@@ -3,9 +3,11 @@ from Standard.Base import all
 from Standard.Test import Test
 
 import project.SQLServer_Spec
+import project.Azure_Storage_Spec
 
 main filter=Nothing =
     suite = Test.build suite_builder->
         SQLServer_Spec.add_specs suite_builder
+        Azure_Storage_Spec.add_specs suite_builder
 
     suite.run_with_filter filter


### PR DESCRIPTION
Fixes #13424

Probably closes https://github.com/enso-org/enso/issues/12448

Supersedes #13418

### Pull Request Description

Add various reflection and jni NI reachability metadata so that it is possible to list blob storage without any errors (on Linux NI). Windows NI still fails with timeout exception. Will be tackled in a separate PR.

### Important Notes

- Added a test that tries to connect to `ensostorage` Azure blob storage with dummy token.
  - This test used to fail on Windows in NI, now it succeeds.
- Extract `libnetty_tcnative` and `libnetty_transport_native_epoll` native libs from Standard.Microsoft.
  - Previously, `libnetty_tcnative` library could not be loaded on Linux neither on Windows. This is fixed now.
- Add [AzureNativeImageFeature](https://github.com/enso-org/enso/blob/b572eedc3af8ee4fd262e1295419fa91bcf770c7/std-bits/microsoft/src/main/java/org/enso/microsoft/nativeimage/AzureNativeImageFeature.java)
  - This feature scans all the `azure-*.jar` files on classpath.
  - For each of these, it looks for classes that implement `com.azure.xml.XmlSerializable` interface and registers them for reflection
  - Not optimal, but it works.
- Add bunch of `jni` and `reflection` entries to [std-bits/microsoft/.../reachability-metadata.json](https://github.com/enso-org/enso/blob/c64259435dd0874b2cd175c86f3dac8813e29882/std-bits/microsoft/src/main/resources/META-INF/native-image/org/enso/microsoft/reachability-metadata.json)
  - It is now possible to list real blob storage on Linux in NI without any errors with these entries.
  - Windows NI still fails on timeout exception. Will be tackled in separate PR.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
