### PR TITLE
Instrument ascribed expressions

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
@@ -324,9 +324,11 @@ case object TypeSignatures extends IRPass {
   private def resolveAscription(sig: Type.Ascription): Expression = {
     val newTyped = sig.typed.mapExpressions(resolveExpression)
     val newSig   = sig.signature.mapExpressions(resolveExpression)
-    newTyped.updateMetadata(
-      new MetadataPair(this, Signature(newSig, sig.comment))
-    )
+    newTyped
+      .setLocation(sig.location())
+      .updateMetadata(
+        new MetadataPair(this, Signature(newSig, sig.comment))
+      )
   }
 
   /** Resolves type signatures in a block.

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeSignaturesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeSignaturesTest.scala
@@ -4,6 +4,7 @@ import org.enso.compiler.Passes
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.Expression
+import org.enso.compiler.core.ir.Literal
 import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Module
 import org.enso.compiler.core.ir.Type
@@ -210,7 +211,7 @@ class TypeSignaturesTest extends CompilerTest {
   "Resolution of type signatures for blocks" should {
     implicit val ctx: InlineContext = mkInlineContext
 
-    val ir =
+    lazy val ir =
       """
         |block =
         |    ## Doc f
@@ -228,7 +229,7 @@ class TypeSignaturesTest extends CompilerTest {
         |""".stripMargin.preprocessExpression.get.resolve
         .asInstanceOf[Expression.Binding]
 
-    val block = ir.expression.asInstanceOf[Expression.Block]
+    lazy val block = ir.expression.asInstanceOf[Expression.Block]
 
     "associate signatures with bindings" in {
       val head = block.expressions.head
@@ -258,7 +259,7 @@ class TypeSignaturesTest extends CompilerTest {
   "Resolution of inline type signatures" should {
     implicit val ctx: InlineContext = mkInlineContext
 
-    val ir =
+    lazy val ir =
       """
         |f a (b = 1 : Int) : Double
         |""".stripMargin.preprocessExpression.get.resolve
@@ -286,5 +287,22 @@ class TypeSignaturesTest extends CompilerTest {
         .getMetadata(TypeSignatures)
       arg1Signature shouldBe empty
     }
+  }
+
+  "Resolution of ascribed expressions" should {
+    implicit val ctx: InlineContext = mkInlineContext
+
+    "associate correct spans" in {
+      val ir =
+        """
+          |42 : Number
+          |""".stripMargin.preprocessExpression.get.resolve
+
+      ir shouldBe an[Literal.Number]
+      val signature = ir.getMetadata(TypeSignatures)
+      signature shouldBe defined
+      signature.get.signature.showCode() shouldEqual "Number"
+    }
+
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -5343,6 +5343,123 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
       new String(data2) shouldEqual "22"
   }
 
+  it should "emit visualization update of ascribed expression" in withContext() {
+    context =>
+      val contextId       = UUID.randomUUID()
+      val requestId       = UUID.randomUUID()
+      val visualizationId = UUID.randomUUID()
+      val moduleName      = "Enso_Test.Test.Main"
+      val metadata        = new Metadata
+
+      val code =
+        """from Standard.Base.Data.Numbers import Number
+          |
+          |main =
+          |    v = 22 : Number
+          |    v
+          |""".stripMargin.linesIterator.mkString("\n")
+      val idV = metadata.addItem(62, 11)
+      val idR = metadata.addItem(78, 1)
+
+      val contents = metadata.appendToCode(code)
+      val mainFile = context.writeMain(contents)
+      val visualizationFile =
+        context.writeInSrcDir("Visualization", context.Visualization.code)
+
+      // create context
+      context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+      context.receive shouldEqual Some(
+        Api.Response(requestId, Api.CreateContextResponse(contextId))
+      )
+
+      // open files
+      context.send(
+        Api.Request(
+          requestId,
+          Api.OpenFileRequest(
+            visualizationFile,
+            context.Visualization.code
+          )
+        )
+      )
+      context.receive shouldEqual Some(
+        Api.Response(Some(requestId), Api.OpenFileResponse)
+      )
+
+      // Open the new file
+      context.send(
+        Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
+      )
+      context.receive shouldEqual Some(
+        Api.Response(Some(requestId), Api.OpenFileResponse)
+      )
+
+      // push main
+      val item1 = Api.StackItem.ExplicitCall(
+        Api.MethodPointer(moduleName, moduleName, "main"),
+        None,
+        Vector()
+      )
+      context.send(
+        Api.Request(requestId, Api.PushContextRequest(contextId, item1))
+      )
+      context.receiveNIgnorePendingExpressionUpdates(
+        4
+      ) should contain theSameElementsAs Seq(
+        Api.Response(requestId, Api.PushContextResponse(contextId)),
+        TestMessages.update(
+          contextId,
+          idV,
+          ConstantsGen.INTEGER
+        ),
+        TestMessages.update(
+          contextId,
+          idR,
+          ConstantsGen.INTEGER
+        ),
+        context.executionComplete(contextId)
+      )
+
+      // attach visualization
+      context.send(
+        Api.Request(
+          requestId,
+          Api.AttachVisualization(
+            visualizationId,
+            idV,
+            Api.VisualizationConfiguration(
+              contextId,
+              Api.VisualizationExpression.Text(
+                "Enso_Test.Test.Visualization",
+                "encode",
+                Vector()
+              ),
+              "Enso_Test.Test.Visualization"
+            )
+          )
+        )
+      )
+      val attachVisualizationResponses = context.receiveN(2)
+      attachVisualizationResponses should contain(
+        Api.Response(requestId, Api.VisualizationAttached())
+      )
+      val Some(data) = attachVisualizationResponses.collectFirst {
+        case Api.Response(
+              None,
+              Api.VisualizationUpdate(
+                Api.VisualizationContext(
+                  `visualizationId`,
+                  `contextId`,
+                  `idV`
+                ),
+                data
+              )
+            ) =>
+          data
+      }
+      new String(data) shouldEqual "22"
+  }
+
   it should "update the value when self argument changes" in withContext() {
     context =>
       val contextId  = UUID.randomUUID()

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -1501,12 +1501,12 @@ public class EnsoParserTest {
         """;
     Module ir = compile(code);
     expectNoErrorsInIr(ir);
-    var typeAscription = (org.enso.compiler.core.ir.Type.Ascription)
-        CollectionConverters.asJava(ir.preorder()).stream()
-            .filter(
-                child -> child instanceof org.enso.compiler.core.ir.Type.Ascription)
-            .findFirst()
-            .get();
+    var typeAscription =
+        (org.enso.compiler.core.ir.Type.Ascription)
+            CollectionConverters.asJava(ir.preorder()).stream()
+                .filter(child -> child instanceof org.enso.compiler.core.ir.Type.Ascription)
+                .findFirst()
+                .get();
     assertTrue(typeAscription.typed() instanceof org.enso.compiler.core.ir.Literal.Number);
     var location = typeAscription.location().get().location();
     assertEquals(14, location.start());

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -1493,6 +1493,26 @@ public class EnsoParserTest {
     """);
   }
 
+  @Test
+  public void testAnnotatedExpression() {
+    String code = """
+        type A
+        main = 42 : A
+        """;
+    Module ir = compile(code);
+    expectNoErrorsInIr(ir);
+    var typeAscription = (org.enso.compiler.core.ir.Type.Ascription)
+        CollectionConverters.asJava(ir.preorder()).stream()
+            .filter(
+                child -> child instanceof org.enso.compiler.core.ir.Type.Ascription)
+            .findFirst()
+            .get();
+    assertTrue(typeAscription.typed() instanceof org.enso.compiler.core.ir.Literal.Number);
+    var location = typeAscription.location().get().location();
+    assertEquals(14, location.start());
+    assertEquals(20, location.end());
+  }
+
   private static void parseTest(String code) {
     parseTest(code, true, true, true);
   }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #13407 

Changelog:
- update: reattach ids from ascribed expression to the expression so that it can be visible to the instrument.

### Important Notes

Visualization of ascribed expression is displayed in gui

<img width="927" height="568" alt="2025-07-18-204857_927x568_scrot" src="https://github.com/user-attachments/assets/10dad449-775a-4a32-9404-00bf882e6821" />


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
