### PR TITLE
Enforcing consistency of cached and uncached version of `Atom.invokeMember` message

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AtomConstructorTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/AtomConstructorTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import java.util.function.Function;
 import org.enso.common.MethodNames;
 import org.enso.interpreter.runtime.data.atom.Atom;
@@ -14,6 +16,7 @@ import org.enso.interpreter.runtime.data.atom.AtomNewInstanceNode;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.test.utils.ContextUtils;
+import org.enso.test.utils.TestRootNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -64,6 +67,30 @@ public class AtomConstructorTest {
 
     assertAtomFactory("getUncached() with priming", uncachedFactory);
     assertLessArguments("getUncached() with priming", uncachedFactory);
+
+    var atom = uncachedFactory.apply(new Object[] {1, 2, 3});
+    {
+      var trn = new TestRootNode();
+      var n = InteropLibrary.getFactory().createDispatched(10);
+      n = trn.insert(n);
+      assertInteropInvoke("Cached invokeMember node yields UnknownIdentifierException", atom, n);
+    }
+    {
+      var n = InteropLibrary.getUncached();
+      assertInteropInvoke("Uncached invokeMember node yields UnknownIdentifierException", atom, n);
+    }
+  }
+
+  private static void assertInteropInvoke(String msg, Atom atom, InteropLibrary node) {
+    try {
+      var res = node.invokeMember(atom, "toString");
+      fail("Expecting exception, now a result: " + res);
+    } catch (UnknownIdentifierException good) {
+      assertEquals(
+          "UnknownIdentifierException is expected", "toString", good.getUnknownIdentifier());
+    } catch (Exception ex) {
+      throw new AssertionError(msg + " got " + ex.getClass().getName(), ex);
+    }
   }
 
   private static void assertAtomFactory(String msg, Function<java.lang.Object[], Atom> factory) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/InvokeMemberConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/InvokeMemberConsistencyTest.java
@@ -1,0 +1,69 @@
+package org.enso.interpreter.test.interop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import java.util.ArrayList;
+import org.enso.interpreter.test.ValuesGenerator;
+import org.enso.test.utils.ContextUtils;
+import org.enso.test.utils.TestRootNode;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class InvokeMemberConsistencyTest {
+  @ClassRule public static final ContextUtils CTX = ContextUtils.createDefault();
+
+  @Parameterized.Parameter(0)
+  public Object raw;
+
+  @Parameterized.Parameters
+  public static Object[][] allPossibleEnsoInterpreterValues() throws Exception {
+    var g = ValuesGenerator.create(CTX);
+    var data = new ArrayList<Object[]>();
+    for (var value : g.allValues()) {
+      var raw = CTX.unwrapValue(value);
+      if (raw instanceof TruffleObject) {
+        data.add(new Object[] {raw});
+      }
+    }
+    return data.toArray(new Object[0][]);
+  }
+
+  @Test
+  public void unknownIdentifierUncached() {
+    assertInteropInvoke("Uncached version", raw, InteropLibrary.getUncached());
+  }
+
+  @Test
+  public void unknownIdentifierCached() {
+
+    var trn = new TestRootNode();
+    var n = InteropLibrary.getFactory().createDispatched(10);
+    n = trn.insert(n);
+
+    assertInteropInvoke("Cached version", raw, n);
+  }
+
+  private static void assertInteropInvoke(String msg, Object raw, InteropLibrary node) {
+    try {
+      var res = node.invokeMember(raw, "unknownIdentifier");
+      fail("Expecting exception, now a result: " + res);
+    } catch (UnknownIdentifierException good) {
+      assertEquals(
+          "UnknownIdentifierException is expected",
+          "unknownIdentifier",
+          good.getUnknownIdentifier());
+    } catch (UnsupportedMessageException ex) {
+      // that's OK
+    } catch (Exception ex) {
+      throw new AssertionError(msg + " got " + ex.getClass().getName() + " for " + raw, ex);
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -74,7 +74,10 @@ public abstract class IndirectInvokeMethodNode extends Node {
       @Shared("typesLib") @CachedLibrary(limit = "10") TypesLibrary dispatch,
       @Shared("methodResolverNode") @Cached MethodResolverNode methodResolverNode,
       @Shared("indirectInvokeFunctionNode") @Cached IndirectInvokeFunctionNode invokeFunctionNode) {
-    Function function = methodResolverNode.expectNonNull(self, dispatch.getType(self), symbol);
+    var function = methodResolverNode.executeResolution(dispatch.getType(self), symbol);
+    if (function == null) {
+      throw InvokeMethodNode.methodNotFound(this, true, symbol, self);
+    }
     return invokeFunctionNode.execute(
         function,
         frame,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -244,7 +244,7 @@ public abstract class InvokeMethodNode extends BaseNode {
       if (imported != null) {
         return imported;
       }
-      throw methodNotFound(symbol, self);
+      throw methodNotFound(this, onBoundary, symbol, self);
     }
     CallArgumentInfo[] invokeFuncSchema = invokeFunctionNode.getSchema();
     var shouldPrependSyntheticSelfArg =
@@ -297,12 +297,12 @@ public abstract class InvokeMethodNode extends BaseNode {
     return invokeFunctionNode.execute(function, frame, state, arguments);
   }
 
-  private PanicException methodNotFound(UnresolvedSymbol symbol, Object self)
-      throws PanicException {
+  static PanicException methodNotFound(
+      Node where, boolean onBoundary, UnresolvedSymbol symbol, Object self) throws PanicException {
     var cause = onBoundary ? UnknownIdentifierException.create(symbol.getName()) : null;
-    var ctx = EnsoContext.get(this);
+    var ctx = EnsoContext.get(where);
     var payload = ctx.getBuiltins().error().makeNoSuchMethod(self, symbol);
-    throw new PanicException(ctx, payload, cause, this);
+    throw new PanicException(ctx, payload, cause, where);
   }
 
   @Specialization
@@ -326,7 +326,7 @@ public abstract class InvokeMethodNode extends BaseNode {
       }
       return invokeFunctionNode.execute(fnAndType.getLeft(), frame, state, arguments);
     }
-    throw methodNotFound(symbol, self);
+    throw methodNotFound(this, onBoundary, symbol, self);
   }
 
   @Specialization


### PR DESCRIPTION
### Pull Request Description

Found while working on #13483 where `InteropLibrary.getUncached()` is used to make calls into _other JVM_ and its results differ from expected ones.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
