### PR TITLE
SocketAppender always forwards telemetry events

### DIFF
--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
@@ -30,6 +30,7 @@ import org.slf4j.event.Level;
 public final class LogbackSetup extends LoggerSetup {
 
   private static final String CONSOLE_APPENDER_NAME = "enso-console";
+  private static final String TELEMETRY_ROOT_LOGGER = "org.enso.telemetry";
 
   private LogbackSetup(LoggingServiceConfig config, LoggerContext context) {
     this.config = config;
@@ -139,8 +140,26 @@ public final class LogbackSetup extends LoggerSetup {
           Duration.buildByMilliseconds(appenderConfig.getReconnectionDelay()));
     }
 
+    acceptAllTelemetryEvents(socketAppender);
     env.finalizeAppender(socketAppender);
     return true;
+  }
+
+  private static void acceptAllTelemetryEvents(
+      ch.qos.logback.core.Appender<ILoggingEvent> appender) {
+    // This filter lets all the telemetry log events through.
+    var telemetryAcceptingFilter =
+        new Filter<ILoggingEvent>() {
+          @Override
+          public FilterReply decide(ILoggingEvent event) {
+            if (event.getLoggerName().startsWith(TELEMETRY_ROOT_LOGGER)) {
+              return FilterReply.ACCEPT;
+            } else {
+              return FilterReply.NEUTRAL;
+            }
+          }
+        };
+    appender.addFilter(telemetryAcceptingFilter);
   }
 
   @Override
@@ -289,7 +308,7 @@ public final class LogbackSetup extends LoggerSetup {
     var executor = new ThreadPoolExecutor(0, 1, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
     telemetryAppender.setExecutor(executor);
 
-    var telemetryLogger = env.ctx.getLogger("org.enso.telemetry");
+    var telemetryLogger = env.ctx.getLogger(TELEMETRY_ROOT_LOGGER);
     telemetryLogger.addAppender(telemetryAppender);
     telemetryLogger.setLevel(ch.qos.logback.classic.Level.ALL);
 
@@ -324,7 +343,7 @@ public final class LogbackSetup extends LoggerSetup {
           @Override
           public FilterReply decide(ILoggingEvent event) {
             var exclude =
-                event.getLoggerName().startsWith("org.enso.telemetry")
+                event.getLoggerName().startsWith(TELEMETRY_ROOT_LOGGER)
                     || event.getLoggerName().startsWith("org.enso.logging.service");
             return exclude ? FilterReply.DENY : FilterReply.NEUTRAL;
           }


### PR DESCRIPTION
Fixes #13631 

### Pull Request Description

There was a regression - no telemetry was sent to the open search server. This PR fixes this regression by ensuring that telemetry events are always accepted and forwarded to the server.

### Important Notes

- I suspect that the regression was caused by #13049, but I was not able to confirm that.

-------------------

- [logging-service/server/log-to-file/log-level in project-manager/application.conf](https://github.com/enso-org/enso/blob/2e9cf92837022f030ccd327109bb6f4d7072c6cf/lib/scala/project-manager/src/main/resources/application.conf#L71) is written into [org.enso.logging.service.LoggingServiceManager#currentLevel](https://github.com/enso-org/enso/blob/566d3d503e35ccf8c363facd590d1332683bce3a/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingServiceManager.java#L36) when project-manager is started.
- This field is later used as a value to `--log-level` cmd line option when language server is started from [project-manager](https://github.com/enso-org/enso/blob/2f2747361254aa8892eb8b5c1bd24b10e7eca9b3/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala#L125). 
- So when set to `debug` (the current default), the language-server is started with `--log-level debug`.
- Which means that `LoggerFactory.get("foo").trace(...)` will not be sent through the socket appender from language-server.
- Note that language server uses a [single socket appender](https://github.com/enso-org/enso/blob/7dcbff420849e00a85e6768616f369e1e03f1589/engine/language-server/src/main/resources/application.conf#L52-L58) to sent the logs to the project-manager's logging server.
- And because all the telemetry logging is done via `trace`, no telemetry events are sent through the socket appender.

------------

- My solution is to [setup the socket appender](https://github.com/enso-org/enso/blob/962c0566bd1db927f93c110fc7bc95ab8ebf8d85/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java#L143) in language server, such that all telemetry events are never dropped.

-------------
Note that:
```diff
diff --git a/engine/language-server/src/main/resources/application.conf b/engine/language-server/src/main/resources/application.conf
index bef31a61f6..b9d068ed6e 100644
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -47,6 +47,7 @@ logging-service {
     org.enso.interpreter.runtime.HostClassLoader = error
     java.lang.ProcessBuilder = warn
     Standard.Base.Logging.Progress = error
+    org.enso.telemetry = trace
   }
   appenders = [
     {
```
also fixes the issue, but feels fragile.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
