### PR TITLE
Add `_display_text_` for Date, Time_Of_Day and Date_Time

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/In_Memory_Column.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/In_Memory_Column.md
@@ -3,7 +3,7 @@
 - type In_Memory_Column
     - max_precision self -> Standard.Base.Any.Any
     - pretty self -> Standard.Base.Any.Any
-    - to_json_data self -> Standard.Base.Data.Text.Text
+    - to_json_data self fallback:Standard.Base.Any.Any= -> Standard.Base.Data.Text.Text
     - to_text self -> Standard.Base.Data.Text.Text
 - Standard.Table.Column.Column.from that:Standard.Table.In_Memory_Column.In_Memory_Column -> Standard.Table.Column.Column
 - Standard.Table.Internal.Visualization_Helpers.Visualization_Helpers.from that:Standard.Table.In_Memory_Column.In_Memory_Column -> Standard.Table.Internal.Visualization_Helpers.Visualization_Helpers

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/In_Memory_Column.enso
@@ -51,8 +51,8 @@ type In_Memory_Column
 
     ## PRIVATE
        Specialised implementation of to_json for a Column.
-    to_json_data self -> Text =
-        JsonOperation.apply self.java_column v->v.to_json
+    to_json_data self fallback=(v->v.to_json) -> Text =
+        JsonOperation.apply self.java_column fallback
 
     ## PRIVATE
        Creates a new column given a name and an internal Java storage.

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -23,10 +23,10 @@ import project.Helpers
     - `y`: The table to prepare for visualization.
     - `max_rows`: The maximum number of rows to display.
 prepare_visualization : Any -> Integer -> Text
-prepare_visualization y max_rows=1000 = if y.is_error then (make_json_for_error y.catch).to_text else
+prepare_visualization y max_rows=1000 = if y.is_error then make_json_for_error y.catch else
     x = Warning.set y []
     case x of
-        v : Vector -> make_json_for_vector v max_rows . to_text
+        v : Vector -> make_json_for_vector v max_rows . to_json
         v : Array -> prepare_visualization v.to_vector max_rows
         v : Dictionary -> make_json_for_dictionary v max_rows
         v : JS_Object -> make_json_for_js_object v max_rows
