### PR TITLE
Fix scrollbars and file browser

### DIFF
--- a/app/gui/src/components/AppContainer/RightPanel.vue
+++ b/app/gui/src/components/AppContainer/RightPanel.vue
@@ -119,6 +119,7 @@ const bounds = computed(() => new Rect(Vec2.Zero, size.value))
   min-width: 312px;
   width: 400px;
   padding: 1.25rem 1rem;
+  overflow: auto;
 }
 
 /* React panels rely on being inside columned flex. */

--- a/app/gui/src/project-view/components/CodeMirrorRoot.vue
+++ b/app/gui/src/project-view/components/CodeMirrorRoot.vue
@@ -12,11 +12,6 @@ defineExpose({ highlightClasses })
 </template>
 
 <style scoped>
-.CodeMirrorRoot {
-  width: 100%;
-  height: 100%;
-}
-
 .CodeMirrorRoot :deep(.cm-content) {
   cursor: text;
 }

--- a/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
@@ -194,6 +194,7 @@ defineExpose({
 .CodeMirrorRoot {
   /* Below popovers from the `belowToolbar` slot. */
   z-index: -1;
+  min-height: 0;
 
   /*noinspection CssUnusedSymbol*/
   & :deep(.cm-content) {

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/ensoPath.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/ensoPath.test.ts
@@ -1,0 +1,31 @@
+import { DirectoryId } from '#/services/Backend'
+import { uuidv4 } from 'lib0/random.js'
+import { expect, test } from 'vitest'
+import { useEnsoPaths } from '../ensoPath'
+
+test.each`
+  userRootPath           | fromUserRoot | segments           | expected
+  ${'enso://'}           | ${true}      | ${[]}              | ${'enso://'}
+  ${'enso://Users/user'} | ${true}      | ${[]}              | ${'enso://Users/user'}
+  ${'enso://Users/user'} | ${false}     | ${[]}              | ${'enso://'}
+  ${'enso://'}           | ${true}      | ${['seg']}         | ${'enso://seg'}
+  ${'enso://Users/user'} | ${true}      | ${['seg']}         | ${'enso://Users/user/seg'}
+  ${'enso://Users/user'} | ${false}     | ${['seg']}         | ${'enso://seg'}
+  ${'enso://'}           | ${true}      | ${['seg', 'seg2']} | ${'enso://seg/seg2'}
+  ${'enso://Users/user'} | ${true}      | ${['seg', 'seg2']} | ${'enso://Users/user/seg/seg2'}
+  ${'enso://Users/user'} | ${false}     | ${['seg', 'seg2']} | ${'enso://seg/seg2'}
+`(
+  'Printing ensopath $expected with user root $userRootPath',
+  ({ userRootPath, fromUserRoot, segments, expected }) => {
+    const files = {
+      rootDirectoryId: DirectoryId(`directory-${uuidv4()}`),
+      rootPath: userRootPath,
+    }
+    const path = {
+      root: fromUserRoot ? files.rootDirectoryId : DirectoryId(`directory-${uuidv4()}`),
+      segments,
+    }
+    const paths = useEnsoPaths(files)
+    expect(paths.printEnsoPath(path)).toBe(expected)
+  },
+)

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/ensoPath.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/ensoPath.ts
@@ -85,7 +85,7 @@ export function useEnsoPaths(
       (path.root === toValue(files?.rootDirectoryId) ? toValue(files?.rootPath) : undefined) ??
       'enso://'
     // Sometimes rootPath ends with /, and sometimes not.
-    if (!rootPath.endsWith('/')) rootPath = rootPath + '/'
+    if (!rootPath.endsWith('/') && path.segments.length) rootPath = rootPath + '/'
     return `${rootPath}${path.segments.join('/')}`
   }
 

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/ensoPath.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/ensoPath.ts
@@ -81,10 +81,12 @@ export function useEnsoPaths(
 
   function printEnsoPath(path: EnsoPath) {
     const files = toValue(userFiles)
-    const rootPath =
+    let rootPath =
       (path.root === toValue(files?.rootDirectoryId) ? toValue(files?.rootPath) : undefined) ??
-      'enso:/'
-    return [rootPath, ...path.segments].join('/')
+      'enso://'
+    // Sometimes rootPath ends with /, and sometimes not.
+    if (!rootPath.endsWith('/')) rootPath = rootPath + '/'
+    return `${rootPath}${path.segments.join('/')}`
   }
 
   return {


### PR DESCRIPTION
### Pull Request Description

Fixes https://github.com/enso-org/enso/issues/13526

Scrollbars are added to the right-side panel; fix the size of MarkdownEditor there.

Also fixed a bug in FileBrowser which caused too many `/` being inserted like `enso:///Teams/...`

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
