### PR TITLE
Panic on unresolved type checks in the IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Allow marking grouped component arguments as required or providing a default
   value.][13254]
 - [New Right Panel Tab with Markdown Description Editor][13347]
+- [Panic on unresolved type checks in the IDE][13467]
 - [Fixed a bug, where "Free plan" user was redirected to Cloud directory,
   resulting in an Error page without option of returning back to Local.][13366]
 - ["Grouped Components" are renamed to "User Defined Components"][13389]
@@ -44,6 +45,7 @@
 [13266]: https://github.com/enso-org/enso/pull/13266
 [13254]: https://github.com/enso-org/enso/pull/13254
 [13347]: https://github.com/enso-org/enso/pull/13347
+[13467]: https://github.com/enso-org/enso/pull/13467
 [13366]: https://github.com/enso-org/enso/pull/13366
 [13389]: https://github.com/enso-org/enso/pull/13389
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
@@ -1,5 +1,6 @@
 package org.enso.compiler.test;
 
+import static org.enso.compiler.test.ExecStrictCompilerTest.ctxRule;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -13,15 +14,11 @@ import org.enso.common.MethodNames;
 import org.enso.common.MethodNames.Module;
 import org.enso.common.RuntimeOptions;
 import org.enso.compiler.core.ir.expression.errors.Conversion.DeclaredAsPrivate$;
-import static org.enso.compiler.test.ExecStrictCompilerTest.ctxRule;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import org.hamcrest.core.AllOf;
 import org.junit.After;
