### PR TITLE
Docs: Fix SVG drop

### DIFF
--- a/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
@@ -55,9 +55,9 @@ const { editorView, setExtraExtensions } = useCodeMirror(editorRoot, {
     EditorView.lineWrapping,
     highlightStyle(useCssModule()),
     ensoMarkdown({
-      tryUploadPastedImage: () =>
-        images?.value &&
-        ((item: ClipboardItem) => images.value.tryUploadPastedImage(editorView, item)),
+      tryUploadPastedImage: (item) => images?.value.tryUploadPastedImage(editorView, item) ?? false,
+      tryUploadDroppedImage: (event) =>
+        images?.value.tryUploadDroppedImage(editorView, event) ?? false,
     }),
     extensions,
   ],
@@ -96,11 +96,7 @@ defineExpose({
 </script>
 
 <template>
-  <div
-    class="MarkdownEditorRoot"
-    @dragover.prevent
-    @drop.prevent="images?.tryUploadDroppedImage?.(editorView, $event)"
-  >
+  <div class="MarkdownEditorRoot" @dragover.prevent>
     <div v-if="toolbar" class="toolbar" @pointerdown.prevent>
       <ActionButton action="panel.fullscreen" />
       <SelectionDropdown v-if="blockTypeDropdown" v-bind="blockTypeDropdown" />

--- a/app/gui/src/project-view/components/MarkdownEditor/codemirror/clipboard.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/codemirror/clipboard.ts
@@ -4,10 +4,8 @@ import { putText } from '@/util/codemirror'
 import type { CmEvent } from '@/util/codemirror/keymap'
 import { handlerToKeyBinding } from '@/util/codemirror/keymap'
 import { LINKABLE_URL_REGEX } from '@/util/link'
-import type { ToValue } from '@/util/reactivity'
 import type { Extension } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
-import { toValue } from 'vue'
 import { prerenderMarkdown } from 'ydoc-shared/ast/documentation'
 
 function uriEscapeChar(char: string) {
@@ -23,17 +21,21 @@ export function transformPastedText(text: string): string {
   return text.replaceAll(LINKABLE_URL_REGEX, toAutoLink)
 }
 
-interface MarkdownClipboardOptions {
-  tryUploadPastedImage: ToValue<((item: ClipboardItem) => boolean) | undefined>
+export interface MarkdownClipboardOptions {
+  tryUploadPastedImage: (item: ClipboardItem) => boolean
+  tryUploadDroppedImage: (event: DragEvent) => boolean
 }
 
 /** @returns a CodeMirror extension customizing the clipboard for Enso Markdown. */
-export function markdownClipboard({ tryUploadPastedImage }: MarkdownClipboardOptions): Extension {
+export function markdownClipboard({
+  tryUploadPastedImage,
+  tryUploadDroppedImage,
+}: MarkdownClipboardOptions): Extension {
   function handlePaste(event: CmEvent, raw: boolean) {
     const view = event.codemirrorView
     window.navigator.clipboard.read().then(async (items) => {
       for (const item of items) {
-        if (toValue(tryUploadPastedImage)?.(item)) continue
+        if (tryUploadPastedImage(item)) continue
         const htmlType = item.types.find((type) => type === 'text/html')
         if (htmlType) {
           const blob = await item.getType(htmlType)
@@ -54,6 +56,9 @@ export function markdownClipboard({ tryUploadPastedImage }: MarkdownClipboardOpt
 
   return [
     EditorView.clipboardInputFilter.of(transformPastedText),
+    EditorView.domEventHandlers({
+      drop: tryUploadDroppedImage,
+    }),
     keymap.of([
       handlerToKeyBinding(
         textEditorsCommonBindings.handler({

--- a/app/gui/src/project-view/components/MarkdownEditor/codemirror/index.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/codemirror/index.ts
@@ -1,23 +1,26 @@
-import { markdownClipboard } from '@/components/MarkdownEditor/codemirror/clipboard'
+import {
+  markdownClipboard,
+  type MarkdownClipboardOptions,
+} from '@/components/MarkdownEditor/codemirror/clipboard'
 import { markdownDecorators } from '@/components/MarkdownEditor/codemirror/decoration'
 import { markdownFormatting } from '@/components/MarkdownEditor/codemirror/formatting'
 import { ensoMarkdownSyntax } from '@/components/MarkdownEditor/markdown/syntax'
-import type { ToValue } from '@/util/reactivity'
 import type { Extension } from '@codemirror/state'
 export { useMarkdownFormatting } from '@/components/MarkdownEditor/codemirror/formatting'
 
-interface EnsoMarkdownOptions {
-  tryUploadPastedImage: ToValue<((item: ClipboardItem) => boolean) | undefined>
+interface EnsoMarkdownOptions extends MarkdownClipboardOptions {
+  tryUploadPastedImage: (item: ClipboardItem) => boolean
+  tryUploadDroppedImage: (event: DragEvent) => boolean
 }
 
 /**
  * CodeMirror Extension for the Enso Markdown dialect.
  */
-export function ensoMarkdown({ tryUploadPastedImage }: EnsoMarkdownOptions): Extension {
+export function ensoMarkdown(options: EnsoMarkdownOptions): Extension {
   return [
     ensoMarkdownSyntax(),
     markdownDecorators(),
     markdownFormatting(),
-    markdownClipboard({ tryUploadPastedImage }),
+    markdownClipboard(options),
   ]
 }

--- a/app/gui/src/project-view/components/MarkdownEditor/imageFiles/backendFiles.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/imageFiles/backendFiles.ts
@@ -41,7 +41,7 @@ export function useDocumentationImagesFromBackend(
       }
     },
     tryUploadImageFile: async () => {},
-    tryUploadDroppedImage: async () => {},
+    tryUploadDroppedImage: () => false,
     tryUploadPastedImage: () => {
       return false
     },

--- a/app/gui/src/project-view/components/MarkdownEditor/imageFiles/common.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/imageFiles/common.ts
@@ -4,7 +4,7 @@ import { Err, Ok } from 'ydoc-shared/util/data/result'
 
 export interface DocumentationImages {
   transformImageUrl: UrlTransformer
-  tryUploadDroppedImage: (view: EditorView, event: DragEvent) => Promise<void>
+  tryUploadDroppedImage: (view: EditorView, event: DragEvent) => boolean
   tryUploadPastedImage: (view: EditorView, item: ClipboardItem) => boolean
   tryUploadImageFile: (view: EditorView) => Promise<void>
 }

--- a/app/gui/src/project-view/components/MarkdownEditor/imageFiles/projectFiles.ts
+++ b/app/gui/src/project-view/components/MarkdownEditor/imageFiles/projectFiles.ts
@@ -105,12 +105,13 @@ export function useDocumentationImagesFromProjectFiles(
     },
   )
 
-  async function uploadImage(
+  async function uploadImageAndInsert(
     view: EditorView,
     name: string,
-    blobPromise: Promise<Blob>,
+    data: Blob | Promise<Blob>,
     position: UploadedImagePosition = { type: 'selection' },
   ) {
+    const blobPromise = Promise.resolve(data)
     try {
       const rootId = await projectFiles.projectRootId
       if (!rootId) {
@@ -150,20 +151,31 @@ export function useDocumentationImagesFromProjectFiles(
     }
   }
 
-  /** If the given drag event contains supported image(s), upload them and insert references into the editor. */
-  async function tryUploadDroppedImage(view: EditorView, event: DragEvent) {
-    if (!event.dataTransfer?.items) return
+  /**
+   * If the given drag event contains supported image(s), upload them and insert references into the
+   * editor.
+   */
+  function tryUploadDroppedImage(view: EditorView, event: DragEvent): boolean {
+    if (!event.dataTransfer?.items) return false
+    const uploads = []
     for (const item of event.dataTransfer.items) {
       if (item.kind !== 'file' || !Object.hasOwn(supportedImageTypes, item.type)) continue
       const file = item.getAsFile()
       if (!file) continue
       const clientPos = new Vec2(event.clientX, event.clientY)
-      event.stopPropagation()
+      uploads.push(
+        uploadImageAndInsert(view, file.name, file, {
+          type: 'coords',
+          coords: clientPos,
+        }),
+      )
+    }
+    if (uploads.length > 0) {
+      event.stopImmediatePropagation()
       event.preventDefault()
-      await uploadImage(view, file.name, Promise.resolve(file), {
-        type: 'coords',
-        coords: clientPos,
-      })
+      return true
+    } else {
+      return false
     }
   }
 
@@ -172,7 +184,7 @@ export function useDocumentationImagesFromProjectFiles(
     const imageType = item.types.find((type): type is MimeType => type in supportedImageTypes)
     if (imageType) {
       const ext = supportedImageTypes[imageType]?.extensions[0] ?? ''
-      uploadImage(view, `image.${ext}`, item.getType(imageType))
+      uploadImageAndInsert(view, `image.${ext}`, item.getType(imageType))
       return true
     } else {
       return false
@@ -194,7 +206,7 @@ export function useDocumentationImagesFromProjectFiles(
 
   async function tryUploadImageFile(view: EditorView) {
     for (const file of await selectFiles()) {
-      await uploadImage(view, file.name, Promise.resolve(file))
+      await uploadImageAndInsert(view, file.name, file)
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Docs: Fix SVG drop

Convert image drop handler to CM extension so that it can prevent editor's builtin drop handler from inserting SVG source code. Fixes #13472.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
