### PR TITLE
Upload flat project archive after hybrid execution

### DIFF
--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -162,14 +162,14 @@ export default function projectManagerShimMiddleware(
         https.get(downloadUrl, (actualResponse) => {
           const projectsDirectory = projectManagement.getProjectsDirectory()
           const parentDirectory = path.join(projectsDirectory, `cloud-${projectId}`)
-          const targetDirectory = path.join(parentDirectory, 'project_root')
+          const projectRootDirectory = path.join(parentDirectory, 'project_root')
 
-          fs.mkdir(targetDirectory, { recursive: true })
-            .then(() => projectManagement.unpackBundle(actualResponse, targetDirectory))
+          fs.mkdir(projectRootDirectory, { recursive: true })
+            .then(() => projectManagement.unpackBundle(actualResponse, projectRootDirectory))
             .then(() => {
               response
                 .writeHead(HTTP_STATUS_OK, COMMON_HEADERS)
-                .end(JSON.stringify({ targetDirectory, parentDirectory }))
+                .end(JSON.stringify({ parentDirectory, projectRootDirectory }))
             })
             .catch((e) => {
               console.error(e)
@@ -188,14 +188,15 @@ export default function projectManagerShimMiddleware(
       }
       case '/api/cloud/get-project-archive': {
         const url = new URL(`https://example.com/${requestUrl}`)
-        const projectDir = url.searchParams.get('directory')
+        const parentDir = url.searchParams.get('directory')
 
-        if (projectDir == null) {
+        if (parentDir == null) {
           response
             .writeHead(HTTP_STATUS_BAD_REQUEST, COMMON_HEADERS)
             .end('Request is missing search parameter `directory`.')
           break
         }
+        const projectDir = path.join(parentDir, 'project_root')
 
         projectManagement
           .createBundle(projectDir)

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -495,7 +495,7 @@ function useOpenHybridProject() {
         const cloudProjectDirectoryPath = asset.ensoPath.slice(0, asset.ensoPath.lastIndexOf('/'))
 
         let project
-        for (const parentId of [localProject.targetId, localProject.parentId]) {
+        for (const parentId of [localProject.parentId, localProject.projectRootId]) {
           const assets = await localBackend.listDirectory({
             parentId: parentId,
             filterBy: null,

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -1383,7 +1383,7 @@ export default class RemoteBackend extends Backend {
   async downloadProject(id: backend.ProjectId) {
     /** The type of the response body of this endpoint. */
     interface ResponseBody {
-      readonly targetDirectory: string
+      readonly projectRootDirectory: string
       readonly parentDirectory: string
     }
     const details = await this.getProjectDetails(id, true)
@@ -1408,7 +1408,7 @@ export default class RemoteBackend extends Backend {
     const responseBody = await response.json()
 
     return {
-      targetId: backend.DirectoryId(`directory-${responseBody.targetDirectory}`),
+      projectRootId: backend.DirectoryId(`directory-${responseBody.projectRootDirectory}`),
       parentId: backend.DirectoryId(`directory-${responseBody.parentDirectory}`),
     }
   }

--- a/app/ide-desktop/client/src/server.ts
+++ b/app/ide-desktop/client/src/server.ts
@@ -246,14 +246,14 @@ export class Server {
           https.get(downloadUrl, async (actualResponse) => {
             const projectsDirectory = projectManagement.getProjectsDirectory()
             const parentDirectory = path.join(projectsDirectory, `cloud-${projectId}`)
-            const targetDirectory = path.join(parentDirectory, 'project_root')
+            const projectRootDirectory = path.join(parentDirectory, 'project_root')
 
             try {
-              await fs.mkdir(targetDirectory, { recursive: true })
-              await projectManagement.unpackBundle(actualResponse, targetDirectory)
+              await fs.mkdir(projectRootDirectory, { recursive: true })
+              await projectManagement.unpackBundle(actualResponse, projectRootDirectory)
               response
                 .writeHead(HTTP_STATUS_OK, COOP_COEP_CORP_HEADERS)
-                .end(JSON.stringify({ targetDirectory, parentDirectory }))
+                .end(JSON.stringify({ projectRootDirectory, parentDirectory }))
             } catch (e) {
               logger.error(e)
               await fs
@@ -272,14 +272,15 @@ export class Server {
         }
         case '/api/cloud/get-project-archive': {
           const url = new URL(`https://example.com/${requestUrl}`)
-          const projectDir = url.searchParams.get('directory')
+          const parentDir = url.searchParams.get('directory')
 
-          if (projectDir == null) {
+          if (parentDir == null) {
             response
               .writeHead(HTTP_STATUS_BAD_REQUEST, COOP_COEP_CORP_HEADERS)
               .end('Request is missing search parameter `directory`.')
             break
           }
+          const projectDir = path.join(parentDir, 'project_root')
 
           projectManagement
             .createBundle(projectDir)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

closes https://github.com/enso-org/cloud-v2/issues/2082

Changelog:
- update: gui downloads and unpacks the project structure as is, but always uploads the flat archive (without the `project_root`. This means that `project_root/project_root` can exist on the first run, but on the next run it will be fixed.

### Important Notes

Tested manually.

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
