### PR TITLE
Close project shortcut & fixing application menu on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - [Graph is not moved when showing/resizing side panels.][13557]
 - [Add "Invite" button to the top bar when using a team or higher plan][13522]
 - ["Welcome Project" is automatically opened for new users][13479]
-- [Project and Setting tab may be now closed with shortcut][13498]. On
+- [Project and Setting tab may be now closed with shortcut][13498][13604]. On
   Windows/Linux <kbd>Ctrl</kbd>+<kbd>W</kbd> or <kbd>Ctrl</kbd> + <kbd>F4</kbd>;
   on macOS: <kbd>⌘</kbd> + <kbd>W</kbd>.
 
@@ -62,6 +62,7 @@
 [13522]: https://github.com/enso-org/enso/pull/13522
 [13479]: https://github.com/enso-org/enso/pull/13479
 [13498]: https://github.com/enso-org/enso/pull/13498
+[13604]: https://github.com/enso-org/enso/pull/13604
 
 #### Enso Standard Library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - [Graph is not moved when showing/resizing side panels.][13557]
 - [Add "Invite" button to the top bar when using a team or higher plan][13522]
 - ["Welcome Project" is automatically opened for new users][13479]
+- [Project and Setting tab may be now closed with shortcut][13498]. On
+  Windows/Linux <kbd>Ctrl</kbd>+<kbd>W</kbd> or <kbd>Ctrl</kbd> + <kbd>F4</kbd>;
+  on macOS: <kbd>⌘</kbd> + <kbd>W</kbd>.
 
 [12774]: https://github.com/enso-org/enso/pull/12774
 [12778]: https://github.com/enso-org/enso/pull/12778
@@ -58,6 +61,7 @@
 [13557]: https://github.com/enso-org/enso/pull/13557
 [13522]: https://github.com/enso-org/enso/pull/13522
 [13479]: https://github.com/enso-org/enso/pull/13479
+[13498]: https://github.com/enso-org/enso/pull/13498
 
 #### Enso Standard Library
 

--- a/app/gui/env.d.ts
+++ b/app/gui/env.d.ts
@@ -8,6 +8,7 @@ import type { FeatureFlags } from '$/providers/featureFlags'
 import type * as saveAccessToken from 'enso-common/src/accessToken'
 import type { $Config } from './src/config'
 import type { FileFilter } from './src/project-view/util/fileFilter'
