### PR TITLE
Fix handshake timeout exception in Azure.list_blob

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3722,6 +3722,7 @@ lazy val `engine-runner` = project
               "com.amazonaws",
               "com.google",
               "io.grpc",
+              "io.netty",
               "io.opencensus",
               "net.snowflake.client",
               "com.sun.jna",

--- a/build.sbt
+++ b/build.sbt
@@ -3675,7 +3675,11 @@ lazy val `engine-runner` = project
               // Needed for the NativeLibraryFeature
               "--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
               // Snowflake uses Apache Arrow (equivalent of #9664 in native-image setup)
-              "--add-opens=java.base/java.nio=ALL-UNNAMED"
+              "--add-opens=java.base/java.nio=ALL-UNNAMED",
+              "-g",
+              "-O0",
+              "-H:+SourceLevelDebug",
+              "-H:-DeleteLocalSymbols",
             ) ++ (if (GraalVM.EnsoLauncher.debug) {
                     // useful perf & debug switches:
                     Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3675,11 +3675,7 @@ lazy val `engine-runner` = project
               // Needed for the NativeLibraryFeature
               "--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
               // Snowflake uses Apache Arrow (equivalent of #9664 in native-image setup)
-              "--add-opens=java.base/java.nio=ALL-UNNAMED",
-              "-g",
-              "-O0",
-              "-H:+SourceLevelDebug",
-              "-H:-DeleteLocalSymbols",
+              "--add-opens=java.base/java.nio=ALL-UNNAMED"
             ) ++ (if (GraalVM.EnsoLauncher.debug) {
                     // useful perf & debug switches:
                     Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3722,7 +3722,7 @@ lazy val `engine-runner` = project
               "com.amazonaws",
               "com.google",
               "io.grpc",
-              "io.netty",
+              "io.netty.util.concurrent.AbstractScheduledEventExecutor",
               "io.opencensus",
               "net.snowflake.client",
               "com.sun.jna",

--- a/engine/runner/src/main/resources/application.conf
+++ b/engine/runner/src/main/resources/application.conf
@@ -21,7 +21,7 @@ logging-service {
       },
       {
         name = "console"
-        pattern = "[%level{lowercase=true}] [%d{yyyy-MM-dd'T'HH:mm:ssXXX}] [%logger] %msg%n%nopex"
+        pattern = "[%level{lowercase=true}] [%d{yyyy-MM-dd'T'HH:mm:ssXXX}] [%logger] %msg%n"
       }
   ]
   default-appender = console

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -103,7 +103,7 @@ object GraalVM {
     private val linuxX64Release   = NativeImageSize(200, 490)
     private val macX64Release     = NativeImageSize(200, 457)
     private val macARM64Release   = NativeImageSize(200, 473)
-    private val testNISize        = NativeImageSize(100, 592)
+    private val testNISize        = NativeImageSize(100, 800)
   }
 
   /** Has the user requested to use Espresso for Java interop? */

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -103,7 +103,7 @@ object GraalVM {
     private val linuxX64Release   = NativeImageSize(200, 490)
     private val macX64Release     = NativeImageSize(200, 457)
     private val macARM64Release   = NativeImageSize(200, 473)
-    private val testNISize        = NativeImageSize(100, 800)
+    private val testNISize        = NativeImageSize(100, 592)
   }
 
   /** Has the user requested to use Espresso for Java interop? */


### PR DESCRIPTION
Fixes #13462

### Pull Request Description

There was an assertion error thrown from `io.netty.util.concurrent.SingleThreadEventExecutor` (see https://github.com/enso-org/enso/pull/13485#issuecomment-3083908279). This assertion error is fixed by https://github.com/enso-org/enso/commit/6af0a7f41f4219de2c612dbf2bc9b4e66385fa0c.

### Important Notes

- Latest NI on merge-base with develop built on CI as part of the `Engine` workflow is at https://github.com/enso-org/enso/actions/runs/16195211948/job/45779259891#step:12:106 and it is broken - failing on assertion error.
- Latest NI on merge-base with develop built on CI as part of the `Package IDE` workflow is at https://github.com/enso-org/enso/actions/runs/16195211930/job/45719993319#step:14:119 and it is broken - failing with `SslHandshakeTimeoutException`.

### Checklist

Ensure that listing Azure blob storage works without any timeouts on:
- [x] locally built NI with `ENSO_LAUNCHER=native`
- [x] locally built NI with `ENSO_LAUNCHER=native,test`
- NI build on CI as part of the `Engine` workflow. This NI is built with `ENSO_LAUNCHER=native,test`:
  - [x] Linux
  - [x] Windows
  - Artifact at https://github.com/enso-org/enso/actions/runs/16375469763/job/46274219726?pr=13485#step:12:122
- NI build on CI as part of the `Package IDE` workflow. This NI is built in release mode (with optimizations) and with `ENSO_LAUNCHER=native`:
  - [x] Linux
  - [x] Windows
  - Artifact at https://github.com/enso-org/enso/actions/runs/16377002913/job/46279605682?pr=13485#step:14:119
- Final packaged IDE tested:
  - [x] Linux
    - Artifact at https://github.com/enso-org/enso/actions/runs/16377002913/job/46280695577?pr=13485#step:15:130 
  - [x] Windows
    - Artifact at https://github.com/enso-org/enso/actions/runs/16377002913/job/46281775825?pr=13485#step:15:133
