### PR TITLE
Don't show selection widget without entries

### DIFF
--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -380,6 +380,13 @@ test('Selection widget with text widget as input', async ({ page }) => {
   await pathArgInput.clear()
   await pathDropdown.expectVisibleWithOptions([...CHOOSE_FILE_OPTIONS, 'File 1', 'File 2'])
 
+  // When a filter doesn't match any entries, the dropdown is hidden.
+  await page.keyboard.insertText('No such entry')
+  await pathDropdown.expectNotVisible()
+  // If the text is changed so that the entries list is no longer empty, the dropdown returns.
+  await pathArgInput.clear()
+  await pathDropdown.expectVisibleWithOptions([...CHOOSE_FILE_OPTIONS, 'File 1', 'File 2'])
+
   // Esc should cancel editing and close drop down
   await page.keyboard.press('Escape')
   await expect(pathArgInput).not.toBeFocused()

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -376,9 +376,9 @@ test('Selection widget with text widget as input', async ({ page }) => {
   // Using `type` instead of `inputText` here to catch keydown bugs like #13505.
   await page.keyboard.type('File 1')
   await pathDropdown.expectVisibleWithOptions(['File 1'])
-  // Clearing input should show all text literal options
+  // Clearing input should show all options
   await pathArgInput.clear()
-  await pathDropdown.expectVisibleWithOptions(['File 1', 'File 2'])
+  await pathDropdown.expectVisibleWithOptions([...CHOOSE_FILE_OPTIONS, 'File 1', 'File 2'])
 
   // Esc should cancel editing and close drop down
   await page.keyboard.press('Escape')

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -71,10 +71,12 @@ function makeExpressionFilter(pattern: Ast.Ast | string | undefined): Expression
   if (!pattern) return undefined
   const editedAst = typeof pattern === 'string' ? Ast.parseExpression(pattern) : pattern
   if (editedAst instanceof Ast.TextLiteral) {
+    const text = editedAst.rawTextContent
+    if (!text) return undefined
     return (tag: ExpressionTag) =>
       (tag.expressionAst instanceof Ast.TextLiteral &&
-        tag.expressionAst.rawTextContent.startsWith(editedAst.rawTextContent)) ||
-      (tag.explicitLabel != null && tag.explicitLabel.startsWith(editedAst.rawTextContent))
+        tag.expressionAst.rawTextContent.startsWith(text)) ||
+      (tag.explicitLabel != null && tag.explicitLabel.startsWith(text))
   }
   const editedCode = pattern instanceof Ast.Ast ? pattern.code() : pattern
   if (editedCode) {
@@ -279,7 +281,7 @@ declare module '@/providers/widgetRegistry' {
     <SelectionSubmenu
       ref="submenuRef"
       :floatReference="floatReference"
-      :show="dropDownInteraction.isActive() && activity == null"
+      :show="dropDownInteraction.isActive() && activity == null && entries.length > 0"
       :entries="entries"
       :topLevel="true"
       :extendUpwards="allowExtendingUpwards"


### PR DESCRIPTION
Don't show selection widget without entries (fixes #13534)

Also: When a text widget is empty, its parent selection widget is now unfiltered.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
