### PR TITLE
Return type check shall not call the body multiple times

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -125,9 +125,7 @@ Table.select_into_database_table self connection (table_name : Text) primary_key
      only on a sample of rows, so errors may still occur when the output action
      is enabled.
 Table.update_rows self (source_table : Table) (update_action : Update_Action = ..Update_Or_Insert) (key_columns : Vector | Nothing = default_key_columns self) (error_on_missing_columns : Boolean = False) (on_problems : Problem_Behavior = ..Report_Warning) -> Table =
-    result = (Table_Upload_Implementation.resolve self "update_rows").update_rows self source_table update_action key_columns error_on_missing_columns on_problems
-    ## Workaround for https://github.com/enso-org/enso/issues/13374
-    result:Table
+    (Table_Upload_Implementation.resolve self "update_rows").update_rows self source_table update_action key_columns error_on_missing_columns on_problems
 
 ## GROUP Standard.Base.Database
    ICON data_output

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/typecheck/TypeCheckValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/typecheck/TypeCheckValueTest.java
@@ -46,7 +46,7 @@ public class TypeCheckValueTest {
         new TestRootNode(
             (frame) -> {
               var arg = frame.getArguments()[0];
-              var res = bothNode.handleCheckOrConversion(frame, arg, null);
+              var res = bothNode.handleCheckOrConversion(frame, arg);
               return res;
             });
     root.insertChildren(bothNode);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -1475,6 +1475,37 @@ public class SignatureTest {
     }
   }
 
