### PR TITLE
Removing `Method.Names.Function` and using `InteropLibrary`

### DIFF
--- a/engine/common/src/main/java/org/enso/common/MethodNames.java
+++ b/engine/common/src/main/java/org/enso/common/MethodNames.java
@@ -28,7 +28,5 @@ public class MethodNames {
 
   public static class Function {
     public static final String EQUALS = "equals";
-    public static final String GET_SOURCE_LENGTH = "get_source_length";
-    public static final String GET_SOURCE_START = "get_source_start";
   }
 }

--- a/engine/common/src/main/java/org/enso/common/MethodNames.java
+++ b/engine/common/src/main/java/org/enso/common/MethodNames.java
@@ -1,8 +1,12 @@
 package org.enso.common;
 
 /** Container for polyglot method names */
-public class MethodNames {
-  public static class TopScope {
+public final class MethodNames {
+  private MethodNames() {}
+
+  public static final class TopScope {
+    private TopScope() {}
+
     public static final String CREATE_MODULE = "create_module";
     public static final String GET_MODULE = "get_module";
     public static final String LEAK_CONTEXT = "leak_context";
@@ -12,7 +16,9 @@ public class MethodNames {
     public static final String FIND_NATIVE_LIBRARY = "find_native_library";
   }
 
-  public static class Module {
+  public static final class Module {
+    private Module() {}
+
     public static final String EVAL_EXPRESSION = "eval_expression";
     public static final String GET_ASSOCIATED_TYPE = "get_associated_type";
     public static final String GET_TYPE = "get_type";
@@ -24,9 +30,5 @@ public class MethodNames {
     public static final String GATHER_IMPORT_STATEMENTS = "gather_import_statements";
     public static final String SET_SOURCE = "set_source";
     public static final String SET_SOURCE_FILE = "set_source_file";
-  }
-
-  public static class Function {
-    public static final String EQUALS = "equals";
   }
 }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/Function.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/Function.scala
@@ -1,7 +1,6 @@
 package org.enso.polyglot
 
 import org.graalvm.polyglot.Value
-import org.enso.common.MethodNames
 
 /** Represents an Enso function.
   *
@@ -27,8 +26,7 @@ class Function(val value: Value) {
     *        `false` otherwise.
     */
   override def equals(obj: Any): Boolean = obj match {
-    case fun: Function =>
-      value.invokeMember(MethodNames.Function.EQUALS, fun.value).asBoolean()
-    case _ => false
+    case fun: Function => value == fun.value
+    case _             => false
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -6,7 +6,6 @@ import org.enso.interpreter.node.controlflow.caseexpr.CaseNode
 import org.enso.interpreter.node.expression.literal.LiteralNode
 import org.enso.interpreter.node.scope.{AssignmentNode, ReadLocalVariableNode}
 import org.enso.interpreter.test.{InterpreterContext, InterpreterTest}
-import org.enso.common.MethodNames
 
 class CodeLocationsTest extends InterpreterTest {
 
@@ -228,15 +227,11 @@ class CodeLocationsTest extends InterpreterTest {
       val mod    = interpreterContext.executionContext.evalModule(code, "Test")
       val tpe    = mod.getAssociatedType
       val method = mod.getMethod(tpe, "foo").get
-      method.value.invokeMember(
-        MethodNames.Function.GET_SOURCE_START
-      ) should (
+      method.value.getSourceLocation().getCharIndex() should (
         equal(44) or
         equal(45)
       )
-      method.value.invokeMember(
-        MethodNames.Function.GET_SOURCE_LENGTH
-      ) should (
+      method.value.getSourceLocation().getCharLength() should (
         equal(24) or
         equal(25)
       )

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -295,22 +295,6 @@ public final class Function extends EnsoObject {
       case MethodNames.Function.EQUALS:
         Object that = Types.extractArguments(args, Object.class);
         return this == that;
-      case MethodNames.Function.GET_SOURCE_START:
-        {
-          SourceSection sect = getSourceSection();
-          if (sect == null) {
-            return null;
-          }
-          return sect.getCharIndex();
-        }
-      case MethodNames.Function.GET_SOURCE_LENGTH:
-        {
-          SourceSection sect = getSourceSection();
-          if (sect == null) {
-            return null;
-          }
-          return sect.getCharLength();
-        }
     }
     throw UnknownIdentifierException.create(member);
   }
@@ -323,9 +307,7 @@ public final class Function extends EnsoObject {
    */
   @ExportMessage
   boolean isMemberInvocable(String member) {
-    return member.equals(MethodNames.Function.EQUALS)
-        || member.equals(MethodNames.Function.GET_SOURCE_START)
-        || member.equals(MethodNames.Function.GET_SOURCE_LENGTH);
+    return member.equals(MethodNames.Function.EQUALS);
   }
 
   /**
@@ -349,9 +331,7 @@ public final class Function extends EnsoObject {
   @ExportMessage
   Object getMembers(boolean includeInternal) {
     return ArrayLikeHelpers.wrapStrings(
-        MethodNames.Function.EQUALS,
-        MethodNames.Function.GET_SOURCE_START,
-        MethodNames.Function.GET_SOURCE_LENGTH);
+        MethodNames.Function.EQUALS);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -9,11 +9,8 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Idempotent;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
-import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
@@ -21,7 +18,6 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.source.SourceSection;
-import org.enso.common.MethodNames;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
@@ -32,10 +28,8 @@ import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallerFrameAccess;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
-import org.enso.interpreter.runtime.type.Types;
 import org.slf4j.LoggerFactory;
 
 /** A runtime representation of a function object in Enso. */
@@ -271,67 +265,6 @@ public final class Function extends EnsoObject {
         throw ex;
       }
     }
-  }
-
-  /**
-   * Handles member invocation through the polyglot API.
-   *
-   * <p>The only supported member is {@code equals} checking for object identity.
-   *
-   * @param member the member name.
-   * @param args arguments to pass to the execution.
-   * @return the result of invoking the member.
-   * @throws ArityException when an invalid number of arguments is passed to the member.
-   * @throws UnknownIdentifierException when an invalid member is requested.
-   */
-  @ExportMessage
-  @CompilerDirectives.TruffleBoundary
-  Object invokeMember(String member, Object... args)
-      throws ArityException,
-          UnknownIdentifierException,
-          UnsupportedTypeException,
-          UnsupportedMessageException {
-    switch (member) {
-      case MethodNames.Function.EQUALS:
-        Object that = Types.extractArguments(args, Object.class);
-        return this == that;
-    }
-    throw UnknownIdentifierException.create(member);
-  }
-
-  /**
-   * Verifies whether a member can be invoked through the polyglot API.
-   *
-   * @param member the member name.
-   * @return {@code true} if the member can be invoked, {@code false} otherwise.
-   */
-  @ExportMessage
-  boolean isMemberInvocable(String member) {
-    return member.equals(MethodNames.Function.EQUALS);
-  }
-
-  /**
-   * Marks the object as having members available for the polyglot API.
-   *
-   * @return {@code true}
-   */
-  @ExportMessage
-  boolean hasMembers() {
-    return true;
-  }
-
-  /**
-   * Returns a collection of all members this object exposes through the polyglot API.
-   *
-   * <p>The only supported member is {@code equals}.
-   *
-   * @param includeInternal ignored
-   * @return a collection of all supported member names.
-   */
-  @ExportMessage
-  Object getMembers(boolean includeInternal) {
-    return ArrayLikeHelpers.wrapStrings(
-        MethodNames.Function.EQUALS);
   }
 
   /**


### PR DESCRIPTION
### Pull Request Description

There doesn't seem to be any need for special `Function.GET_SOURCE_*`  support when there is a standard Truffle `InteropLibrary` message `getSourceLocation` and it is properly implemented for the `Function` objects.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been updated
