### PR TITLE
Fix bazel-clean on CI

### DIFF
--- a/.github/workflows/engine-pull-request.yml
+++ b/.github/workflows/engine-pull-request.yml
@@ -1,4 +1,5 @@
 # This file is not auto-generated. Feel free to edit it.
+# DEBUG: trigger rebuild
 
 name: ✨ Engine
 

--- a/.github/workflows/engine-pull-request.yml
+++ b/.github/workflows/engine-pull-request.yml
@@ -1,5 +1,4 @@
 # This file is not auto-generated. Feel free to edit it.
-# DEBUG: trigger rebuild
 
 name: ✨ Engine
 

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -767,6 +767,12 @@ pub async fn main_internal(config: Option<Config>) -> Result {
             }
 
             if !dry_run {
+                enso_build::web::install(&ctx.repo_root).await?;
+                enso_build::web::run_script(&ctx.repo_root, enso_build::web::Script::BazelClean)
+                    .await?;
+            }
+
+            if !dry_run {
                 // On Windows, `npm` uses junctions as symbolic links for in-workspace dependencies.
                 // Unfortunately, Git for Windows treats those as hard links. That then leads to
                 // `git clean` recursing into those linked directories, happily deleting sources of
@@ -778,10 +784,6 @@ pub async fn main_internal(config: Option<Config>) -> Result {
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-enso")).await?;
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-out")).await?;
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-bin")).await?;
-
-                enso_build::web::install(&ctx.repo_root).await?;
-                enso_build::web::run_script(&ctx.repo_root, enso_build::web::Script::BazelClean)
-                    .await?;
             }
 
             let git_clean = clean::clean_except_for(&ctx.repo_root, exclusions, dry_run);

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -778,6 +778,10 @@ pub async fn main_internal(config: Option<Config>) -> Result {
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-enso")).await?;
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-out")).await?;
                 ide_ci::fs::tokio::remove_dir_if_exists(ctx.repo_root.join("bazel-bin")).await?;
+
+                enso_build::web::install(&ctx.repo_root).await?;
+                enso_build::web::run_script(&ctx.repo_root, enso_build::web::Script::BazelClean)
+                    .await?;
             }
 
             let git_clean = clean::clean_except_for(&ctx.repo_root, exclusions, dry_run);
@@ -787,10 +791,8 @@ pub async fn main_internal(config: Option<Config>) -> Result {
                 }
                 Result::Ok(())
             };
-            let bazel_clean =
-                enso_build::web::run_script(&ctx.repo_root, enso_build::web::Script::BazelClean);
 
-            try_join!(git_clean, clean_cache, bazel_clean)?;
+            try_join!(git_clean, clean_cache)?;
         }
         Target::Fmt => {
             enso_build::web::install(&ctx.repo_root).await?;


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

followup #13419

Fixes CI issue during the git-clean https://github.com/enso-org/enso/actions/runs/16282746195/job/45989022376

Changelog:
- update: run bazel-clean before the git-clean. `pnpm run bazel-clean` requires `node_modules` to be present, but it is removed during the git-clean action.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
