### PR TITLE
Fix misplaced edited-node output port

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/GraphEdges.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphEdges.vue
@@ -157,6 +157,7 @@ function onNewNodeClick(id: NodeId) {
       />
       <template v-for="id in nodeIdsWithOutputPorts" :key="id">
         <GraphNodeOutputPorts
+          v-show="id !== graph.editedNodeInfo?.id"
           :nodeId="id"
           @newNodeClick="onNewNodeClick(id)"
           @portClick="(event, portId) => graph.createEdgeFromOutput(portId, event)"

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -192,11 +192,11 @@ const {
   emit,
 })
 
-watch(isVisualizationPreviewed, (newVal, oldVal) => {
-  if (!newVal) {
-    graph.nodeHovered.delete(nodeId.value)
-  } else if (newVal && !oldVal) {
+watch(isVisualizationPreviewed, (newVal) => {
+  if (newVal) {
     graph.db.moveNodeToTop(nodeId.value)
+  } else {
+    graph.nodeHovered.delete(nodeId.value)
   }
 })
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -44,7 +44,7 @@ import { onWindowBlur } from '@/util/autoBlur'
 import type { Opt } from '@/util/data/opt'
 import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
-import { ComponentInstance, computed, onUnmounted, ref, watch, watchEffect } from 'vue'
+import { ComponentInstance, computed, onUnmounted, ref, toRef, watch, watchEffect } from 'vue'
 import type { VisualizationIdentifier } from 'ydoc-shared/yjsModel'
 
 const contentNodeStyle = {
@@ -189,6 +189,7 @@ const {
   isFocused: extended,
   typeinfo: () => expressionInfo.value?.typeInfo,
   dataSource: () => ({ type: 'node', nodeId: props.node.rootExpr.externalId }) as const,
+  hidden: toRef(props, 'edited'),
   emit,
 })
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
@@ -27,6 +27,7 @@ interface NodeVisualizationOptions {
   isFocused: ToValue<boolean>
   typeinfo: ToValue<Opt<TypeInfo>>
   dataSource: ToValue<Opt<VisualizationDataSource | RawDataSource>>
+  hidden: ToValue<boolean>
   emit: Emit
 }
 
@@ -39,6 +40,7 @@ export function useNodeVisualization({
   isFocused,
   typeinfo,
   dataSource,
+  hidden,
   emit,
 }: NodeVisualizationOptions) {
   const keyboard = injectKeyboard()
@@ -72,7 +74,10 @@ export function useNodeVisualization({
   })
 
   const visRect = shallowRef<Rect>()
-  watch(visRect, (rect) => emit('update:visualizationRect', rect))
+  const visibleVisRect = computed(
+    (): Opt<Rect> => (isVisualizationVisible.value && !toValue(hidden) ? visRect.value : null),
+  )
+  watch(visibleVisRect, (rect) => emit('update:visualizationRect', rect ?? undefined))
 
   const visualization = computed((): ComponentProps<typeof GraphVisualization> => {
     const { size: nodeSize, pos: nodePosition } = toValue(nodeRect)
@@ -103,7 +108,7 @@ export function useNodeVisualization({
     visualizationWidth,
     isVisualizationEnabled,
     isVisualizationPreviewed,
-    visRect: computed((): Opt<Rect> => (isVisualizationVisible.value ? visRect.value : null)),
+    visRect: visibleVisRect,
     visualization: computed(() => (isVisualizationVisible.value ? visualization.value : null)),
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fix for misplaced edited-node output port (Fixes #13508): When a node is being edited, hide its output port.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
