### PR TITLE
Fix Settings tab

### DIFF
--- a/app/gui/src/components/AppContainer.vue
+++ b/app/gui/src/components/AppContainer.vue
@@ -107,6 +107,7 @@ const onSignOut = () => {
             :selected="true"
             icon="settings"
             label="Settings"
+            @close="tab = 'drive'"
           />
         </div>
         <div class="filler" />

--- a/app/gui/src/components/AppContainer/SelectableTab.vue
+++ b/app/gui/src/components/AppContainer/SelectableTab.vue
@@ -6,14 +6,15 @@ import { AnimatePresence, motion } from 'motion-v'
 import { computed } from 'vue'
 import CloseButton from '../CloseButton.vue'
 
-const selected = defineModel<boolean>('selected')
 const {
+  selected,
   selectionLayoutId,
   label,
   tooltip,
   orientation = 'horizontal',
   enabled = true,
 } = defineProps<{
+  selected: boolean
   selectionLayoutId: string
   icon?: Icon | undefined
   label?: string | undefined
@@ -22,6 +23,9 @@ const {
   enabled?: boolean
   onClose?: (() => void) | undefined
 }>()
+// We don't use defineModel, because we want to let component user decide what to do on selection
+// change.
+const emit = defineEmits<{ 'update:selected': [value: boolean] }>()
 
 const tooltipPlacement = computed(() => (orientation === 'horizontal' ? 'top' : 'left'))
 const whenTooltip = computed(() => (label && !tooltip ? 'whenOverflow' : 'always'))
@@ -35,7 +39,7 @@ const VARIANTS = {
 <template>
   <TooltipTrigger :placement="tooltipPlacement" :when="whenTooltip">
     <template #default="triggerProps">
-      <div class="SelectableTab" :class="orientation" @click="selected = !selected">
+      <div class="SelectableTab" :class="orientation" @click="emit('update:selected', !selected)">
         <AnimatePresence :initial="selected != null">
           <motion.div
             v-if="selected"


### PR DESCRIPTION
### Pull Request Description

The settings tab has "close" button and is not "deselectable" anymore.

<img width="729" height="157" alt="image" src="https://github.com/user-attachments/assets/4abaf8a1-0fe5-4640-8043-71b270d59c3e" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
