### PR TITLE
Allow scrolling in context menu

### DIFF
--- a/app/gui/src/dashboard/components/ContextMenu.tsx
+++ b/app/gui/src/dashboard/components/ContextMenu.tsx
@@ -72,7 +72,11 @@ export const ContextMenu = forwardRef(function ContextMenu(
   useEventListener(
     'scroll',
     (event) => {
-      if (event.target instanceof Element && !popoverRef.current?.contains(event.target)) {
+      if (
+        event.target instanceof Element &&
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target)
+      ) {
         setIsOpen(false)
       }
     },

--- a/app/gui/src/dashboard/components/ContextMenu.tsx
+++ b/app/gui/src/dashboard/components/ContextMenu.tsx
@@ -4,6 +4,7 @@ import ContextMenuEntry from '#/components/ContextMenuEntry'
 import { Popover } from '#/components/Dialog'
 import type { MenuEntryProps } from '#/components/MenuEntry'
 import { usePortalContext } from '#/components/Portal'
+import { useEventListener } from '#/hooks/eventListenerHooks'
 import { useInputBindings } from '#/providers/InputBindingsProvider'
 import { twMerge } from '#/utilities/tailwindMerge'
 import { isOnMacOS } from 'enso-common/src/detect'
@@ -66,6 +67,15 @@ export const ContextMenu = forwardRef(function ContextMenu(
     })
   }, [inputBindings, isOpen])
 
+  useEventListener(
+    'scroll',
+    () => {
+      setIsOpen(false)
+    },
+    document,
+    { capture: true },
+  )
+
   return (
     <Popover.Trigger>
       <Pressable>
@@ -73,6 +83,8 @@ export const ContextMenu = forwardRef(function ContextMenu(
       </Pressable>
       <Popover
         data-testid="context-menu"
+        // Remove the underlay element to allow scrolling.
+        isNonModal
         style={{ left: position.pageX, top: position.pageY }}
         shouldCloseOnInteractOutside={() => true}
         className="sticky flex w-min items-start"

--- a/app/gui/src/dashboard/components/ContextMenu.tsx
+++ b/app/gui/src/dashboard/components/ContextMenu.tsx
@@ -12,6 +12,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
   type ForwardedRef,
   type MouseEvent,
@@ -40,6 +41,7 @@ export const ContextMenu = forwardRef(function ContextMenu(
 
   const inputBindings = useInputBindings()
   const root = usePortalContext()
+  const popoverRef = useRef<HTMLElement>(null)
   const [isOpen, setIsOpen] = useState(initialPosition != null)
   const [position, setPosition] = useState<Pick<MouseEvent, 'pageX' | 'pageY'>>(
     initialPosition ?? {
@@ -69,8 +71,10 @@ export const ContextMenu = forwardRef(function ContextMenu(
 
   useEventListener(
     'scroll',
-    () => {
-      setIsOpen(false)
+    (event) => {
+      if (event.target instanceof Element && popoverRef.current?.contains(event.target) !== true) {
+        setIsOpen(false)
+      }
     },
     document,
     { capture: true },
@@ -85,9 +89,12 @@ export const ContextMenu = forwardRef(function ContextMenu(
         data-testid="context-menu"
         // Remove the underlay element to allow scrolling.
         isNonModal
-        style={{ left: position.pageX, top: position.pageY }}
+        ref={popoverRef}
+        // `position: sticky` must be here rather than in tailwind as `react-aria-components`
+        // sets `position: absolute` via `style`.
+        style={{ position: 'sticky', left: position.pageX, top: position.pageY }}
         shouldCloseOnInteractOutside={() => true}
-        className="sticky flex w-min items-start"
+        className="flex w-min items-start"
         UNSTABLE_portalContainer={root}
         isOpen={isOpen}
         onOpenChange={setIsOpen}

--- a/app/gui/src/dashboard/components/ContextMenu.tsx
+++ b/app/gui/src/dashboard/components/ContextMenu.tsx
@@ -72,7 +72,7 @@ export const ContextMenu = forwardRef(function ContextMenu(
   useEventListener(
     'scroll',
     (event) => {
-      if (event.target instanceof Element && popoverRef.current?.contains(event.target) !== true) {
+      if (event.target instanceof Element && !popoverRef.current?.contains(event.target)) {
         setIsOpen(false)
       }
     },

--- a/app/gui/src/dashboard/components/Dialog/Popover.tsx
+++ b/app/gui/src/dashboard/components/Dialog/Popover.tsx
@@ -4,10 +4,12 @@
  * Can be used to display alerts, confirmations, or other content.
  */
 import * as aria from '#/components/aria'
+import { DialogTrigger } from '#/components/Dialog/DialogTrigger'
 import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { usePortalContext } from '#/components/Portal'
 import * as suspense from '#/components/Suspense'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
+import { mergeRefs } from '#/utilities/mergeRefs'
 import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 import * as React from 'react'
 import { ResetButtonGroupContext } from '../Button'
@@ -15,7 +17,6 @@ import type { Placement } from '../types'
 import { Close } from './Close'
 import { DialogProvider } from './DialogProvider'
 import { DialogStackRegistrar } from './DialogStackProvider'
-import { DialogTrigger } from './DialogTrigger'
 import { animateScale, useInteractOutside } from './utilities'
 import { DIALOG_BACKGROUND } from './variants'
 
@@ -84,59 +85,67 @@ const SUSPENSE_LOADER_PROPS = { minHeight: 'h32' } as const
  * A popover is an overlay element positioned relative to a trigger.
  * It can be used to display additional content or actions.
  */
-export function Popover(props: PopoverProps) {
-  const {
-    children,
-    className,
-    size,
-    rounded,
-    variant,
-    placement,
-    isDismissable = true,
-    onClose,
-    ...ariaPopoverProps
-  } = props
+export const Popover = Object.assign(
+  React.forwardRef(function Popover(props: PopoverProps, ref: React.ForwardedRef<HTMLElement>) {
+    const {
+      children,
+      className,
+      size,
+      rounded,
+      variant,
+      placement,
+      isDismissable = true,
+      onClose,
+      ...ariaPopoverProps
+    } = props
 
-  const popoverRef = React.useRef<HTMLDivElement>(null)
-  const root = usePortalContext()
-  const popoverStyle = { zIndex: '' }
+    const popoverRef = React.useRef<HTMLDivElement>(null)
+    const root = usePortalContext()
+    const popoverStyle = { zIndex: '' }
 
-  return (
-    <aria.Popover
-      ref={popoverRef}
-      className={(values) =>
-        POPOVER_STYLES({
-          isEntering: values.isEntering,
-          isExiting: values.isExiting,
-          size,
-          rounded,
-          variant,
-        }).base({
-          className: typeof className === 'function' ? className(values) : className,
-        })
-      }
-      UNSTABLE_portalContainer={root}
-      style={popoverStyle}
-      shouldCloseOnInteractOutside={() => false}
-      {...(placement != null ? { placement } : {})}
-      {...ariaPopoverProps}
-    >
-      {(opts) => (
-        <PopoverContent
-          popoverRef={popoverRef}
-          size={size}
-          rounded={rounded}
-          opts={opts}
-          isDismissable={isDismissable}
-          variant={variant}
-          onClose={onClose}
-        >
-          {children}
-        </PopoverContent>
-      )}
-    </aria.Popover>
-  )
-}
+    return (
+      <aria.Popover
+        ref={(element) => mergeRefs(popoverRef, ref)(element)}
+        className={(values) =>
+          POPOVER_STYLES({
+            isEntering: values.isEntering,
+            isExiting: values.isExiting,
+            size,
+            rounded,
+            variant,
+          }).base({
+            className: typeof className === 'function' ? className(values) : className,
+          })
+        }
+        UNSTABLE_portalContainer={root}
+        style={popoverStyle}
+        shouldCloseOnInteractOutside={() => false}
+        {...(placement != null ? { placement } : {})}
+        {...ariaPopoverProps}
+      >
+        {(opts) => (
+          <PopoverContent
+            popoverRef={popoverRef}
+            size={size}
+            rounded={rounded}
+            opts={opts}
+            isDismissable={isDismissable}
+            variant={variant}
+            onClose={onClose}
+          >
+            {children}
+          </PopoverContent>
+        )}
+      </aria.Popover>
+    )
+  }),
+  {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Trigger: DialogTrigger,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Close,
+  },
+)
 
 /**
  * Props for a {@link PopoverContent}.
@@ -225,6 +234,3 @@ function PopoverContent(props: PopoverContentProps) {
     </ResetButtonGroupContext>
   )
 }
-
-Popover.Trigger = DialogTrigger
-Popover.Close = Close


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/enso/issues/13588
  - Allow scrolling while in context menu, which will close the context menu
  - Make context menu `position: sticky` to ensure it stays onscreen

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
