### PR TITLE
Rewriting TypeNames to a mini pass

### DIFF
--- a/docs/runtime/compiler-ir.md
+++ b/docs/runtime/compiler-ir.md
@@ -43,7 +43,7 @@ package of GraalVM JDK's module which is not exported by default.
 Usage example:
 
 ```
-$ env JAVA_TOOL_OPTIONS='--add-exports jdk.graal.compiler/jdk.graal.compiler.graphio=org.enso.runtime.compiler.dump.igv -Denso.compiler.dumpIr=Vector' ./built-distribution/*/bin/enso --no-ir-caches --run tmp.enso
+$ env JAVA_TOOL_OPTIONS='--add-exports=jdk.graal.compiler/jdk.graal.compiler.graphio=org.enso.runtime.compiler.dump.igv -Denso.compiler.dumpIr=Vector' ./built-distribution/*/bin/enso --no-ir-caches --run tmp.enso
 ```
 
 The IR graphs are dumped directly to IGV, if it is running, or to the `ir-dumps`

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumper.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumper.java
@@ -15,12 +15,11 @@ import jdk.graal.compiler.graphio.GraphOutput;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
-import org.enso.compiler.dump.service.IRDumper;
 import org.enso.compiler.dump.service.IRSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class IGVDumper implements IRDumper {
+final class IGVDumper {
 
   private static final String DEFAULT_DUMP_DIR = "ir-dumps";
   private static final Logger LOGGER = LoggerFactory.getLogger(IGVDumper.class);
@@ -73,13 +72,11 @@ public final class IGVDumper implements IRDumper {
     return channel;
   }
 
-  @Override
   public void dumpModule(IRSource<Module> ctx) {
     assert ctx.name().equals(this.moduleName);
     dumpTask(ctx);
   }
 
-  @Override
   public void dumpExpression(IRSource<Expression> ctx) {
     dumpTask(ctx);
   }
@@ -121,7 +118,6 @@ public final class IGVDumper implements IRDumper {
     return props;
   }
 
-  @Override
   public void close() {
     if (groupCreated) {
       assert graphOutput != null;

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumperFactory.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumperFactory.java
@@ -1,11 +1,13 @@
 package org.enso.compiler.dump.igv;
 
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Module;
 import org.enso.compiler.dump.service.IRDumpFactoryService;
-import org.enso.compiler.dump.service.IRDumper;
+import org.enso.compiler.dump.service.IRSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IGVDumperFactory implements IRDumpFactoryService {
+public final class IGVDumperFactory extends IRDumpFactoryService<IGVDumper> {
   private static final Logger LOGGER = LoggerFactory.getLogger(IGVDumperFactory.class);
   private static final String GRAPHIO_PKG = "jdk.graal.compiler.graphio";
   private static final String COMPILER_MOD = "jdk.graal.compiler";
@@ -32,11 +34,26 @@ public class IGVDumperFactory implements IRDumpFactoryService {
   }
 
   @Override
-  public IRDumper create(String moduleName) {
+  protected IGVDumper create(String moduleName) {
     LOGGER.trace("Creating IGV dumper for module {}", moduleName);
     return IGVDumper.createForModule(moduleName);
   }
 
   @Override
-  public void shutdown() {}
+  protected void shutdown() {}
+
+  @Override
+  protected void dumpModule(IGVDumper group, IRSource<Module> src) {
+    group.dumpModule(src);
+  }
+
+  @Override
+  protected void dumpExpression(IGVDumper group, IRSource<Expression> src) {
+    group.dumpExpression(src);
+  }
+
+  @Override
+  protected void close(IGVDumper group) {
+    group.close();
+  }
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpFactoryService.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpFactoryService.java
@@ -1,13 +1,45 @@
 package org.enso.compiler.dump.service;
 
-/** A service that creates {@link org.enso.compiler.core.IR} dumpers for modules. */
-public interface IRDumpFactoryService {
-  static final IRDumpFactoryService DEFAULT = IRDumpSingleton.DEFAULT;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Module;
 
-  String SYSTEM_PROP = "enso.compiler.dumpIr";
-  String DEFAULT_DUMP_DIR = "ir-dumps";
+/**
+ * A service provider interface to implement to handler dumping of {@link Module} and {@link
+ * Expression} IRs. Contains methods that create and deal with {@link org.enso.compiler.core.IR}
+ * dumpers. Don't call directly. Use {@link IRDumper} which contains the API for perform the
+ * dumping.
+ *
+ * @param <Dump> type to use for grouping of dumpings
+ */
+public abstract class IRDumpFactoryService<Dump> {
+  public static final String SYSTEM_PROP = "enso.compiler.dumpIr";
+  public static final String DEFAULT_DUMP_DIR = "ir-dumps";
 
-  IRDumper create(String moduleName);
+  protected abstract Dump create(String moduleName);
 
-  void shutdown();
+  protected abstract void shutdown();
+
+  /**
+   * Dumps module IR.
+   *
+   * @param group
+   * @param src what to dump
+   */
+  protected abstract void dumpModule(Dump group, IRSource<Module> src);
+
+  /**
+   * Dumps a single expression IR.
+   *
+   * @param group
+   * @param src
+   */
+  protected abstract void dumpExpression(Dump group, IRSource<Expression> src);
+
+  /**
+   * Close and flush all the underlying resources. There will be no more dumps for the module after
+   * this call.
+   *
+   * @param group
+   */
+  protected abstract void close(Dump group);
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpSingleton.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpSingleton.java
@@ -1,12 +1,13 @@
 package org.enso.compiler.dump.service;
 
 import java.util.ServiceLoader;
+import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
 
 final class IRDumpSingleton {
-  static final IRDumpFactoryService DEFAULT = find();
+  static final IRDumpFactoryService<?> DEFAULT = find();
 
-  private static IRDumpFactoryService find() {
+  private static IRDumpFactoryService<?> find() {
     IRDumpFactoryService service = new NoDumping();
     var loader = ServiceLoader.load(IRDumpFactoryService.class);
     var it = loader.iterator();
@@ -18,19 +19,22 @@ final class IRDumpSingleton {
     return service;
   }
 
-  private static final class NoDumping implements IRDumpFactoryService, IRDumper {
+  private static final class NoDumping extends IRDumpFactoryService<Void> {
     @Override
-    public IRDumper create(String moduleName) {
-      return this;
+    public Void create(String moduleName) {
+      return null;
     }
 
     @Override
     public void shutdown() {}
 
     @Override
-    public void dumpModule(IRSource<Module> ir) {}
+    public void dumpModule(Void group, IRSource<Module> ir) {}
 
     @Override
-    public void close() {}
+    public void dumpExpression(Void group, IRSource<Expression> ir) {}
+
+    @Override
+    public void close(Void group) {}
   }
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumper.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumper.java
@@ -3,23 +3,71 @@ package org.enso.compiler.dump.service;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
 
-public interface IRDumper {
+/** Main entry point to dumping of IR graphs. */
+public abstract class IRDumper {
+  IRDumper() {}
 
   /**
-   * Dumps module IR.
+   * Creates new dumping group.
    *
-   * @param dump what to dump
+   * @param name name of the dumping group
+   * @return
    */
-  void dumpModule(IRSource<Module> dump);
-
-  /** Dumps a single expression IR. */
-  default void dumpExpression(IRSource<Expression> dump) {
-    // nop
+  public static IRDumper create(String name) {
+    return Impl.create(name, IRDumpSingleton.DEFAULT);
   }
+
+  /**
+   * Dumps provide source into this group.
+   *
+   * @param src info about the data to dump
+   */
+  public abstract void dumpModule(IRSource<Module> src);
+
+  /**
+   * Dumps provide source into this group.
+   *
+   * @param src info about the data to dump
+   */
+  public abstract void dumpExpression(IRSource<Expression> src);
 
   /**
    * Close and flush all the underlying resources. There will be no more dumps for the module after
    * this call.
    */
-  void close();
+  public abstract void close();
+
+  /**
+   * Open class to hold service and a dumper.
+   *
+   * @param <D> the type shared by service and dumper.
+   */
+  private static final class Impl<D> extends IRDumper {
+    final IRDumpFactoryService<D> service;
+    final D dumper;
+
+    private Impl(IRDumpFactoryService<D> service, D dumper) {
+      this.service = service;
+      this.dumper = dumper;
+    }
+
+    static <D> IRDumper create(String name, IRDumpFactoryService<D> factory) {
+      return new Impl<>(factory, factory.create(name));
+    }
+
+    @Override
+    public void close() {
+      service.close(dumper);
+    }
+
+    @Override
+    public void dumpModule(IRSource<Module> src) {
+      service.dumpModule(dumper, src);
+    }
+
+    @Override
+    public void dumpExpression(IRSource<Expression> src) {
+      service.dumpExpression(dumper, src);
+    }
+  }
 }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
@@ -17,7 +17,7 @@ import org.enso.compiler.core.ir.module.scope.definition.Method;
 import org.enso.compiler.core.ir.type.Set;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.pass.resolve.MethodDefinitions;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.pkg.QualifiedName;
@@ -170,7 +170,7 @@ final class DocsUtils {
   }
 
   private static QualifiedName extractFqnOrNull(IR ir) {
-    var typeNameOpt = ir.passData().get(TypeNames$.MODULE$);
+    var typeNameOpt = ir.passData().get(TypeNames.INSTANCE);
     if (typeNameOpt.isDefined()) {
       var typeName = (BindingsMap.Resolution) typeNameOpt.get();
       return typeName.target().qualifiedName();

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/MiniPassTraverser.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/MiniPassTraverser.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
@@ -76,16 +77,48 @@ final class MiniPassTraverser {
   private static List<IR> enqueueSubExpressions(
       Collection<MiniPassTraverser> queue, IR ir, MiniIRPass miniPass) {
     var childExpressions = new ArrayList<IR>();
-    var i = new int[1];
+    var i = new AtomicInteger();
+    if (ir instanceof Module mod) {
+      mod.imports()
+          .foreach(
+              v -> {
+                iterateSubExpressions(i, childExpressions, queue, v, miniPass);
+                return null;
+              });
+      mod.exports()
+          .foreach(
+              v -> {
+                iterateSubExpressions(i, childExpressions, queue, v, miniPass);
+                return null;
+              });
+      mod.bindings()
+          .foreach(
+              v -> {
+                iterateSubExpressions(i, childExpressions, queue, v, miniPass);
+                return null;
+              });
+    } else {
+      iterateSubExpressions(i, childExpressions, queue, ir, miniPass);
+    }
+    return childExpressions;
+  }
+
+  private static void iterateSubExpressions(
+      AtomicInteger counter,
+      List<IR> childExpressions,
+      Collection<MiniPassTraverser> queue,
+      IR ir,
+      MiniIRPass miniPass) {
     ir.mapExpressions(
         (ch) -> {
           var preparedMiniPass = miniPass.prepare(ir, ch);
           childExpressions.add(ch);
           if (preparedMiniPass != null) {
-            queue.add(new MiniPassTraverser(preparedMiniPass, childExpressions, i[0]++));
+            queue.add(
+                new MiniPassTraverser(
+                    preparedMiniPass, childExpressions, counter.getAndIncrement()));
           }
           return ch;
         });
-    return childExpressions;
   }
 }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -23,7 +23,7 @@ import org.enso.compiler.pass.resolve.MethodDefinitions;
 import org.enso.compiler.pass.resolve.ModuleAnnotations;
 import org.enso.compiler.pass.resolve.ModuleAnnotations$;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.persist.Persistable;
@@ -49,7 +49,7 @@ import org.enso.persist.Persistance;
 @Persistable(clazz = IgnoredBindings$.class, id = 1206)
 @Persistable(clazz = Patterns$.class, id = 1207)
 @Persistable(clazz = TailCall.class, id = 1208)
-@Persistable(clazz = TypeNames$.class, id = 1209)
+@Persistable(clazz = TypeNames.class, id = 1209)
 @Persistable(clazz = TypeSignatures$.class, id = 1210)
 @Persistable(clazz = DocumentationComments$.class, id = 1211)
 @Persistable(clazz = ModuleAnnotations$.class, id = 1212)

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferencePropagation.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferencePropagation.java
@@ -19,7 +19,7 @@ import org.enso.compiler.pass.analyse.types.scope.StaticModuleScopeAnalysis;
 import org.enso.compiler.pass.resolve.FullyQualifiedNames$;
 import org.enso.compiler.pass.resolve.GlobalNames$;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.scala.wrapper.ScalaConversions;
 import org.slf4j.Logger;
@@ -143,7 +143,7 @@ public final class TypeInferencePropagation implements IRPass {
             BindingAnalysis$.MODULE$,
             GlobalNames$.MODULE$,
             FullyQualifiedNames$.MODULE$,
-            TypeNames$.MODULE$,
+            TypeNames.INSTANCE,
             Patterns$.MODULE$,
             TypeSignatures$.MODULE$,
             StaticModuleScopeAnalysis.INSTANCE,

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferenceSignatures.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferenceSignatures.java
@@ -17,7 +17,7 @@ import org.enso.compiler.pass.analyse.types.scope.StaticModuleScopeAnalysis;
 import org.enso.compiler.pass.resolve.FullyQualifiedNames$;
 import org.enso.compiler.pass.resolve.GlobalNames$;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.scala.wrapper.ScalaConversions;
 import org.slf4j.Logger;
@@ -68,7 +68,7 @@ public final class TypeInferenceSignatures implements IRPass {
             BindingAnalysis$.MODULE$,
             GlobalNames$.MODULE$,
             FullyQualifiedNames$.MODULE$,
-            TypeNames$.MODULE$,
+            TypeNames.INSTANCE,
             Patterns$.MODULE$,
             TypeSignatures$.MODULE$);
     return ScalaConversions.seq(passes);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeResolver.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeResolver.java
@@ -11,7 +11,7 @@ import org.enso.compiler.core.ir.expression.Operator;
 import org.enso.compiler.core.ir.type.Set;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.slf4j.Logger;
@@ -83,7 +83,7 @@ public class TypeResolver {
 
   private TypeRepresentation getResolvedTypeFromBindingsMap(Name name) {
     BindingsMap.Resolution resolutionOrNull =
-        getMetadataOrNull(name, TypeNames$.MODULE$, BindingsMap.Resolution.class);
+        getMetadataOrNull(name, TypeNames.INSTANCE, BindingsMap.Resolution.class);
 
     if (resolutionOrNull == null) {
       // As fallback, try getting from the Patterns pass.

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/StaticModuleScopeAnalysis.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/StaticModuleScopeAnalysis.java
@@ -27,7 +27,7 @@ import org.enso.compiler.pass.analyse.types.TypeResolver;
 import org.enso.compiler.pass.resolve.FullyQualifiedNames$;
 import org.enso.compiler.pass.resolve.GlobalNames$;
 import org.enso.compiler.pass.resolve.MethodDefinitions;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.pkg.QualifiedName;
 import org.enso.scala.wrapper.ScalaConversions;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ public class StaticModuleScopeAnalysis implements IRPass {
             GlobalNames$.MODULE$,
             BindingAnalysis$.MODULE$,
             FullyQualifiedNames$.MODULE$,
-            TypeNames$.MODULE$,
+            TypeNames.INSTANCE,
             MethodDefinitions.INSTANCE,
             TypeInferenceSignatures.INSTANCE);
     return ScalaConversions.seq(passes);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/lint/unusedimports/UnusedImports.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/lint/unusedimports/UnusedImports.java
@@ -33,7 +33,7 @@ import org.enso.compiler.pass.resolve.GenericAnnotations$;
 import org.enso.compiler.pass.resolve.GlobalNames$;
 import org.enso.compiler.pass.resolve.MethodDefinitions;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.pkg.QualifiedName;
 import org.enso.scala.wrapper.ScalaConversions;
@@ -65,7 +65,7 @@ public final class UnusedImports implements IRPass {
             BindingAnalysis$.MODULE$,
             ImportSymbolAnalysis.INSTANCE,
             AmbiguousImportsAnalysis.INSTANCE,
-            TypeNames$.MODULE$,
+            TypeNames.INSTANCE,
             TypeSignatures$.MODULE$,
             MethodDefinitions.INSTANCE,
             GlobalNames$.MODULE$,

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/lint/unusedimports/UsedSymbolsCollector.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/lint/unusedimports/UsedSymbolsCollector.java
@@ -28,7 +28,7 @@ import org.enso.compiler.pass.resolve.MethodDefinitions;
 import org.enso.compiler.pass.resolve.ModuleAnnotations;
 import org.enso.compiler.pass.resolve.ModuleAnnotations.Annotations;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.pkg.QualifiedName;
@@ -296,7 +296,7 @@ final class UsedSymbolsCollector {
 
   private static BindingsMap.Resolution getTypeNameMeta(IR ir) {
     return MetadataInteropHelpers.getMetadataOrNull(
-        ir, TypeNames$.MODULE$, BindingsMap.Resolution.class);
+        ir, TypeNames.INSTANCE, BindingsMap.Resolution.class);
   }
 
   private static BindingsMap.Resolution getMethodDefinitionsMeta(IR ir) {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/TypeNames.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/TypeNames.java
@@ -11,18 +11,18 @@ import org.enso.compiler.core.ir.Function;
 import org.enso.compiler.core.ir.MetadataStorage;
 import org.enso.compiler.core.ir.Module;
 import org.enso.compiler.core.ir.Name;
+import org.enso.compiler.core.ir.expression.errors.Resolution;
 import org.enso.compiler.core.ir.module.scope.Definition;
 import org.enso.compiler.core.ir.module.scope.definition.Method;
 import org.enso.compiler.core.ir.type.Set;
 import org.enso.compiler.data.BindingsMap;
-import org.enso.compiler.data.BindingsMap.Resolution;
-import org.enso.compiler.data.BindingsMap.ResolvedModule;
 import org.enso.compiler.pass.IRPass;
 import org.enso.compiler.pass.MiniIRPass;
 import org.enso.compiler.pass.MiniPassFactory;
 import org.enso.compiler.pass.analyse.BindingAnalysis$;
 import org.enso.scala.wrapper.ScalaConversions;
 import scala.Option;
+import scala.PartialFunction;
 import scala.collection.immutable.Seq;
 import scala.util.Either;
 import scala.util.Left;
@@ -95,10 +95,7 @@ public final class TypeNames implements MiniPassFactory {
      */
     @Override
     public MiniIRPass prepare(IR parent, Expression child) {
-      if (!(parent instanceof Module)) {
-        return this;
-      }
-      return switch (child) {
+      return switch (parent) {
         case Definition.Type t -> {
           var selfType = SelfTypeInfo.fromTypeDefinition(t);
           yield withSelfType(selfType);
@@ -149,6 +146,11 @@ public final class TypeNames implements MiniPassFactory {
   private record SelfTypeInfo(
       Option<BindingsMap.ResolvedType> selfType, scala.collection.immutable.List<Name> typeParams) {
 
+    @Override
+    public String toString() {
+      return "SelfTypeInfo{" + "selfType=" + selfType + ", typeParams=" + typeParams + '}';
+    }
+
     static final SelfTypeInfo empty = new SelfTypeInfo(Option.empty(), ScalaConversions.nil());
 
     static SelfTypeInfo fromTypeDefinition(Definition.Type d) {
@@ -169,7 +171,7 @@ public final class TypeNames implements MiniPassFactory {
         var p = m.typePointer().get();
         var resolution =
             MetadataInteropHelpers.getMetadataOrNull(
-                m, MethodDefinitions.INSTANCE, BindingsMap.Resolution.class);
+                p, MethodDefinitions.INSTANCE, BindingsMap.Resolution.class);
         // It is unexpected that the metadata is missing here, but we don't fail because other
         // passes should fail
         // with more detailed info.
@@ -184,7 +186,9 @@ public final class TypeNames implements MiniPassFactory {
                               new Name.Literal(
                                   n, false, null, Option.empty(), new MetadataStorage()))
                       .toList();
-              yield new SelfTypeInfo(Option.apply(typ), params);
+              @SuppressWarnings("unchecked")
+              var info = new SelfTypeInfo(Option.apply(typ), params);
+              yield info;
             }
             case BindingsMap.ResolvedModule __ -> SelfTypeInfo.empty;
             case Object other -> throw new CompilerError(
@@ -202,9 +206,8 @@ public final class TypeNames implements MiniPassFactory {
         MetadataInteropHelpers.getMetadataOrNull(
             ir, TypeSignatures$.MODULE$, TypeSignatures.Signature.class);
     if (s != null) {
-      var meta =
-          new TypeSignatures.Signature(
-              resolveSignature(selfTypeInfo, bindingsMap, s.signature()), s.comment());
+      var sig = resolveSignature(selfTypeInfo, bindingsMap, s.signature());
+      var meta = new TypeSignatures.Signature(sig, s.comment());
       MetadataInteropHelpers.updateMetadata(ir, TypeSignatures$.MODULE$, meta);
     }
     return ir;
@@ -212,53 +215,70 @@ public final class TypeNames implements MiniPassFactory {
 
   private static Expression resolveSignature(
       SelfTypeInfo selfTypeInfo, BindingsMap bindingsMap, Expression expression) {
-    return expression.mapExpressions(
-        (expr) -> {
-          if (SuspendedArguments.representsSuspended(expr)) {
-            return expr;
-          } else {
-            return switch (expr) {
-              case Name.Literal n -> {
-                if (selfTypeInfo
-                    .typeParams()
-                    .exists(
-                        p -> {
-                          return p.name().equals(n.name());
-                        })) {
-                  yield n;
-                } else {
-                  var rn = bindingsMap.resolveName(n.name());
-                  yield processResolvedName(n, rn);
-                }
+    class Fn implements PartialFunction<Expression, Expression> {
+      @Override
+      public boolean isDefinedAt(Expression expr) {
+        if (SuspendedArguments.representsSuspended(expr)) {
+          return true;
+        } else {
+          return switch (expr) {
+            case Name.Literal n -> true;
+            case Name.Qualified n -> true;
+            case Name.SelfType selfRef -> true;
+            case Set s -> true;
+            default -> false;
+          };
+        }
+      }
+
+      @Override
+      public Expression apply(Expression expr) {
+        if (SuspendedArguments.representsSuspended(expr)) {
+          return expr;
+        } else {
+          return switch (expr) {
+            case Name.Literal n -> {
+              if (selfTypeInfo
+                  .typeParams()
+                  .exists(
+                      p -> {
+                        return p.name().equals(n.name());
+                      })) {
+                yield n;
+              } else {
+                var rn = bindingsMap.resolveName(n.name());
+                yield processResolvedName(n, rn);
               }
-              case Name.Qualified n -> {
-                var parts = bindingsMap.resolveQualifiedName(n.parts().map(p -> p.name()));
-                yield processResolvedName(n, parts);
+            }
+            case Name.Qualified n -> {
+              var parts = bindingsMap.resolveQualifiedName(n.parts().map(p -> p.name()));
+              yield processResolvedName(n, parts);
+            }
+            case Name.SelfType selfRef -> {
+              Either<
+                      BindingsMap.ResolutionError,
+                      scala.collection.immutable.List<? extends BindingsMap.ResolvedName>>
+                  resolvedSelfType;
+              if (selfTypeInfo.selfType().isEmpty()) {
+                resolvedSelfType = new Left<>(BindingsMap.SelfTypeOutsideOfTypeDefinition$.MODULE$);
+              } else {
+                var list = ScalaConversions.set(selfTypeInfo.selfType().get()).toList();
+                resolvedSelfType = new Right<>(list);
               }
-              case Name.SelfType selfRef -> {
-                Either<
-                        BindingsMap.ResolutionError,
-                        scala.collection.immutable.List<? extends BindingsMap.ResolvedName>>
-                    resolvedSelfType;
-                if (selfTypeInfo.selfType().isEmpty()) {
-                  resolvedSelfType =
-                      new Left<>(BindingsMap.SelfTypeOutsideOfTypeDefinition$.MODULE$);
-                } else {
-                  var list = ScalaConversions.set(selfTypeInfo.selfType().get()).toList();
-                  resolvedSelfType = new Right<>(list);
-                }
-                yield processResolvedName(selfRef, resolvedSelfType);
-              }
-              case Set s -> {
-                yield s.mapExpressions(
-                    (sig) -> {
-                      return resolveSignature(selfTypeInfo, bindingsMap, sig);
-                    });
-              }
-              default -> expr;
-            };
-          }
-        });
+              yield processResolvedName(selfRef, resolvedSelfType);
+            }
+            case Set s -> {
+              yield s.mapExpressions(
+                  (sig) -> {
+                    return resolveSignature(selfTypeInfo, bindingsMap, sig);
+                  });
+            }
+            default -> null;
+          };
+        }
+      }
+    }
+    return expression.transformExpressions(new Fn());
   }
 
   private static Name processResolvedName(
@@ -267,35 +287,35 @@ public final class TypeNames implements MiniPassFactory {
               BindingsMap.ResolutionError,
               ? extends scala.collection.immutable.List<? extends BindingsMap.ResolvedName>>
           resolvedNamesOpt) {
-    var either =
-        resolvedNamesOpt.map(
-            (resolvedNames) -> {
-              resolvedNames.foreach(
-                  resolvedName -> {
-                    MetadataInteropHelpers.updateMetadata(
-                        name, INSTANCE, new Resolution(resolvedName));
-                    return null;
-                  });
-              return name;
-            });
-    return either.fold(
-        (error) -> {
-          var res = new org.enso.compiler.core.ir.expression.errors.Resolution.ResolverError(error);
-          return new org.enso.compiler.core.ir.expression.errors.Resolution(
-              name, res, new MetadataStorage());
-        },
-        (n) -> {
-          var meta = MetadataInteropHelpers.getMetadata(n, INSTANCE, Resolution.class);
-          return switch (meta.target()) {
-            case ResolvedModule rm -> {
-              var res =
-                  new org.enso.compiler.core.ir.expression.errors.Resolution.UnexpectedModule(
-                      "type signature");
-              yield new org.enso.compiler.core.ir.expression.errors.Resolution(
-                  name, res, new MetadataStorage());
-            }
-            default -> n;
-          };
-        });
+    var res =
+        resolvedNamesOpt
+            .map(
+                (resolvedNames) -> {
+                  resolvedNames.foreach(
+                      resolvedName -> {
+                        MetadataInteropHelpers.updateMetadata(
+                            name, INSTANCE, new BindingsMap.Resolution(resolvedName));
+                        return null;
+                      });
+                  return name;
+                })
+            .fold(
+                (error) -> {
+                  var err = new Resolution.ResolverError(error);
+                  return new Resolution(name, err, new MetadataStorage());
+                },
+                (n) -> {
+                  var meta =
+                      MetadataInteropHelpers.getMetadata(n, INSTANCE, BindingsMap.Resolution.class);
+                  return switch (meta.target()) {
+                    case BindingsMap.ResolvedModule rm -> {
+                      var err = new Resolution.UnexpectedModule("type signature");
+                      var r = new Resolution(name, err, new MetadataStorage());
+                      yield r;
+                    }
+                    default -> n;
+                  };
+                });
+    return res;
   }
 }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/TypeNames.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/TypeNames.java
@@ -1,0 +1,301 @@
+package org.enso.compiler.pass.resolve;
+
+import java.util.List;
+import org.enso.compiler.MetadataInteropHelpers;
+import org.enso.compiler.context.InlineContext;
+import org.enso.compiler.context.ModuleContext;
+import org.enso.compiler.core.CompilerError;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Function;
+import org.enso.compiler.core.ir.MetadataStorage;
+import org.enso.compiler.core.ir.Module;
+import org.enso.compiler.core.ir.Name;
+import org.enso.compiler.core.ir.module.scope.Definition;
+import org.enso.compiler.core.ir.module.scope.definition.Method;
+import org.enso.compiler.core.ir.type.Set;
+import org.enso.compiler.data.BindingsMap;
+import org.enso.compiler.data.BindingsMap.Resolution;
+import org.enso.compiler.data.BindingsMap.ResolvedModule;
+import org.enso.compiler.pass.IRPass;
+import org.enso.compiler.pass.MiniIRPass;
+import org.enso.compiler.pass.MiniPassFactory;
+import org.enso.compiler.pass.analyse.BindingAnalysis$;
+import org.enso.scala.wrapper.ScalaConversions;
+import scala.Option;
+import scala.collection.immutable.Seq;
+import scala.util.Either;
+import scala.util.Left;
+import scala.util.Right;
+
+/** Resolves and desugars referent name occurrences in type positions. */
+public final class TypeNames implements MiniPassFactory {
+
+  public static final TypeNames INSTANCE = new TypeNames();
+
+  private TypeNames() {}
+
+  @Override
+  public Seq<IRPass> precursorPasses() {
+    return ScalaConversions.seq(List.of(BindingAnalysis$.MODULE$));
+  }
+
+  @Override
+  public Seq<IRPass> invalidatedPasses() {
+    return ScalaConversions.seq(List.of());
+  }
+
+  @Override
+  public MiniIRPass createForModuleCompilation(ModuleContext moduleContext) {
+    return new Mini(moduleContext);
+  }
+
+  /** This pass can only process whole modules */
+  @Override
+  public MiniIRPass createForInlineCompilation(InlineContext inlineContext) {
+    return null;
+  }
+
+  private static final class Mini extends MiniIRPass {
+
+    private final ModuleContext moduleContext;
+    private final BindingsMap bindingsMap;
+    private final SelfTypeInfo selfTypeInfo;
+
+    /** Initial constructor for processing the whole module */
+    private Mini(ModuleContext mc) {
+      this.moduleContext = mc;
+      this.bindingsMap = mc.bindingsAnalysis();
+      this.selfTypeInfo = SelfTypeInfo.empty;
+    }
+
+    private Mini(ModuleContext mc, BindingsMap map, SelfTypeInfo info) {
+      this.moduleContext = mc;
+      this.bindingsMap = map;
+      this.selfTypeInfo = info;
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param info new info to use
+     * @return new instance of mini pass
+     */
+    private Mini withSelfType(SelfTypeInfo info) {
+      return new Mini(moduleContext, bindingsMap, info);
+    }
+
+    /**
+     * Descend down to children. Detect definitions of type and methods. Record self type by copying
+     * itself.
+     *
+     * @param parent process only bindings - direct children of main module
+     * @param child expression to check
+     * @return itself or own copy
+     */
+    @Override
+    public MiniIRPass prepare(IR parent, Expression child) {
+      if (!(parent instanceof Module)) {
+        return this;
+      }
+      return switch (child) {
+        case Definition.Type t -> {
+          var selfType = SelfTypeInfo.fromTypeDefinition(t);
+          yield withSelfType(selfType);
+        }
+        case Method.Explicit m -> {
+          var selfType = SelfTypeInfo.fromMethodReference(m.methodReference());
+          yield withSelfType(selfType);
+        }
+        default -> this;
+      };
+    }
+
+    @Override
+    public Expression transformExpression(Expression ir) {
+      if (ir instanceof Function.Lambda fn) {
+        ir =
+            fn.copyWithArguments(
+                fn.arguments().map(a -> doResolveType(selfTypeInfo, bindingsMap, a)));
+      }
+      var expr = doResolveType(selfTypeInfo, bindingsMap, ir);
+      return expr;
+    }
+
+    @Override
+    public Module transformModule(Module ir) {
+      /*
+      var withResolvedArguments = switch (mapped) {
+        case Definition.Type typ -> {
+          typ.members().foreach(m ->
+            m.arguments().foreach(a ->
+              doResolveType(
+                SelfTypeInfo.fromTypeDefinition(typ),
+                bindingsMap,
+                a
+              )
+            )
+          );
+          yield typ;
+        }
+        case Expression x -> x;
+      };
+      doResolveType(selfTypeInfo, bindingsMap, withResolvedArguments);
+             */
+      return ir;
+    }
+  }
+
+  private record SelfTypeInfo(
+      Option<BindingsMap.ResolvedType> selfType, scala.collection.immutable.List<Name> typeParams) {
+
+    static final SelfTypeInfo empty = new SelfTypeInfo(Option.empty(), ScalaConversions.nil());
+
+    static SelfTypeInfo fromTypeDefinition(Definition.Type d) {
+      // TODO currently the `Self` type is only used internally as an ascription for static method
+      // bindings
+      //  Once we actually start supporting the `Self` syntax, we should set the self type here to
+      // the ResolvedType
+      //  corresponding to the current definition, so that we can correctly resolve `Self`
+      // references in constructor
+      //  argument types.
+      var selfType = Option.<BindingsMap.ResolvedType>empty();
+      var typeParams = d.params().map(p -> p.name());
+      return new SelfTypeInfo(selfType, typeParams);
+    }
+
+    static SelfTypeInfo fromMethodReference(Name.MethodReference m) {
+      if (m.typePointer().isDefined()) {
+        var p = m.typePointer().get();
+        var resolution =
+            MetadataInteropHelpers.getMetadataOrNull(
+                m, MethodDefinitions.INSTANCE, BindingsMap.Resolution.class);
+        // It is unexpected that the metadata is missing here, but we don't fail because other
+        // passes should fail
+        // with more detailed info.
+        if (resolution != null) {
+          return switch (resolution.target()) {
+            case BindingsMap.ResolvedType typ -> {
+              var params =
+                  typ.tp()
+                      .params()
+                      .map(
+                          n ->
+                              new Name.Literal(
+                                  n, false, null, Option.empty(), new MetadataStorage()))
+                      .toList();
+              yield new SelfTypeInfo(Option.apply(typ), params);
+            }
+            case BindingsMap.ResolvedModule __ -> SelfTypeInfo.empty;
+            case Object other -> throw new CompilerError(
+                "Method target not resolved as ResolvedType, but %s.".formatted(other));
+          };
+        }
+      }
+      return empty;
+    }
+  }
+
+  private static <T extends IR> T doResolveType(
+      SelfTypeInfo selfTypeInfo, BindingsMap bindingsMap, T ir) {
+    var s =
+        MetadataInteropHelpers.getMetadataOrNull(
+            ir, TypeSignatures$.MODULE$, TypeSignatures.Signature.class);
+    if (s != null) {
+      var meta =
+          new TypeSignatures.Signature(
+              resolveSignature(selfTypeInfo, bindingsMap, s.signature()), s.comment());
+      MetadataInteropHelpers.updateMetadata(ir, TypeSignatures$.MODULE$, meta);
+    }
+    return ir;
+  }
+
+  private static Expression resolveSignature(
+      SelfTypeInfo selfTypeInfo, BindingsMap bindingsMap, Expression expression) {
+    return expression.mapExpressions(
+        (expr) -> {
+          if (SuspendedArguments.representsSuspended(expr)) {
+            return expr;
+          } else {
+            return switch (expr) {
+              case Name.Literal n -> {
+                if (selfTypeInfo
+                    .typeParams()
+                    .exists(
+                        p -> {
+                          return p.name().equals(n.name());
+                        })) {
+                  yield n;
+                } else {
+                  var rn = bindingsMap.resolveName(n.name());
+                  yield processResolvedName(n, rn);
+                }
+              }
+              case Name.Qualified n -> {
+                var parts = bindingsMap.resolveQualifiedName(n.parts().map(p -> p.name()));
+                yield processResolvedName(n, parts);
+              }
+              case Name.SelfType selfRef -> {
+                Either<
+                        BindingsMap.ResolutionError,
+                        scala.collection.immutable.List<? extends BindingsMap.ResolvedName>>
+                    resolvedSelfType;
+                if (selfTypeInfo.selfType().isEmpty()) {
+                  resolvedSelfType =
+                      new Left<>(BindingsMap.SelfTypeOutsideOfTypeDefinition$.MODULE$);
+                } else {
+                  var list = ScalaConversions.set(selfTypeInfo.selfType().get()).toList();
+                  resolvedSelfType = new Right<>(list);
+                }
+                yield processResolvedName(selfRef, resolvedSelfType);
+              }
+              case Set s -> {
+                yield s.mapExpressions(
+                    (sig) -> {
+                      return resolveSignature(selfTypeInfo, bindingsMap, sig);
+                    });
+              }
+              default -> expr;
+            };
+          }
+        });
+  }
+
+  private static Name processResolvedName(
+      Name name,
+      Either<
+              BindingsMap.ResolutionError,
+              ? extends scala.collection.immutable.List<? extends BindingsMap.ResolvedName>>
+          resolvedNamesOpt) {
+    var either =
+        resolvedNamesOpt.map(
+            (resolvedNames) -> {
+              resolvedNames.foreach(
+                  resolvedName -> {
+                    MetadataInteropHelpers.updateMetadata(
+                        name, INSTANCE, new Resolution(resolvedName));
+                    return null;
+                  });
+              return name;
+            });
+    return either.fold(
+        (error) -> {
+          var res = new org.enso.compiler.core.ir.expression.errors.Resolution.ResolverError(error);
+          return new org.enso.compiler.core.ir.expression.errors.Resolution(
+              name, res, new MetadataStorage());
+        },
+        (n) -> {
+          var meta = MetadataInteropHelpers.getMetadata(n, INSTANCE, Resolution.class);
+          return switch (meta.target()) {
+            case ResolvedModule rm -> {
+              var res =
+                  new org.enso.compiler.core.ir.expression.errors.Resolution.UnexpectedModule(
+                      "type signature");
+              yield new org.enso.compiler.core.ir.expression.errors.Resolution(
+                  name, res, new MetadataStorage());
+            }
+            default -> n;
+          };
+        });
+  }
+}

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -386,11 +386,17 @@ class Compiler(
           isGeneratingDocs = generateDocs
         )
         val compilerOutput =
-          runGlobalTypingPasses(
-            module.getIr(),
-            moduleContext,
-            irDumper = getOrCreateDumper(module)
-          )
+          try {
+            runGlobalTypingPasses(
+              module.getIr(),
+              moduleContext,
+              irDumper = getOrCreateDumper(module)
+            )
+          } catch {
+            case err: CompilerError =>
+              err.attachInfo("At " + moduleContext.getName())
+              throw err
+          }
 
         context.updateModule(
           module,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -31,7 +31,7 @@ import org.enso.editions.LibraryName
 import org.enso.pkg.QualifiedName
 import org.enso.common.CompilationStage
 import org.enso.compiler.docs.{DocsGenerate, DocsVisit}
-import org.enso.compiler.dump.service.{IRDumpFactoryService, IRDumper}
+import org.enso.compiler.dump.service.IRDumper
 import org.enso.compiler.pass.lint.unusedimports.UnusedImportsRemover
 import org.enso.compiler.phase.exports.{
   ExportCycleException,
@@ -304,8 +304,7 @@ class Compiler(
           moduleIrDumpers.get(module) match {
             case Some(existing) => Some(existing)
             case None =>
-              val dumper =
-                IRDumpFactoryService.DEFAULT.create(module.getName.toString)
+              val dumper = IRDumper.create(module.getName.toString)
               moduleIrDumpers = moduleIrDumpers.updated(module, dumper)
               Some(dumper)
           }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
@@ -72,7 +72,7 @@ class Passes(config: CompilerConfig) {
       AliasAnalysis,
       FullyQualifiedNames,
       GlobalNames,
-      TypeNames,
+      TypeNames.INSTANCE,
       MethodCalls,
       FullyAppliedFunctionUses,
       AliasAnalysis

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/passes/resolve/NameResolutionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/passes/resolve/NameResolutionTest.java
@@ -28,7 +28,7 @@ import org.enso.compiler.pass.resolve.FullyQualifiedNames$;
 import org.enso.compiler.pass.resolve.GlobalNames$;
 import org.enso.compiler.pass.resolve.Patterns;
 import org.enso.compiler.pass.resolve.Patterns$;
-import org.enso.compiler.pass.resolve.TypeNames$;
+import org.enso.compiler.pass.resolve.TypeNames;
 import org.enso.compiler.pass.resolve.TypeSignatures;
 import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.pkg.QualifiedName;
@@ -153,7 +153,7 @@ public final class NameResolutionTest {
           assertThat(signatureMeta.signature(), instanceOf(Name.Qualified.class));
           var res =
               MetadataInteropHelpers.getMetadataOrNull(
-                  signatureMeta.signature(), TypeNames$.MODULE$, BindingsMap.Resolution.class);
+                  signatureMeta.signature(), TypeNames.INSTANCE, BindingsMap.Resolution.class);
           assertThat(res, is(notNullValue()));
           assertThat(res.target(), instanceOf(BindingsMap.ResolvedType.class));
           assertThat(res.target().qualifiedName().toString(), is("local.Proj.My_Module.My_Type"));
@@ -205,7 +205,7 @@ public final class NameResolutionTest {
           var ascribedTypeName = ((Name.Qualified) defArg.ascribedType().get());
           var res =
               MetadataInteropHelpers.getMetadataOrNull(
-                  ascribedTypeName, TypeNames$.MODULE$, BindingsMap.Resolution.class);
+                  ascribedTypeName, TypeNames.INSTANCE, BindingsMap.Resolution.class);
           assertThat(res.target(), instanceOf(BindingsMap.ResolvedType.class));
           assertThat(res.target().qualifiedName().toString(), is("local.Proj.My_Module.My_Type"));
         });
@@ -255,7 +255,7 @@ public final class NameResolutionTest {
       var ascribedTypeName = ((Name.Qualified) defArg.ascribedType().get());
       var res =
           MetadataInteropHelpers.getMetadataOrNull(
-              ascribedTypeName, TypeNames$.MODULE$, BindingsMap.Resolution.class);
+              ascribedTypeName, TypeNames.INSTANCE, BindingsMap.Resolution.class);
       assertThat(res.target(), instanceOf(BindingsMap.ResolvedType.class));
       assertThat(res.target().qualifiedName().toString(), is("local.Lib.My_Module.My_Type"));
     }
@@ -350,7 +350,7 @@ public final class NameResolutionTest {
       var ascribedTypeName = ((Name.Qualified) defArg.ascribedType().get());
       var res =
           MetadataInteropHelpers.getMetadataOrNull(
-              ascribedTypeName, TypeNames$.MODULE$, BindingsMap.Resolution.class);
+              ascribedTypeName, TypeNames.INSTANCE, BindingsMap.Resolution.class);
       assertThat(res.target(), instanceOf(BindingsMap.ResolvedType.class));
       assertThat(res.target().qualifiedName().toString(), is("local.Lib.Data.Numbers.Integer"));
     }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesOrig.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesOrig.scala
@@ -1,5 +1,8 @@
-package org.enso.compiler.pass.resolve
+package org.enso.compiler.test.pass.resolve
 
+import org.enso.compiler.pass.resolve.MethodDefinitions
+import org.enso.compiler.pass.resolve.TypeSignatures
+import org.enso.compiler.pass.resolve.SuspendedArguments
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.MetadataStorage.MetadataPair
@@ -15,7 +18,7 @@ import org.enso.compiler.pass.analyse.BindingAnalysis
 
 /** Resolves and desugars referent name occurrences in type positions.
   */
-case object TypeNames extends IRPass {
+case object TypeNamesOrig extends IRPass {
 
   /** The type of the metadata object that the pass writes to the IR. */
   override type Metadata = BindingsMap.Resolution

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesTest.scala
@@ -1,5 +1,6 @@
 package org.enso.compiler.test.pass.resolve
 
+import org.enso.test.utils.IRDumperTestWrapper
 import org.enso.compiler.Passes
 import org.enso.compiler.pass.MiniIRPass
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
@@ -10,8 +11,6 @@ import org.enso.compiler.data.BindingsMap.ResolutionNotFound
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
 import org.enso.compiler.pass.resolve.{TypeNames, TypeSignatures}
 import org.enso.compiler.test.CompilerTest
-import org.enso.compiler.dump.service.IRDumpFactoryService
-import org.enso.compiler.dump.service.IRSource
 
 class TypeNamesTest extends CompilerTest {
 
@@ -46,23 +45,10 @@ class TypeNamesTest extends CompilerTest {
 
       if (orig != now) {
         val modName = moduleContext.getName().toString()
-        val dumper  = IRDumpFactoryService.DEFAULT.create(modName)
-        val origSrc = new IRSource(
-          orig,
-          modName,
-          "Original",
-          null,
-          null
-        );
-        dumper.dumpModule(origSrc)
-        val newSrc = new IRSource(
-          now,
-          modName,
-          "New",
-          null,
-          null
-        );
-        dumper.dumpModule(newSrc)
+        val dumper  = new IRDumperTestWrapper()
+        dumper.dump(orig, modName, "Original pass")
+        dumper.dump(now, modName, "New pass")
+        dumper.close()
         throw new IllegalStateException()
       }
       return now

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/TypeNamesTest.scala
@@ -1,6 +1,7 @@
 package org.enso.compiler.test.pass.resolve
 
 import org.enso.compiler.Passes
+import org.enso.compiler.pass.MiniIRPass
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{Diagnostic, Expression, Module}
@@ -9,6 +10,8 @@ import org.enso.compiler.data.BindingsMap.ResolutionNotFound
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
 import org.enso.compiler.pass.resolve.{TypeNames, TypeSignatures}
 import org.enso.compiler.test.CompilerTest
+import org.enso.compiler.dump.service.IRDumpFactoryService
+import org.enso.compiler.dump.service.IRSource
 
 class TypeNamesTest extends CompilerTest {
 
@@ -16,7 +19,7 @@ class TypeNamesTest extends CompilerTest {
 
   val passes = new Passes(defaultConfig)
 
-  val precursorPasses: PassGroup = passes.getPrecursors(TypeNames).get
+  val precursorPasses: PassGroup = passes.getPrecursors(TypeNames.INSTANCE).get
 
   val passConfiguration: PassConfiguration = PassConfiguration()
 
@@ -36,7 +39,33 @@ class TypeNamesTest extends CompilerTest {
       * @return [[ir]], with all type signatures resolved
       */
     def resolve(implicit moduleContext: ModuleContext): Module = {
-      TypeNames.runModule(ir, moduleContext)
+      val orig = TypeNamesOrig.runModule(ir.duplicate(), moduleContext)
+
+      val mini = TypeNames.INSTANCE.createForModuleCompilation(moduleContext)
+      val now  = MiniIRPass.compile(classOf[Module], ir, mini)
+
+      if (orig != now) {
+        val modName = moduleContext.getName().toString()
+        val dumper  = IRDumpFactoryService.DEFAULT.create(modName)
+        val origSrc = new IRSource(
+          orig,
+          modName,
+          "Original",
+          null,
+          null
+        );
+        dumper.dumpModule(origSrc)
+        val newSrc = new IRSource(
+          now,
+          modName,
+          "New",
+          null,
+          null
+        );
+        dumper.dumpModule(newSrc)
+        throw new IllegalStateException()
+      }
+      return now
     }
   }
 
@@ -53,7 +82,12 @@ class TypeNamesTest extends CompilerTest {
       * @return [[ir]], with all type signatures resolved
       */
     def resolve(implicit inlineContext: InlineContext): Expression = {
-      TypeNames.runExpression(ir, inlineContext)
+      val mini = TypeNames.INSTANCE.createForInlineCompilation(inlineContext)
+      if (mini != null) {
+        MiniIRPass.compile(classOf[Expression], ir, mini)
+      } else {
+        ir
+      }
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/TypeSignaturesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/semantic/TypeSignaturesTest.scala
@@ -1,5 +1,6 @@
 package org.enso.compiler.test.semantic
 
+import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{Expression, Module, Type}
 import org.enso.compiler.core.ir
@@ -63,19 +64,24 @@ trait TypeMatchers {
       case (Name(n), t: ir.Name.Literal) =>
         Option.when(n != t.name)((sig, expr, "names do not match"))
       case (AnyQualName(n), _) =>
-        val meta = expr.getMetadata(TypeNames)
+        val meta = expr.getMetadata(TypeNames.INSTANCE)
         meta match {
           case None =>
             Some((sig, expr, "the expression does not have a resolution"))
           case Some(resolution) =>
-            if (resolution.target.qualifiedName == n) {
+            if (
+              resolution
+                .asInstanceOf[BindingsMap.Resolution]
+                .target
+                .qualifiedName == n
+            ) {
               None
             } else {
               Some(
                 (
                   sig,
                   expr,
-                  s"The resolution is ${resolution.target.qualifiedName}, but expected ${n}"
+                  s"The resolution is ${resolution.asInstanceOf[BindingsMap.Resolution].target.qualifiedName}, but expected ${n}"
                 )
               )
             }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerError.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerError.java
@@ -1,11 +1,27 @@
 package org.enso.compiler.core;
 
 public class CompilerError extends RuntimeException {
+  private final StringBuilder info = new StringBuilder();
+
   public CompilerError(String message) {
-    this(message, null);
+    super();
+    info.append(message);
   }
 
   public CompilerError(String message, Throwable cause) {
-    super("Compiler Internal Error: " + message, cause);
+    super(null, cause);
+    info.append("Compiler Internal Error: ").append(message);
+  }
+
+  public final void attachInfo(CharSequence seq) {
+    if (!info.isEmpty()) {
+      info.append("\n");
+    }
+    info.append(seq);
+  }
+
+  @Override
+  public final String getMessage() {
+    return info.toString();
   }
 }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -562,9 +562,8 @@ final class TreeToIr {
       if (body == null) {
         body = translateSyntaxError(fun, Syntax.UnexpectedExpression$.MODULE$);
       }
-      final var raw = new Expression.Binding(name, body, loc, meta());
-      final var ascribedBody = addTypeAscription(name.name(), raw, returnType, loc);
-      return ascribedBody;
+      final var ascribedBody = addTypeAscription(name.name(), body, returnType, loc);
+      return new Expression.Binding(name, ascribedBody, loc, meta());
     } else {
       final var body = translateExpression(fun.getBody());
       if (body == null) {
@@ -574,10 +573,9 @@ final class TreeToIr {
       if (isOperator && args.size() != 2) {
         return translateSyntaxError(fun, Syntax.InvalidOperator$.MODULE$);
       }
+      final var ascribedBody = addTypeAscription(name.name(), body, returnType, loc);
       final var isPrivate = fun.getPrivate() != null;
-      final var raw = new Function.Binding(name, args, body, isPrivate, loc, true, meta());
-      final var ascribedBody = addTypeAscription(name.name(), raw, returnType, loc);
-      return ascribedBody;
+      return new Function.Binding(name, args, ascribedBody, isPrivate, loc, true, meta());
     }
   }
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -562,8 +562,9 @@ final class TreeToIr {
       if (body == null) {
         body = translateSyntaxError(fun, Syntax.UnexpectedExpression$.MODULE$);
       }
-      final var ascribedBody = addTypeAscription(name.name(), body, returnType, loc);
-      return new Expression.Binding(name, ascribedBody, loc, meta());
+      final var raw = new Expression.Binding(name, body, loc, meta());
+      final var ascribedBody = addTypeAscription(name.name(), raw, returnType, loc);
+      return ascribedBody;
     } else {
       final var body = translateExpression(fun.getBody());
       if (body == null) {
@@ -573,9 +574,10 @@ final class TreeToIr {
       if (isOperator && args.size() != 2) {
         return translateSyntaxError(fun, Syntax.InvalidOperator$.MODULE$);
       }
-      final var ascribedBody = addTypeAscription(name.name(), body, returnType, loc);
       final var isPrivate = fun.getPrivate() != null;
-      return new Function.Binding(name, args, ascribedBody, isPrivate, loc, true, meta());
+      final var raw = new Function.Binding(name, args, body, isPrivate, loc, true, meta());
+      final var ascribedBody = addTypeAscription(name.name(), raw, returnType, loc);
+      return ascribedBody;
     }
   }
 

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -538,8 +538,10 @@ final class SuggestionBuilder[A: IndexedSource](
         buildTypeSignature(tpeError.typed)
       case tname: Name =>
         tname
-          .getMetadata(TypeNames)
-          .map(t => buildResolvedTypeName(t.target))
+          .getMetadata(TypeNames.INSTANCE)
+          .map(t =>
+            buildResolvedTypeName(t.asInstanceOf[BindingsMap.Resolution].target)
+          )
           .getOrElse(TypeArg.Value(QualifiedName.simpleName(tname.name)))
 
       case _ =>

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -836,7 +836,7 @@ class IrToTruffle(
     case err: errors.Resolution =>
       TypeCheckValueNode.fail("unresolved symbol " + err.originalName.name)
     case t => {
-      val res = t.getMetadata(TypeNames)
+      val res = t.getMetadata(TypeNames.INSTANCE)
       res match {
         case Some(
               BindingsMap

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/IRDumperTestWrapper.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/IRDumperTestWrapper.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
-import org.enso.compiler.dump.service.IRDumpFactoryService;
+import org.enso.compiler.dump.service.IRDumper;
 import org.enso.compiler.dump.service.IRSource;
 
 /** Utility class for {@link org.enso.compiler.dump.service.IRDumper}. */
@@ -21,7 +21,7 @@ public final class IRDumperTestWrapper implements AutoCloseable {
   public void dump(IR ir, String moduleName, String passName) {
     var dumper = dumpers.get(moduleName);
     if (dumper == null) {
-      dumper = IRDumpFactoryService.DEFAULT.create(moduleName);
+      dumper = IRDumper.create(moduleName);
       dumpers.put(moduleName, dumper);
     }
     if (ir instanceof Module modIr) {


### PR DESCRIPTION
### Pull Request Description

- derived from a work on #13593
- while trying to change handling of `->`
- I decided to rewrite the pass to mini pass in Java

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [ ] Unit tests have been written where possible.
