### PR TITLE
Fix cloud category switcher

### DIFF
--- a/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
+++ b/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
@@ -42,6 +42,7 @@ interface CategoryMetadata {
 interface InternalCategorySwitcherItemProps extends CategoryMetadata {
   readonly badgeContent?: React.ReactNode
   readonly isDisabled: boolean
+  readonly disabledReason?: string | null | undefined
   readonly onPress?: (() => void) | undefined
 }
 
@@ -58,7 +59,8 @@ const CATEGORY_SWITCHER_VARIANTS = tv({
 function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
   const {
     badgeContent,
-    isDisabled: isDisabledRaw,
+    isDisabled = false,
+    disabledReason,
     isNested = false,
     category,
     buttonLabel,
@@ -69,43 +71,13 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
 
   const [isTransitioning, startTransition] = React.useTransition()
 
-  const { user } = authProvider.useFullUserSession()
   const { getText } = useText()
-  const { localBackend } = useBackends()
-  const { isOffline } = offlineHooks.useOffline()
 
   const isCurrent = areCategoriesEqual(currentCategory, category)
 
   const transferBetweenCategories = useTransferBetweenCategories(currentCategory)
 
-  const getCategoryError = useEventCallback((otherCategory: Category) => {
-    switch (otherCategory.type) {
-      case 'local':
-      case 'local-directory': {
-        if (localBackend == null) {
-          return getText('localBackendNotDetectedError')
-        } else {
-          return null
-        }
-      }
-      case 'cloud':
-      case 'recent':
-      case 'trash':
-      case 'user':
-      case 'team': {
-        if (isOffline) {
-          return getText('unavailableOffline')
-        } else if (!user.isEnabled) {
-          return getText('notEnabledSubtitle')
-        } else {
-          return null
-        }
-      }
-    }
-  })
-  const error = getCategoryError(category)
-  const isDisabled = error != null || isDisabledRaw
-  const tooltip = error ?? false
+  const tooltip = (isDisabled && disabledReason) ?? false
 
   const isDropTarget =
     !areCategoriesEqual(currentCategory, category) &&
@@ -113,7 +85,7 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
   const acceptedDragTypes = isDropTarget ? [mimeTypes.ASSETS_MIME_TYPE] : []
 
   const onPress = useEventCallback(() => {
-    if (error == null) {
+    if (!isDisabled) {
       // We use startTransition to trigger a background transition between categories.
       // and to not invoke the Suspense boundary.
       // This makes the transition feel more responsive and natural.
@@ -256,11 +228,33 @@ function CategorySwitcher(props: CategorySwitcherProps) {
   const { getText } = useText()
 
   const { isOffline } = offlineHooks.useOffline()
+  const { localBackend } = useBackends()
+  const { user } = authProvider.useFullUserSession()
 
   const { cloudCategories, localCategories } = useCategoriesAPI()
 
   const { cloudCategory, recentCategory, trashCategory, teamCategories } = cloudCategories
   const { localCategory, directories, addDirectory, removeDirectory } = localCategories
+
+  const cloudDisabledReason = React.useMemo(() => {
+    if (isOffline) {
+      return getText('unavailableOffline')
+    } else if (!user.isEnabled) {
+      return getText('notEnabledSubtitle')
+    } else {
+      return null
+    }
+  }, [isOffline, user, getText])
+  const isCloudDisabled = cloudDisabledReason != null
+
+  const localDisabledReason = React.useMemo(() => {
+    if (localBackend == null) {
+      return getText('localBackendNotDetectedError')
+    } else {
+      return null
+    }
+  }, [localBackend, getText])
+  const isLocalDisabled = localDisabledReason != null
 
   return (
     <AnimatedBackground>
@@ -271,7 +265,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
       >
         <CategorySwitcherItem
           category={cloudCategory}
-          isDisabled={isOffline}
+          isDisabled={isCloudDisabled}
+          disabledReason={cloudDisabledReason}
           buttonLabel={getText('cloudCategoryButtonLabel')}
           dropZoneLabel={getText('cloudCategoryDropZoneLabel')}
           badgeContent={getText('cloudCategoryBadgeContent')}
@@ -282,7 +277,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
             key={teamCategory.id}
             isNested
             category={teamCategory}
-            isDisabled={isOffline}
+            isDisabled={isCloudDisabled}
+            disabledReason={cloudDisabledReason}
             buttonLabel={getText('teamCategoryButtonLabel', teamCategory.team.name)}
             dropZoneLabel={getText('teamCategoryDropZoneLabel', teamCategory.team.name)}
             onPress={onChange}
@@ -291,7 +287,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
         <CategorySwitcherItem
           isNested
           category={recentCategory}
-          isDisabled={isOffline}
+          isDisabled={isCloudDisabled}
+          disabledReason={cloudDisabledReason}
           buttonLabel={getText('recentCategoryButtonLabel')}
           dropZoneLabel={getText('recentCategoryDropZoneLabel')}
           onPress={onChange}
@@ -299,7 +296,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
         <CategorySwitcherItem
           isNested
           category={trashCategory}
-          isDisabled={isOffline}
+          isDisabled={isCloudDisabled}
+          disabledReason={cloudDisabledReason}
           buttonLabel={getText('trashCategoryButtonLabel')}
           dropZoneLabel={getText('trashCategoryDropZoneLabel')}
           onPress={onChange}
@@ -308,7 +306,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
           <div className="group flex items-center gap-2 self-stretch drop-target-after">
             <CategorySwitcherItem
               category={localCategory}
-              isDisabled={false}
+              isDisabled={isLocalDisabled}
+              disabledReason={localDisabledReason}
               buttonLabel={getText('localCategoryButtonLabel')}
               dropZoneLabel={getText('localCategoryDropZoneLabel')}
               onPress={onChange}
@@ -338,7 +337,8 @@ function CategorySwitcher(props: CategorySwitcherProps) {
               <CategorySwitcherItem
                 isNested
                 category={directory}
-                isDisabled={false}
+                isDisabled={isLocalDisabled}
+                disabledReason={localDisabledReason}
                 buttonLabel={getText('localCategoryButtonLabel')}
                 dropZoneLabel={getText('localCategoryDropZoneLabel')}
                 onPress={onChange}


### PR DESCRIPTION
### Pull Request Description

One of the issues in #13469

Avoid double-checks of `isOffline` that led to the disabled status being stuck when switching the internet connection.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
