### PR TITLE
Scatterplot Improvement, C/B fix and Dropdown arrow fix

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -123,6 +123,7 @@ const rootStyle = computed(() => {
 
 .componentEditorLabel {
   position: absolute;
+  top: 3px;
   width: 100%;
   padding-right: 20px;
   text-align: right;

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>()
 
 const additionalTypes = computed<string[]>(() => {
-  if (props.typeInfo == null || props.typeInfo?.visibleTypes?.length === 1) {
+  if (props.typeInfo == null) {
     return []
   }
 
@@ -38,11 +38,13 @@ const label = computed(() => {
 
   return undefined
 })
+
+console.log(props.typeInfo, additionalTypes.value, hiddenTypes.value, label.value)
 </script>
 
 <template>
   <div v-if="label" :data-testid="props.testId" class="componentEditorLabel">
-    <TooltipTrigger v-if="additionalTypes.length > 0 || hiddenTypes.length > 0">
+    <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1">
       <template #default="triggerProps">
         <span
           class="additionalTypesPlaceholder"

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -16,7 +16,9 @@ const additionalTypes = computed<string[]>(() => {
   }
 
   const typeInfo = props.typeInfo
-  return typeInfo?.visibleTypes?.flatMap((type) => (type.path ? qnLastSegment(type.path) : [])) ?? []
+  return (
+    typeInfo?.visibleTypes?.flatMap((type) => (type.path ? qnLastSegment(type.path) : [])) ?? []
+  )
 })
 
 const hiddenTypes = computed<string[]>(() => {

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -11,16 +11,21 @@ const props = defineProps<{
 }>()
 
 const additionalTypes = computed<string[]>(() => {
-  if (props.typeInfo == null) {
+  if (props.typeInfo == null || props.typeInfo?.visibleTypes?.length === 1) {
     return []
   }
 
   const typeInfo = props.typeInfo
-  const combinedTypes = [...(typeInfo?.visibleTypes ?? []), ...(typeInfo?.hiddenTypes ?? [])]
-  const additionalTypes = combinedTypes.flatMap((type) =>
-    type.path ? qnLastSegment(type.path) : [],
-  )
-  return additionalTypes.length === 1 ? [] : additionalTypes
+  return typeInfo?.visibleTypes?.flatMap((type) => (type.path ? qnLastSegment(type.path) : [])) ?? []
+})
+
+const hiddenTypes = computed<string[]>(() => {
+  if (props.typeInfo == null || props.typeInfo?.hiddenTypes?.length === 0) {
+    return []
+  }
+
+  const typeInfo = props.typeInfo
+  return typeInfo?.hiddenTypes?.flatMap((type) => (type.path ? qnLastSegment(type.path) : [])) ?? []
 })
 
 const label = computed(() => {
@@ -35,17 +40,18 @@ const label = computed(() => {
 
 <template>
   <div v-if="label" :data-testid="props.testId" class="componentEditorLabel">
-    <TooltipTrigger v-if="additionalTypes.length > 0">
+    <TooltipTrigger v-if="additionalTypes.length > 0 || hiddenTypes.length > 0">
       <template #default="triggerProps">
         <span
           class="additionalTypesPlaceholder"
           v-bind="triggerProps"
-          v-text="`${label} & + ${additionalTypes.length - 1}`"
+          v-text="`${label} & + ${additionalTypes.length + hiddenTypes.length - 1}`"
         />
       </template>
       <template #tooltip>
         <div class="flex flex-col">
           <span v-for="type in additionalTypes" :key="type" v-text="type" />
+          <span v-for="type in hiddenTypes" :key="type" v-text="type" class="hiddenType" />
         </div>
       </template>
     </TooltipTrigger>
@@ -63,5 +69,9 @@ const label = computed(() => {
 .componentEditorLabel {
   white-space: nowrap;
   opacity: 0.7;
+}
+
+.hiddenType {
+  font-style: italic;
 }
 </style>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -51,7 +51,7 @@ const label = computed(() => {
       <template #tooltip>
         <div class="flex flex-col">
           <span v-for="type in additionalTypes" :key="type" v-text="type" />
-          <span v-for="type in hiddenTypes" :key="type" v-text="type" class="hiddenType" />
+          <span v-for="type in hiddenTypes" :key="type" class="hiddenType" v-text="type" />
         </div>
       </template>
     </TooltipTrigger>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditorLabel.vue
@@ -38,8 +38,6 @@ const label = computed(() => {
 
   return undefined
 })
-
-console.log(props.typeInfo, additionalTypes.value, hiddenTypes.value, label.value)
 </script>
 
 <template>

--- a/app/gui/src/project-view/components/DropdownMenu.vue
+++ b/app/gui/src/project-view/components/DropdownMenu.vue
@@ -92,7 +92,7 @@ const { floatingStyles } = useFloating(rootElement, floatElement, {
   .DropdownMenu:has(.MenuButton:hover) &,
   &.visible {
     opacity: 0.8;
-    visibility: visible;
+    visibility: inherit;
   }
 }
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization.vue
@@ -253,6 +253,7 @@ customElements.define(ensoVisualizationHost, defineCustomElement(VisualizationHo
         <VisualizationToolbar
           :currentVis="currentVisualization"
           :showControls="!isPreview"
+          :isFocused="isFocused"
           :allVisualizations="allVisualizations"
           :visualizationDefinedToolbar="visualizationDefinedToolbar"
           :typename="typename"

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
@@ -24,6 +24,7 @@ const UNKNOWN_TYPE = 'Unknown'
 
 const props = defineProps<{
   showControls: boolean
+  isFocused: boolean
   allVisualizations: ReadonlyArray<VisualizationIdentifier>
   visualizationDefinedToolbar: ReadonlyArray<Readonly<ToolbarItem>> | undefined
   typename: ProjectPath | undefined
@@ -44,7 +45,7 @@ const visualizationSelector = useVisualizationSelector({
       </div>
       <div class="toolbarSection">
         <ActionButton action="panel.fullscreen" />
-        <SelectionDropdown v-bind="visualizationSelector" />
+        <SelectionDropdown v-bind="visualizationSelector" :alwaysShowArrow="isFocused" />
       </div>
       <div v-if="visualizationDefinedToolbar" class="visualization-defined-toolbars toolbarSection">
         <template v-for="(item, index) in visualizationDefinedToolbar" :key="index">
@@ -69,7 +70,7 @@ const visualizationSelector = useVisualizationSelector({
             v-model="item.selected.value"
             :options="item.options"
             :title="item.title"
-            alwaysShowArrow
+            :alwaysShowArrow="isFocused"
           />
           <SelectionDropdownText
             v-else-if="isTextSelectionMenu(item)"
@@ -77,7 +78,7 @@ const visualizationSelector = useVisualizationSelector({
             :options="item.options"
             :title="item.title"
             :heading="item.heading"
-            alwaysShowArrow
+            :alwaysShowArrow="isFocused"
           />
           <div v-else>?</div>
         </template>

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationSelector.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationSelector.ts
@@ -57,7 +57,6 @@ export function useVisualizationSelector({ selectedType, types }: VisualizationS
       ...bindModelValue(selectedTypeKey),
       options: visualizationOptions.value,
       title: 'Visualization Selector',
-      alwaysShowArrow: true,
       entriesTestId: 'visualization-selector-entries',
     }),
   )

--- a/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
@@ -22,7 +22,7 @@ export const defaultPreprocessor = [
   'process_to_json_text',
   'Nothing',
   DEFAULT_LIMIT.toString(),
-]
+] as const
 
 const bindings = defineKeybinds('scatterplot-visualization', {
   zoomToSelected: ['Mod+A'],

--- a/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
@@ -11,7 +11,8 @@ import { ToolbarItem } from './toolbar'
 
 export const name = 'Scatter Plot'
 export const icon = 'points'
-export const inputType = 'Standard.Table.Table.Table | Standard.Table.Column.Column | Standard.Base.Data.Vector.Vector'
+export const inputType =
+  'Standard.Table.Table.Table | Standard.Table.Column.Column | Standard.Base.Data.Vector.Vector'
 
 // The number of points to display by default.
 const DEFAULT_LIMIT = 15000
@@ -712,94 +713,99 @@ watchPostEffect(() => {
   const yScale_ = yScale.value
 
   const allPlotData = getPlotData(data.value) as Point[]
-  const circleData = allPlotData.filter(p => (p.shape || 'circle') === 'circle')
-  const symbolData = allPlotData.filter(p => (p.shape || 'circle') !== 'circle')
-  const labelsData = data.value.points.labels === VISIBLE_POINTS ? [] : allPlotData.filter(d => (d.label != null && d.label !== ''))
+  const circleData = allPlotData.filter((p) => (p.shape || 'circle') === 'circle')
+  const symbolData = allPlotData.filter((p) => (p.shape || 'circle') !== 'circle')
+  const labelsData =
+    data.value.points.labels === VISIBLE_POINTS ?
+      []
+    : allPlotData.filter((d) => d.label != null && d.label !== '')
   console.log(allPlotData, circleData, symbolData, labelsData)
 
   const series = Object.keys(data.value.axis).filter((s) => s != 'x')
   const color = d3.scaleOrdinal(d3.schemeCategory10).domain(series)
-  
-  const colorScale = data.value.is_multi_series ? (d: Point) => color(d.series ?? '') : (d: Point) => d.color ?? DEFAULT_FILL_COLOR;
+
+  const colorScale =
+    data.value.is_multi_series ?
+      (d: Point) => color(d.series ?? '')
+    : (d: Point) => d.color ?? DEFAULT_FILL_COLOR
 
   // Circles
   d3Points.value
     .selectAll<SVGCircleElement, Point>('circle')
-    .data(circleData, pt => pt.row_number)
-    .join(
-      enter =>
-        enter.append('circle')
-          .attr('class', 'scatterPoint')
-          .on('dblclick', (d:any) => {
-            createNode(d.srcElement.__data__.row_number)
-          })
-          .on('mouseover', (event, d) => {
-            d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
-          })
-          .on('mouseout', (event) => {
-            d3.select(event.currentTarget).select('title').remove()
-          })
+    .data(circleData, (pt) => pt.row_number)
+    .join((enter) =>
+      enter
+        .append('circle')
+        .attr('class', 'scatterPoint')
+        .on('dblclick', (d: any) => {
+          createNode(d.srcElement.__data__.row_number)
+        })
+        .on('mouseover', (event, d) => {
+          d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
+        })
+        .on('mouseout', (event) => {
+          d3.select(event.currentTarget).select('title').remove()
+        }),
     )
-      .style('fill', colorScale)
-      .attr('r', (d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER / 5)
-      .attr('cx', (d:Point) => xScale_(Number(d.x)))
-      .attr('cy', (d:Point) => yScale_(d.y))
+    .style('fill', colorScale)
+    .attr('r', (d) => ((d.size ?? 0.15) * SIZE_SCALE_MULTIPLER) / 5)
+    .attr('cx', (d: Point) => xScale_(Number(d.x)))
+    .attr('cy', (d: Point) => yScale_(d.y))
 
   // Symbols
   d3Points.value
     .selectAll<SVGPathElement, Point>('path')
-    .data(symbolData, pt => pt.row_number)
-    .join(
-      enter => 
-        enter.append('path')
-          .attr('class', 'scatterPoint')
-          .on('dblclick', (d:any) => {
-            createNode(d.srcElement.__data__.row_number)
-          })
-          .on('mouseover', (event, d) => {
-            d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
-          })
-          .on('mouseout', (event) => {
-            d3.select(event.currentTarget).select('title').remove()
-          })
+    .data(symbolData, (pt) => pt.row_number)
+    .join((enter) =>
+      enter
+        .append('path')
+        .attr('class', 'scatterPoint')
+        .on('dblclick', (d: any) => {
+          createNode(d.srcElement.__data__.row_number)
+        })
+        .on('mouseover', (event, d) => {
+          d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
+        })
+        .on('mouseout', (event) => {
+          d3.select(event.currentTarget).select('title').remove()
+        }),
     )
-      .style('--color', colorScale)
-      .attr(
-        'd',
-        symbol.type(matchShape).size((d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER),
-      )
-      .attr('transform', (d:Point) => `translate(${xScale_(Number(d.x))}, ${yScale_(d.y)})`)
+    .style('--color', colorScale)
+    .attr(
+      'd',
+      symbol.type(matchShape).size((d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER),
+    )
+    .attr('transform', (d: Point) => `translate(${xScale_(Number(d.x))}, ${yScale_(d.y)})`)
 
   // Render the points labels
   d3Points.value
-      .selectAll<SVGPathElement, Point>('text')
-      .data(labelsData, pt => pt.row_number)
-      .join(
-        enter => enter.append('text').attr('class', 'label')
-      )
-        .text((d) => d.label ?? '')
-        .attr('x', (d) => xScale_(Number(d.x)) + POINT_LABEL_PADDING_X_PX)
-        .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
+    .selectAll<SVGPathElement, Point>('text')
+    .data(labelsData, (pt) => pt.row_number)
+    .join((enter) => enter.append('text').attr('class', 'label'))
+    .text((d) => d.label ?? '')
+    .attr('x', (d) => xScale_(Number(d.x)) + POINT_LABEL_PADDING_X_PX)
+    .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
 
   // Render the Legend
   if (data.value.is_multi_series) {
-    const formatLabel = (lbl: string) =>
-      lbl.length > 15 ? `${lbl.substring(0, 15)}...` : lbl
+    const formatLabel = (lbl: string) => (lbl.length > 15 ? `${lbl.substring(0, 15)}...` : lbl)
 
     d3Legend.value
       .selectAll('circle')
       .data(seriesLabels.value)
-      .join(
-        enter => enter.append('circle').attr('r', 5).attr('cy', 9)
-      )
-        .attr('cx', (d, i) => 90 + i * 120)
-        .style('fill', (d) => color(d) || DEFAULT_FILL_COLOR)
+      .join((enter) => enter.append('circle').attr('r', 5).attr('cy', 9))
+      .attr('cx', (d, i) => 90 + i * 120)
+      .style('fill', (d) => color(d) || DEFAULT_FILL_COLOR)
 
     d3Legend.value
       .selectAll('text')
       .data(seriesLabels.value)
-      .join(
-        enter => enter.append('text').attr('y', 10).style('font-size', LABEL_FONT_STYLE).attr('alignment-baseline', 'middle')
+      .join((enter) =>
+        enter
+          .append('text')
+          .attr('y', 10)
+          .style('font-size', LABEL_FONT_STYLE)
+          .attr('alignment-baseline', 'middle'),
       )
       .attr('x', (d, i) => 100 + i * 120)
       .text((d) => formatLabel(d))

--- a/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/ScatterplotVisualization.vue
@@ -11,14 +11,17 @@ import { ToolbarItem } from './toolbar'
 
 export const name = 'Scatter Plot'
 export const icon = 'points'
-export const inputType = 'Standard.Table.Table.Table | Standard.Base.Data.Vector.Vector'
-const DEFAULT_LIMIT = 1024
+export const inputType = 'Standard.Table.Table.Table | Standard.Table.Column.Column | Standard.Base.Data.Vector.Vector'
+
+// The number of points to display by default.
+const DEFAULT_LIMIT = 15000
+
 export const defaultPreprocessor = [
   'Standard.Visualization.Scatter_Plot',
   'process_to_json_text',
   'Nothing',
   DEFAULT_LIMIT.toString(),
-] as const
+]
 
 const bindings = defineKeybinds('scatterplot-visualization', {
   zoomToSelected: ['Mod+A'],
@@ -128,7 +131,7 @@ const POINT_LABEL_PADDING_Y_PX = 2
 const ANIMATION_DURATION_MS = 400
 const VISIBLE_POINTS = 'visible'
 const ACCENT_COLOR: Color = { red: 78, green: 165, blue: 253 }
-const SIZE_SCALE_MULTIPLER = 100
+const SIZE_SCALE_MULTIPLER = 50
 const DEFAULT_FILL_COLOR = `rgba(${ACCENT_COLOR.red},${ACCENT_COLOR.green},${ACCENT_COLOR.blue},0.8)`
 
 const ZOOM_EXTENT = [0.5, 20] satisfies d3.BrushSelection
@@ -697,9 +700,9 @@ function getTooltipMessage(point: Point) {
       point.series && point.series in axis ?
         axis[point.series as keyof AxesConfiguration].label
       : ''
-    return `${formatXPoint(point.x)}, ${point.y}, ${label}- Double click to inspect point`
+    return `${formatXPoint(point.x)}, ${point.y}, ${label} - Double click to inspect point`
   }
-  return `${formatXPoint(point.x)}, ${point.y}- Double click to inspect point`
+  return `${formatXPoint(point.x)}, ${point.y} - Double click to inspect point`
 }
 
 // === Update contents ===
@@ -707,80 +710,99 @@ function getTooltipMessage(point: Point) {
 watchPostEffect(() => {
   const xScale_ = data.value.isTimeSeries ? xScaleTime.value : xScale.value
   const yScale_ = yScale.value
-  const plotData = getPlotData(data.value) as Point[]
+
+  const allPlotData = getPlotData(data.value) as Point[]
+  const circleData = allPlotData.filter(p => (p.shape || 'circle') === 'circle')
+  const symbolData = allPlotData.filter(p => (p.shape || 'circle') !== 'circle')
+  const labelsData = data.value.points.labels === VISIBLE_POINTS ? [] : allPlotData.filter(d => (d.label != null && d.label !== ''))
+  console.log(allPlotData, circleData, symbolData, labelsData)
+
   const series = Object.keys(data.value.axis).filter((s) => s != 'x')
-  const colorScale = (d: Point) => {
-    const color = d3.scaleOrdinal(d3.schemeCategory10).domain(series)
-    if (data.value.is_multi_series) {
-      return color(d.series ?? '')
-    }
-    return d.color ?? DEFAULT_FILL_COLOR
-  }
+  const color = d3.scaleOrdinal(d3.schemeCategory10).domain(series)
+  
+  const colorScale = data.value.is_multi_series ? (d: Point) => color(d.series ?? '') : (d: Point) => d.color ?? DEFAULT_FILL_COLOR;
+
+  // Circles
   d3Points.value
-    .selectAll<SVGPathElement, unknown>('path')
-    .data(plotData)
-    .join((enter) => enter.append('path'))
-    .call((data) => {
-      return data.append('title').text((d) => getTooltipMessage(d))
-    })
-    .on('dblclick', (d) => {
-      createNode(d.srcElement.__data__.row_number)
-    })
-    .transition()
-    .duration(animationDuration.value)
-    .attr('class', 'scatterPoint')
-    .attr(
-      'd',
-      symbol.type(matchShape).size((d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER),
+    .selectAll<SVGCircleElement, Point>('circle')
+    .data(circleData, pt => pt.row_number)
+    .join(
+      enter =>
+        enter.append('circle')
+          .attr('class', 'scatterPoint')
+          .on('dblclick', (d:any) => {
+            createNode(d.srcElement.__data__.row_number)
+          })
+          .on('mouseover', (event, d) => {
+            d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
+          })
+          .on('mouseout', (event) => {
+            d3.select(event.currentTarget).select('title').remove()
+          })
     )
-    .style('--color', (d) => colorScale(d))
-    .attr('transform', (d) => `translate(${xScale_(Number(d.x))}, ${yScale_(d.y)})`)
-  if (data.value.points.labels === VISIBLE_POINTS) {
-    d3Points.value
-      .selectAll<SVGPathElement, unknown>('text')
-      .data(plotData)
-      .join((enter) => enter.append('text').attr('class', 'label'))
-      .transition()
-      .duration(animationDuration.value)
-      .text((d) => d.label ?? '')
-      .attr('x', (d) => xScale_(Number(d.x)) + POINT_LABEL_PADDING_X_PX)
-      .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
-  }
-})
+      .style('fill', colorScale)
+      .attr('r', (d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER / 5)
+      .attr('cx', (d:Point) => xScale_(Number(d.x)))
+      .attr('cy', (d:Point) => yScale_(d.y))
 
-watchPostEffect(() => {
+  // Symbols
+  d3Points.value
+    .selectAll<SVGPathElement, Point>('path')
+    .data(symbolData, pt => pt.row_number)
+    .join(
+      enter => 
+        enter.append('path')
+          .attr('class', 'scatterPoint')
+          .on('dblclick', (d:any) => {
+            createNode(d.srcElement.__data__.row_number)
+          })
+          .on('mouseover', (event, d) => {
+            d3.select(event.currentTarget).append('title').text(getTooltipMessage(d))
+          })
+          .on('mouseout', (event) => {
+            d3.select(event.currentTarget).select('title').remove()
+          })
+    )
+      .style('--color', colorScale)
+      .attr(
+        'd',
+        symbol.type(matchShape).size((d) => (d.size ?? 0.15) * SIZE_SCALE_MULTIPLER),
+      )
+      .attr('transform', (d:Point) => `translate(${xScale_(Number(d.x))}, ${yScale_(d.y)})`)
+
+  // Render the points labels
+  d3Points.value
+      .selectAll<SVGPathElement, Point>('text')
+      .data(labelsData, pt => pt.row_number)
+      .join(
+        enter => enter.append('text').attr('class', 'label')
+      )
+        .text((d) => d.label ?? '')
+        .attr('x', (d) => xScale_(Number(d.x)) + POINT_LABEL_PADDING_X_PX)
+        .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
+
+  // Render the Legend
   if (data.value.is_multi_series) {
-    const formatLabel = (string: string) =>
-      string.length > 15 ? `${string.substr(0, 15)}...` : string
-
-    const color = d3
-      .scaleOrdinal<string>()
-      .domain(seriesLabels.value)
-      .range(d3.schemeCategory10)
-      .domain(seriesLabels.value)
+    const formatLabel = (lbl: string) =>
+      lbl.length > 15 ? `${lbl.substring(0, 15)}...` : lbl
 
     d3Legend.value
       .selectAll('circle')
       .data(seriesLabels.value)
-      .join((enter) => enter.append('circle'))
-      .attr('cx', function (d, i) {
-        return 90 + i * 120
-      })
-      .attr('cy', 9)
-      .attr('r', 5)
-      .style('fill', (d) => color(d) || DEFAULT_FILL_COLOR)
+      .join(
+        enter => enter.append('circle').attr('r', 5).attr('cy', 9)
+      )
+        .attr('cx', (d, i) => 90 + i * 120)
+        .style('fill', (d) => color(d) || DEFAULT_FILL_COLOR)
 
     d3Legend.value
       .selectAll('text')
       .data(seriesLabels.value)
-      .join((enter) => enter.append('text'))
-      .attr('x', function (d, i) {
-        return 100 + i * 120
-      })
-      .attr('y', 10)
-      .style('font-size', LABEL_FONT_STYLE)
+      .join(
+        enter => enter.append('text').attr('y', 10).style('font-size', LABEL_FONT_STYLE).attr('alignment-baseline', 'middle')
+      )
+      .attr('x', (d, i) => 100 + i * 120)
       .text((d) => formatLabel(d))
-      .attr('alignment-baseline', 'middle')
       .call((labels) => labels.append('title').text((d) => d))
   }
 })


### PR DESCRIPTION
### Pull Request Description

- Fix defect in dropdown arrows in visualisation if in code edit mode.
- Make it so that the dropdown arrows in the visualisation only show when hovered or focused.
- Fix positioning of type label in component browser.
- Adjust the tooltip for the type label to show hidden types in italic.
- Allow ScatterPlot to show 15,000 points.
- Redo the D3 Join code for the ScatterPlot.
- Special path for circles (the norm) versus symbols.

<img width="710" height="628" alt="image" src="https://github.com/user-attachments/assets/47b4659b-9356-48f1-98e6-9a3526b257b8" />

<img width="688" height="140" alt="image" src="https://github.com/user-attachments/assets/1deaa50a-f003-4002-b431-3e0711967b42" />

<img width="592" height="304" alt="image" src="https://github.com/user-attachments/assets/5ee53b30-0d08-41d9-be68-8cd67ff74246" />

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
