### PR TITLE
Fixing `jvm: true` in `package.yaml` behavior

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
+++ b/engine/runner/src/main/java/org/enso/runner/JavaFinder.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
+import org.enso.common.Platform;
 import org.enso.distribution.DistributionManager;
 import org.enso.distribution.Environment;
 import org.enso.distribution.PortableDistributionManager;
@@ -38,7 +39,7 @@ final class JavaFinder {
     if (javaHome != null) {
       var binDir = Path.of(javaHome).resolve("bin");
       Path javaExe;
-      if (isOnWindows()) {
+      if (Platform.getOperatingSystem().isWindows()) {
         javaExe = binDir.resolve("java.exe");
       } else {
         javaExe = binDir.resolve("java");
@@ -61,10 +62,6 @@ final class JavaFinder {
     }
     logger.warn("No JDK found on PATH. Cannot start the runtime.");
     return null;
-  }
-
-  private static boolean isOnWindows() {
-    return System.getProperty("os.name").toLowerCase().contains("win");
   }
 
   /**
@@ -110,7 +107,7 @@ final class JavaFinder {
   private static File findJavaOnPath() {
     try {
       ProcessBuilder processBuilder;
-      if (isOnWindows()) {
+      if (Platform.getOperatingSystem().isWindows()) {
         processBuilder = new ProcessBuilder("java.exe", "-h");
       } else {
         processBuilder = new ProcessBuilder("java", "-h");

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1404,36 +1404,38 @@ public class Main {
    * Checks if JVM mode should be enabled in a project defined by arguments, based on a project's
    * config file, if any.
    *
+   * @param cwd current working directory or {@code null}
    * @param line parsed command line arguments
    * @return true, if project should be launched in JVM mode, false otherwise
    */
-  private boolean isJvmModeEnabled(CommandLine line) {
-    var target = line.getOptionValue(RUN_OPTION);
-    if (target == null) {
-      return false;
-    }
-
-    var f = new File(target);
-    // Guess project's root directory
-    File configFile = null;
-    while (configFile == null && f != null) {
-      var testFile = f.toPath().resolve(org.enso.pkg.Config.ensoPackageConfigName());
-      if (testFile.toFile().exists()) {
-        configFile = testFile.toFile();
-      } else {
-        f = f.getParentFile();
-      }
-    }
-    if (configFile == null) {
-      return false;
-    } else {
-      try (FileReader fileReader = new FileReader(configFile)) {
-        return org.enso.pkg.Config.fromYaml(fileReader)
-            .map(c -> c.jvm().getOrElse(() -> false))
-            .getOrElse(() -> false);
-      } catch (IOException e) {
+  private boolean isJvmModeEnabled(String cwd, CommandLine line) {
+    try {
+      var projectPath = line.getOptionValue(IN_PROJECT_OPTION);
+      var path = line.getOptionValue(RUN_OPTION);
+      if (path == null) {
         return false;
       }
+
+      var fileAndProject = Utils.findFileAndProject(cwd, path, projectPath);
+      if (fileAndProject._3() == null) {
+        return false;
+      } else {
+        var configFile =
+            new File(fileAndProject._3())
+                .toPath()
+                .resolve(org.enso.pkg.Config.ensoPackageConfigName());
+        if (!configFile.toFile().exists()) {
+          return false;
+        } else {
+          try (var fileReader = new FileReader(configFile.toFile())) {
+            return org.enso.pkg.Config.fromYaml(fileReader)
+                .map(c -> c.jvm().getOrElse(() -> false))
+                .getOrElse(() -> false);
+          }
+        }
+      }
+    } catch (IOException e) {
+      return false;
     }
   }
 
@@ -1548,7 +1550,7 @@ public class Main {
     }
     assert checkOutdatedLauncher(new File(loc.toURI()), component) || true;
     var hasJVMOption = line.hasOption(JVM_OPTION);
-    var jvmInProjectEnforced = isJvmModeEnabled(line);
+    var jvmInProjectEnforced = isJvmModeEnabled(originalCwdOrNull, line);
     if (hasJVMOption || jvmInProjectEnforced) {
       var jvm = line.getOptionValue(JVM_OPTION);
       var current = System.getProperty("java.home");
@@ -1567,20 +1569,21 @@ public class Main {
         }
       }
     }
-    if (jvmInProjectEnforced) {
-      throw exitFail("Cannot find java executable to run in JVM mode");
-    } else {
-      if (System.getProperty("java.home") == null) {
-        assert HostEnsoUtils.isAot() : "Otherwise java.home would be defined";
-        var exe = JavaFinder.findJavaExecutable();
-        if (exe != null) {
-          var path = exe.getParentFile().getParentFile().getAbsolutePath();
-          System.setProperty("java.home", path);
-          LOGGER.debug("Setting java.home property for AOT mode to {}", path);
+    if (HostEnsoUtils.isAot()) {
+      if (jvmInProjectEnforced) {
+        throw exitFail("Cannot find java executable to run in JVM mode");
+      } else {
+        if (System.getProperty("java.home") == null) {
+          var exe = JavaFinder.findJavaExecutable();
+          if (exe != null) {
+            var path = exe.getParentFile().getParentFile().getAbsolutePath();
+            System.setProperty("java.home", path);
+            LOGGER.debug("Setting java.home property for AOT mode to {}", path);
+          }
         }
       }
-      handleLaunch(originalCwdOrNull, line, logLevel, logMasking[0]);
     }
+    handleLaunch(originalCwdOrNull, line, logLevel, logMasking[0]);
   }
 
   final CommandLine preprocessArguments(String... args) {

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1556,38 +1556,31 @@ public class Main {
         jvm = current;
       }
       var shouldLaunchJvm = current == null || !current.equals(jvm);
-      if (!shouldLaunchJvm) {
-        if (hasJVMOption) {
-          stderr(JVM_OPTION + " option has no effect - already running in JVM " + current);
-        }
-      } else {
-        if (jvm == null) {
-          var javaExe = JavaFinder.findJavaExecutable();
-          if (javaExe == null) {
-            // Try your best if `jvm` mode enabled in a project
-            if (!jvmInProjectEnforced) {
-              throw exitFail("Cannot find java executable");
-            }
-          } else {
-            launchJvm(originalCwdOrNull, line, props, component, javaExe);
-          }
-        } else {
-          var javaExecutable = new File(new File(new File(jvm), "bin"), "java").getAbsoluteFile();
+      if (shouldLaunchJvm) {
+        var javaExecutable =
+            jvm != null
+                ? new File(new File(new File(jvm), "bin"), "java").getAbsoluteFile()
+                : JavaFinder.findJavaExecutable();
+        if (javaExecutable != null) {
           launchJvm(originalCwdOrNull, line, props, component, javaExecutable);
+          return;
         }
       }
     }
-
-    if (System.getProperty("java.home") == null) {
-      assert HostEnsoUtils.isAot() : "Otherwise java.home would be defined";
-      var exe = JavaFinder.findJavaExecutable();
-      if (exe != null) {
-        var path = exe.getParentFile().getParentFile().getAbsolutePath();
-        System.setProperty("java.home", path);
-        LOGGER.debug("Setting java.home property for AOT mode to {}", path);
+    if (jvmInProjectEnforced) {
+      throw exitFail("Cannot find java executable to run in JVM mode");
+    } else {
+      if (System.getProperty("java.home") == null) {
+        assert HostEnsoUtils.isAot() : "Otherwise java.home would be defined";
+        var exe = JavaFinder.findJavaExecutable();
+        if (exe != null) {
+          var path = exe.getParentFile().getParentFile().getAbsolutePath();
+          System.setProperty("java.home", path);
+          LOGGER.debug("Setting java.home property for AOT mode to {}", path);
+        }
       }
+      handleLaunch(originalCwdOrNull, line, logLevel, logMasking[0]);
     }
-    handleLaunch(originalCwdOrNull, line, logLevel, logMasking[0]);
   }
 
   final CommandLine preprocessArguments(String... args) {

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -42,7 +42,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
 
             proj_dir.exists . should_be_true
             proj_dir.is_directory . should_be_true
-            out = enso_run cwd=tmp_root.path args=["--run", if relative then "NeedJvm/Proj" else proj_dir.to_text ]
+            out = enso_run cwd=tmp_root.path args=["--run", if relative then "NeedsJvm/Proj" else proj_dir.to_text ]
             clue = "Output from subprocess: " + out.to_text
             Test.with_clue clue <|
                 clue . should_contain expected_version
@@ -50,7 +50,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
                 clue . should_contain "Server VM"
 
     group_builder.specify "package.yaml JVM mode (relative)" <|
-        test_jvm_mode False
+        test_jvm_mode True
 
     group_builder.specify "package.yaml JVM mode  (absolute)" <|
         test_jvm_mode False

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -24,17 +24,9 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             proj_dir.is_directory . should_be_true
             # The spawned subprocess will try to run the newly created project
             # via a relative path
-            args = [enso_bin, "--vm.D", "org.enso.runner.Main.Logger.level=trace", "--run", "Dir1/Dir2/Proj"]
-            proc_bldr = J_ProcessBuilder.new args
-            proc_bldr.redirectErrorStream True
-            proc_bldr.directory (J_File.new tmp_root.path)
-            proc = proc_bldr.start
-            retcode = proc.waitFor
-            bytes = proc.getInputStream.readAllBytes
-            out = J_String.new bytes
+            out = enso_run cwd=tmp_root.path args=["--vm.D", "org.enso.runner.Main.Logger.level=trace", "--run", "Dir1/Dir2/Proj"]
             clue = "Output from subprocess: " + out.to_text
             Test.with_clue clue <|
-                retcode . should_equal 0
                 clue . should_contain "org.enso.runner.Main"
 
 
@@ -51,8 +43,20 @@ tmp_dir -> File =
     d.create_directory
     d
 
-enso_bin -> Text =
+private enso_bin -> Text =
     J_ExecutableLocation.getExecutableLocation
+
+private enso_run (cwd:Text) (args : Vector Text) -> Text =
+    proc_bldr = J_ProcessBuilder.new [enso_bin]+args
+    proc_bldr.redirectErrorStream True
+    proc_bldr.directory (J_File.new cwd)
+    proc = proc_bldr.start
+    retcode = proc.waitFor
+    bytes = proc.getInputStream.readAllBytes
+    out = J_String.new bytes
+    if retcode != 0 then
+        Test.fail out
+    out
 
 create_dummy_project parent_dir:File proj_name:Text main_src:Text -> File =
     Runtime.assert parent_dir.exists

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -10,6 +10,51 @@ polyglot java import org.enso.base_test_helpers.ExecutableLocation as J_Executab
 
 
 add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
+    test_jvm_mode relative:Boolean =
+        tmp_root = tmp_dir
+
+        cleanup =
+            tmp_root.delete recursive=True
+
+        Panic.with_finalizer cleanup <|
+            proj_parent_dir = tmp_root / "NeedsJvm"
+            proj_parent_dir.create_directory
+
+            expected_version = J_System.getProperty "java.vm.version"
+
+            proj_dir = create_dummy_project proj_parent_dir "Proj" """
+                polyglot java import java.lang.System
+                import Standard.Base.IO
+
+                main =
+                    IO.println <| System.getProperty "java.vm.version"
+                    IO.println <| System.getProperty "java.vm.name"
+
+            yaml_file = proj_dir / "package.yaml"
+            yaml_file.exists . should_be_true
+            yaml_basic = Data.read_text yaml_file
+            yaml_with_jvm = yaml_basic + """
+
+                jvm: true
+
+            yaml_with_jvm.write yaml_file
+
+
+            proj_dir.exists . should_be_true
+            proj_dir.is_directory . should_be_true
+            out = enso_run cwd=tmp_root.path args=["--run", if relative then "NeedJvm/Proj" else proj_dir.to_text ]
+            clue = "Output from subprocess: " + out.to_text
+            Test.with_clue clue <|
+                clue . should_contain expected_version
+                clue . should_contain "OpenJDK"
+                clue . should_contain "Server VM"
+
+    group_builder.specify "package.yaml JVM mode (relative)" <|
+        test_jvm_mode False
+
+    group_builder.specify "package.yaml JVM mode  (absolute)" <|
+        test_jvm_mode False
+
     group_builder.specify "should be able to run a project specified with relative path" <|
         tmp_root = tmp_dir
 


### PR DESCRIPTION
### Pull Request Description

- fixes #13567 
- by failing when JVM mode is needed, but not entered: ce115e8aa7662e8c7e39cbf5d04d97b2b1dabcba
- using `findFileAndProject` to resolve local paths properly: 25a8a11518828ad188e6fd53cebc446ec72676a2
- plus a minor fix - 39a156a832dfd56ddffae1c84f05b73767cab432

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written in af3bbb1