### PR TITLE
Avoid changing directory when moving via drag

### DIFF
--- a/app/gui/src/dashboard/hooks/cutAndPasteHooks.tsx
+++ b/app/gui/src/dashboard/hooks/cutAndPasteHooks.tsx
@@ -26,13 +26,8 @@ export function usePaste(category: Category) {
 
   return (options: PasteActionOptions) => {
     const { newParentId, pasteData, fromCategory, toCategory, method } = options
-
     const dropOperation = dropOperationBetweenCategories(fromCategory, toCategory, newParentId)
-
-    if (dropOperation === 'cancel') {
-      return
-    }
-
+    if (dropOperation === 'cancel') return
     return transferBetweenCategories(
       fromCategory,
       toCategory,

--- a/app/gui/src/dashboard/hooks/dragDelayHooks.ts
+++ b/app/gui/src/dashboard/hooks/dragDelayHooks.ts
@@ -1,6 +1,7 @@
 /** @file Hooks to trigger an action on drag delay. */
 import type { DropEnterEvent, DropOptions } from '#/components/aria'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
+import { useUnmount } from '#/hooks/unmountHooks'
 import type { DOMAttributes, DragEvent } from 'react'
 import { useRef } from 'react'
 
@@ -31,6 +32,19 @@ export function useDragDelayAction<T>(
     handle.current = null
   })
 
+  useUnmount(cancelPreviousCallback)
+
+  const onDragLeave = useEventCallback((event: DragEvent<T>) => {
+    if (
+      event.currentTarget instanceof HTMLElement &&
+      event.relatedTarget instanceof HTMLElement &&
+      event.currentTarget.contains(event.relatedTarget)
+    ) {
+      return
+    }
+    cancelPreviousCallback()
+  })
+
   return {
     onDragEnter: useEventCallback((event: DragEvent<T>) => {
       if (
@@ -45,16 +59,8 @@ export function useDragDelayAction<T>(
         callback?.(event)
       }, delayMs)
     }),
-    onDragLeave: useEventCallback((event: DragEvent<T>) => {
-      if (
-        event.currentTarget instanceof HTMLElement &&
-        event.relatedTarget instanceof HTMLElement &&
-        event.currentTarget.contains(event.relatedTarget)
-      ) {
-        return
-      }
-      cancelPreviousCallback()
-    }),
+    onDragLeave,
+    onDrop: onDragLeave,
   } as const satisfies DOMAttributes<T>
 }
 
@@ -77,6 +83,8 @@ export function useAriaDragDelayAction(
     handle.current = null
   })
 
+  useUnmount(cancelPreviousCallback)
+
   return {
     onDropEnter: useEventCallback((event) => {
       cancelPreviousCallback()
@@ -84,6 +92,7 @@ export function useAriaDragDelayAction(
         callback?.(event)
       }, delayMs)
     }),
-    onDropExit: useEventCallback(cancelPreviousCallback),
+    onDropExit: cancelPreviousCallback,
+    onDrop: cancelPreviousCallback,
   } as const satisfies Omit<DropOptions, 'getDropOperationForPoint' | 'hasDropButton' | 'ref'>
 }

--- a/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
+++ b/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
@@ -98,38 +98,29 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
 
   const onDrop = useEventCallback(async (event: aria.DropEvent) => {
     unsetModal()
-
-    if (event.dropOperation === 'cancel') {
-      return
-    }
-
-    const payloadSchema = ASSETS_DATA_TRANSFER_PAYLOAD
-
+    if (event.dropOperation === 'cancel') return
     const payloads = await Promise.all(
       event.items
         .filter((item) => item.kind === 'text')
         .map(async (item) => {
           const text = await item.getText(mimeTypes.ASSETS_MIME_TYPE)
-          const parsedPayload = payloadSchema.safeParse(JSON.parse(text))
-
+          const parsedPayload = ASSETS_DATA_TRANSFER_PAYLOAD.safeParse(JSON.parse(text))
           return parsedPayload.success ? parsedPayload.data : null
         }),
-    )
+    ).then((items) => items.filter((payload) => payload != null))
     const firstItem = payloads[0]?.items[0]
 
     const transfer = async () => {
       await Promise.all(
-        payloads
-          .filter((payload) => payload != null)
-          .map((payload) =>
-            transferBetweenCategories(
-              payload.category,
-              category,
-              payload.items,
-              null,
-              event.dropOperation,
-            ),
+        payloads.map((payload) =>
+          transferBetweenCategories(
+            payload.category,
+            category,
+            payload.items,
+            null,
+            event.dropOperation,
           ),
+        ),
       )
     }
 
@@ -142,7 +133,7 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
               getText('deleteSelectedAssetActionText', firstItem.title)
             : getText(
                 'deleteSelectedAssetsActionText',
-                payloads.flatMap((payload) => payload?.items ?? []).length,
+                payloads.flatMap(({ items }) => items).length,
               )
           }
           onConfirm={transfer}
@@ -166,8 +157,7 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
         return 'cancel'
       }}
       className="group relative flex w-full min-w-0 flex-auto items-start rounded-full drop-target-after"
