### PR TITLE
Remove cache invalidation for visualizations

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -44,7 +44,7 @@ logging-service {
     org.enso.languageserver.protocol.json.JsonConnectionController = debug
     org.enso.jsonrpc.JsonRpcServer = debug
     org.enso.languageserver.runtime.RuntimeConnector = debug
-    org.enso.interpreter.runtime.HostClassLoader = error
+    org.enso.interpreter.epb.HostClassLoader = error
     java.lang.ProcessBuilder = warn
     Standard.Base.Logging.Progress = error
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -5,11 +5,7 @@ import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Name
 import org.enso.compiler.core.ir.module.scope.{definition, Definition}
-import org.enso.compiler.refactoring.IRUtils
-import org.enso.compiler.pass.analyse.{
-  CachePreferenceAnalysis,
-  DataflowAnalysis
-}
+import org.enso.compiler.pass.analyse.CachePreferenceAnalysis
 import org.enso.interpreter.instrument.execution.{Executable, RuntimeContext}
 import org.enso.interpreter.instrument.job.UpsertVisualizationJob.{
   EvaluationFailed,
@@ -226,20 +222,6 @@ class UpsertVisualizationJob(
 object UpsertVisualizationJob {
   private lazy val logger =
     LoggerFactory.getLogger(classOf[UpsertVisualizationJob])
-
-  /** Invalidate caches for a particular expression id. */
-  sealed private case class InvalidateCaches(
-    expressionId: Api.ExpressionId
-  )(implicit ctx: RuntimeContext)
-      extends Runnable {
-
-    override def run(): Unit = {
-      ctx.locking.withWriteCompilationLock(
-        classOf[UpsertVisualizationJob],
-        () => invalidateCaches(expressionId)
-      )
-    }
-  }
 
   /** The number of times to retry the expression evaluation. */
   private val MaxEvaluationRetryCount: Int = 5
@@ -591,7 +573,7 @@ object UpsertVisualizationJob {
     * @param ctx the runtime context
     * @return the re-evaluated visualization
     */
-  def updateAttachedVisualization(
+  private def updateAttachedVisualization(
     visualizationId: Api.VisualizationId,
     expressionId: Api.ExpressionId,
     module: Module,
@@ -613,7 +595,6 @@ object UpsertVisualizationJob {
         arguments
       )
     setCacheWeights(visualization)
-    ctx.state.executionHooks.add(InvalidateCaches(expressionId))
     ctx.contextManager.upsertVisualization(
       visualizationConfig.executionContextId,
       visualization
@@ -664,44 +645,6 @@ object UpsertVisualizationJob {
     }
   }
 
-  /** Update the caches. */
-  private def invalidateCaches(
-    expressionId: Api.ExpressionId
-  )(implicit ctx: RuntimeContext): Unit = {
-    val stacks = ctx.contextManager.getAllContexts.values
-    /* The invalidation of the first cached dependent node is required for
-     * attaching the visualizations to sub-expressions. Consider the example
-     * ```
-     * op = target.foo arg
-     * ```
-     * The result of expression `target.foo arg` is cached. If you attach the
-     * visualization to say `target`, the sub-expression `target` won't be
-     * executed because the whole expression is cached. And the visualization
-     * won't be computed.
-     * To workaround this issue, the logic below tries to identify if the
-     * visualized expression is a sub-expression and invalidate the first parent
-     * expression accordingly.
-     */
-    if (!stacks.exists(isExpressionCached(expressionId, _))) {
-      invalidateFirstDependent(expressionId)
-    }
-  }
-
-  /** Check if the expression is cached in the execution stack.
-    *
-    * @param expressionId the expression id to check
-    * @param stack the execution stack
-    * @return `true` if the expression exists in the frame cache
-    */
-  private def isExpressionCached(
-    expressionId: Api.ExpressionId,
-    stack: Iterable[InstrumentFrame]
-  ): Boolean = {
-    stack.headOption.exists { frame =>
-      frame.cache.get(expressionId) ne null
-    }
-  }
-
   /** Set the cache weights for the provided visualization.
     *
     * @param visualization the visualization to update
@@ -714,52 +657,6 @@ object UpsertVisualizationJob {
           Seq(visualization),
           CacheInvalidation.Command.SetMetadata(metadata)
         )
-      }
-  }
-
-  /** Invalidate the first cached dependent node of the provided expression.
-    *
-    * @param expressionId the expression id
-    */
-  private def invalidateFirstDependent(
-    expressionId: Api.ExpressionId
-  )(implicit ctx: RuntimeContext): Unit = {
-    ctx.executionService.getContext
-      .findModuleByExpressionId(expressionId)
-      .ifPresent { module =>
-        module.getIr
-          .getMetadata(DataflowAnalysis)
-          .foreach { metadata =>
-            val externalId = expressionId
-            IRUtils
-              .findByExternalId(module.getIr, externalId)
-              .map { ir =>
-                DataflowAnalysis.DependencyInfo.Type
-                  .Static(ir.getId, ir.getExternalId)
-              }
-              .flatMap { expressionKey =>
-                metadata.dependents.getExternal(expressionKey)
-              }
-              .foreach { dependents =>
-                val stacks = ctx.contextManager.getAllContexts.values
-                stacks.foreach { stack =>
-                  stack.headOption.foreach { frame =>
-                    dependents
-                      .find { id => frame.cache.get(id) ne null }
-                      .foreach { firstDependent =>
-                        CacheInvalidation.run(
-                          stack,
-                          CacheInvalidation(
-                            CacheInvalidation.StackSelector.Top,
-                            CacheInvalidation.Command
-                              .InvalidateKeys(Seq(firstDependent))
-                          )
-                        )
-                      }
-                  }
-                }
-              }
-          }
       }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -3,7 +3,7 @@ package org.enso.interpreter.test.instrument
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
 
-//import org.enso.pkg.QualifiedName
+import org.enso.pkg.QualifiedName
 import org.enso.common.RuntimeOptions
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -3,7 +3,7 @@ package org.enso.interpreter.test.instrument
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
 
-import org.enso.pkg.QualifiedName
+//import org.enso.pkg.QualifiedName
 import org.enso.common.RuntimeOptions
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
@@ -4487,19 +4487,15 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
         Vector()
       )
       context.send(
-        Api.Request(requestId, Api.PushContextRequest(contextId, item1))
+        Api.Request(
+          requestId,
+          Api.PushContextRequest(contextId, item1, execute = false)
+        )
       )
       context.receiveNIgnorePendingExpressionUpdates(
-        3
+        1
       ) should contain theSameElementsAs Seq(
-        Api.Response(requestId, Api.PushContextResponse(contextId)),
-        TestMessages.update(
-          contextId,
-          idY,
-          ConstantsGen.INTEGER,
-          Api.MethodCall(Api.MethodPointer(moduleName, s"$moduleName.T", "inc"))
-        ),
-        context.executionComplete(contextId)
+        Api.Response(requestId, Api.PushContextResponse(contextId))
       )
 
       // Send IdMap
@@ -4509,9 +4505,11 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
           Api.EditFileNotification(
             mainFile,
             Seq(),
-            execute = false,
+            execute = true,
             idMap = Some(
-              model.IdMap(Vector(model.Span(100, 101) -> idYX))
+              model.IdMap(
+                Vector(model.Span(100, 101) -> idYX, model.Span(65, 72) -> idY)
+              )
             )
           )
         )
@@ -4537,9 +4535,15 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
         )
       )
       val attachVisualizationResponses =
-        context.receiveNIgnoreExpressionUpdates(3)
+        context.receiveNIgnoreStdLib(5)
       attachVisualizationResponses should contain allOf (
         Api.Response(requestId, Api.VisualizationAttached()),
+        TestMessages.update(
+          contextId,
+          idY,
+          ConstantsGen.INTEGER,
+          Api.MethodCall(Api.MethodPointer(moduleName, s"$moduleName.T", "inc"))
+        ),
         context.executionComplete(contextId)
       )
       val Some(data) = attachVisualizationResponses.collectFirst {


### PR DESCRIPTION
### Pull Request Description

A visualization or execute expression request always triggered cache invalidation for target expression. This was meant to allow re-calculation for subexpressios that are part of bigger (cached) expressions.
It also can cause massive delays when expressions are computationally-intensive.

However cache-invalidation is currently unnecessary, as idmap is set before first execution and we currently don't attach visualizations to self arguments (that may change in the future).
The better way to handle this is to make cache reactive, which is the role of #10525. That would make cache invalidation logic obsolete.

This change improves the overall startup time as it reduces constant re-compilation of expensive nodes.

Improves #13580. The attempt was previously attempted in https://github.com/enso-org/enso/pull/11949 but reverted due to widgets regression.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