+import type { MenuItem, MenuItemHandler } from './src/project-view/util/menuItems'
 
 /** Nested configuration options with `string` values. */
 interface StringConfig {
@@ -69,7 +70,7 @@ interface NavigationApi {
 /** `window.menuApi` exposes functionality related to the system menu. */
 interface MenuApi {
   /** Set the callback to be called when the "about" entry is clicked in the "help" menu. */
-  readonly setShowAboutModalHandler: (callback: () => void) => void
+  readonly setMenuItemHandler: (name: MenuItem, callback: MenuItemHandler) => void
 }
 
 /** Options for downloading a URL. */

--- a/app/gui/src/App.vue
+++ b/app/gui/src/App.vue
@@ -12,7 +12,7 @@ import { useText } from '$/providers/text'
 import ReactRoot from '$/ReactRoot'
 import { appOpenCloseCallback } from '$/utils/analytics'
 import '@/assets/base.css'
-import { interactionBindings } from '@/bindings'
+import { appBindings } from '@/bindings'
 import TooltipDisplayer from '@/components/TooltipDisplayer.vue'
 import { useEvent, useMounted } from '@/composables/events'
 import ProjectView from '@/ProjectView.vue'
@@ -61,21 +61,19 @@ registerGlobalBlurHandler()
 
 const actionHandlers = registerHandlers(
   {
-    'interaction.cancel': { action: () => interaction.cancelAll() },
+    'app.cancel': { action: () => interaction.cancelAll() },
+    'app.close': { action: () => window.close() },
   },
   actions,
 )
 
-const interactionBindingsHandler = interactionBindings.handler(
-  objects.mapEntries(
-    interactionBindings.bindings,
-    (actionName) => actionHandlers[actionName].action,
-  ),
+const bindingsHandlers = appBindings.handler(
+  objects.mapEntries(appBindings.bindings, (actionName) => actionHandlers[actionName].action),
 )
 
 const { globalEventRegistry } = provideGlobalEventRegistry()
 
-useEvent(window, 'keydown', interactionBindingsHandler)
+useEvent(window, 'keydown', bindingsHandlers)
 useEvent(globalEventRegistry, 'pointerdown', (e) => interaction.handlePointerDown(e))
 
 const platformClass = (() => {

--- a/app/gui/src/components/AppContainer/AppContainerInner.vue
+++ b/app/gui/src/components/AppContainer/AppContainerInner.vue
@@ -5,8 +5,12 @@ import { BackendType, EnsoPath, type ProjectId } from '#/services/Backend'
 import { useContainerData, type LaunchedProject, type TabId } from '$/providers/container'
 import { RightPanelDataProviderForReact } from '$/providers/react/container'
 import { provideRightPanelData } from '$/providers/rightPanel'
+import { appContainerBindings } from '@/bindings'
 import GrowingSpinner from '@/components/shared/GrowingSpinner.vue'
+import { useEvent } from '@/composables/events'
+import { registerHandlers } from '@/providers/action'
 import { provideFullscreenRoot } from '@/providers/fullscreenRoot'
+import * as objects from 'enso-common/src/utilities/data/object'
 import { applyPureReactInVue } from 'veaury'
 import { reactive, shallowRef, toRefs, watch } from 'vue'
 import { Drive, Editor, Settings } from './reactTabs'
@@ -73,6 +77,42 @@ watch(openedProjects, (openedProjectsList) => {
   }
 })
 
+function closeSettingsTab() {
+  // The settings tab autohide when not selected.
+  tab.value = 'drive'
+}
+
+const actionHandlers = registerHandlers({
+  'app.closeTab': {
+    action: () => {
+      switch (tab.value) {
+        case 'settings':
+          closeSettingsTab()
+          break
+        case 'drive':
+          break
+        default: {
+          // project id
+          const project = openedProjects.value.find((proj) => proj.ensoPath === tab.value)
+          if (project) emit('closeProject', project)
+          break
+        }
+      }
+    },
+  },
+})
+
+useEvent(
+  window,
+  'keydown',
+  appContainerBindings.handler(
+    objects.mapEntries(
+      appContainerBindings.bindings,
+      (actionName) => actionHandlers[actionName].action,
+    ),
+  ),
+)
+
 const onSignOut = () => {
   emit('closeAllProjects')
 }
@@ -112,7 +152,7 @@ const onSignOut = () => {
           :selected="true"
           icon="settings"
           label="Settings"
-          @close="tab = 'drive'"
+          @close="closeSettingsTab"
         />
       </div>
       <div class="filler" />

--- a/app/gui/src/components/AppContainer/AppContainerInner.vue
+++ b/app/gui/src/components/AppContainer/AppContainerInner.vue
@@ -12,7 +12,7 @@ import { registerHandlers } from '@/providers/action'
 import { provideFullscreenRoot } from '@/providers/fullscreenRoot'
 import * as objects from 'enso-common/src/utilities/data/object'
 import { applyPureReactInVue } from 'veaury'
-import { reactive, shallowRef, toRefs, watch } from 'vue'
+import { onMounted, reactive, shallowRef, toRefs, watch } from 'vue'
 import { Drive, Editor, Settings } from './reactTabs'
 import RightPanel from './RightPanel.vue'
 import SelectableTab from './SelectableTab.vue'
@@ -82,23 +82,29 @@ function closeSettingsTab() {
   tab.value = 'drive'
 }
 
+function closeTab() {
+  switch (tab.value) {
+    case 'settings':
+      closeSettingsTab()
+      break
+    case 'drive':
+      break
+    default: {
+      // project id
+      const project = openedProjects.value.find((proj) => proj.ensoPath === tab.value)
+      if (project) emit('closeProject', project)
+      break
+    }
+  }
+}
+
+onMounted(() => {
+  window.menuApi?.setMenuItemHandler('closeTab', closeTab)
+})
+
 const actionHandlers = registerHandlers({
   'app.closeTab': {
-    action: () => {
-      switch (tab.value) {
-        case 'settings':
-          closeSettingsTab()
-          break
-        case 'drive':
-          break
-        default: {
-          // project id
-          const project = openedProjects.value.find((proj) => proj.ensoPath === tab.value)
-          if (project) emit('closeProject', project)
-          break
-        }
-      }
-    },
+    action: closeTab,
   },
 })
 

--- a/app/gui/src/dashboard/App.tsx
+++ b/app/gui/src/dashboard/App.tsx
@@ -124,7 +124,7 @@ function AppRouter(props: React.PropsWithChildren) {
   const aboutModalRef = React.useRef<ModalApi>(null)
 
   React.useEffect(() => {
-    window.menuApi?.setShowAboutModalHandler(() => {
+    window.menuApi?.setMenuItemHandler('about', () => {
       aboutModalRef.current?.open()
     })
 

--- a/app/gui/src/dashboard/components/MenuEntry.tsx
+++ b/app/gui/src/dashboard/components/MenuEntry.tsx
@@ -39,7 +39,6 @@ export const ACTION_TO_TEXT_ID: Readonly<
   >
 > = {
   settings: 'settingsShortcut',
-  closeTab: 'closeTabShortcut',
   open: 'openShortcut',
   run: 'runShortcut',
   close: 'closeShortcut',

--- a/app/gui/src/dashboard/configurations/inputBindings.ts
+++ b/app/gui/src/dashboard/configurations/inputBindings.ts
@@ -15,8 +15,6 @@ export function createBindings() {
 
 export const BINDINGS = inputBindings.defineBindings({
   settings: { bindings: ['Mod+,'], icon: 'settings' },
-  // An alternative shortcut is required because Mod+W cannot be overridden in browsers.
-  closeTab: { bindings: ['Mod+W', 'Mod+Alt+W'], icon: 'close' },
   open: { bindings: ['Enter'], icon: 'open' },
   run: { bindings: ['Shift+Enter'], icon: 'workflow_play' },
   close: { bindings: [], icon: 'close' },

--- a/app/gui/src/project-view/bindings.ts
+++ b/app/gui/src/project-view/bindings.ts
@@ -1,6 +1,20 @@
 import { isMacLike } from '@/composables/events'
 import { defineKeybinds } from '@/util/shortcuts'
 
+// Some debug shortcuts are also defined in electron
+// (Look for `registerShortcuts` method).
+
+export const appBindings = defineKeybinds('app', {
+  'app.cancel': ['Escape'],
+  'app.close': ['Mod+Q'],
+})
+
+export const appContainerBindings = defineKeybinds('app-container', {
+  'app.closeTab':
+    // An alternative shortcut is required because Mod+W cannot be overridden in browsers.
+    ['Mod+W', 'Mod+Alt+W', ...(!isMacLike ? ['Mod+F4' as const] : [])],
+})
+
 export const documentationEditorFormatBindings = defineKeybinds('documentation-editor-formatting', {
   'documentationEditor.italic': ['Mod+I'],
   'documentationEditor.bold': ['Mod+B'],
@@ -30,10 +44,6 @@ export const listBindings = defineKeybinds('list', {
   'list.moveUp': [{ key: 'ArrowUp', allowRepeat: true }],
   'list.moveDown': [{ key: 'ArrowDown', allowRepeat: true }],
   'list.accept': ['Enter'],
-})
-
-export const interactionBindings = defineKeybinds('current-interaction', {
-  'interaction.cancel': ['Escape'],
 })
 
 export const componentBrowserBindings = defineKeybinds('component-browser', {

--- a/app/gui/src/project-view/providers/action.ts
+++ b/app/gui/src/project-view/providers/action.ts
@@ -1,4 +1,6 @@
 import {
+  appBindings,
+  appContainerBindings,
   componentBrowserBindings,
   documentationEditorFormatBindings,
   graphBindings,
@@ -272,6 +274,16 @@ const displayableActions = {
 } satisfies Record<string, DisplayableAction>
 export type DisplayableActionName = keyof typeof displayableActions
 const undisplayableActions = {
+  // === App ===
+
+  'app.cancel': {},
+  'app.close': {
+    shortcut: appBindings.bindings['app.close'],
+  },
+  'app.closeTab': {
+    shortcut: appContainerBindings.bindings['app.closeTab'],
+  },
+
   // === Component Browser ===
 
   'componentBrowser.acceptInput': {
@@ -339,10 +351,6 @@ const undisplayableActions = {
   'textEditor.deleteBack': {},
   'textEditor.deleteForward': {},
   'textEditor.newline': {},
-
-  // === Interactions ===
-
-  'interaction.cancel': {},
 }
 export type UndisplayableActionName = keyof typeof undisplayableActions
 

--- a/app/gui/src/project-view/util/menuItems.ts
+++ b/app/gui/src/project-view/util/menuItems.ts
@@ -1,0 +1,4 @@
+/** @file API for custom menu items in the Electron application. */
+
+export type MenuItem = 'about' | 'closeTab'
+export type MenuItemHandler = () => void

--- a/app/ide-desktop/client/src/globals.d.ts
+++ b/app/ide-desktop/client/src/globals.d.ts
@@ -4,6 +4,7 @@
  * monkeypatching on `window` and generated code.
  */
 
+import type { MenuItem, MenuItemHandler } from 'enso-gui/src/project-view/util/menuItems'
 import type { FileFilter } from './fileBrowser'
 
 // =============
@@ -86,7 +87,7 @@ interface NavigationApi {
 /** `window.menuApi` exposes functionality related to the system menu. */
 interface MenuApi {
   /** Set the callback to be called when the "about" entry is clicked in the "help" menu. */
-  readonly setShowAboutModalHandler: (callback: () => void) => void
+  readonly setMenuItemHandler: (name: MenuItem, callback: MenuItemHandler) => void
 }
 
 // ==================

--- a/app/ide-desktop/client/src/index.ts
+++ b/app/ide-desktop/client/src/index.ts
@@ -419,33 +419,23 @@ class App {
           : {}),
         }
         const window = new electron.BrowserWindow(windowPreferences)
+
+        const menu = electron.Menu.buildFromTemplate([
+          {
+            label: common.PRODUCT_NAME,
+            role: 'windowMenu',
+            submenu: electron.Menu.buildFromTemplate([
+              {
+                label: `About ${common.PRODUCT_NAME}`,
+                click: () => {
+                  window.webContents.send(ipc.Channel.showAboutModal)
+                },
+              },
+            ]),
+          },
+        ])
+        electron.Menu.setApplicationMenu(menu)
         window.setMenuBarVisibility(false)
-        const oldMenu = electron.Menu.getApplicationMenu()
-        if (oldMenu != null) {
-          const items = oldMenu.items.map((item) => {
-            if (item.role !== 'help') {
-              return item
-            } else {
-              // `click` is a property that is intentionally removed from this
-              // destructured object, in order to satisfy TypeScript.
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              const { click, ...passthrough } = item
-              return new electron.MenuItem({
-                ...passthrough,
-                submenu: electron.Menu.buildFromTemplate([
-                  new electron.MenuItem({
-                    label: `About ${common.PRODUCT_NAME}`,
-                    click: () => {
-                      window.webContents.send(ipc.Channel.showAboutModal)
-                    },
-                  }),
-                ]),
-              })
-            }
-          })
-          const newMenu = electron.Menu.buildFromTemplate(items)
-          electron.Menu.setApplicationMenu(newMenu)
-        }
 
         if (this.args.groups.debug.options.devTools.value) {
           window.webContents.openDevTools()
@@ -697,7 +687,6 @@ class App {
     }
   }
 
-  /** Register keyboard shortcuts. */
   registerShortcuts() {
     electron.app.on('web-contents-created', (_webContentsCreatedEvent, webContents) => {
       webContents.on('before-input-event', (_beforeInputEvent, input) => {
@@ -711,18 +700,6 @@ class App {
             if (control && alt && shift && !meta && code === 'KeyR') {
               focusedWindow.reload()
             }
-          }
-
-          const cmdQ = meta && !control && !alt && !shift && code === 'KeyQ'
-          const ctrlQ = !meta && control && !alt && !shift && code === 'KeyQ'
-          const altF4 = !meta && !control && alt && !shift && code === 'F4'
-          const ctrlW = !meta && control && !alt && !shift && code === 'KeyW'
-          const quitOnMac = process.platform === 'darwin' && (cmdQ || altF4)
-          const quitOnWin = process.platform === 'win32' && (altF4 || ctrlW)
-          const quitOnLinux = process.platform === 'linux' && (altF4 || ctrlQ || ctrlW)
-          const quit = quitOnMac || quitOnWin || quitOnLinux
-          if (quit) {
-            electron.app.quit()
           }
         }
       })

--- a/app/ide-desktop/client/src/index.ts
+++ b/app/ide-desktop/client/src/index.ts
@@ -41,6 +41,7 @@ import { FileFilter, toElectronFileFilter } from './fileBrowser'
 
 import * as download from 'electron-dl'
 import type { DownloadUrlOptions } from './globals'
+import { filterByRole, inheritMenuItem, makeMenuItem, replaceMenuItems } from './menuItems'
 const logger = contentConfig.logger
 
 /** Convert path to proper `file://` URL. */
@@ -420,21 +421,35 @@ class App {
         }
         const window = new electron.BrowserWindow(windowPreferences)
 
-        const menu = electron.Menu.buildFromTemplate([
-          {
-            label: common.PRODUCT_NAME,
-            role: 'windowMenu',
-            submenu: electron.Menu.buildFromTemplate([
-              {
-                label: `About ${common.PRODUCT_NAME}`,
-                click: () => {
-                  window.webContents.send(ipc.Channel.showAboutModal)
-                },
-              },
-            ]),
-          },
-        ])
-        electron.Menu.setApplicationMenu(menu)
+        const oldMenu = electron.Menu.getApplicationMenu()
+        if (oldMenu != null) {
+          const newMenu = replaceMenuItems(oldMenu.items, [
+            {
+              filter: [filterByRole('help')],
+              replacement: (item) =>
+                inheritMenuItem(item, undefined, [
+                  makeMenuItem(window, `About ${common.PRODUCT_NAME}`, 'about'),
+                ]),
+            },
+            {
+              filter: [filterByRole('fileMenu'), filterByRole('close')],
+              replacement: () => makeMenuItem(window, 'Close Tab', 'closeTab', 'CmdOrCtrl+W'),
+            },
+            {
+              filter: [filterByRole('appMenu'), filterByRole('about')],
+              replacement: () => undefined,
+            },
+            {
+              filter: [filterByRole('appMenu'), filterByRole('hide')],
+              replacement: (item) => inheritMenuItem(item, `Hide ${common.PRODUCT_NAME}`),
+            },
+            {
+              filter: [filterByRole('appMenu'), filterByRole('quit')],
+              replacement: (item) => inheritMenuItem(item, `Quit ${common.PRODUCT_NAME}`),
+            },
+          ])
+          electron.Menu.setApplicationMenu(newMenu)
+        }
         window.setMenuBarVisibility(false)
 
         if (this.args.groups.debug.options.devTools.value) {

--- a/app/ide-desktop/client/src/ipc.ts
+++ b/app/ide-desktop/client/src/ipc.ts
@@ -33,5 +33,5 @@ export enum Channel {
   showItemInFolder = 'show-item-in-folder',
   /** Download a file using its URL. */
   downloadURL = 'download-url',
-  showAboutModal = 'show-about-modal',
+  handleMenuItem = 'handle-menu-item',
 }

--- a/app/ide-desktop/client/src/menuItems.ts
+++ b/app/ide-desktop/client/src/menuItems.ts
@@ -1,0 +1,90 @@
+/** @file Utilities for setting up menu items on Mac OS. */
+
+import * as electron from 'electron'
+import type { MenuItem } from 'enso-gui/src/project-view/util/menuItems'
+import * as ipc from './ipc'
+
+/** Make new menu item from scratch, with the given label, action, and accelerator (shortcut). */
+export function makeMenuItem(
+  window: electron.BrowserWindow,
+  label: string,
+  action: MenuItem,
+  accelerator?: string,
+) {
+  return new electron.MenuItem({
+    label,
+    click: () => window.webContents.send(ipc.Channel.handleMenuItem, action),
+    ...(accelerator != null ? { accelerator } : {}),
+  })
+}
+
+/** Make new menu item by inheriting properties from the given item. */
+export function inheritMenuItem(
+  item: electron.MenuItem,
+  newLabel?: string,
+  newSubmenu?: electron.MenuItem[],
+) {
+  // `click` is a property that is intentionally removed from this
+  // destructured object, in order to satisfy TypeScript.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { click, ...passthrough } = item
+  return new electron.MenuItem({
+    ...passthrough,
+    ...(newLabel != null ? { label: newLabel } : {}),
+    ...(newSubmenu != null ? { submenu: electron.Menu.buildFromTemplate(newSubmenu) } : {}),
+  })
+}
+
+/** A predicate for choosing menu items. */
+export type MenuItemFilter = (item: electron.MenuItem) => boolean
+
+/** Create a filter that matches menu items with the given role. */
+export function filterByRole(role: string): MenuItemFilter {
+  // Comparing roles case-insensitively as a workaround for
+  // https://github.com/electron/electron/issues/46128.
+  return (item) => item.role != null && item.role.toLowerCase() === role.toLowerCase()
+}
+
+/** A replacement configuration for a menu item. Can be used to update, replace, or remove menu items with arbitrary nesting. */
+export type MenuItemReplacement = {
+  filter: MenuItemFilter[]
+  replacement: (original: electron.MenuItem) => electron.MenuItem | undefined
+}
+
+/** Replace menu items with the given replacements, recursively descending into submenus. */
+export function replaceMenuItems(
+  items: electron.MenuItem[],
+  replacements: MenuItemReplacement[],
+  path: electron.MenuItem[] = [],
+): electron.Menu {
+  const newMenu = electron.Menu.buildFromTemplate(
+    items.flatMap((item) => {
+      const currentPath = [...path, item]
+      const replacement = replacements.find(({ filter }) => {
+        for (let i = 0; i < filter.length; i++) {
+          const pathSegment = currentPath[i]
+          if (pathSegment == null || !filter[i]?.(pathSegment)) return false
+        }
+        return true
+      })
+      if (replacement != null) {
+        const newItem = replacement.replacement(item)
+        return newItem != null ? [newItem] : []
+      } else {
+        const submenu = item.submenu
+        if (submenu != null) {
+          const newItems = replaceMenuItems(submenu.items, replacements, currentPath)
+          return [
+            {
+              ...item,
+              submenu: newItems,
+            },
+          ]
+        } else {
+          return [item]
+        }
+      }
+    }),
+  )
+  return newMenu
+}

--- a/app/ide-desktop/client/src/preload.ts
+++ b/app/ide-desktop/client/src/preload.ts
@@ -10,6 +10,7 @@ import type * as accessToken from 'enso-common/src/accessToken'
 import * as debug from '@/debug'
 import * as ipc from '@/ipc'
 import type * as projectManagement from '@/projectManagement'
+import { MenuItem, MenuItemHandler } from 'enso-gui/src/project-view/util/menuItems'
 import { FileFilter } from './fileBrowser'
 
 // Even though this is already built as an mjs module, we are "faking" cjs format on preload script
@@ -180,15 +181,18 @@ exposeInMainWorld(PROJECT_MANAGEMENT_API_KEY, {
 // === Menu API ===
 // ================
 
-let showAboutModalHandler: (() => void) | null = null
+const menuApiHandlers: Record<MenuItem, MenuItemHandler | undefined> = {
+  about: undefined,
+  closeTab: undefined,
+}
 
-electron.ipcRenderer.on(ipc.Channel.showAboutModal, () => {
-  showAboutModalHandler?.()
+electron.ipcRenderer.on(ipc.Channel.handleMenuItem, (_event, name: MenuItem) => {
+  menuApiHandlers[name]?.()
 })
 
 exposeInMainWorld(MENU_API_KEY, {
-  setShowAboutModalHandler: (callback: () => void) => {
-    showAboutModalHandler = callback
+  setMenuItemHandler: (name: MenuItem, handler: MenuItemHandler) => {
+    menuApiHandlers[name] = handler
   },
 })
 


### PR DESCRIPTION
### Pull Request Description

Closes #13571

- This is a re-implementation of https://github.com/enso-org/enso/pull/13498 after fixing the bug with non-working system-wide shortcuts (like ⌘+C and ⌘+V)
- New API for controlling the application menu in Electron
- New API for menu item handlers
- Some minor adjustments to the menu:
  - Removed “About” item from app menu (last screenshot)
  - Fixed capitalization of “Enso” in “Quit” and “Hide” items (last screenshot)
  - “File → Close Window” item replaced with “File → Close Tab”, which is more accurate, and its behavior also matches the behavior of the shortcut now.

Now the menus look like this:
<img width="399" height="90" alt="Screenshot 2025-07-23 at 11 01 25 PM" src="https://github.com/user-attachments/assets/8d0d6e38-d967-46b1-a69d-bc1cdc213751" />
<img width="391" height="287" alt="Screenshot 2025-07-23 at 11 01 21 PM" src="https://github.com/user-attachments/assets/f6d5e523-09bd-4dbe-bb77-f7198c995bbc" />
<img width="258" height="221" alt="Screenshot 2025-07-23 at 11 01 17 PM" src="https://github.com/user-attachments/assets/a140e37a-0d3c-45bc-9a5e-98183acdcfb0" />
<img width="292" height="397" alt="Screenshot 2025-07-23 at 11 01 13 PM" src="https://github.com/user-attachments/assets/3d83480c-bbb1-481e-9748-f1d3cae4a7bb" />
<img width="171" height="76" alt="Screenshot 2025-07-23 at 11 01 08 PM" src="https://github.com/user-attachments/assets/5716eb97-8e12-4ac9-9b2f-fe4143a0807e" />
<img width="192" height="177" alt="Screenshot 2025-07-23 at 11 01 02 PM" src="https://github.com/user-attachments/assets/49ae20d1-ff6a-4e8e-9aab-78d43fc8f2f8" />


### Important Notes

I didn’t check it on other platforms, but I assume we don’t have the application menu there.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
