### PR TITLE
Show info bar on crash

### DIFF
--- a/app/gui/src/dashboard/components/Page.tsx
+++ b/app/gui/src/dashboard/components/Page.tsx
@@ -1,4 +1,5 @@
 /** @file A page. */
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import Portal from '#/components/Portal'
 import InfoBar from '#/layouts/InfoBar'
 import TheModal from '#/pages/dashboard/components/TheModal'
@@ -15,17 +16,19 @@ export default function Page(props: PageProps) {
 
   return (
     <>
-      {children}
+      <ErrorBoundary>{children}</ErrorBoundary>
       {!hideInfoBar && (
         <div className="fixed right top z-1 m-2.5 text-primary">
           <InfoBar />
         </div>
       )}
-      <Portal>
-        <div className="select-none text-xs text-primary">
-          <TheModal />
-        </div>
-      </Portal>
+      <ErrorBoundary>
+        <Portal>
+          <div className="select-none text-xs text-primary">
+            <TheModal />
+          </div>
+        </Portal>
+      </ErrorBoundary>
     </>
   )
 }

--- a/app/gui/src/dashboard/layouts/Drive.tsx
+++ b/app/gui/src/dashboard/layouts/Drive.tsx
@@ -28,9 +28,11 @@ import { useCategoriesAPI } from './Drive/Categories/categoriesHooks'
 /** Contains directory path and directory contents (projects, folders, secrets and files). */
 export const Drive = React.memo(function Drive() {
   return (
-    <DriveProvider>
-      <DriveInner />
-    </DriveProvider>
+    <ErrorBoundary>
+      <DriveProvider>
+        <DriveInner />
+      </DriveProvider>
+    </ErrorBoundary>
   )
 })
 

--- a/app/gui/src/dashboard/layouts/Editor.tsx
+++ b/app/gui/src/dashboard/layouts/Editor.tsx
@@ -1,8 +1,8 @@
 /** @file The container that launches the IDE. */
 import { Button } from '#/components/Button'
-import * as errorBoundary from '#/components/ErrorBoundary'
+import { ErrorBoundary, ErrorDisplay } from '#/components/ErrorBoundary'
 import { Result } from '#/components/Result'
-import * as suspense from '#/components/Suspense'
+import { Loader } from '#/components/Suspense'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import * as projectHooks from '#/hooks/projectHooks'
 import { useTimeoutCallback } from '#/hooks/timeoutHooks'