@@ -42,12 +42,12 @@ prepare_visualization y max_rows=1000 = if y.is_error then (make_json_for_error 
         f : Function ->
             pairs = [['_display_text_', '[Function '+f.to_text+']']]
             value = JS_Object.from_pairs pairs
-            JS_Object.from_pairs [["json", value]] . to_text
+            JS_Object.from_pairs [["json", value]] . to_json
         v : Number ->
-            JS_Object.from_pairs [["json", _make_json_for_value v]] . to_text
+            JS_Object.from_pairs [["json", _make_json_for_value v]] . to_json
         v : XML_Document -> make_json_for_xml_element v.root_element max_rows "XML_Document"
         v : XML_Element -> make_json_for_xml_element v max_rows
-        _ -> (Table_Viz_Data.from x).get_js_object.to_text
+        _ -> (Table_Viz_Data.from x).get_js_object.to_json
 
 ## ---
    private: true
@@ -61,7 +61,7 @@ max_columns = 250
    Render Error to JSON
 make_json_for_error : Any -> Text
 make_json_for_error error =
-    (Table_Viz_Data.Error error.to_display_text).get_js_object.to_text
+    (Table_Viz_Data.Error error.to_display_text).get_js_object.to_json
 
 ## ---
    private: true
@@ -76,7 +76,7 @@ make_json_for_row row =
     data = ["data", [column_names, values]]
     links = ["get_child_node_action", "at"]
     get_child_node_action_link_name = ["get_child_node_link_name", "column"]
-    JS_Object.from_pairs [header, all_rows, data, links, get_child_node_action_link_name, ["type", "Map"]] . to_text
+    JS_Object.from_pairs [header, all_rows, data, links, get_child_node_action_link_name, ["type", "Map"]] . to_json
 
 ## ---
    private: true
@@ -154,7 +154,7 @@ make_json_for_dictionary dict max_items =
     data = ["data", [mapped.map .first, mapped.map .second]]
     links = ["get_child_node_action", "at {{#key}}"]
     get_child_node_action_link_name = ["get_child_node_link_name", "key"]
-    JS_Object.from_pairs [header, data, all_rows, links, get_child_node_action_link_name, ["type", "Map"], ["child_label", "value"]] . to_text
+    JS_Object.from_pairs [header, data, all_rows, links, get_child_node_action_link_name, ["type", "Map"], ["child_label", "value"]] . to_json
 
 ## ---
    private: true
@@ -168,7 +168,7 @@ make_json_for_js_object js_object max_items =
     map_vector = Warning.clear (fields.take max_items)
     mapped = map_vector . map p-> [p, _make_json_for_value (js_object.get p)]
     data = ["data", [mapped.map .first, mapped.map .second]]
-    JS_Object.from_pairs [header, data, all_rows, ["type", "Map"]] . to_text
+    JS_Object.from_pairs [header, data, all_rows, ["type", "Map"]] . to_json
 
 ## ---
    private: true
@@ -194,7 +194,7 @@ make_json_for_xml_element xml_element max_items type:Text="XML_Element" =
     data = ["data", [map_vector.map .first, map_vector.map .second, map_vector.map i-> i.at 2]]
     child_node_action = if type == "XML_Element" then "get" else "get_child_element"
     get_child_node_fields = [["get_child_node_action", child_node_action + " {{#key}}"], ["get_child_node_link_name", "key"]]
-    JS_Object.from_pairs <| [header, data, all_rows, ["type", type]] + get_child_node_fields . to_text
+    JS_Object.from_pairs <| [header, data, all_rows, ["type", type]] + get_child_node_fields . to_json
 
 private _make_json_for_db_table t max_rows is_column =
     dataframe = t.read (..First max_rows)
@@ -203,7 +203,7 @@ private _make_json_for_db_table t max_rows is_column =
             all_rows_count = t.row_count
             make_json_for_table dataframe max_rows all_rows_count True is_column
         True ->
-            JS_Object.from_pairs [["error", 'Error querying the database:\n' + dataframe.catch.to_display_text]] . to_text
+            JS_Object.from_pairs [["error", 'Error querying the database:\n' + dataframe.catch.to_display_text]] . to_json
 
 ## ---
    private: true
@@ -234,7 +234,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
     enable_create_node         = ["enable_create_node", if is_column then False else True]
     child_label                = ["child_label", "row"]
     is_using_server_model      = if is_db_table then False else all_rows_count > 1000
-    data                       = if is_using_server_model.not then columns.map (c-> c.to_json_data (v-> _make_json_for_value v . to_text)) . join "," else Nothing
+    data                       = if is_using_server_model.not then columns.map (c-> c.to_json_data (v-> _make_json_for_value v . to_json)) . join "," else Nothing
     requires_number_formatting = ["requires_number_format", column_vis_helpers.map .requires_numeric_formatter_check]
     is_using_multi_filter      = ["is_using_multi_filter", column_vis_helpers.map .check_distinct_values]
     table_version_hash_val     = if is_using_server_model then dataframe.table_version_hash else Nothing
@@ -251,7 +251,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
         number_non_trivial     = make_data_quality_entry ("% with odd whitespace" + sampled_label) .count_non_trivial_whitespace "Percentage"
         incomplete + range + distinct_count + number_nothing + type_record + number_empty + number_untrimmed + number_non_trivial
     pairs                      = [header, value_type, all_rows, has_index_col, links, use_bottom_status_bar, enable_create_node, ["data_quality_metrics", data_quality_metrics] ,["type", "EnsoTableOrColumn"], child_label, ["is_using_server_sort_and_filter", is_using_server_model], requires_number_formatting, table_version_hash, is_using_multi_filter]
-    all_except_data = JS_Object.from_pairs pairs . to_text
+    all_except_data = JS_Object.from_pairs pairs . to_json
     all_except_data . drop (..Last 1) + (if is_using_server_model then ',"data":null}' else ',"data":[' + data + ']}')
 
 ## ---
@@ -332,7 +332,7 @@ get_rows_for_table table_or_column start_number sort_col_index_list=Nothing sort
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns
     filtered_table = if filter_col.is_nothing then table_with_index_ordered else apply_filter_to_table table_with_index_ordered 0 filter_col filter_condition True
     sorted_table = if sort_col_index_list.is_nothing then filtered_table else apply_sort_to_table filtered_table sort_col_index_list sort_direction_list
-    sliced_json = sorted_table.drop start_number . take max_rows . columns . map (c-> c.to_json_data (v-> _make_json_for_value v . to_text))
+    sliced_json = sorted_table.drop start_number . take max_rows . columns . map (c-> c.to_json_data (v-> _make_json_for_value v . to_json))
     '{"rows":[' + (sliced_json.join ",") + '], "row_count":' + filtered_table.row_count.to_text + '}'
 
 ## ---

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -234,7 +234,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
     enable_create_node         = ["enable_create_node", if is_column then False else True]
     child_label                = ["child_label", "row"]
     is_using_server_model      = if is_db_table then False else all_rows_count > 1000
-    data                       = if is_using_server_model.not then columns.map .to_json_data . join "," else Nothing
+    data                       = if is_using_server_model.not then columns.map (c-> c.to_json_data (v-> _make_json_for_value v . to_text)) . join "," else Nothing
     requires_number_formatting = ["requires_number_format", column_vis_helpers.map .requires_numeric_formatter_check]
     is_using_multi_filter      = ["is_using_multi_filter", column_vis_helpers.map .check_distinct_values]
     table_version_hash_val     = if is_using_server_model then dataframe.table_version_hash else Nothing
@@ -332,7 +332,7 @@ get_rows_for_table table_or_column start_number sort_col_index_list=Nothing sort
     table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns
     filtered_table = if filter_col.is_nothing then table_with_index_ordered else apply_filter_to_table table_with_index_ordered 0 filter_col filter_condition True
     sorted_table = if sort_col_index_list.is_nothing then filtered_table else apply_sort_to_table filtered_table sort_col_index_list sort_direction_list
-    sliced_json = sorted_table.drop start_number . take max_rows . columns . map .to_json_data
+    sliced_json = sorted_table.drop start_number . take max_rows . columns . map (c-> c.to_json_data (v-> _make_json_for_value v . to_text))
     '{"rows":[' + (sliced_json.join ",") + '], "row_count":' + filtered_table.row_count.to_text + '}'
 
 ## ---
@@ -372,7 +372,7 @@ _make_json_for_other x =
    private: true
    ---
    Create JSON serialization of values for the table.
-_make_json_for_value : Any -> Integer -> Text
+_make_json_for_value : Any -> Integer -> JS_Object
 _make_json_for_value val level=0 = case val of
     Nothing -> Nothing
     txt : Text -> txt

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
@@ -133,10 +133,11 @@ public class JsonOperation {
 
   private static long MAX_JSON_LONG = 9007199254740991L;
   private static BigInteger MAX_JSON_LONG_BIGINT = BigInteger.valueOf(MAX_JSON_LONG);
+
   private static DateTimeFormatter TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
   private static DateTimeFormatter TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
   private static DateTimeFormatter DATE_TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-  private static DateTimeFormatter DATE_TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.sss");
+  private static DateTimeFormatter DATE_TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.ggg");
   private static DateTimeFormatter ZONE_FORMAT = DateTimeFormatter.ofPattern("'['zz']'");
 
   private static String toJson(long value) {
@@ -184,7 +185,7 @@ public class JsonOperation {
         + date.getMonthValue()
         + ",\"year\":"
         + date.getYear()
-        + ",`\"}";
+        + "}";
   }
 
   private static String toJson(LocalTime time) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
@@ -6,7 +6,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.function.Function;
 import org.enso.table.data.column.builder.Builder;
@@ -131,6 +133,11 @@ public class JsonOperation {
 
   private static long MAX_JSON_LONG = 9007199254740991L;
   private static BigInteger MAX_JSON_LONG_BIGINT = BigInteger.valueOf(MAX_JSON_LONG);
+  private static DateTimeFormatter TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+  private static DateTimeFormatter TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
+  private static DateTimeFormatter DATE_TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+  private static DateTimeFormatter DATE_TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.sss");
+  private static DateTimeFormatter ZONE_FORMAT = DateTimeFormatter.ofPattern("'['zz']'");
 
   private static String toJson(long value) {
     if (value < -MAX_JSON_LONG || value > MAX_JSON_LONG) {
@@ -169,17 +176,22 @@ public class JsonOperation {
   }
 
   private static String toJson(LocalDate date) {
-    return "{\"type\":\"Date\",\"constructor\":\"new\",\"day\":"
+    return "{\"type\":\"Date\",\"constructor\":\"new\",\"_display_text_\":\""
+        + date.toString()
+        + "\",\"day\":"
         + date.getDayOfMonth()
         + ",\"month\":"
         + date.getMonthValue()
         + ",\"year\":"
         + date.getYear()
-        + "}";
+        + ",`\"}";
   }
 
   private static String toJson(LocalTime time) {
-    return "{\"type\":\"Time_Of_Day\",\"constructor\":\"new\",\"hour\":"
+    var timeString = time.format(time.getNano() == 0 ? TIME_SHORT_FORMAT : TIME_LONG_FORMAT);
+    return "{\"type\":\"Time_Of_Day\",\"constructor\":\"new\",\"_display_text_\":\""
+        + timeString
+        + "\",\"hour\":"
         + time.getHour()
         + ",\"minute\":"
         + time.getMinute()
@@ -191,11 +203,16 @@ public class JsonOperation {
   }
 
   private static String toJson(ZonedDateTime datetime) {
+    var datetimeString = datetime.format(
+        datetime.getNano() == 0 ? DATE_TIME_SHORT_FORMAT : DATE_TIME_LONG_FORMAT);
+    var zoneString = datetime.getZone() == ZoneId.systemDefault() ? "" : datetime.format(ZONE_FORMAT);
     var zone_json =
         "{\"type\":\"Time_Zone\",\"constructor\":\"parse\",\"id\":\""
             + datetime.getZone().getId()
             + "\"}";
-    return "{\"type\":\"Date_Time\",\"constructor\":\"new\",\"year\":"
+    return "{\"type\":\"Date_Time\",\"constructor\":\"new\",\"_display_text_\":\""
+        + datetimeString + zoneString
+        + "\",\"year\":"
         + datetime.getYear()
         + ",\"month\":"
         + datetime.getMonthValue()

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/JsonOperation.java
@@ -135,9 +135,12 @@ public class JsonOperation {
   private static BigInteger MAX_JSON_LONG_BIGINT = BigInteger.valueOf(MAX_JSON_LONG);
 
   private static DateTimeFormatter TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
-  private static DateTimeFormatter TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
-  private static DateTimeFormatter DATE_TIME_SHORT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-  private static DateTimeFormatter DATE_TIME_LONG_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.ggg");
+  private static DateTimeFormatter TIME_LONG_FORMAT =
+      DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
+  private static DateTimeFormatter DATE_TIME_SHORT_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+  private static DateTimeFormatter DATE_TIME_LONG_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.ggg");
   private static DateTimeFormatter ZONE_FORMAT = DateTimeFormatter.ofPattern("'['zz']'");
 
   private static String toJson(long value) {
@@ -204,15 +207,17 @@ public class JsonOperation {
   }
 
   private static String toJson(ZonedDateTime datetime) {
-    var datetimeString = datetime.format(
-        datetime.getNano() == 0 ? DATE_TIME_SHORT_FORMAT : DATE_TIME_LONG_FORMAT);
-    var zoneString = datetime.getZone() == ZoneId.systemDefault() ? "" : datetime.format(ZONE_FORMAT);
+    var datetimeString =
+        datetime.format(datetime.getNano() == 0 ? DATE_TIME_SHORT_FORMAT : DATE_TIME_LONG_FORMAT);
+    var zoneString =
+        datetime.getZone() == ZoneId.systemDefault() ? "" : datetime.format(ZONE_FORMAT);
     var zone_json =
         "{\"type\":\"Time_Zone\",\"constructor\":\"parse\",\"id\":\""
             + datetime.getZone().getId()
             + "\"}";
     return "{\"type\":\"Date_Time\",\"constructor\":\"new\",\"_display_text_\":\""
-        + datetimeString + zoneString
+        + datetimeString
+        + zoneString
         + "\",\"year\":"
         + datetime.getYear()
         + ",\"month\":"

--- a/test/Table_Tests/src/IO/Json_Spec.enso
+++ b/test/Table_Tests/src/IO/Json_Spec.enso
@@ -71,20 +71,23 @@ add_specs suite_builder =
         group_builder.specify 'should convert columns to JSON using to_json_data (Date)' <|
             date txt = txt.parse_date
             dates = [date "2020-01-01", date "2021-02-02", date "2022-03-03"]
+            dates_json = '[{"type":"Date","constructor":"new","_display_text_":"2020-01-01","day":1,"month":1,"year":2020},{"type":"Date","constructor":"new","_display_text_":"2021-02-02","day":2,"month":2,"year":2021},{"type":"Date","constructor":"new","_display_text_":"2022-03-03","day":3,"month":3,"year":2022}]'
             dates_column = Table.new [['Dates', dates]] . at 'Dates'
-            dates_column.to_json_data . should_equal dates.to_json
+            dates_column.to_json_data . should_equal dates_json
 
         group_builder.specify 'should convert columns to JSON using to_json_data (Time_Of_Day)' <|
             time_of_day txt = txt.parse_time_of_day
             times_of_day = [time_of_day "00:00:00", time_of_day "12:34:56", time_of_day "23:59:59"]
+            times_of_day_json = '[{"type":"Time_Of_Day","constructor":"new","_display_text_":"00:00:00","hour":0,"minute":0,"second":0,"nanosecond":0},{"type":"Time_Of_Day","constructor":"new","_display_text_":"12:34:56","hour":12,"minute":34,"second":56,"nanosecond":0},{"type":"Time_Of_Day","constructor":"new","_display_text_":"23:59:59","hour":23,"minute":59,"second":59,"nanosecond":0}]'
             times_of_day_column = Table.new [['TimesOfDay', times_of_day]] . at 'TimesOfDay'
-            times_of_day_column.to_json_data . should_equal times_of_day.to_json
+            times_of_day_column.to_json_data . should_equal times_of_day_json
 
         group_builder.specify 'should convert columns to JSON using to_json_data (Date_Time)' <|
             date_time txt = txt.parse_date_time
             date_times = [date_time "2020-01-01T00:00:00Z", date_time "2021-02-02T12:34:56Z", date_time "2022-03-03T23:59:59Z"]
+            date_times_json = '[{"type":"Date_Time","constructor":"new","_display_text_":"2020-01-01 00:00:00[Z]","year":2020,"month":1,"day":1,"hour":0,"minute":0,"second":0,"nanosecond":0,"zone":{"type":"Time_Zone","constructor":"parse","id":"Z"}},{"type":"Date_Time","constructor":"new","_display_text_":"2021-02-02 12:34:56[Z]","year":2021,"month":2,"day":2,"hour":12,"minute":34,"second":56,"nanosecond":0,"zone":{"type":"Time_Zone","constructor":"parse","id":"Z"}},{"type":"Date_Time","constructor":"new","_display_text_":"2022-03-03 23:59:59[Z]","year":2022,"month":3,"day":3,"hour":23,"minute":59,"second":59,"nanosecond":0,"zone":{"type":"Time_Zone","constructor":"parse","id":"Z"}}]'
             date_times_column = Table.new [['DateTimes', date_times]] . at 'DateTimes'
-            date_times_column.to_json_data . should_equal date_times.to_json
+            date_times_column.to_json_data . should_equal date_times_json
 
 
 main filter=Nothing =


### PR DESCRIPTION
### Pull Request Description

- Table viz needs `_display_text_` to render date and time fields.
- Also adjusted to use `_make_json_for_value` fallback when an unsupported value.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
