### PR TITLE
Sort out vizzes in Enso

### DIFF
--- a/app/gui/integration-test/project-view/table-vis-json/singleColumnDates.json
+++ b/app/gui/integration-test/project-view/table-vis-json/singleColumnDates.json
@@ -2,7 +2,6 @@
   "header": ["Value"],
   "value_type": [
     {
-      "type": "Value_Type",
       "constructor": "Date",
       "display_text": "Date"
     }

--- a/app/gui/integration-test/project-view/table-vis-json/singleColumnDatetimes.json
+++ b/app/gui/integration-test/project-view/table-vis-json/singleColumnDatetimes.json
@@ -2,7 +2,6 @@
   "header": ["Value"],
   "value_type": [
     {
-      "type": "Value_Type",
       "constructor": "Date_Time",
       "display_text": "Date_Time (with timezone)"
     }

--- a/app/gui/integration-test/project-view/table-vis-json/singleColumnTimes.json
+++ b/app/gui/integration-test/project-view/table-vis-json/singleColumnTimes.json
@@ -2,7 +2,6 @@
   "header": ["Value"],
   "value_type": [
     {
-      "type": "Value_Type",
       "constructor": "Time",
       "display_text": "Time"
     }

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Geo_Map.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Geo_Map.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Table import Table
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
@@ -29,6 +30,7 @@ json_from_table table =
    ## Arguments
     - `value`: the value to be visualized.
 process_to_json_text : Any -> Text
-process_to_json_text value = case value of
-    _ : Table -> json_from_table value . to_text
-    _ -> value.to_json
+process_to_json_text value = time_visualization Geo_Map ("process_to_json_text: " + value.to_display_text) <|
+    case value of
+        _ : Table -> json_from_table value . to_text
+        _ -> value.to_json

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Data.Array_Proxy.Array_Proxy
 from Standard.Base.Data.Json import render
+from Standard.Base.Logging import all
 
 import Standard.Table.Row.Row
 from Standard.Table import Column, Table
@@ -235,10 +236,11 @@ Table.to_default_visualization_data self =
     max_size = 10
     row_count = ['number_of_rows', self.row_count]
     cols = self.columns.map c->
-        name = c.name
-        items = c.to_vector.take (..First max_size)
-        JS_Object.from_pairs [['name', name], ['data', items]]
+        name = c.name.to_json
+        items = c.to_json_data 0 max_size
+        '{"name":'+name+',"data":' + items + '}'
     JS_Object.from_pairs [row_count, ['columns', cols]] . to_text
+    '{"number_of_rows":' + self.row_count.to_text + ',"columns":[' + (cols.join ",") + ']}'
 
 ## ---
    private: true
@@ -343,3 +345,18 @@ Table.to_lazy_visualization_data self table_cell_position text_window_position t
 truncate : Text -> Integer -> Text -> Text
 truncate message max_length=256 suffix='...' =
     if message.length > max_length then message.take max_length-suffix.length + suffix else message
+
+## ---
+   private: true
+   ---
+   If ENSO_TIME_VIZZES is set, then log the time it took to compute the function
+private time_visualization module ~name ~action =
+    level = case Environment.get "ENSO_TIME_VIZZES" of
+        Nothing -> Nothing
+        "warning" -> ..Warning
+        "info" -> ..Info
+        _ -> ..Trace
+    if level . is_nothing then action else
+        pair = Duration.time_execution action
+        module.log_message ("Execution time for " + name + ": " + pair.first.to_text) level
+        pair.second

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Histogram.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Histogram.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Table import Column, Table
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
@@ -80,5 +81,5 @@ from_value value =
    ## Arguments
     - `value`: the value to be visualized.
 process_to_json_text : Any -> Text
-process_to_json_text value =
+process_to_json_text value = time_visualization Histogram ("process_to_json_text: " + value.to_display_text) <|
     from_value value . to_json

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Preprocessor.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Preprocessor.enso
@@ -1,12 +1,13 @@
 from Standard.Base import all
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
    ---
    Default visualization preprocessor.
-default_preprocessor x =
+default_preprocessor x = time_visualization Preprocessor ("default_preprocessor: " + x.to_display_text) <|
     result = x.to_default_visualization_data
     case result.is_error of
         True -> Helpers.truncate x.to_display_text . to_json
@@ -24,7 +25,7 @@ lazy_preprocessor x = x.to_lazy_visualization_data
    private: true
    ---
    Error visualization preprocessor.
-error_preprocessor x =
+error_preprocessor x = time_visualization Preprocessor ("error_preprocessor: " + x.to_display_text) <|
     ok = JS_Object.from_pairs [['message', '']] . to_json
     result = x.map_error err->
         message = err.to_display_text

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/SQL/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/SQL/Visualization.enso
@@ -4,6 +4,7 @@ import Standard.Database.DB_Column.DB_Column
 import Standard.Database.DB_Table.DB_Table
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
@@ -19,7 +20,7 @@ import project.Helpers
    ## Arguments
     - `table`: The database table to prepare for visualization.
 prepare_visualization : DB_Table -> Text
-prepare_visualization table =
+prepare_visualization table = time_visualization Visualization ("prepare_visualization: " + table.to_display_text) <|
     prepared = (table:DB_Table|DB_Column).to_sql.prepare
     code = prepared.first
     interpolations = prepared.second

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -4,6 +4,7 @@ import Standard.Base.Data.Vector.Builder
 from Standard.Table import Column, Table, Value_Type
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
@@ -317,7 +318,7 @@ json_from_vector vec bounds limit =
    ## Arguments
     - `value`: the value to be visualized.
 process_to_json_text : Any -> Integer | Nothing -> Integer | Nothing -> Text
-process_to_json_text value bounds=Nothing limit=Nothing =
+process_to_json_text value bounds=Nothing limit=Nothing = time_visualization Scatter_Plot ("process_to_json_text: " + value.to_display_text) <|
     json = case value of
         _ : Table  -> json_from_table  value bounds limit
         _ : Vector -> json_from_vector value bounds limit

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -11,6 +11,7 @@ import Standard.Database.DB_Column.DB_Column
 import Standard.Database.DB_Table.DB_Table
 
 import project.Helpers
+from project.Helpers import time_visualization
 
 ## ---
    private: true
@@ -23,31 +24,32 @@ import project.Helpers
     - `y`: The table to prepare for visualization.
     - `max_rows`: The maximum number of rows to display.
 prepare_visualization : Any -> Integer -> Text
-prepare_visualization y max_rows=1000 = if y.is_error then make_json_for_error y.catch else
-    x = Warning.set y []
-    case x of
-        v : Vector -> make_json_for_vector v max_rows . to_json
-        v : Array -> prepare_visualization v.to_vector max_rows
-        v : Dictionary -> make_json_for_dictionary v max_rows
-        v : JS_Object -> make_json_for_js_object v max_rows
-        v : Row -> make_json_for_row v
-        _ : In_Memory_Table ->
-            all_rows_count = x.row_count
-            make_json_for_table x max_rows all_rows_count False False
-        c : Column ->
-            case DB_Column.is_database_column c of
-                False -> make_json_for_table c.to_table max_rows c.length False True
-                True -> _make_json_for_db_table c.to_table max_rows is_column=True
-        _ : DB_Table -> _make_json_for_db_table x max_rows is_column=False
-        f : Function ->
-            pairs = [['_display_text_', '[Function '+f.to_text+']']]
-            value = JS_Object.from_pairs pairs
-            JS_Object.from_pairs [["json", value]] . to_json
-        v : Number ->
-            JS_Object.from_pairs [["json", _make_json_for_value v]] . to_json
-        v : XML_Document -> make_json_for_xml_element v.root_element max_rows "XML_Document"
-        v : XML_Element -> make_json_for_xml_element v max_rows
-        _ -> (Table_Viz_Data.from x).get_js_object.to_json
+prepare_visualization y max_rows=1000 = time_visualization Visualization ("prepare_visualization: " + y.to_display_text) <|
+    if y.is_error then make_json_for_error y.catch else
+        x = Warning.set y []
+        case x of
+            v : Vector -> make_json_for_vector v max_rows . to_json
+            v : Array -> prepare_visualization v.to_vector max_rows
+            v : Dictionary -> make_json_for_dictionary v max_rows
+            v : JS_Object -> make_json_for_js_object v max_rows
+            v : Row -> make_json_for_row v
+            _ : In_Memory_Table ->
+                all_rows_count = x.row_count
+                make_json_for_table x max_rows all_rows_count False False
+            c : Column ->
+                case DB_Column.is_database_column c of
+                    False -> make_json_for_table c.to_table max_rows c.length False True
+                    True -> _make_json_for_db_table c.to_table max_rows is_column=True
+            _ : DB_Table -> _make_json_for_db_table x max_rows is_column=False
+            f : Function ->
+                pairs = [['_display_text_', '[Function '+f.to_text+']']]
+                value = JS_Object.from_pairs pairs
+                JS_Object.from_pairs [["json", value]] . to_json
+            v : Number ->
+                JS_Object.from_pairs [["json", _make_json_for_value v]] . to_json
+            v : XML_Document -> make_json_for_xml_element v.root_element max_rows "XML_Document"
+            v : XML_Element -> make_json_for_xml_element v max_rows
+            _ -> (Table_Viz_Data.from x).get_js_object.to_json
 
 ## ---
    private: true
@@ -225,8 +227,13 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
             values = column_vis_helpers.map method
             [JS_Object.from_pairs [["name", name], ["values", values], ["type", displayType]]]
 
+    ## Only serialize what we need for the visualization.
+    make_value_type column =
+        value_type = column.value_type
+        [JS_Object.from_pairs [["constructor",  Meta.meta value_type . constructor . name], ["display_text", value_type.to_display_text]]]
+
     header                     = ["header", dataframe.column_names]
-    value_type                 = ["value_type", columns.map .value_type]
+    value_type                 = ["value_type", columns.map make_value_type]
     all_rows                   = ["all_rows_count", all_rows_count]
     has_index_col              = ["has_index_col", True]
     links                      = ["get_child_node_action", if is_column then "at" else "get_row"]
@@ -302,12 +309,13 @@ apply_filter_to_table table i filter_cols filter_conditions has_index_col =
     - `filter_condition`: list of filter conditions for the columns
 get_distinct_values_for_column : Table -> Integer -> Vector | Nothing -> Vector | Nothing -> JS_Object
 get_distinct_values_for_column table column_index filter_col=Nothing filter_condition=Nothing =
-    filtered_table = if filter_col.is_nothing then table else apply_filter_to_table table 0 filter_col filter_condition False
-    (filtered_table:Visualization_Helpers).distinct_values <|
-        column = filtered_table.at column_index
-        values = column.to_vector.distinct
-        result = JS_Object.from_pairs [["distinct_vals", values]]
-        result.to_json
+    time_visualization Visualization ("get_distinct_values_for_column: " + table.to_display_text + "[" + column_index.to_text + "]") <|
+        filtered_table = if filter_col.is_nothing then table else apply_filter_to_table table 0 filter_col filter_condition False
+        (filtered_table:Visualization_Helpers).distinct_values <|
+            column = filtered_table.at column_index
+            values = column.to_vector.distinct
+            result = JS_Object.from_pairs [["distinct_vals", values]]
+            result.to_json
 
 ## ---
    private: true
@@ -324,17 +332,18 @@ get_distinct_values_for_column table column_index filter_col=Nothing filter_cond
     - `filter_condition`: list of filter conditions for the columns
 get_rows_for_table : Any -> Integer -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> Vector | Nothing -> JS_Object
 get_rows_for_table table_or_column start_number sort_col_index_list=Nothing sort_direction_list=Nothing filter_col=Nothing filter_condition=Nothing =
-    max_rows=1000
-    table = case table_or_column of
-        c : Column -> c.to_table
-        _ -> table_or_column
-    col_name = table.make_temp_column_name
-    table_with_index = table.add_row_number col_name
-    table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns
-    filtered_table = if filter_col.is_nothing then table_with_index_ordered else apply_filter_to_table table_with_index_ordered 0 filter_col filter_condition True
-    sorted_table = if sort_col_index_list.is_nothing then filtered_table else apply_sort_to_table filtered_table sort_col_index_list sort_direction_list
-    sliced_json = sorted_table.columns.map (c-> c.to_json_data start_number max_rows fallback=(v-> _make_json_for_value v . to_json))
-    '{"rows":[' + (sliced_json.join ",") + '], "row_count":' + filtered_table.row_count.to_text + '}'
+    time_visualization Visualization ("get_rows_for_table: " + table_or_column.to_display_text + "[" + start_number.to_text + "]") <|
+        max_rows=1000
+        table = case table_or_column of
+            c : Column -> c.to_table
+            _ -> table_or_column
+        col_name = table.make_temp_column_name
+        table_with_index = table.add_row_number col_name
+        table_with_index_ordered = table_with_index.reorder_columns [col_name] ..Before_Other_Columns
+        filtered_table = if filter_col.is_nothing then table_with_index_ordered else apply_filter_to_table table_with_index_ordered 0 filter_col filter_condition True
+        sorted_table = if sort_col_index_list.is_nothing then filtered_table else apply_sort_to_table filtered_table sort_col_index_list sort_direction_list
+        sliced_json = sorted_table.columns.map (c-> c.to_json_data start_number max_rows fallback=(v-> _make_json_for_value v . to_json))
+        '{"rows":[' + (sliced_json.join ",") + '], "row_count":' + filtered_table.row_count.to_text + '}'
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -230,7 +230,7 @@ make_json_for_table dataframe max_rows all_rows_count is_db_table is_column =
     ## Only serialize what we need for the visualization.
     make_value_type column =
         value_type = column.value_type
-        [JS_Object.from_pairs [["constructor",  Meta.meta value_type . constructor . name], ["display_text", value_type.to_display_text]]]
+        JS_Object.from_pairs [["constructor",  Meta.meta value_type . constructor . name], ["display_text", value_type.to_display_text]]
 
     header                     = ["header", dataframe.column_names]
     value_type                 = ["value_type", columns.map make_value_type]

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
@@ -1,5 +1,7 @@
 from Standard.Base import all
 
+from project.Helpers import time_visualization
+
 ## ---
    private: true
    ---
@@ -9,7 +11,7 @@ from Standard.Base import all
    ## Arguments
     - `value`: the value to be visualized.
 process_to_json_text : Any -> Text
-process_to_json_text value =
+process_to_json_text value = time_visualization Warnings ("process_to_json_text: " + value.to_display_text) <|
     warnings = Warning.get_all value wrap_errors=True
     texts = warnings.map w->w.value.to_display_text
     vec = case Warning.limit_reached value of

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -6,13 +6,15 @@ from Standard.Table import all
 
 from Standard.Database import all
 
+from project.Helpers import time_visualization
+
 ## ---
    private: true
    ---
    Basic preprocessor for widgets metadata visualization.
    Returns full annotation data for all requested arguments.
 get_widget_json : Any -> Any -> Vector Text -> Text -> Text
-get_widget_json value call_name argument_names uuids="{}" =
+get_widget_json value call_name argument_names uuids="{}" = time_visualization Widgets (value.to_display_text + ":" + (call_name.to_text.replace (regex "^.*<|>$") "") + argument_names.pretty) <|
     other_args = uuids.parse_json
 
     cache (name_or_index:Text|Integer) -> Any =

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -79,15 +79,15 @@ add_specs suite_builder =
 
         group_builder.specify "should visualize database tables" <|
             vis = Visualization.prepare_visualization data.t 1
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
             json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False requires_number_format=[False, False, False] use_bottom_status_bar=False enable_create_node=True is_using_multi_filter=[True, True, True]
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["display_text", "Float (64 bits)"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
+            value_type_float = JS_Object.from_pairs [["constructor", "Float"], ["display_text", "Float (64 bits)"]]
             json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char] has_index_col=True get_child_node="at" is_ssrm=False requires_number_format=[False] use_bottom_status_bar=False enable_create_node=False is_using_multi_filter=[True]
             vis . should_equal json
 
@@ -98,13 +98,13 @@ add_specs suite_builder =
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False range=["1 - 3","4 - 6","7 - 9"] number_of_distinct=[3,3,3] number_of_nothing=[0,0,0] requires_number_format=[False, False, False] use_bottom_status_bar=True enable_create_node=True is_using_multi_filter=[True, True, True]
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int] has_index_col=True get_child_node="at" is_ssrm=False number_of_nothing=[0] range=["1 - 3"] number_of_distinct=[3] requires_number_format=[False] use_bottom_status_bar=True enable_create_node=False is_using_multi_filter=[True]
             vis . should_equal json
 
@@ -147,21 +147,21 @@ add_specs suite_builder =
 
         group_builder.specify "should indicate number of Nothing/Nulls" <|
             vis = Visualization.prepare_visualization data.t3_with_nulls 3
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A", "B", "C"] data=[[1, Nothing, 3], [4, Nothing, Nothing], [7, Nothing, Nothing]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False range=["1 - 3", "4", "7"] number_of_distinct=[2, 1, 1] number_of_nothing=[1, 2, 2] requires_number_format=[False, False, False] is_using_multi_filter=[True, True, True]
             vis . should_equal json
 
         group_builder.specify "should indicate number of leading/trailing whitespace" <|
             vis = Visualization.prepare_visualization data.t4_with_space 3
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A", "B", "C"] data=[['hello', '   leading space', 'trailing space    '], ['a', 'b', 'c'], [7, 8, 9]] all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False range=["   leading space - trailing space    ","a - c","7 - 9"] number_of_distinct=[3, 3, 3] number_of_nothing=[0, 0, 0] number_of_empty=[0, 0, Nothing] number_of_untrimmed_whitespace=[2, 0, Nothing] number_non_trivial_ws=[0, 0, Nothing] requires_number_format=[False, False, False] is_using_multi_filter=[True, True, True]
             vis . should_equal json
 
         group_builder.specify "should indicate number of non trivial whitespace" <|
             vis = Visualization.prepare_visualization data.t5_with_non_trivial_ws 3
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A", "B", "C"] data=[['hello', 'extra \r space', 'world'], ['a', 'b', 'c'], [7, 8, 9]] all_rows=3 value_type=[value_type_char, value_type_char, value_type_int] has_index_col=True get_child_node="get_row" is_ssrm=False range=['extra \r space - world',"a - c","7 - 9"] number_of_distinct=[3, 3, 3] number_of_nothing=[0, 0, 0] number_of_empty=[0, 0, Nothing] number_of_untrimmed_whitespace=[0,0,Nothing] number_non_trivial_ws=[1, 0, Nothing] requires_number_format=[False, False, False] is_using_multi_filter=[True, True, True]
             vis . should_equal json
 
@@ -175,7 +175,7 @@ add_specs suite_builder =
             ## Read the column_info as that will force materialization of the metrics
             space_table.column_info
             vis = Visualization.prepare_visualization space_table 1000
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
             json = make_json header=["A"] data=Nothing all_rows=11000 value_type=[value_type_char] has_index_col=True get_child_node="get_row" is_ssrm=True range=["   leading and trailing space     - trailing space    "] number_of_distinct=[4] number_of_nothing=[0] number_of_empty_sampled=[0] number_of_untrimmed_whitespace_sampled=[7515] number_non_trivial_ws_sampled=[0] requires_number_format=[False] table_version_hash=space_table.table_version_hash is_using_multi_filter=[True]
             vis . should_equal json
 
@@ -188,7 +188,7 @@ add_specs suite_builder =
             ## Read the column_info as that will force materialization of the metrics
             space_table.column_info
             vis = Visualization.prepare_visualization space_table 1000
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
+            value_type_char = JS_Object.from_pairs [["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"]]
             json = make_json header=["A"] data=Nothing all_rows=11000 value_type=[value_type_char] has_index_col=True get_child_node="get_row" is_ssrm=True range=['I have a \r space - hello'] number_of_distinct=[3] number_of_nothing=[0] number_of_empty_sampled=[0] number_of_untrimmed_whitespace_sampled=[3326] number_non_trivial_ws_sampled=[6714] requires_number_format=[False] table_version_hash=space_table.table_version_hash is_using_multi_filter=[True]
             vis . should_equal json
         
@@ -197,7 +197,7 @@ add_specs suite_builder =
             ## Read the column_info as that will force materialization of the metrics
             num_table.column_info
             vis = Visualization.prepare_visualization num_table 1000
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["constructor", "Integer"], ["display_text", "Integer (64 bits)"]]
             json = make_json header=["A", "B", "C"] data=[[1, 2, 3], [12345678, 5,6], [-12345678, -5,6]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True is_ssrm=False get_child_node="get_row" range=["1 - 3","5 - 12345678","-12345678 - 6"] number_of_distinct=[3,3,3] number_of_nothing=[0,0,0] requires_number_format=[False, True, True] is_using_multi_filter=[True, True, True] use_bottom_status_bar=True enable_create_node=True
             vis . should_equal json
 


### PR DESCRIPTION
### Pull Request Description

- Add timing to visualization calls. Turn on by setting ENSO_TIME_VIZZES environment flag.
- Improve Table serialisation format for Value_Type. 
- Alter the default viz data for Table to be fast.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
