### PR TITLE
First step to try and improve the async calls inside Table viz

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -17,7 +17,6 @@ import { toError } from '@/util/data/error'
 import { ProjectPath } from '@/util/projectPath'
 import type { ToValue } from '@/util/reactivity'
 import { computedAsync } from '@vueuse/core'
-import { wait } from 'lib0/promise.js'
 import {
   computed,
   onErrorCaptured,
@@ -102,7 +101,7 @@ export function useVisualizationData({
 
   const executeExpression = async (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-    timeoutMs = 5000,
+    executionTime?: number
   ) => {
     const dataSourceValue = toValue(dataSource)
     if (dataSourceValue?.type !== 'node') return
@@ -113,18 +112,14 @@ export function useVisualizationData({
     if (identifier === undefined) return
 
     const contextId =
-      dataSourceValue.nodeId &&
-      graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
+        dataSourceValue.nodeId &&
+        graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
     if (contextId === undefined) return
 
     const expression = expressionFunction(identifier)
-
-    const result = await Promise.race([
-      projectStore.executeExpression(contextId, expression.code()),
-      wait(timeoutMs).then(() => Err('Expression timeout')),
-    ])
-
-    return result
+    return executionTime
+        ? await projectStore.executeExpression(contextId, expression.code(), executionTime)
+        : await projectStore.executeExpression(contextId, expression.code())
   }
 
   const currentVisualization = computed(() => {

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -118,8 +118,8 @@ export function useVisualizationData({
 
     const expression = expressionFunction(identifier)
     return timeoutMs ?
-        await projectStore.executeExpression(contextId, expression.code(), timeoutMs)
-      : await projectStore.executeExpression(contextId, expression.code())
+        await projectStore.queuedExecuteExpression(contextId, expression.code(), timeoutMs)
+      : await projectStore.queuedExecuteExpression(contextId, expression.code())
   }
 
   const currentVisualization = computed(() => {

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -29,7 +29,7 @@ import {
 } from 'vue'
 import { isIdentifier } from 'ydoc-shared/ast'
 import type { Opt } from 'ydoc-shared/util/data/opt'
-import { Err, type Result } from 'ydoc-shared/util/data/result'
+import { type Result } from 'ydoc-shared/util/data/result'
 import type { VisualizationIdentifier } from 'ydoc-shared/yjsModel'
 
 /** Used for testing. */
@@ -101,7 +101,7 @@ export function useVisualizationData({
 
   const executeExpression = async (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-    executionTime?: number
+    timeoutMs?: number
   ) => {
     const dataSourceValue = toValue(dataSource)
     if (dataSourceValue?.type !== 'node') return
@@ -117,8 +117,8 @@ export function useVisualizationData({
     if (contextId === undefined) return
 
     const expression = expressionFunction(identifier)
-    return executionTime
-        ? await projectStore.executeExpression(contextId, expression.code(), executionTime)
+    return timeoutMs
+        ? await projectStore.executeExpression(contextId, expression.code(), timeoutMs)
         : await projectStore.executeExpression(contextId, expression.code())
   }
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/visualizationData.ts
@@ -101,7 +101,7 @@ export function useVisualizationData({
 
   const executeExpression = async (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-    timeoutMs?: number
+    timeoutMs?: number,
   ) => {
     const dataSourceValue = toValue(dataSource)
     if (dataSourceValue?.type !== 'node') return
@@ -112,14 +112,14 @@ export function useVisualizationData({
     if (identifier === undefined) return
 
     const contextId =
-        dataSourceValue.nodeId &&
-        graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
+      dataSourceValue.nodeId &&
+      graphDb.nodeIdToNode.get(dataSourceValue.nodeId as NodeId)?.outerAst.externalId
     if (contextId === undefined) return
 
     const expression = expressionFunction(identifier)
-    return timeoutMs
-        ? await projectStore.executeExpression(contextId, expression.code(), timeoutMs)
-        : await projectStore.executeExpression(contextId, expression.code())
+    return timeoutMs ?
+        await projectStore.executeExpression(contextId, expression.code(), timeoutMs)
+      : await projectStore.executeExpression(contextId, expression.code())
   }
 
   const currentVisualization = computed(() => {

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -437,8 +437,6 @@ async function getFilterValues(params: SetFilterValuesFuncParams) {
   }
 }
 
-const attepmtedCalls = ref(0)
-
 function createServer() {
   return {
     getSetFilterValues: async (
@@ -468,15 +466,24 @@ function createServer() {
         `${columnIndex}`,
         //column indexes that require a filter
         filterColumnIndexList as string[] | 'Nothing',
-        //column actions i.e Greater Than, Between...
+        //column actions i.e. Greater Than, Between...
         filterActions as string[] | 'Nothing',
         //values to filter on
         valueList as string[] | 'Nothing',
       )
-      const response = await config.executeExpression(expressionFunction)
-      return {
-        success: true,
-        data: response.value.distinct_vals,
+
+      try {
+        const response = await config.executeExpression(expressionFunction, 2000)
+        return {
+          success: true,
+          data: response.value.distinct_vals,
+        }
+      } catch (error) {
+        console.warn('Error loading filterValues for column.', error)
+        return {
+          success: false,
+          data: [],
+        }
       }
     },
     getData: async (request: IServerSideGetRowsRequest) => {
@@ -509,21 +516,16 @@ function createServer() {
         valueList as string[] | 'Nothing',
       )
 
-      const response = await config.executeExpression(expressionFunction)
-      if (response.ok) {
+      try {
+        const response = await config.executeExpression(expressionFunction)
         filteredRowCount.value = response.value.row_count
         return {
           success: true,
           data: response.value.rows,
           rowCount: response.value.row_count,
         }
-      } else {
-        if (attepmtedCalls.value < 3) {
-          grid.value?.gridApi?.refreshServerSide({ purge: true })
-          attepmtedCalls.value++
-          return
-        }
-        console.error('Error loading rows:', response.error)
+      } catch (error) {
+        console.warn('Error loading rows for table.', error)
         return {
           success: false,
           data: null,

--- a/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
+++ b/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
     toolbarOverflow?: boolean
     executeExpression: (
       expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-      timeoutMs?: number
+      timeoutMs?: number,
     ) => any
   }
 }>()
@@ -57,8 +57,10 @@ provideVisualizationConfig({
   setToolbar: (items) => emit('updateToolbar', items),
   setToolbarOverlay: (overlay) => emit('updateToolbarOverlay', overlay),
   createNodes: (...nodes) => emit('createNodes', nodes),
-  executeExpression: (expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>, timeoutMs?: number) =>
-    props.params.executeExpression(expressionFunction, timeoutMs),
+  executeExpression: (
+    expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
+    timeoutMs?: number,
+  ) => props.params.executeExpression(expressionFunction, timeoutMs),
 })
 
 initializeActions()

--- a/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
+++ b/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
     toolbarOverflow?: boolean
     executeExpression: (
       expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-      executionTime?: number
+      timeoutMs?: number
     ) => any
   }
 }>()
@@ -57,8 +57,8 @@ provideVisualizationConfig({
   setToolbar: (items) => emit('updateToolbar', items),
   setToolbarOverlay: (overlay) => emit('updateToolbarOverlay', overlay),
   createNodes: (...nodes) => emit('createNodes', nodes),
-  executeExpression: (expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>, executionTime?: number) =>
-    props.params.executeExpression(expressionFunction, executionTime),
+  executeExpression: (expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>, timeoutMs?: number) =>
+    props.params.executeExpression(expressionFunction, timeoutMs),
 })
 
 initializeActions()

--- a/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
+++ b/app/gui/src/project-view/components/visualizations/VisualizationHost.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
     toolbarOverflow?: boolean
     executeExpression: (
       expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
+      executionTime?: number
     ) => any
   }
 }>()
@@ -56,8 +57,8 @@ provideVisualizationConfig({
   setToolbar: (items) => emit('updateToolbar', items),
   setToolbarOverlay: (overlay) => emit('updateToolbarOverlay', overlay),
   createNodes: (...nodes) => emit('createNodes', nodes),
-  executeExpression: (expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>) =>
-    props.params.executeExpression(expressionFunction),
+  executeExpression: (expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>, executionTime?: number) =>
+    props.params.executeExpression(expressionFunction, executionTime),
 })
 
 initializeActions()

--- a/app/gui/src/project-view/providers/visualizationConfig.ts
+++ b/app/gui/src/project-view/providers/visualizationConfig.ts
@@ -28,6 +28,7 @@ export interface VisualizationConfig {
   setToolbarOverlay: (enableOverlay: boolean) => void
   executeExpression: (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
+    executionTime?: number,
   ) => any
 }
 

--- a/app/gui/src/project-view/providers/visualizationConfig.ts
+++ b/app/gui/src/project-view/providers/visualizationConfig.ts
@@ -28,7 +28,7 @@ export interface VisualizationConfig {
   setToolbarOverlay: (enableOverlay: boolean) => void
   executeExpression: (
     expressionFunction: (nodeIdentifier: string) => Ast.Owned<Ast.Expression>,
-    executionTime?: number,
+    timeoutMs?: number,
   ) => any
 }
 

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -300,10 +300,10 @@ export function createProjectStore(
   function executeExpression(
       expressionId: ExternalId,
       expression: string,
-      executionTime: number = 5000,
+      timeoutMs: number = 5000,
   ): Promise<Result<any> | null> {
     if (inProgress.value > MAX_IN_PROGRESS) {
-      if (executionTime < 0) {
+      if (timeoutMs < 0) {
         console.warn(`executeExpression: Execution timed out.`)
         return Promise.reject(Err(`executeExpression: Execution timed out.`))
       }
@@ -312,7 +312,7 @@ export function createProjectStore(
       const pause = queueLength.value * 250
       return new Promise((resolve) => setTimeout(resolve, pause)).then(() => {
         queueLength.value -= 1
-        return executeExpression(expressionId, expression, executionTime - pause)
+        return executeExpression(expressionId, expression, timeoutMs - pause)
       })
     }
 
@@ -351,7 +351,7 @@ export function createProjectStore(
         reject(Err(message))
       }
 
-      wait((executionTime < 1000 ? 1000 : executionTime) + 100).then(() => {
+      wait((timeoutMs < 1000 ? 1000 : timeoutMs) + 100).then(() => {
         if (state === 1) {
           inProgress.value -= 1
           state = 0 // Prevent further updates from this handler.

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -291,28 +291,64 @@ export function createProjectStore(
     module.value?.undoManager.stopCapturing()
   }
 
+  function executeExpression(
+    expressionId: ExternalId,
+    expression: string,
+  ): Promise<Result<any> | null> {
+    return new Promise((resolve) => {
+      const visualizationId = crypto.randomUUID() as Uuid
+      const dataHandler = (visData: VisualizationUpdate, uuid: Uuid | null) => {
+        if (uuid === visualizationId) {
+          dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
+          executionContext.off('visualizationEvaluationFailed', errorHandler)
+          const dataStr = Ok(visData.dataString())
+          resolve(parseVisualizationData(dataStr))
+        }
+      }
+      const errorHandler = (
+        uuid: Uuid,
+        _expressionId: ExpressionId,
+        message: string,
+        _diagnostic: Diagnostic | undefined,
+      ) => {
+        if (uuid == visualizationId) {
+          resolve(Err(message))
+          dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
+          executionContext.off('visualizationEvaluationFailed', errorHandler)
+        }
+      }
+      dataConnection.on(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
+      executionContext.on('visualizationEvaluationFailed', errorHandler)
+      return lsRpcConnection.executeExpression(
+        executionContext.id,
+        visualizationId,
+        expressionId,
+        expression,
+      )
+    })
+  }
+
   // Maximum number of in-progress expressions.
   const MAX_IN_PROGRESS = 5
 
   const inProgress = ref(0)
   const queueLength = ref(0)
 
-  function executeExpression(
+  function queuedExecuteExpression(
     expressionId: ExternalId,
     expression: string,
     timeoutMs: number = 5000,
   ): Promise<Result<any> | null> {
     if (inProgress.value > MAX_IN_PROGRESS) {
       if (timeoutMs < 0) {
-        console.warn(`executeExpression: Execution timed out.`)
-        return Promise.reject(Err(`executeExpression: Execution timed out.`))
+        return Promise.reject(Err(`queuedExecuteExpression: Execution timed out.`))
       }
 
       queueLength.value += 1
       const pause = queueLength.value * 250
       return new Promise((resolve) => setTimeout(resolve, pause)).then(() => {
         queueLength.value -= 1
-        return executeExpression(expressionId, expression, timeoutMs - pause)
+        return queuedExecuteExpression(expressionId, expression, timeoutMs - pause)
       })
     }
 
@@ -444,6 +480,7 @@ export function createProjectStore(
     recordMode,
     dataflowErrors,
     executeExpression,
+    queuedExecuteExpression,
     renameProject,
   })
 }

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -43,6 +43,7 @@ import {
   type Uuid,
 } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
+import {wait} from "lib0/promise";
 
 export interface LsUrls {
   rpcUrl: string
@@ -290,19 +291,48 @@ export function createProjectStore(
     module.value?.undoManager.stopCapturing()
   }
 
+  // Maximum number of in-progress expressions.
+  const MAX_IN_PROGRESS = 5
+
+  const inProgress = ref(0)
+  const queueLength = ref(0)
+
   function executeExpression(
-    expressionId: ExternalId,
-    expression: string,
+      expressionId: ExternalId,
+      expression: string,
+      executionTime: number = 5000,
   ): Promise<Result<any> | null> {
-    return new Promise((resolve) => {
+    if (inProgress.value > MAX_IN_PROGRESS) {
+      if (executionTime < 0) {
+        console.warn(`executeExpression: Execution timed out.`)
+        return Promise.reject(Err(`executeExpression: Execution timed out.`))
+      }
+
+      queueLength.value += 1
+      const pause = queueLength.value * 250
+      return new Promise((resolve) => setTimeout(resolve, pause)).then(() => {
+        queueLength.value -= 1
+        return executeExpression(expressionId, expression, executionTime - pause)
+      })
+    }
+
+    inProgress.value += 1
+    return new Promise<Result<any> | null>((resolve, reject) => {
       const visualizationId = crypto.randomUUID() as Uuid
+      let state = 1
+
       const dataHandler = (visData: VisualizationUpdate, uuid: Uuid | null) => {
-        if (uuid === visualizationId) {
-          dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
-          executionContext.off('visualizationEvaluationFailed', errorHandler)
-          const dataStr = Ok(visData.dataString())
-          resolve(parseVisualizationData(dataStr))
+        if (uuid !== visualizationId) {
+          return
         }
+
+        inProgress.value -= state
+        state = 0 // Prevent further updates from this handler.
+        dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
+        executionContext.off('visualizationEvaluationFailed', errorHandler)
+        const dataStr = Ok(visData.dataString())
+        const parsed = parseVisualizationData(dataStr)
+        resolve(parsed)
       }
       const errorHandler = (
         uuid: Uuid,
@@ -310,15 +340,30 @@ export function createProjectStore(
         message: string,
         _diagnostic: Diagnostic | undefined,
       ) => {
-        if (uuid == visualizationId) {
-          resolve(Err(message))
+        if (uuid !== visualizationId) {
+          return
+        }
+
+        inProgress.value -= state
+        state = 0 // Prevent further updates from this handler.
+        dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
+        executionContext.off('visualizationEvaluationFailed', errorHandler)
+        reject(Err(message))
+      }
+
+      wait((executionTime < 1000 ? 1000 : executionTime) + 100).then(() => {
+        if (state === 1) {
+          inProgress.value -= 1
+          state = 0 // Prevent further updates from this handler.
           dataConnection.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
           executionContext.off('visualizationEvaluationFailed', errorHandler)
+          reject(Err(`executeExpression: Execution timed out.`))
         }
-      }
+      })
+
       dataConnection.on(`${OutboundPayload.VISUALIZATION_UPDATE}`, dataHandler)
       executionContext.on('visualizationEvaluationFailed', errorHandler)
-      return lsRpcConnection.executeExpression(
+      lsRpcConnection.executeExpression(
         executionContext.id,
         visualizationId,
         expressionId,

--- a/app/gui/src/project-view/stores/project/index.ts
+++ b/app/gui/src/project-view/stores/project/index.ts
@@ -20,6 +20,7 @@ import { ProjectPath } from '@/util/projectPath'
 import { isIdentifier, tryQualifiedName, type QualifiedName } from '@/util/qualifiedName'
 import { proxyRefs } from '@/util/reactivity'
 import { computedAsync } from '@vueuse/core'
+import { wait } from 'lib0/promise'
 import {
   computed,
   markRaw,
@@ -43,7 +44,6 @@ import {
   type Uuid,
 } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
-import {wait} from "lib0/promise";
 
 export interface LsUrls {
   rpcUrl: string
@@ -298,9 +298,9 @@ export function createProjectStore(
   const queueLength = ref(0)
 
   function executeExpression(
-      expressionId: ExternalId,
-      expression: string,
-      timeoutMs: number = 5000,
+    expressionId: ExternalId,
+    expression: string,
+    timeoutMs: number = 5000,
   ): Promise<Result<any> | null> {
     if (inProgress.value > MAX_IN_PROGRESS) {
       if (timeoutMs < 0) {


### PR DESCRIPTION
### Pull Request Description

- Limit the number of simultaneous `executeExpressions` from Table viz - added a `queuedExecuteExpression`.
- Move the timeout logic into the store.
- Handle rejected in Table viz a bit better.

Improves stability of real user workflows. Will need to add ability to retry in the UI, but will do in a separate PR.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