+  @Test
+  public void avoidDoubleEvaluation() {
+    var code =
+        """
+        from Standard.Base import IO, Integer
+
+        type A
+            A_Ctor a
+        type B
+            B_Ctor b
+
+        A.from that:B =
+            A.A_Ctor that
+
+        A.extension_method self (arg1:Integer) -> A =
+            IO.println "extension_method called"
+            constructed_b = B.B_Ctor "constructed {self.A="+self.to_text+"} {arg1="+arg1.to_text+"}"
+            constructed_b
+
+        main =
+            a = A.A_Ctor "a"
+            v = a.extension_method 42
+            v
+        """;
+
+    ctxRule.resetOut();
+    var res = ctxRule.evalModule(code);
+    assertEquals(res.getMetaObject().getMetaSimpleName(), "A");
+    assertEquals("One call", "extension_method called\n", ctxRule.getOut());
+  }
+
   static void assertTypeError(String expArg, String expType, String realType, String msg) {
     assertEquals(
         "Type error: expected " + expArg + " to be " + expType + ", but got " + realType + ".",

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -1503,7 +1503,7 @@ public class SignatureTest {
     ctxRule.resetOut();
     var res = ctxRule.evalModule(code);
     assertEquals(res.getMetaObject().getMetaSimpleName(), "A");
-    assertEquals("One call", "extension_method called\n", ctxRule.getOut());
+    assertEquals("One call", "extension_method called", ctxRule.getOut().trim());
   }
 
   static void assertTypeError(String expArg, String expType, String realType, String msg) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
@@ -29,7 +29,7 @@ public abstract class InteropConversionCallNode extends Node {
     return InteropConversionCallNodeGen.create();
   }
 
-  public abstract Object execute(UnresolvedConversion conversion, Object state, Object[] arguments)
+  public abstract Object execute(UnresolvedConversion conversion, State state, Object[] arguments)
       throws ArityException;
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import java.util.List;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.data.text.Text;
 
 /**
@@ -24,7 +23,7 @@ abstract sealed class AbstractTypeCheckNode extends Node
 
   abstract Object findDirectMatch(VirtualFrame frame, Object value);
 
-  abstract Object executeConversion(VirtualFrame frame, Object value, ExpressionNode valueNode);
+  abstract Object executeConversion(VirtualFrame frame, Object value);
 
   abstract String expectedTypeMessage();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.Type;
@@ -49,14 +48,14 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
+  Object executeConversion(VirtualFrame frame, Object value) {
     var values = new Object[checks.length];
     var valueTypes = new Type[checks.length];
     var at = 0;
     var integers = 0;
     var floats = 0;
     for (var n : checks) {
-      var result = n.executeConversion(frame, value, expr);
+      var result = n.executeConversion(frame, value);
       if (result == null) {
         return null;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/LazyCheckRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/LazyCheckRootNode.java
@@ -39,7 +39,7 @@ final class LazyCheckRootNode extends RootNode {
     assert args.length == 1;
     assert args[0] instanceof Function fn && fn.isThunk();
     var raw = evalThunk.executeThunk(frame, args[0], state, BaseNode.TailStatus.NOT_TAIL);
-    var result = check.handleCheckOrConversion(frame, raw, null);
+    var result = check.handleCheckOrConversion(frame, raw);
     return result;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
@@ -23,7 +22,7 @@ final class MetaTypeCheckNode extends AbstractTypeCheckNode {
   }
 
   @Override
-  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode ignore) {
+  Object executeConversion(VirtualFrame frame, Object value) {
     return null;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import org.enso.interpreter.node.ExpressionNode;
 
 final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
 
@@ -29,9 +28,9 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeConversion(VirtualFrame frame, Object value, ExpressionNode expr) {
+  Object executeConversion(VirtualFrame frame, Object value) {
     for (var n : checks) {
-      var result = n.executeConversion(frame, value, expr);
+      var result = n.executeConversion(frame, value);
       if (result != null) {
         return result;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -4,14 +4,10 @@ package org.enso.interpreter.node.typecheck;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.node.ExpressionNode;
-import org.enso.interpreter.node.callable.ApplicationNode;
-import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
-import org.enso.interpreter.node.expression.literal.LiteralNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
-import org.enso.interpreter.runtime.callable.argument.CallArgument;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.Type;
@@ -27,8 +23,8 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 
 non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   private final Type expectedType;
@@ -70,8 +66,8 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
       ExpressionNode valueSource,
       @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
       @Cached(value = "findType(typeOfNode, v)", dimensions = 1) Type[] cachedType,
-      @Cached("findConversionNode(valueSource, cachedType)") ApplicationNode convertNode) {
-    return handleWithConversion(frame, v, convertNode);
+      @Cached("findConversionNode(valueSource, cachedType)") TypeToConvertNode node) {
+    return handleWithConversion(frame, v, node);
   }
 
   @Specialization(replaces = "doWithConversionCached")
@@ -135,10 +131,25 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     return null;
   }
 
-  ApplicationNode findConversionNode(ExpressionNode valueNode, Type[] allTypes) {
-    if (valueNode == null) {
-      return null;
+  static final class TypeToConvertNode extends Node {
+    final Function conv;
+    final Type intoType;
+    @Child InvokeFunctionNode invokeNode;
+
+    private TypeToConvertNode(Function conv, Type intoType) {
+      this.conv = conv;
+      this.intoType = intoType;
+      this.invokeNode = InvokeFunctionNode.buildWithArity(2);
     }
+
+    final Object executeConvert(VirtualFrame frame, Object value) {
+      var ctx = EnsoContext.get(this);
+      var state = ctx.currentState();
+      return invokeNode.execute(conv, frame, state, new Object[] { intoType, value });
+    }
+  }
+
+  final TypeToConvertNode findConversionNode(ExpressionNode valueNode, Type[] allTypes) {
     if (allTypes == null) {
       allTypes = new Type[] {null};
     }
@@ -147,14 +158,9 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
 
       if (convAndType != null) {
         CompilerAsserts.neverPartOfCompilation();
-        var convNode = LiteralNode.build(convAndType.getLeft());
-        var intoNode = LiteralNode.build(convAndType.getRight());
-        var args =
-            new CallArgument[] {
-              new CallArgument(null, intoNode), new CallArgument(null, valueNode)
-            };
-        return ApplicationNode.build(
-            convNode, args, InvokeCallableNode.DefaultsExecutionMode.EXECUTE);
+        var confFn = convAndType.getLeft();
+        var intoType = convAndType.getRight();
+        return new TypeToConvertNode(confFn, intoType);
       }
     }
     return null;
@@ -182,12 +188,12 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     return null;
   }
 
-  private Object handleWithConversion(VirtualFrame frame, Object v, ApplicationNode convertNode)
+  private Object handleWithConversion(VirtualFrame frame, Object v, TypeToConvertNode convertPair)
       throws PanicException {
-    if (convertNode == null) {
+    if (convertPair == null) {
       return directMatchImpl(v);
     } else {
-      var converted = convertNode.executeGeneric(frame);
+      var converted = convertPair.executeConvert(frame, v);
       return converted;
     }
   }
@@ -195,8 +201,8 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   @CompilerDirectives.TruffleBoundary
   private Object doWithConversionUncachedBoundary(
       MaterializedFrame frame, Object v, ExpressionNode expr, Type[] type) {
-    var convertNode = findConversionNode(expr, type);
-    return handleWithConversion(frame, v, convertNode);
+    var c = findConversionNode(expr, type);
+    return handleWithConversion(frame, v, c);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.node.typecheck;
 
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.EnsoRootNode;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
@@ -39,11 +38,10 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     this.expectedType = expectedType;
   }
 
-  abstract Object executeConversion(
-      VirtualFrame frame, Object value, ExpressionNode valueSource);
+  abstract Object executeConversion(VirtualFrame frame, Object value);
 
   @Specialization
-  Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel, ExpressionNode ignore) {
+  Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel) {
     throw panicSentinel;
   }
 
@@ -51,7 +49,6 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doUnresolvedConstructor(
       VirtualFrame frame,
       UnresolvedConstructor unresolved,
-      ExpressionNode ignore,
       @Cached UnresolvedConstructor.ConstructNode construct) {
     var state = EnsoContext.get(this).currentState();
     return construct.execute(frame, state, expectedType, unresolved);
@@ -63,10 +60,9 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doWithConversionCached(
       VirtualFrame frame,
       Object v,
-      ExpressionNode valueSource,
       @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
       @Cached(value = "findType(typeOfNode, v)", dimensions = 1) Type[] cachedType,
-      @Cached("findConversionNode(valueSource, cachedType)") TypeToConvertNode node) {
+      @Cached("findConversionNode(cachedType)") TypeToConvertNode node) {
     return handleWithConversion(frame, v, node);
   }
 
@@ -74,11 +70,10 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doWithConversionUncached(
       VirtualFrame frame,
       Object v,
-      ExpressionNode expr,
       @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode) {
     var type = findType(typeOfNode, v);
     return doWithConversionUncachedBoundary(
-        frame == null ? null : frame.materialize(), v, expr, type);
+        frame == null ? null : frame.materialize(), v, type);
   }
 
   @Override
@@ -149,7 +144,7 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
     }
   }
 
-  final TypeToConvertNode findConversionNode(ExpressionNode valueNode, Type[] allTypes) {
+  final TypeToConvertNode findConversionNode(Type[] allTypes) {
     if (allTypes == null) {
       allTypes = new Type[] {null};
     }
@@ -200,8 +195,8 @@ non-sealed abstract class SingleTypeCheckNode extends AbstractTypeCheckNode {
 
   @CompilerDirectives.TruffleBoundary
   private Object doWithConversionUncachedBoundary(
-      MaterializedFrame frame, Object v, ExpressionNode expr, Type[] type) {
-    var c = findConversionNode(expr, type);
+      MaterializedFrame frame, Object v, Type[] type) {
+    var c = findConversionNode(type);
     return handleWithConversion(frame, v, c);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckExpressionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckExpressionNode.java
@@ -20,7 +20,7 @@ final class TypeCheckExpressionNode extends ExpressionNode {
   @Override
   public Object executeGeneric(VirtualFrame frame) {
     var value = original.executeGeneric(frame);
-    var result = check.handleCheckOrConversion(frame, value, original);
+    var result = check.handleCheckOrConversion(frame, value);
     return result;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -57,12 +57,10 @@ public final class TypeCheckValueNode extends Node {
    *
    * @param frame frame requesting the conversion
    * @param value the value to convert
-   * @param expr the expression node that produced the {@code value}
    * @return {@code null} when the check isn't satisfied and conversion isn't possible or non-{@code
    *     null} value that can be used as a result
    */
-  public final Object handleCheckOrConversion(
-      VirtualFrame frame, Object value, ExpressionNode expr) {
+  public final Object handleCheckOrConversion(VirtualFrame frame, Object value) {
     if (isAllFitValue(value)) {
       return value;
     }
@@ -73,7 +71,7 @@ public final class TypeCheckValueNode extends Node {
       }
       try {
         var plainValue = warnings.removeWarnings(value);
-        var result = handleCheckOrConversionImpl(frame, plainValue, expr);
+        var result = handleCheckOrConversionImpl(frame, plainValue);
         if (result == plainValue) {
           return value;
         } else {
@@ -85,17 +83,16 @@ public final class TypeCheckValueNode extends Node {
         throw ctx.raiseAssertionPanic(this, null, ex);
       }
     } else {
-      return handleCheckOrConversionImpl(frame, value, expr);
+      return handleCheckOrConversionImpl(frame, value);
     }
   }
 
-  private final Object handleCheckOrConversionImpl(
-      VirtualFrame frame, Object value, ExpressionNode expr) {
+  private final Object handleCheckOrConversionImpl(VirtualFrame frame, Object value) {
     var direct = check.findDirectMatch(frame, value);
     if (direct != null) {
       return direct;
     }
-    var result = check.executeConversion(frame, value, expr);
+    var result = check.executeConversion(frame, value);
     if (result == null) {
       throw panicAtTheEnd(value);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Layout.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Layout.java
@@ -285,7 +285,7 @@ class Layout {
 
     @Override
     public void execute(Atom atom, Object value) {
-      var valueOrConvertedValue = checkNode.handleCheckOrConversion(null, value, null);
+      var valueOrConvertedValue = checkNode.handleCheckOrConversion(null, value);
       setterNode.execute(atom, valueOrConvertedValue);
     }
   }


### PR DESCRIPTION
### Pull Request Description

Fixes #13374 by using `InvokeFunctionNode` instead of `ApplicationNode`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] [Benchmarks](https://github.com/enso-org/enso/actions/runs/16112077250) should not regress (they might even improve when we no longer execute function bodies twice ;-)
