### PR TITLE
Log cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ Global / onLoad := {
 ThisBuild / organization := "org.enso"
 ThisBuild / scalaVersion := scalacVersion
 ThisBuild / publish / skip := true
+ThisBuild / assembly / logLevel := Level.Warn
 
 /* Tag limiting the concurrent access to tools/simple-library-server in tests.
  */

--- a/build.sbt
+++ b/build.sbt
@@ -571,7 +571,7 @@ val generateRustParserLib =
       "unstable-options"
     ) ++ target.map(t => Seq("--target", t)).getOrElse(Seq()) ++
       Seq(
-        "--out-dir",
+        "--artifact-dir",
         (`syntax-rust-definition` / rustParserTargetDirectory).value.toString
       )
     val envVars = target

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -345,8 +345,7 @@ public class Main {
             .argName("log-level")
             .longOpt(LOG_LEVEL)
             .desc(
-                "Sets the runtime log level. Possible values are: OFF, ERROR, "
-                    + "WARNING, INFO, DEBUG and TRACE. Default: INFO.")
+                "Sets the runtime log level. Possible values are: " + getPossibleLogLevels() + ". Default: info.")
             .build();
     var loggerConnectOption =
         cliOptionBuilder()
@@ -1065,14 +1064,16 @@ public class Main {
     var found =
         Stream.of(Level.values()).filter(x -> name.equals(x.name().toLowerCase())).findFirst();
     if (found.isEmpty()) {
-      var possible =
-          Stream.of(Level.values())
-              .map(x -> x.toString().toLowerCase())
-              .collect(Collectors.joining(", "));
-      throw exitFail("Invalid log level. Possible values are " + possible + ".");
+      throw exitFail("Invalid log level. Possible values are " + getPossibleLogLevels() + ".");
     } else {
       return found.get();
     }
+  }
+
+  private static String getPossibleLogLevels() {
+    return Stream.of(Level.values())
+        .map(x -> x.toString().toLowerCase())
+        .collect(Collectors.joining(", "));
   }
 
   /** Parses an URI that specifies the logging service connection. */

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -345,7 +345,9 @@ public class Main {
             .argName("log-level")
             .longOpt(LOG_LEVEL)
             .desc(
-                "Sets the runtime log level. Possible values are: " + getPossibleLogLevels() + ". Default: info.")
+                "Sets the runtime log level. Possible values are: "
+                    + getPossibleLogLevels()
+                    + ". Default: info.")
             .build();
     var loggerConnectOption =
         cliOptionBuilder()

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -247,7 +247,13 @@ public final class EnsoContext {
       var cwd = environment.getCurrentWorkingDirectory().getAbsoluteFile().normalize();
       try {
         if (!cwd.isSameFile(parent)) {
-          environment.setCurrentWorkingDirectory(parent);
+          var maskedPath = MaskedPath$.MODULE$.apply(Path.of(parent.toString()));
+          logger.log(
+              Level.WARNING,
+              "Initializing the context in a different working directory than the one containing"
+                  + " the project root. This may lead to relative paths not behaving as advertised"
+                  + " by `File.new`. Please run the engine inside of `{0}` directory.",
+              maskedPath);
         }
       } catch (IOException e) {
         logger.severe("Error checking working directory: " + e.getMessage());

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -247,13 +247,7 @@ public final class EnsoContext {
       var cwd = environment.getCurrentWorkingDirectory().getAbsoluteFile().normalize();
       try {
         if (!cwd.isSameFile(parent)) {
-          var maskedPath = MaskedPath$.MODULE$.apply(Path.of(parent.toString()));
-          logger.log(
-              Level.WARNING,
-              "Initializing the context in a different working directory than the one containing"
-                  + " the project root. This may lead to relative paths not behaving as advertised"
-                  + " by `File.new`. Please run the engine inside of `{0}` directory.",
-              maskedPath);
+          environment.setCurrentWorkingDirectory(parent);
         }
       } catch (IOException e) {
         logger.severe("Error checking working directory: " + e.getMessage());

--- a/project/Cargo.scala
+++ b/project/Cargo.scala
@@ -36,7 +36,9 @@ object Cargo {
     log.debug(cmd.toString())
 
     val exitCode =
-      try Process(cmd, None, extraEnv: _*).!(ProcessLogger(log.debug(_), log.debug(_)))
+      try Process(cmd, None, extraEnv: _*).!(
+        ProcessLogger(log.debug(_), log.debug(_))
+      )
       catch {
         case _: RuntimeException =>
           throw new RuntimeException(s"`$cargoCmd` command failed to run.")

--- a/project/Cargo.scala
+++ b/project/Cargo.scala
@@ -33,10 +33,10 @@ object Cargo {
     if (!cargoOk(log))
       throw new RuntimeException("Cargo isn't installed!")
 
-    log.info(cmd.toString())
+    log.debug(cmd.toString())
 
     val exitCode =
-      try Process(cmd, None, extraEnv: _*).!
+      try Process(cmd, None, extraEnv: _*).!(ProcessLogger(log.debug(_), log.debug(_)))
       catch {
         case _: RuntimeException =>
           throw new RuntimeException(s"`$cargoCmd` command failed to run.")

--- a/test/Base_Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Java_Interop_Spec.enso
@@ -27,7 +27,7 @@ add_specs suite_builder =
             list = ArrayList.new
             list.add 432
             list.get 0 . should_equal 432
-        group_builder.specify "should report missing method error on Java Arrays" pending="Failing due to #6609" <|
+        group_builder.specify "should report missing method error on Java Arrays" <|
             list = ArrayList.new
             list.add 432
             Test.expect_panic_with (list.asList) No_Such_Method


### PR DESCRIPTION
### Pull Request Description

Some clean-up on the verbosity of our logs. I am open to discussion if anyone thinks these logs were useful as they were before.

1. "should report missing method error on Java Arrays"  was pending="Failing due to #6609". But #6609 is fixed to we can enable this test.

2. When using `runEngineDistribution --run` I always get this warning `warning: the --out-dir flag has been changed to --artifact-dir`. This is a change in Rust so I changed sbt to use the new option.

3. The documentation for runEngineDistribution log-level suggested I could use OFF. But that isn't a valid option. Updated the documentation to match the code.

4. ~~Whenever I run `runEngineDistribution --run **/Users/adriley/Code/enso-org/enso/test/Base_Tests/src/Semantic/Java_Interop_Spec.enso**` I always get told `[WARN] [2025-07-14T10:15:17+01:00] [enso.org.enso.interpreter.runtime.EnsoContext] Initializing the context in a different working directory than the one containing the project root. This may lead to relative paths not behaving as advertised by `File.new`. Please run the engine inside of `/Users/adriley/Code/enso-org/enso/test` directory.` Well if I should do that why can't the code just do it for me?~~

5. Whenever I run `runEngineDistribution --run **/Users/adriley/Code/enso-org/enso/test/Base_Tests/src/Semantic/Java_Interop_Spec.enso**` I get these messages 
```
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/scala-libs-wrapper/target/scala-2.13/scala-libs-wrapper-assembly-0.1.0-SNAPSHOT.jar
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/fansi-wrapper/target/scala-2.13/fansi-wrapper-assembly-0.1.0-SNAPSHOT.jar
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/zio-wrapper/target/scala-2.13/zio-wrapper-assembly-0.1.0-SNAPSHOT.jar
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/jna-wrapper/target/scala-2.13/jna-wrapper-assembly-0.1.0-SNAPSHOT.jar
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/poi-wrapper/target/scala-2.13/poi-wrapper-assembly-0.1.jar
[info] Assembly jar up to date: /Users/adriley/Code/enso-org/enso/lib/java/language-server-deps-wrapper/target/scala-2.13/language-server-deps-wrapper-assembly-0.1.0-SNAPSHOT.jar
```
They don't seem very interesting so I have suppressed them

6. Suppressed these 2 lines
```
[info] List(cargo, build, -p, enso-parser-jni, --profile, fuzz, -Z, unstable-options, --artifact-dir, /Users/adriley/Code/enso-org/enso/target/rust/parser-jni)
    Finished `fuzz` profile [optimized] target(s) in 0.08s
```



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