-      onDrop={onDrop}
-      {...dragDelayProps}
+      {...aria.mergeProps<aria.DropZoneProps>()({ onDrop }, dragDelayProps)}
     >
       <AnimatedBackground.Item
         isSelected={isCurrent}

--- a/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
@@ -29,9 +29,7 @@ import {
 } from './Category'
 import { useCategories } from './categoriesHooks'
 
-/**
- * A transferrable asset.
- */
+/** A transferrable asset. */
 export const TRANSFERRABLE_ASSET_SCHEMA = z.object({
   // eslint-disable-next-line no-restricted-syntax
   id: z.string().transform((id) => id as AssetId),
@@ -43,22 +41,16 @@ export const TRANSFERRABLE_ASSET_SCHEMA = z.object({
   virtualParentsPath: z.string(),
 })
 
-/**
- * A data transfer payload for assets.
- */
+/** A data transfer payload for assets. */
 export const ASSETS_DATA_TRANSFER_PAYLOAD = z.object({
   category: CATEGORY_SCHEMA,
   items: z.array(TRANSFERRABLE_ASSET_SCHEMA),
 })
 
-/**
- * A data transfer payload for assets.
- */
+/** A data transfer payload for assets. */
 export type AssetsDataTransferPayload = z.infer<typeof ASSETS_DATA_TRANSFER_PAYLOAD>
 
-/**
- * A transferrable asset.
- */
+/** A transferrable asset. */
 export type TransferrableAsset = z.infer<typeof TRANSFERRABLE_ASSET_SCHEMA>
 
 /** A function to transfer a list of assets between categories. */
@@ -67,9 +59,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
   const backend = backendForType(currentCategory.backend)
 
   const { rootDirectoryId } = useUser()
-
   const { getCategoryByDirectoryId } = useCategories()
-
   const { getText } = useText()
 
   const uploadFileToCloudMutation = useUploadFileToCloudMutation()
@@ -97,15 +87,8 @@ export function useTransferBetweenCategories(currentCategory: Category) {
       method: DropOperation = 'move',
     ) => {
       const operation = dropOperationBetweenCategories(from, to, newParentId)
-
-      if (operation === 'cancel') {
-        return
-      }
-
-      if (to.type === 'recent') {
-        return
-      }
-
+      if (operation === 'cancel') return
+      if (to.type === 'recent') return
       const assetsArray = Array.from(assets)
       const keysArray = assetsArray.map((asset) => asset.id)
       const targetDirectoryId = newParentId ?? to.homeDirectoryId
@@ -217,19 +200,13 @@ export function useTransferBetweenCategories(currentCategory: Category) {
             localBackend != null,
             'The Local backend must be present to transfer assets from or to the local category.',
           )
-
           if (isCloudCategory(to)) {
             return uploadFileToCloudMutation(localBackend, {
               assets: assetsArray,
               targetDirectoryId,
             })
           }
-
-          if (to.type === 'local') {
-            return mutationByOperation[method](keysArray, targetDirectoryId)
-          }
-
-          return
+          return mutationByOperation[method](keysArray, targetDirectoryId)
         }
         case 'recent': {
           return
@@ -239,9 +216,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
   )
 }
 
-/**
- * Groups transferrable assets by category.
- */
+/** Groups transferrable assets by category. */
 function groupTransferrableAssetsByCategory(
   assets: Iterable<TransferrableAsset>,
   rootDirectoryId: DirectoryId,
@@ -267,9 +242,7 @@ function groupTransferrableAssetsByCategory(
   return groups
 }
 
-/**
- * Asks the user to copy instead of the operation.
- */
+/** Asks the user to copy instead of the operation. */
 function askToCopyInstead(getText: GetText, text: string) {
   return ask(AlertDialog, {
     title: getText('actionUnavailable'),

--- a/app/gui/src/dashboard/pages/dashboard/components/AssetRow.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/components/AssetRow.tsx
@@ -441,6 +441,7 @@ export function RealAssetRow(props: RealAssetRowProps) {
               event.stopPropagation()
 
               setIsDraggedOver(false)
+              dragDelayProps.onDrop(event)
               props.onDrop(event, item)
             }}
           >

--- a/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
@@ -382,14 +382,7 @@ export class ProjectManager {
 
   /** Move a file or directory. */
   async moveFile(from: Path, to: Path) {
-    await this.runStandaloneCommand(
-      null,
-      'filesystem-move-from',
-      'json',
-      from,
-      '--filesystem-move-to',
-      to,
-    )
+    await this.runStandaloneCommand(null, 'filesystem-move-from', from, '--filesystem-move-to', to)
   }
 
   /** Delete a file or directory. */


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/2090
  - Avoid changing directory when dragging into a folder, breadcrumb, or sidebar category

### Important Notes
None

### Testing Instructions
- Test dragging onto a folder in the current directory list
- Test dragging onto a breadcrumb above the directory list
- Test dragging onto sidebar category
- All of the above, but after hovering over a folder(/breadcrumb/category) to navigate somewhere else

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