-import static org.junit.Assert.fail;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -553,9 +550,11 @@ public class ExecCompilerTest {
 
   @Test
   public void castToUnresolvedType() throws Exception {
-    var code = """
-                 fn f = (f : Unknown).to_text
-                 """;
+    var code =
+        """
+        from Standard.Base import all
+        fn f = (f : Unknown).to_text
+        """;
     try {
       var module = ctxRule.eval(LanguageInfo.ID, code);
       var fn = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fn");
@@ -564,7 +563,9 @@ public class ExecCompilerTest {
     } catch (PolyglotException ex) {
       assertThat(
           ex.getMessage(),
-          AllOf.allOf(containsString("Unknown"), containsString("could not be found")));
+          AllOf.allOf(
+              containsString("expected unresolved symbol Unknown"),
+              containsString("to be resolved to a type")));
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
@@ -258,7 +258,9 @@ public class ExecCompilerTest {
   public void inlineReturnSignature() {
     var module =
         ctxRule.eval(
-            LanguageInfo.ID, """
+            LanguageInfo.ID,
+            """
+    import Standard.Base.Data.Numbers.Integer
     foo (x : Integer) (y : Integer) -> Integer = 10*x + y
     """);
     var foo = module.invokeMember("eval_expression", "foo");
@@ -273,6 +275,7 @@ public class ExecCompilerTest {
             LanguageInfo.ID,
             """
             import Standard.Base.Data.Numbers
+            import Standard.Base.Data.Numbers.Integer
             type My_Type
                 Value x
 
@@ -310,6 +313,7 @@ public class ExecCompilerTest {
         ctxRule.eval(
             LanguageInfo.ID,
             """
+    import Standard.Base.Data.Numbers.Integer
     foo x y =
         inner_foo (z : Integer) -> Integer = 100*z + 10*y + x
         a = 3
@@ -323,7 +327,11 @@ public class ExecCompilerTest {
 
   @Test
   public void inlineReturnSignatureWithoutArguments() {
-    var module = ctxRule.eval(LanguageInfo.ID, """
+    var module =
+        ctxRule.eval(
+            LanguageInfo.ID,
+            """
+    import Standard.Base.Data.Numbers.Integer
     the_number -> Integer = 23
     """);
     var result = module.invokeMember("eval_expression", "the_number");

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
@@ -13,11 +13,15 @@ import org.enso.common.MethodNames;
 import org.enso.common.MethodNames.Module;
 import org.enso.common.RuntimeOptions;
 import org.enso.compiler.core.ir.expression.errors.Conversion.DeclaredAsPrivate$;
+import static org.enso.compiler.test.ExecStrictCompilerTest.ctxRule;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import org.hamcrest.core.AllOf;
 import org.junit.After;
+import static org.junit.Assert.fail;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -544,6 +548,23 @@ public class ExecCompilerTest {
       var typeError = ex.getGuestObject();
       assertEquals("Expected type", "First_Type", typeError.getMember("expected").asString());
       assertEquals("Got wrong value", 42, typeError.getMember("actual").asInt());
+    }
+  }
+
+  @Test
+  public void castToUnresolvedType() throws Exception {
+    var code = """
+                 fn f = (f : Unknown).to_text
+                 """;
+    try {
+      var module = ctxRule.eval(LanguageInfo.ID, code);
+      var fn = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fn");
+      var r = fn.execute(0);
+      fail("We don't expect any result, but exception: " + r);
+    } catch (PolyglotException ex) {
+      assertThat(
+          ex.getMessage(),
+          AllOf.allOf(containsString("Unknown"), containsString("could not be found")));
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -152,9 +152,11 @@ public class ExecStrictCompilerTest {
 
   @Test
   public void castToUnresolvedType() throws Exception {
-    var code = """
-                 fn f = (f : Unknown).to_text
-                 """;
+    var code =
+        """
+        from Standard.Base import all
+        fn f = (f : Unknown).to_text
+        """;
     try {
       var module = ctxRule.eval(LanguageInfo.ID, code);
       var fn = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fn");

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -1,5 +1,6 @@
 package org.enso.compiler.test;
 
+import static org.enso.compiler.test.ExecCompilerTest.ctxRule;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -9,10 +10,13 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.enso.common.LanguageInfo;
+import org.enso.common.MethodNames;
 import org.enso.common.RuntimeOptions;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
+import org.hamcrest.core.AllOf;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -144,5 +148,22 @@ public class ExecStrictCompilerTest {
         "There should be no errors or warnings. But there was: " + errors,
         errors.isEmpty(),
         is(true));
+  }
+
+  @Test
+  public void castToUnresolvedType() throws Exception {
+    var code = """
+                 fn f = (f : Unknown).to_text
+                 """;
+    try {
+      var module = ctxRule.eval(LanguageInfo.ID, code);
+      var fn = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fn");
+      var r = fn.execute(0);
+      fail("We don't expect any result, but exception: " + r);
+    } catch (PolyglotException ex) {
+      assertThat(
+          ex.getMessage(),
+          AllOf.allOf(containsString("Unknown"), containsString("could not be found")));
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -13,7 +13,11 @@ import org.enso.interpreter.runtime.data.text.Text;
  * detail. The API to perform the check or conversion is in {@link TypeCheckValueNode}.
  */
 abstract sealed class AbstractTypeCheckNode extends Node
-    permits OneOfTypesCheckNode, AllOfTypesCheckNode, SingleTypeCheckNode, MetaTypeCheckNode {
+    permits OneOfTypesCheckNode,
+        AllOfTypesCheckNode,
+        SingleTypeCheckNode,
+        MetaTypeCheckNode,
+        FailCheckNode {
   private final String comment;
   @CompilerDirectives.CompilationFinal private String expectedTypeMessage;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/FailCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/FailCheckNode.java
@@ -1,0 +1,24 @@
+package org.enso.interpreter.node.typecheck;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+final class FailCheckNode extends AbstractTypeCheckNode {
+  FailCheckNode(String comment) {
+    super(comment);
+  }
+
+  @Override
+  Object findDirectMatch(VirtualFrame frame, Object value) {
+    return null;
+  }
+
+  @Override
+  Object executeConversion(VirtualFrame frame, Object value) {
+    return null;
+  }
+
+  @Override
+  String expectedTypeMessage() {
+    return "resolved to a type";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -152,6 +152,10 @@ public final class TypeCheckValueNode extends Node {
     };
   }
 
+  public static TypeCheckValueNode fail(String comment) {
+    return new TypeCheckValueNode(new FailCheckNode(comment), true);
+  }
+
   /**
    * Constructs "single type" check.
    *

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -833,6 +833,7 @@ class IrToTruffle(
     case typeInContext: Tpe.Context =>
       // Type contexts aren't currently really used. But we should still check the base type.
       extractAscribedType(comment, typeInContext.typed)
+    case err: errors.Resolution => TypeCheckValueNode.fail("unresolved symbol " + err.originalName.name)
     case t => {
       val res = t.getMetadata(TypeNames)
       res match {

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -833,7 +833,8 @@ class IrToTruffle(
     case typeInContext: Tpe.Context =>
       // Type contexts aren't currently really used. But we should still check the base type.
       extractAscribedType(comment, typeInContext.typed)
-    case err: errors.Resolution => TypeCheckValueNode.fail("unresolved symbol " + err.originalName.name)
+    case err: errors.Resolution =>
+      TypeCheckValueNode.fail("unresolved symbol " + err.originalName.name)
     case t => {
       val res = t.getMetadata(TypeNames)
       res match {

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -273,7 +273,7 @@ object DistributionPackage {
           val runningProcess = Process(
             command,
             Some(path.getAbsoluteFile.getParentFile),
-            "JAVA_TOOL_OPTIONS" -> "-Dorg.jline.terminal.dumb=true"
+            "NO_COLOR" -> "true"
           ).run
           // Poor man's solution to stuck index generation
           val GENERATING_INDEX_TIMEOUT = 60 * 4 // 2 minutes


### PR DESCRIPTION
### Pull Request Description

Fixes #13358 by inserting _always failing_ type check for unresolved symbols. Such unresolved symbols yield compiler error in CLI mode - e.g. the runtime check isn't needed. However in the IDE with _less strict mode_ the compilation succeeds. Hence we need to insert additional runtime check to _panic_. Of course, in the IDE a panic only influences the node that's being computed.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

<img width="987" height="614" alt="Image" src="https://github.com/user-attachments/assets/c4811d2e-fce5-4f97-b095-224a9264d9db" />

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
