### PR TITLE
Directly search meta parents rather than using `isMetaInstance`

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/example/TestClass.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/example/TestClass.java
@@ -101,4 +101,19 @@ public class TestClass {
     ENUM_VALUE_1,
     ENUM_VALUE_2
   }
+
+  public interface FnIntrfc {
+    Object perform(Object obj);
+  }
+
+  public static FnIntrfc identityFnIntrfc() {
+    return x -> x;
+  }
+
+  public static final class FnIntrfcSubclass implements FnIntrfc {
+    @Override
+    public Object perform(Object obj) {
+      return "subclass";
+    }
+  }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
+import java.util.function.Function;
+import org.enso.example.TestClass;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
@@ -104,6 +106,57 @@ public class JavaInteropTest {
             IO.println <| to_string TestClass.InnerEnum.ENUM_VALUE_2
         """;
     checkPrint(code, List.of("one", "two"));
+  }
+
+  @Test
+  public void testCaseOnFunctionalInterface() {
+    var code =
+        """
+        from Standard.Base import IO
+        polyglot java import org.enso.example.TestClass
+        polyglot java import org.enso.example.TestClass.FnIntrfc
+
+        check x y=42 = case x of
+          call:FnIntrfc -> call.perform y
+          _ -> "no"
+
+        main = check
+        """;
+    var check = ctxRule.evalModule(code);
+
+    assertEquals("'no'", check.execute("Not FnIntrfc").toString());
+
+    Function<Object, Object> alien = (x) -> x;
+    assertEquals(
+        "Function isn't the right Java interface", "'no'", check.execute(alien).toString());
+
+    TestClass.FnIntrfc real = (x) -> x;
+    assertEquals(
+        "FnIntrfc is the right interface", "'good'", check.execute(real, "good").toString());
+
+    var atomCode =
+        """
+        type My_Type
+            Value x
+
+        main = My_Type.Value 1
+        """;
+    var atom = ctxRule.evalModule(atomCode);
+    assertEquals(
+        "atom is not Java interface at all " + "and it shouldn't pass the call:FnIntrfc check",
+        "'no'",
+        check.execute(atom).toString());
+
+    TestClass.FnIntrfc subclass = new TestClass.FnIntrfcSubclass();
+    assertEquals(
+        "FnIntrfcSubclass implements the right interface",
+        "'subclass'",
+        check.execute(subclass, "good").toString());
+
+    assertEquals(
+        "TestClass doesn't implement the interface",
+        "'no'",
+        check.execute(new TestClass(), "good").toString());
   }
 
   @Test

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
@@ -15,7 +15,6 @@ import org.enso.interpreter.node.expression.builtin.meta.IsSameObjectNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
-import org.enso.interpreter.runtime.library.dispatch.TypeOfNode;
 
 /** An implementation of the case expression specialised to working on polyglot types. */
 @NodeInfo(shortName = "PolyglotSymbolTypeMatch")
@@ -23,7 +22,6 @@ import org.enso.interpreter.runtime.library.dispatch.TypeOfNode;
 public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
 
   private final Object polyglotSymbol;
-  private @Child TypeOfNode typeOfNode = TypeOfNode.create();
   private @Child IsSameObjectNode isSameObject = IsSameObjectNode.build();
   private final CountingConditionProfile profile = CountingConditionProfile.create();
 
@@ -51,19 +49,20 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
       Object state,
       Object target,
       @CachedLibrary(limit = "3") InteropLibrary interop) {
-    Object tpeOfTarget = typeOfNode.findTypeOrError(target);
-    boolean test = isSameObject.execute(polyglotSymbol, tpeOfTarget);
-    if (profile.profile(test)) {
-      accept(frame, state, new Object[] {target});
-    } else {
-      try {
-        if (interop.hasMetaParents(tpeOfTarget) && findPolyglotSymbolInTypeHierarchy(tpeOfTarget)) {
+    try {
+      if (interop.hasMetaObject(target)) {
+        var tpeOfTarget = interop.getMetaObject(target);
+        var test = isSameObject.execute(polyglotSymbol, tpeOfTarget);
+        if (!test && interop.hasMetaParents(tpeOfTarget)) {
+          test = findPolyglotSymbolInTypeHierarchy(tpeOfTarget);
+        }
+        if (profile.profile(test)) {
           accept(frame, state, new Object[] {target});
         }
-      } catch (InteropException e) {
-        Atom err = reportError(polyglotSymbol, target);
-        throw new PanicException(err, this);
       }
+    } catch (InteropException e) {
+      Atom err = reportError(polyglotSymbol, target);
+      throw new PanicException(err, this);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
@@ -4,14 +4,15 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 import org.enso.interpreter.node.expression.builtin.meta.IsSameObjectNode;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.library.dispatch.TypeOfNode;
@@ -25,7 +26,6 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
   private @Child TypeOfNode typeOfNode = TypeOfNode.create();
   private @Child IsSameObjectNode isSameObject = IsSameObjectNode.build();
   private final CountingConditionProfile profile = CountingConditionProfile.create();
-  private final CountingConditionProfile subtypeProfile = CountingConditionProfile.create();
 
   PolyglotSymbolTypeBranchNode(
       Object polyglotSymbol, RootCallTarget functionNode, boolean terminalBranch) {
@@ -57,12 +57,10 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
       accept(frame, state, new Object[] {target});
     } else {
       try {
-        if (subtypeProfile.profile(
-            interop.isMetaObject(polyglotSymbol)
-                && interop.isMetaInstance(polyglotSymbol, target))) {
+        if (interop.hasMetaParents(tpeOfTarget) && findPolyglotSymbolInTypeHierarchy(tpeOfTarget)) {
           accept(frame, state, new Object[] {target});
         }
-      } catch (UnsupportedMessageException e) {
+      } catch (InteropException e) {
         Atom err = reportError(polyglotSymbol, target);
         throw new PanicException(err, this);
       }
@@ -70,10 +68,31 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
   }
 
   @CompilerDirectives.TruffleBoundary
+  private boolean findPolyglotSymbolInTypeHierarchy(Object type)
+      throws InvalidArrayIndexException, UnsupportedMessageException {
+    if (isSameObject.execute(polyglotSymbol, type)) {
+      return true;
+    }
+    var iop = InteropLibrary.getUncached();
+    if (!iop.hasMetaParents(type)) {
+      return false;
+    }
+    var parents = iop.getMetaParents(type);
+    var len = iop.getArraySize(parents);
+    for (var i = 0L; i < len; i++) {
+      var p = iop.readArrayElement(parents, i);
+      if (findPolyglotSymbolInTypeHierarchy(p)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @CompilerDirectives.TruffleBoundary
   private Atom reportError(Object expected, Object target) {
-    Builtins builtins = EnsoContext.get(this).getBuiltins();
+    var builtins = EnsoContext.get(this).getBuiltins();
     return builtins
         .error()
-        .makeCompileError("unable to check if " + target + " is an instance of " + polyglotSymbol);
+        .makeCompileError("unable to check if " + target + " is an instance of " + expected);
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fixes #12266 by avoiding usage of `InteropLibrary.isMetaInstance`. The _host interop layer_ of Truffle is performing various conversions that we want to avoid. For example it was able to convert an `Atom` into functional interface. To avoid such conversions just search the `InteropLibrary.getMetaParents` hierarchy manually.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] Benchmarks ([engine run](https://github.com/enso-org/enso/actions/runs/16223836601)) seem unaffected, [second run](https://github.com/enso-org/enso/actions/runs/16284915404)
- [x] Standard libs [benchmarks run](https://github.com/enso-org/enso/actions/runs/16284930057)
