### PR TITLE
Fixing project rename

### DIFF
--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -416,20 +416,8 @@ export function useRenameProjectMutation() {
     },
     onError: (_err, _variables, context) => {
       if (context?.queryKey) {
-        const toInvalidate = [
-          {
-            predicate: (query: reactQuery.Query) =>
-              reactQuery.matchQuery({ queryKey: ['listDirectory'] }, query),
-          },
-          {
-            predicate: (query: reactQuery.Query) =>
-              reactQuery.matchQuery({ queryKey: ['getAssetDetails'] }, query),
-          },
-          {
-            queryKey: context.queryKey,
-          },
-        ]
-        return Promise.all(toInvalidate.map((invalidate) => client.invalidateQueries(invalidate)))
+        const toInvalidate = [['listDirectory'], ['getAssetDetails'], context.queryKey]
+        return Promise.all(toInvalidate.map((queryKey) => client.invalidateQueries({ queryKey })))
       }
     },
     onSuccess: (_, { newName, project }) => {

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -404,13 +404,13 @@ export function useRenameProjectMutation() {
         queryKey,
       })
       // Optimistically update the project name.
-      const previousProjectDetails = client.getQueryData<backendModule.Project>(queryKey)
-      if (previousProjectDetails) {
-        client.setQueryData<backendModule.Project>(queryKey, {
-          ...previousProjectDetails,
+      client.setQueryData<backendModule.Project>(queryKey, (data) => {
+        if (data == null) return undefined
+        return {
+          ...data,
           name: newName,
-        })
-      }
+        }
+      })
 
       return { queryKey }
     },

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -381,6 +381,7 @@ export function useCloseProjectMutation() {
 /** Mutation to rename a project. */
 export function useRenameProjectMutation() {
   const updateLaunchedProjects = useUpdateLaunchedProjects()
+  const client = reactQuery.useQueryClient()
 
   return useMutationCallback({
     mutationKey: ['renameProject'],
@@ -396,6 +397,40 @@ export function useRenameProjectMutation() {
       const { id, title } = project
 
       return backend.updateProject(id, { projectName: newName }, title)
+    },
+    onMutate: async ({ newName, project }) => {
+      const queryKey = createGetProjectDetailsQuery.getQueryKey(project.id)
+      await client.cancelQueries({
+        queryKey,
+      })
+      // Optimistically update the project name.
+      const previousProjectDetails = client.getQueryData<backendModule.Project>(queryKey)
+      if (previousProjectDetails) {
+        client.setQueryData<backendModule.Project>(queryKey, {
+          ...previousProjectDetails,
+          name: newName,
+        })
+      }
+
+      return { queryKey }
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.queryKey) {
+        const toInvalidate = [
+          {
+            predicate: (query: reactQuery.Query) =>
+              reactQuery.matchQuery({ queryKey: ['listDirectory'] }, query),
+          },
+          {
+            predicate: (query: reactQuery.Query) =>
+              reactQuery.matchQuery({ queryKey: ['getAssetDetails'] }, query),
+          },
+          {
+            queryKey: context.queryKey,
+          },
+        ]
+        return Promise.all(toInvalidate.map((invalidate) => client.invalidateQueries(invalidate)))
+      }
     },
     onSuccess: (_, { newName, project }) => {
       updateLaunchedProjects((projects) =>

--- a/app/gui/src/dashboard/layouts/Editor.tsx
+++ b/app/gui/src/dashboard/layouts/Editor.tsx
@@ -207,7 +207,7 @@ export default function Editor(props: EditorProps) {
 interface EditorInternalProps extends Omit<EditorProps, 'project'> {
   readonly openedProject: backendModule.Project
   readonly backendType: backendModule.BackendType
-  readonly renameProject: (newName: string) => void
+  readonly renameProject: (newName: string) => Promise<void>
   readonly projectName: string
 }
 
@@ -227,8 +227,8 @@ function EditorInternal(props: EditorInternalProps) {
     }
   }, [hidden])
 
-  const onRenameProject = useEventCallback((newName: string) => {
-    renameProject(newName)
+  const onRenameProject = useEventCallback(async (newName: string) => {
+    await renameProject(newName)
   })
 
   const jsonAddress = openedProject.jsonAddress

--- a/app/gui/src/project-view/ProjectView.vue
+++ b/app/gui/src/project-view/ProjectView.vue
@@ -30,7 +30,7 @@ const props = defineProps<{
   readonly projectNamespace?: string
   readonly projectPath: string
   readonly engine: LsUrls
-  readonly renameProject: (newName: string) => void
+  readonly renameProject: (newName: string) => Promise<void>
   /** The current project's backend, which may be remote or local. */
   readonly projectBackend?: Opt<Backend>
   /**

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -108,7 +108,7 @@ export interface ProjectProps {
 export function createProjectStore(
   props: {
     projectId: ProjectId
-    renameProject: (newName: string) => void
+    renameProject: (newName: string) => Promise<void>
     engine: LsUrls
   },
   projectNames: ProjectNameStore,
@@ -354,12 +354,13 @@ export function createProjectStore(
     executionContext.executionEnvironment = modeValue === 'live' ? 'Live' : 'Design'
   })
 
-  function renameProject(newDisplayedName: string) {
+  async function renameProject(newDisplayedName: string) {
     try {
-      renameProjectBackend(newDisplayedName)
       projectNames.onProjectRenameRequested(newDisplayedName)
+      await renameProjectBackend(newDisplayedName)
       return Ok()
     } catch (err) {
+      projectNames.onProjectRenameFailed()
       return Err(err)
     }
   }

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -17,7 +17,7 @@ import { type MethodPointer } from '@/util/methodPointer'
 import { createDataWebsocket, createRpcTransport, useAbortScope } from '@/util/net'
 import { DataServer } from '@/util/net/dataServer'
 import { ProjectPath } from '@/util/projectPath'
-import { isIdentifier, tryQualifiedName, type QualifiedName } from '@/util/qualifiedName'
+import { tryQualifiedName, type QualifiedName } from '@/util/qualifiedName'
 import { proxyRefs } from '@/util/reactivity'
 import { computedAsync } from '@vueuse/core'
 import {
@@ -357,11 +357,7 @@ export function createProjectStore(
   function renameProject(newDisplayedName: string) {
     try {
       renameProjectBackend(newDisplayedName)
-      if (isIdentifier(newDisplayedName)) {
-        projectNames.onProjectRenameRequested(newDisplayedName)
-      } else {
-        console.error(`Renaming project: Not a valid identifier: ${newDisplayedName}`)
-      }
+      projectNames.onProjectRenameRequested(newDisplayedName)
       return Ok()
     } catch (err) {
       return Err(err)

--- a/app/gui/src/project-view/stores/projectNames.ts
+++ b/app/gui/src/project-view/stores/projectNames.ts
@@ -1,8 +1,9 @@
 import { Ok, Result } from '@/util/data/result'
+import { normalizeName } from '@/util/nameValidation'
 import { parseAbsoluteProjectPath, ProjectPath } from '@/util/projectPath'
 import { normalizeQualifiedName, qnJoin, tryQualifiedName } from '@/util/qualifiedName'
 import { type ToValue } from '@/util/reactivity'
-import { computed, readonly, ref, toRef, toValue } from 'vue'
+import { computed, ref, toValue } from 'vue'
 import { type Identifier, type QualifiedName } from 'ydoc-shared/ast'
 
 export type ProjectNameStore = ReturnType<typeof createProjectNameStore>
@@ -26,11 +27,13 @@ export function createProjectNameStore({
     return (toValue(projectNamespace) ?? 'local') as Identifier
   })
   const synchronizedName = ref(projectInitialName as Identifier)
-  const pendingName = ref<Identifier>()
+  const pendingName = ref<string>()
+
+  const displayedName = computed(() => pendingName.value ?? toValue(projectDisplayedName))
 
   const inboundProject = computed(() => qnJoin(ns.value, synchronizedName.value))
   const outboundProject = computed(() =>
-    pendingName.value ? qnJoin(ns.value, pendingName.value) : inboundProject.value,
+    pendingName.value ? qnJoin(ns.value, normalizeName(pendingName.value)) : inboundProject.value,
   )
 
   /**
@@ -85,7 +88,7 @@ export function createProjectNameStore({
     parseProjectPathRaw,
     printProjectPath,
     serializeProjectPathForBackend,
-    onProjectRenameRequested: (newName: Identifier) => {
+    onProjectRenameRequested: (newName: string) => {
       pendingName.value = newName
     },
     onProjectRenamed: (oldName: string, newName: string) => {
@@ -94,7 +97,7 @@ export function createProjectNameStore({
         pendingName.value = undefined
       }
     },
-    displayName: readonly(toRef(projectDisplayedName)),
+    displayName: displayedName,
   }
 }
 

--- a/app/gui/src/project-view/stores/projectNames.ts
+++ b/app/gui/src/project-view/stores/projectNames.ts
@@ -91,6 +91,9 @@ export function createProjectNameStore({
     onProjectRenameRequested: (newName: string) => {
       pendingName.value = newName
     },
+    onProjectRenameFailed: () => {
+      pendingName.value = undefined
+    },
     onProjectRenamed: (oldName: string, newName: string) => {
       if ((oldName as Identifier) === synchronizedName.value) {
         synchronizedName.value = newName as Identifier

--- a/app/gui/src/project-view/util/__tests__/nameValidation.test.ts
+++ b/app/gui/src/project-view/util/__tests__/nameValidation.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import { normalizeName } from '../nameValidation'
+
+test('should sanitize the name of the project', () => {
+  expect(normalizeName('My_Project')).toBe('My_Project')
+  expect(normalizeName('My___Project')).toBe('My___Project')
+  expect(normalizeName('myProject')).toBe('MyProject')
+  expect(normalizeName('myPro??^ject123')).toBe('MyProject123')
+  expect(normalizeName('???%$6543lib')).toBe('Project_6543lib')
+  expect(normalizeName('MyProject™')).toBe('MyProject')
+  expect(normalizeName('$$$$')).toBe('Project')
+  expect(normalizeName('$$42$$')).toBe('Project_42')
+  expect(normalizeName('AoC_1')).toBe('AoC_1')
+  expect(normalizeName('🚀')).toBe('Project')
+  expect(normalizeName('🚀_😊')).toBe('Project')
+  expect(normalizeName('🚀_😊__')).toBe('Project')
+  expect(normalizeName('__🚀_😊_')).toBe('Project')
+  expect(normalizeName('')).toBe('Project')
+  expect(normalizeName('123')).toBe('Project_123')
+  expect(normalizeName('Test123')).toBe('Test123')
+  expect(normalizeName('test_123')).toBe('Test_123')
+})

--- a/app/gui/src/project-view/util/nameValidation.ts
+++ b/app/gui/src/project-view/util/nameValidation.ts
@@ -1,0 +1,39 @@
+/**
+ * @file Name validation utilities for Enso project names.
+ *
+ * This module copies implementation from NameValidation.scala module in the backend.
+ */
+
+import { Identifier, isIdentifier } from '@/util/qualifiedName'
+
+/**
+ * Transforms the given string into a valid package name.
+ */
+export function normalizeName(name: string): Identifier {
+  const starting =
+    (
+      name.length === 0 ||
+      name
+        .split('')
+        .filter((c) => c !== '_')
+        .every((c) => !isAllowedNameCharacter(c))
+    ) ?
+      'Project'
+    : !name[0]?.match(/[a-zA-Z]/) ? 'Project_' + name
+    : name
+
+  const startingWithUppercase = starting.charAt(0).toUpperCase() + starting.slice(1)
+  const onlyAlphanumeric = startingWithUppercase.split('').filter(isAllowedNameCharacter).join('')
+  if (!isIdentifier(onlyAlphanumeric)) {
+    throw new Error(`Project name normalization failed: ${name}`)
+  }
+
+  return onlyAlphanumeric
+}
+
+/**
+ * Checks if a character is allowed in a project name.
+ */
+function isAllowedNameCharacter(char: string): boolean {
+  return /[a-zA-Z0-9_]/.test(char)
+}

--- a/app/gui/src/providers/openedProjects.ts
+++ b/app/gui/src/providers/openedProjects.ts
@@ -27,7 +27,7 @@ export interface ProjectProps {
   projectNamespace: string | undefined
   projectInitialName: string
   projectDisplayedName: string
-  renameProject: (newName: string) => void
+  renameProject: (newName: string) => Promise<void>
   engine: LsUrls
 }
 

--- a/app/ydoc-shared/src/util/data/result.ts
+++ b/app/ydoc-shared/src/util/data/result.ts
@@ -137,8 +137,20 @@ export class ResultError<E = unknown> {
   message(preamble: string = 'error') {
     const ctx =
       this.context.length > 0 ? `\n${Array.from(this.context, (ctx) => ctx()).join('\n')}` : ''
-    return `${preamble}${preamble ? ': ' : ''}${this.payload}${ctx}`
+    const payload = coercePayloadToString(this.payload)
+    return `${preamble}${preamble ? ': ' : ''}${payload}${ctx}`
   }
+}
+
+function coercePayloadToString(payload: unknown) {
+  if (payload == null) return 'unknown error'
+  if (payload instanceof Error) return payload.message
+  if (payload != null && typeof payload === 'object') {
+    if ('code' in payload && 'message' in payload) {
+      return `[${payload.code}] ${payload.message}`
+    } else return JSON.stringify(payload)
+  }
+  return payload
 }
 
 /**


### PR DESCRIPTION
### Pull Request Description

Fixes #13531

- Implemented optimistic update for the renameProject mutation. It is necessary because the tanstack query provides the “displayed” project name, and it takes some time for the query to refetch.
- Fixed error handling on rename inside the graph editor.
- Copied `nameValidation` module from the engine to update the project identifier even if the user entered a non-identifier string.

https://github.com/user-attachments/assets/82316dac-cf9c-4f5f-9b1e-9053407e6bb7


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
