### PR TITLE
Limit code editor size (Fixes #13333)

### DIFF
--- a/app/gui/src/project-view/components/BottomPanel.vue
+++ b/app/gui/src/project-view/components/BottomPanel.vue
@@ -73,6 +73,12 @@ const style = computed(() =>
   --panel-size: var(--code-editor-default-height);
   position: relative;
   height: var(--panel-size);
+  /*
+   * Limit the size of the panel. Because size is persisted, allowing the panel to fill the screen
+   * may be confusing, especially if the user sets the size on one screen and then reopens the code
+   * editor on a screen with a lower resolution.
+   */
+  max-height: 85svh;
   margin-right: 1px;
   /*
    * Ensure that the content height doesn't exceed the panel's height while animating, which can


### PR DESCRIPTION
### Pull Request Description

Limit the size of the code editor panel (when not maximized) to 85% of the browser viewport.

Because size is persisted, allowing the panel to fill the screen may be confusing, especially if the user sets the size on one screen and then reopens the code editor on a screen with a lower resolution.

Fixes #13333.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
