### PR TITLE
Move markdown link popup to floating layer

### DIFF
--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -139,16 +139,15 @@ test('Documentation reflects entered function', async ({ page }) => {
 
 test('Link in documentation is rendered and interactive', async ({ page, context }) => {
   const { docsContent } = await goToGraphAndGetDocs(page)
-  const rightDock = locate.rightDock(page)
   await expect(docsContent.locator('a')).toHaveAccessibleDescription(
     /Click to edit.*Click to open link/,
   )
 
   await expect(docsContent.locator('a')).toHaveText('https://example.com')
   await docsContent.locator('a').click()
-  await expect(rightDock.locator('.LinkEditPopup')).toBeVisible()
+  await expect(page.locator('.LinkEditPopup')).toBeVisible()
   await locate.graphEditor(page).click()
-  await expect(rightDock.locator('.LinkEditPopup')).toBeHidden()
+  await expect(page.locator('.LinkEditPopup')).toBeHidden()
   context.route('https://example.com', (route) => route.fulfill({ status: 200, body: 'YAY' }))
   const newPagePromise = context.waitForEvent('page', { timeout: 10000 })
   await docsContent.locator('a').click({ modifiers: ['ControlOrMeta'] })
@@ -171,7 +170,7 @@ test('Insert link button inserts link and focuses editor', async ({ page }) => {
 
   // The link exists and is being edited
   await expect(docsContent.locator('a')).toExist()
-  await expect(rightDock.locator('.LinkEditPopup')).toExist()
+  await expect(page.locator('.LinkEditPopup')).toExist()
 })
 
 test('Documentation editor: Editing with keyboard', async ({ page }) => {

--- a/app/gui/integration-test/project-view/nodeComments.spec.ts
+++ b/app/gui/integration-test/project-view/nodeComments.spec.ts
@@ -85,7 +85,6 @@ test('Delete comment by clearing text', async ({ page }) => {
 
 test('URL added to comment is rendered as link', async ({ page, context }) => {
   await actions.goToGraph(page)
-  const comment = locate.nodeComment(locate.graphNodeByBinding(page, 'final'))
   const commentContent = locate.nodeCommentContent(locate.graphNodeByBinding(page, 'final'))
   await expect(commentContent).toHaveText('This node can be entered')
   await expect(commentContent.locator('a')).toBeHidden()
@@ -104,10 +103,10 @@ test('URL added to comment is rendered as link', async ({ page, context }) => {
   )
   await commentContent.locator('a').click()
   await expect(commentContent).toBeFocused()
-  await expect(comment.locator('.LinkEditPopup')).toBeVisible()
+  await expect(page.locator('.LinkEditPopup')).toBeVisible()
   await page.keyboard.press(`Enter`)
   await expect(commentContent).not.toBeFocused()
-  await expect(comment.locator('.LinkEditPopup')).toBeHidden()
+  await expect(page.locator('.LinkEditPopup')).toBeHidden()
   context.route('https://example.com', (route) => route.fulfill({ status: 200, body: 'YAY' }))
   const newPagePromise = context.waitForEvent('page', { timeout: 10000 })
   await commentContent.locator('a').click({ modifiers: ['ControlOrMeta'] })

--- a/app/gui/src/project-view/components/LinkEditPopup.vue
+++ b/app/gui/src/project-view/components/LinkEditPopup.vue
@@ -20,11 +20,13 @@ const { floatingStyles } = useFloating(toRef(props, 'referenceElement'), floatin
 </script>
 
 <template>
-  <div ref="floating" class="LinkEditPopup" :style="floatingStyles" @pointerdown.stop.prevent>
-    <a class="link" :href="href" target="_blank" rel="noopener,noreferrer">Follow link</a> ({{
-      textEditorsBindings.bindings.openLink.humanReadable
-    }})
-  </div>
+  <teleport to="#floatingLayer">
+    <div ref="floating" class="LinkEditPopup" :style="floatingStyles" @pointerdown.stop.prevent>
+      <a class="link" :href="href" target="_blank" rel="noopener,noreferrer">Follow link</a> ({{
+        textEditorsBindings.bindings.openLink.humanReadable
+      }})
+    </div>
+  </teleport>
 </template>
 
 <style scoped>
@@ -37,6 +39,7 @@ const { floatingStyles } = useFloating(toRef(props, 'referenceElement'), floatin
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
   padding: 8px;
   width: max-content;
+  z-index: 9999999;
 }
 
 .link {

--- a/app/gui/src/project-view/components/LinkEditPopup.vue
+++ b/app/gui/src/project-view/components/LinkEditPopup.vue
@@ -39,7 +39,6 @@ const { floatingStyles } = useFloating(toRef(props, 'referenceElement'), floatin
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
   padding: 8px;
   width: max-content;
-  z-index: 9999999;
 }
 
 .link {

--- a/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor/MarkdownEditorImpl.vue
@@ -120,7 +120,7 @@ const { editorView, setExtraExtensions } = useCodeMirror(editorRoot, {
   scrollerTestId,
 })
 
-useLinkTitles(editorView, { readonly })
+useLinkTitles(editorView, { readonly: () => readonly })
 
 const { focused, focusHandlers } = useEditorFocus(editorView)
 watch(focused, (focused) => {


### PR DESCRIPTION
### Pull Request Description

Fixes #13553

Markdown link popups now teleport out of the markdown editor, so they can be rendered outside of codemirror's scroll area.

<img width="275" height="134" alt="image" src="https://github.com/user-attachments/assets/ed464dad-c55e-40d7-87b8-10a83e920b30" />
