### PR TITLE
Fix renaming local project

### DIFF
--- a/app/gui/src/components/ProtectedLayout.vue
+++ b/app/gui/src/components/ProtectedLayout.vue
@@ -4,7 +4,10 @@
  * if user lost privileges to see them. Also makes sure user will agree with Terms of Service and
  * privacy policy.
  */
-import { EnsoDevtools as EnsoDevToolsReact } from '#/components/Devtools'
+import {
+  EnsoDevtools as EnsoDevToolsReact,
+  ReactQueryDevtools as ReactQueryDevtoolsReact,
+} from '#/components/Devtools'
 import {
   AgreementsModal as AgreementsModalReact,
   type AgreementsModalProps,
@@ -125,6 +128,7 @@ const router = useRouter()
 const queryClient = useQueryClient()
 const text = useText()
 const EnsoDevtools = reactComponent(EnsoDevToolsReact)
+const ReactQueryDevtools = reactComponent(ReactQueryDevtoolsReact)
 
 const allowed = computed(() => routeAllowed(route, auth))
 watch(
@@ -182,4 +186,5 @@ const shouldDisplayAgreementsModal = computed(
   <RouterView v-else-if="allowed || route.meta.access == null || route.meta.access === 'guest'" />
 
   <EnsoDevtools v-if="displayDevTools" />
+  <ReactQueryDevtools v-if="displayDevTools" />
 </template>

--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -370,7 +370,7 @@ export default class LocalBackend extends Backend {
   }
 
   /**
-   * Close the project identified by the given project ID.
+   * Returns information about the project identified by the given project ID.
    * @throws An error if the JSON-RPC call fails.
    */
   override async getProjectDetails(projectId: backend.ProjectId): Promise<backend.Project> {

--- a/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
@@ -6,9 +6,10 @@
 import invariant from 'tiny-invariant'
 
 import * as backend from '#/services/Backend'
+import { getFileName } from '#/utilities/fileInfo'
 import { getDirectoryAndName, normalizeSlashes } from '#/utilities/path'
+import { normalizeName } from '@/util/nameValidation'
 import * as dateTime from 'enso-common/src/utilities/data/dateTime'
-import { getFileName } from '../../utilities/fileInfo'
 import {
   MissingComponentAction,
   PROJECT_MANAGER_LOADING_FAILED_EVENT,
@@ -221,7 +222,11 @@ export class ProjectManager {
     if (state?.state === backend.ProjectState.opened) {
       this.internalProjects.set(params.projectId, {
         state: state.state,
-        data: { ...state.data, projectName: params.name },
+        data: {
+          ...state.data,
+          projectName: params.name,
+          projectNormalizedName: normalizeName(params.name),
+        },
       })
     }
     // Update `internalDirectories` by listing the project's parent directory, because the new


### PR DESCRIPTION
### Pull Request Description

Fix renaming project on local backend (Fixes #13601).

Also, fix the Tanstack-query debug tools, the button to open them was missing.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
