### PR TITLE
Snowflake in --jvm mode cannot find `java.rmi.UnexpectedException`

### DIFF
--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -72,8 +72,93 @@ jobs:
     env:
       ENSO_LAUNCHER: native,test
       GRAAL_EDITION: GraalVM CE
-  enso-build-ci-gen-job-snowflake-tests-linux-amd64:
-    name: Snowflake Tests (LinuxLatest)
+  enso-build-ci-gen-job-snowflake-tests-jvm-linux-amd64:
+    name: Snowflake Tests (JVM) (LinuxLatest)
+    needs:
+      - enso-build-ci-gen-job-build-engine-distribution-graal-vm-ce-linux-amd64
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - if: runner.os == 'Windows'
+        name: Setup required bazel environment
+        run: "\n\"BAZEL_SH=C:\\Program Files\\Git\\bin\\bash.exe\" >> $env:GITHUB_ENV\n\"BAZEL_VC=C:\\BuildTools\\VC\" >> $env:GITHUB_ENV\n        "
+        shell: pwsh
+      - name: Setup bazel environment
+        uses: bazel-contrib/setup-bazel@0.13.0
+        with:
+          bazelrc: build --remote_cache=grpcs://${{ vars.ENSO_BAZEL_CACHE_URI }} --remote_cache_header="authorization=Basic ${{ secrets.ENSO_BAZEL_CACHE_TOKEN }}"
+          output-base: ${{ runner.os == 'Windows' && 'c:/_bazel' || '' }}
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+      - if: runner.os == 'macOS'
+        name: Setup nodejs version
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - if: runner.os != 'Linux'
+        run: npm install -g corepack@0.31.0 && corepack --version
+      - name: Build Script Setup
+        run: ./run --help || (git clean -ffdx && ./run --help)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: "(contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required)"
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rm -rf built-distribution test
+        shell: bash
+      - name: Download Engine Distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: Engine Distribution (GraalVM CE) (native,test) (linux, amd64)
+      - run: ls -l built-distribution.tar
+        shell: bash
+      - name: Unpack Engine Distribution
+        run: |-
+          tar -xvf built-distribution.tar -C .
+          rm built-distribution.tar
+      - run: ./run backend test std-snowflake-jvm
+        env:
+          ENSO_CLOUD_COGNITO_REGION: ${{ vars.ENSO_CLOUD_COGNITO_REGION }}
+          ENSO_CLOUD_COGNITO_USER_POOL_ID: ${{ vars.ENSO_CLOUD_COGNITO_USER_POOL_ID }}
+          ENSO_CLOUD_COGNITO_USER_POOL_WEB_CLIENT_ID: ${{ vars.ENSO_CLOUD_COGNITO_USER_POOL_WEB_CLIENT_ID }}
+          ENSO_CLOUD_TEST_ACCOUNT_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
+          ENSO_CLOUD_TEST_ACCOUNT_USERNAME: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
+          ENSO_SNOWFLAKE_ACCOUNT: ${{ secrets.ENSO_SNOWFLAKE_ACCOUNT }}
+          ENSO_SNOWFLAKE_DATABASE: ${{ secrets.ENSO_SNOWFLAKE_DATABASE }}
+          ENSO_SNOWFLAKE_PASSWORD: ${{ secrets.ENSO_SNOWFLAKE_PASSWORD }}
+          ENSO_SNOWFLAKE_SCHEMA: ${{ secrets.ENSO_SNOWFLAKE_SCHEMA }}
+          ENSO_SNOWFLAKE_USER: ${{ secrets.ENSO_SNOWFLAKE_USER }}
+          ENSO_SNOWFLAKE_WAREHOUSE: ${{ secrets.ENSO_SNOWFLAKE_WAREHOUSE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Extra Library Test Reporter
+        uses: dorny/test-reporter@v1
+        with:
+          max-annotations: 50
+          name: Extra Library Tests Report (GraalVM CE, linux, amd64)
+          path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
+          path-replace-backslashes: true
+          reporter: java-junit
+      - if: "(always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required)"
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      GRAAL_EDITION: GraalVM CE
+      REPORT_ALL_TESTS: "1"
+    permissions:
+      checks: write
+  enso-build-ci-gen-job-snowflake-tests-native-linux-amd64:
+    name: Snowflake Tests (Native) (LinuxLatest)
     needs:
       - enso-build-ci-gen-job-build-engine-distribution-graal-vm-ce-linux-amd64
     runs-on:

--- a/build_tools/build/src/ci_gen.rs
+++ b/build_tools/build/src/ci_gen.rs
@@ -921,9 +921,16 @@ pub fn extra_nightly_tests() -> Result<Workflow> {
     let engine_launcher = engine::EngineLauncher::TestNative;
     let build_engine_distribution_id =
         workflow.add(target, job::BuildEngineDistribution { graal_edition, engine_launcher });
-    workflow.add_dependent(target, job::SnowflakeTests { graal_edition, engine_launcher }, &[
-        &build_engine_distribution_id,
-    ]);
+    workflow.add_dependent(
+        target,
+        job::SnowflakeTests { graal_edition, engine_launcher, jvm_mode: false },
+        &[&build_engine_distribution_id],
+    );
+    workflow.add_dependent(
+        target,
+        job::SnowflakeTests { graal_edition, engine_launcher, jvm_mode: true },
+        &[&build_engine_distribution_id],
+    );
     workflow.add_dependent(
         target,
         job::StandardLibraryTests {

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -602,6 +602,7 @@ fn build_job_ensuring_cloud_tests_run_on_github(
 pub struct SnowflakeTests {
     pub graal_edition:   graalvm::Edition,
     pub engine_launcher: engine::EngineLauncher,
+    pub jvm_mode:        bool,
 }
 
 const GRAAL_EDITION_FOR_EXTRA_TESTS: graalvm::Edition = graalvm::Edition::Community;
@@ -612,9 +613,19 @@ impl JobArchetype for SnowflakeTests {
             panic!("Snowflake tests currently require GitHub hosted runner for Cloud auth, so they only run on Linux.");
         }
         let job_name = "Snowflake Tests";
+        let job_name = if self.jvm_mode {
+            format!("{job_name} (JVM)")
+        } else {
+            format!("{job_name} (Native)")
+        };
         let graal_edition = self.graal_edition;
         let engine_launcher = self.engine_launcher;
-        let mut job = RunStepsBuilder::new("backend test std-snowflake")
+        let run_command = if self.jvm_mode {
+            "backend test std-snowflake-jvm"
+        } else {
+            "backend test std-snowflake"
+        };
+        let mut job = RunStepsBuilder::new(run_command)
             .customize(move |step| {
                 let main_step = step
                     .with_secret_exposed_as(
@@ -669,7 +680,11 @@ impl JobArchetype for SnowflakeTests {
     }
 
     fn key(&self, (os, arch): Target) -> String {
-        format!("{}-{os}-{arch}", self.id_key_base())
+        if self.jvm_mode {
+            format!("{}-jvm-{os}-{arch}", self.id_key_base())
+        } else {
+            format!("{}-native-{os}-{arch}", self.id_key_base())
+        }
     }
 }
 

--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -92,6 +92,9 @@ pub enum Tests {
     /// Run the Snowflake tests.
     StdSnowflake,
 
+    /// Run the Snowflake tests in `--jvm` mode.
+    StdSnowflakeJVM,
+
     /// Run a subset of Standard Library tests that deals with Cloud-related functionality.
     StdCloudRelated,
 

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -444,6 +444,14 @@ impl Processor {
                                 ]));
                             config.use_native_runner = false;
                         }
+                        Tests::StdSnowflakeJVM => {
+                            config.test_standard_library =
+                                Some(StandardLibraryTestsSelection::whitelist(vec![
+                                    "Snowflake_Tests".to_string(),
+                                ]));
+                            config.use_native_runner = false;
+                            config.extra_engine_runner_args = Some(vec!["--jvm".to_string()])
+                        }
                         Tests::StdCloudRelated => {
                             config.test_standard_library =
                                 Some(StandardLibraryTestsSelection::whitelist(vec![

--- a/engine/runner/src/main/java/module-info.java
+++ b/engine/runner/src/main/java/module-info.java
@@ -24,4 +24,7 @@ module org.enso.runner {
   requires org.jline.reader;
   requires scala.library;
   requires org.slf4j;
+
+  // required by Snowflake
+  requires java.rmi;
 }

--- a/project/SmallJDK.scala
+++ b/project/SmallJDK.scala
@@ -90,7 +90,8 @@ object SmallJDK {
     val mp = modulePath()
       .map(_.toAbsolutePath.toString)
       .mkString(File.pathSeparator)
-    val modules = JDK_MODULES ++ NI_BASE_MODULES ++ PYTHON_MODULES
+    val modules =
+      JDK_MODULES ++ NI_BASE_MODULES ++ DEBUG_MODULES ++ PYTHON_MODULES
     val jlinkArgs = Seq(
       "--no-header-files",
       "--no-man-pages",


### PR DESCRIPTION
### Pull Request Description

We have to enable `java.rmi` in boot layer to allow Snowflake libraries to access the `java.rmi.UnexpectedException`.

### Important Notes

- addresses https://github.com/enso-org/enso/pull/13164#issuecomment-3052403621
- it is unfortunate Snowflake has a dependency on `java.rmi` when it is only using the exception
- this [CI definition](https://github.com/enso-org/enso/blob/c54ef7a023fe43ca956e50a3993abea33fbcd644/.github/workflows/extra-nightly-tests.yml#L127) deserves to be modified to run also in `--jvm` mode - [done](https://github.com/enso-org/enso/pull/13465/commits/37a96b2b2ed267b08eead52705690d3c33656f0f)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible - thanks for [changes the CI](https://github.com/enso-org/enso/blob/c54ef7a023fe43ca956e50a3993abea33fbcd644/.github/workflows/extra-nightly-tests.yml#L127)