@@ -33,6 +33,15 @@ export interface EditorProps {
 
 /** The container that launches the IDE. */
 export default function Editor(props: EditorProps) {
+  return (
+    <ErrorBoundary>
+      <EditorContents {...props} />
+    </ErrorBoundary>
+  )
+}
+
+/** The container that launches the IDE. */
+function EditorContents(props: EditorProps) {
   const { project, onReadyUpdate, onNameUpdate } = props
   const preventAutoReopen =
     project.type !== backendModule.BackendType.local || project.hybrid != null
@@ -155,7 +164,7 @@ export default function Editor(props: EditorProps) {
 
   if (openProjectMutation.isError) {
     return (
-      <errorBoundary.ErrorDisplay
+      <ErrorDisplay
         error={openProjectMutation.error}
         resetErrorBoundary={async () => {
           if (isProjectClosed) {
@@ -173,7 +182,7 @@ export default function Editor(props: EditorProps) {
         switch (true) {
           case projectQuery.isError:
             return (
-              <errorBoundary.ErrorDisplay
+              <ErrorDisplay
                 error={projectQuery.error}
                 resetErrorBoundary={() => projectQuery.refetch()}
               />
@@ -182,7 +191,7 @@ export default function Editor(props: EditorProps) {
           case isProjectClosed:
           case isProjectClosing:
           case isProjectOpening:
-            return <suspense.Loader minHeight="full" />
+            return <Loader minHeight="full" />
 
           case isProjectOpened:
             return (

--- a/app/gui/src/dashboard/layouts/Settings/Settings.tsx
+++ b/app/gui/src/dashboard/layouts/Settings/Settings.tsx
@@ -2,6 +2,7 @@
 import { Heading } from '#/components/aria'
 import { Button } from '#/components/Button'
 import { Popover } from '#/components/Dialog'
+import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Menu } from '#/components/Menu'
 import { usePortalContext } from '#/components/Portal'
 import { Text } from '#/components/Text'
@@ -187,56 +188,60 @@ export function Settings() {
   })
 
   return (
-    <div className="flex h-full w-full flex-col gap-4 overflow-hidden pl-page-x pt-4">
-      <Heading level={1} className="flex items-center px-heading-x">
-        <Menu.Trigger>
-          <Button variant="icon" icon="3_dot_menu" className="mr-3 sm:hidden" />
-          <Popover size="auto" UNSTABLE_portalContainer={root}>
+    <ErrorBoundary>
+      <div className="flex h-full w-full flex-col gap-4 overflow-hidden pl-page-x pt-4">
+        <Heading level={1} className="flex items-center px-heading-x">
+          <Menu.Trigger>
+            <Button variant="icon" icon="3_dot_menu" className="mr-3 sm:hidden" />
+            <Popover size="auto" UNSTABLE_portalContainer={root}>
+              <SettingsSidebar
+                context={context}
+                tabsToShow={tabsToShow}
+                tab={effectiveTab}
+                setTab={setTab}
+              />
+            </Popover>
+          </Menu.Trigger>
+
+          <Text nowrap variant="h1" className="cursor-default font-bold">
+            {getText('settingsFor')}
+          </Text>
+
+          <Text
+            variant="h1"
+            truncate="1"
+            className="ml-2.5 mr-8 max-w-[min(32rem,_100%)] cursor-default rounded-full bg-white px-2.5 font-bold"
+            aria-hidden
+          >
+            {data.organizationOnly === true ?
+              (organization?.name ?? 'your organization')
+            : user.name}
+          </Text>
+        </Heading>
+        <div className="sm:ml-[14rem]">
+          <SearchBar
+            data-testid="settings-search-bar"
+            query={query}
+            setQuery={setQuery}
+            label={getText('settingsSearchBarLabel')}
+            placeholder={getText('settingsSearchBarPlaceholder')}
+          />
+        </div>
+        <div className="flex sm:ml-[222px]" />
+        <div className="flex flex-1 gap-4 overflow-hidden">
+          <aside className="hidden h-full shrink-0 basis-[206px] flex-col overflow-y-auto overflow-x-hidden pb-12 sm:flex">
             <SettingsSidebar
               context={context}
               tabsToShow={tabsToShow}
               tab={effectiveTab}
               setTab={setTab}
             />
-          </Popover>
-        </Menu.Trigger>
-
-        <Text nowrap variant="h1" className="cursor-default font-bold">
-          {getText('settingsFor')}
-        </Text>
-
-        <Text
-          variant="h1"
-          truncate="1"
-          className="ml-2.5 mr-8 max-w-[min(32rem,_100%)] cursor-default rounded-full bg-white px-2.5 font-bold"
-          aria-hidden
-        >
-          {data.organizationOnly === true ? (organization?.name ?? 'your organization') : user.name}
-        </Text>
-      </Heading>
-      <div className="sm:ml-[14rem]">
-        <SearchBar
-          data-testid="settings-search-bar"
-          query={query}
-          setQuery={setQuery}
-          label={getText('settingsSearchBarLabel')}
-          placeholder={getText('settingsSearchBarPlaceholder')}
-        />
+          </aside>
+          <main className="flex flex-1 flex-col overflow-y-auto pb-12 pl-1 scrollbar-gutter-stable">
+            <SettingsTab context={context} data={data} onInteracted={changeTab} />
+          </main>
+        </div>
       </div>
-      <div className="flex sm:ml-[222px]" />
-      <div className="flex flex-1 gap-4 overflow-hidden">
-        <aside className="hidden h-full shrink-0 basis-[206px] flex-col overflow-y-auto overflow-x-hidden pb-12 sm:flex">
-          <SettingsSidebar
-            context={context}
-            tabsToShow={tabsToShow}
-            tab={effectiveTab}
-            setTab={setTab}
-          />
-        </aside>
-        <main className="flex flex-1 flex-col overflow-y-auto pb-12 pl-1 scrollbar-gutter-stable">
-          <SettingsTab context={context} data={data} onInteracted={changeTab} />
-        </main>
-      </div>
-    </div>
+    </ErrorBoundary>
   )
 }


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/2089
  - Wrap `ErrorBoundary` around various components to avoid a full-screen crash
  - This allows users to sign out on a crash rather than the app being stuck

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
