### PR TITLE
Bubbling keyboard modifiers

### DIFF
--- a/app/gui/src/App.vue
+++ b/app/gui/src/App.vue
@@ -23,7 +23,7 @@ import { provideFullscreenRoot } from '@/providers/fullscreenRoot'
 import { provideGlobalEventRegistry } from '@/providers/globalEventRegistry'
 import { injectGuiConfig } from '@/providers/guiConfig'
 import { provideInteractionHandler } from '@/providers/interactionHandler'
-import { provideKeyboard } from '@/providers/keyboard'
+import { provideBubblingKeyboard, provideKeyboard } from '@/providers/keyboard'
 import { provideTooltipRegistry } from '@/providers/tooltipRegistry'
 import { registerAutoBlurHandler, registerGlobalBlurHandler } from '@/util/autoBlur'
 import { reactComponent } from '@/util/react'
@@ -54,6 +54,7 @@ const userSession = computed(() => auth.session)
 useAppTitle(userSession)
 
 provideKeyboard()
+provideBubblingKeyboard()
 const interaction = provideInteractionHandler()
 const actions = initializeActions()
 registerAutoBlurHandler()

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -100,7 +100,7 @@ providePopoverRoot(rootNode)
 const { visibleMessage, hiddenMessage } = useNodeMessage({
   projectStore,
   graphDb: graph.db,
-  passEvents: () => outputHovered.value,
+  passEvents: () => outputVisible.value,
   expand: () => nodeHovered.value || selected.value,
   nodeId,
 })
@@ -168,7 +168,8 @@ function ensureSelected() {
   }
 }
 
-const outputHovered = computed(() => graph.nodeOutputVisible.get(nodeId.value))
+const outputVisible = computed(() => graph.nodeOutputVisible.get(nodeId.value))
+const outputHovered = computed(() => graph.nodeOutputHovered.get(nodeId.value))
 
 const scale = computed(() => navigator?.scale ?? 1)
 const nodeRect = computed(() => new Rect(props.node.position, nodeSize.value))

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
@@ -1,6 +1,6 @@
 import type GraphVisualization from '@/components/GraphEditor/GraphVisualization.vue'
 import { type RawDataSource } from '@/components/GraphEditor/GraphVisualization/visualizationData'
-import { injectKeyboard } from '@/providers/keyboard'
+import { injectBubblingKeyboard } from '@/providers/keyboard'
 import type { TypeInfo } from '@/stores/project/computedValueRegistry'
 import { type VisualizationDataSource } from '@/stores/visualization'
 import { type Opt } from '@/util/data/opt'
@@ -43,7 +43,7 @@ export function useNodeVisualization({
   hidden,
   emit,
 }: NodeVisualizationOptions) {
-  const keyboard = injectKeyboard()
+  const keyboard = injectBubblingKeyboard()
   const metadata = computed(() => toValue(vis))
   const visualizationWidth = computed<number | null>({
     get: () => metadata.value?.width ?? null,

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeVisualization.ts
@@ -1,7 +1,7 @@
 import type GraphVisualization from '@/components/GraphEditor/GraphVisualization.vue'
 import { type RawDataSource } from '@/components/GraphEditor/GraphVisualization/visualizationData'
 import { injectKeyboard } from '@/providers/keyboard'
-import { TypeInfo } from '@/stores/project/computedValueRegistry'
+import type { TypeInfo } from '@/stores/project/computedValueRegistry'
 import { type VisualizationDataSource } from '@/stores/visualization'
 import { type Opt } from '@/util/data/opt'
 import { type Rect } from '@/util/data/rect'

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
@@ -120,6 +120,7 @@ const portsVisible = computed(
 const portsHoverAnimation = useApproach(() => (portsVisible.value ? 1 : 0), 50, 0.01)
 
 watchEffect(() => graph.value?.nodeOutputVisible.set(props.nodeId, portsVisible.value))
+watchEffect(() => graph.value?.nodeOutputHovered.set(props.nodeId, outputHovered.value != null))
 watchEffect(() => graph.value?.nodeOutputAnimations.set(props.nodeId, portsHoverAnimation.value))
 
 const hoverAnimations = new Map<AstId, [ReturnType<typeof useApproach>, EffectScope]>()

--- a/app/gui/src/project-view/composables/__tests__/navigator.test.ts
+++ b/app/gui/src/project-view/composables/__tests__/navigator.test.ts
@@ -4,7 +4,7 @@ import { Vec2 } from '@/util/data/vec2'
 import { withSetup } from '@/util/testing'
 import { describe, expect, test, vi } from 'vitest'
 import { ref } from 'vue'
-import { useKeyboard } from '../keyboard'
+import { useGlobalKeyboard } from '../keyboard'
 
 describe('useNavigator', () => {
   function makeTestNavigator() {
@@ -12,7 +12,7 @@ describe('useNavigator', () => {
       const node = document.createElement('div')
       vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(new DOMRect(150, 150, 800, 400))
       const viewportNode = ref(node)
-      const keyboard = useKeyboard()
+      const keyboard = useGlobalKeyboard()
       return useNavigator(viewportNode, keyboard)
     })
   }

--- a/app/gui/src/project-view/composables/__tests__/selection.test.ts
+++ b/app/gui/src/project-view/composables/__tests__/selection.test.ts
@@ -7,7 +7,7 @@ import { isPointer, pointerButtonToEventInfo, type BindingInfo } from '@/util/sh
 import { appWithSetup } from '@/util/testing'
 import { beforeAll, expect, test, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
-import { useKeyboard } from '../keyboard'
+import { useGlobalKeyboard } from '../keyboard'
 import { useNavigator } from '../navigator'
 
 function selectionWithMockData() {
@@ -22,7 +22,7 @@ function selectionWithMockData() {
   mockDom.style.height = '300px'
   vi.spyOn(mockDom, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 500, 300))
 
-  const navigator = useNavigator(ref(mockDom), useKeyboard())
+  const navigator = useNavigator(ref(mockDom), useGlobalKeyboard())
 
   const selection = useSelection(navigator, rects)
   selection.setSelection(new Set([1, 2]))

--- a/app/gui/src/project-view/composables/keyboard.ts
+++ b/app/gui/src/project-view/composables/keyboard.ts
@@ -11,9 +11,9 @@ export interface KeyboardComposable {
   /** The control key; see also the platform-specific modifier key {@link mod}. */
   readonly ctrl: boolean
   /**
-   * Update the known state of modifier keys using the information in the given event. This can be used in an event
-   * handler to ensure the state is accurate; currently we miss transitions in some cases when they occur while the
-   * window is not focused.
+   * Update the known state of modifier keys using the information in the given event. This can be
+   * used in an event handler to ensure the state is accurate; currently we miss transitions in some
+   * cases when they occur while the window is not focused.
    */
   readonly updateState: (e: MouseEvent | KeyboardEvent) => void
 }

--- a/app/gui/src/project-view/composables/keyboard.ts
+++ b/app/gui/src/project-view/composables/keyboard.ts
@@ -1,45 +1,102 @@
 import { isMacLike, useEvent } from '@/composables/events'
-import { proxyRefs } from '@/util/reactivity'
-import { ref } from 'vue'
+import { proxyRefs, type ToValue } from '@/util/reactivity'
+import { type Ref, ref, toRef, watch } from 'vue'
+import type { Opt } from 'ydoc-shared/util/data/opt'
 
-/** {@link useKeyboard} composable object */
-export type KeyboardComposable = ReturnType<typeof useKeyboard>
-/** Composable containing reactive flags for modifier's press state. */
-export function useKeyboard() {
-  const state = {
-    alt: ref(false),
-    shift: ref(false),
-    meta: ref(false),
-    ctrl: ref(false),
-  }
-
+/** Keyboard modifier state API */
+export interface KeyboardComposable {
+  readonly alt: boolean
+  readonly shift: boolean
+  readonly mod: boolean
+  /** The control key; see also the platform-specific modifier key {@link mod}. */
+  readonly ctrl: boolean
   /**
    * Update the known state of modifier keys using the information in the given event. This can be used in an event
    * handler to ensure the state is accurate; currently we miss transitions in some cases when they occur while the
    * window is not focused.
    */
-  const updateState = (e: MouseEvent | KeyboardEvent) => {
-    state.alt.value = e.altKey
-    state.shift.value = e.shiftKey
-    state.meta.value = e.metaKey
-    state.ctrl.value = e.ctrlKey
-  }
-  const resetState = () => {
-    state.alt.value = false
-    state.shift.value = false
-    state.meta.value = false
-    state.ctrl.value = false
-  }
+  readonly updateState: (e: MouseEvent | KeyboardEvent) => void
+}
+
+/** Composable containing reactive flags for modifier's press state. */
+export function useGlobalKeyboard(): KeyboardComposable {
+  const { state, updateState, resetState } = useKeyboardState()
+
   useEvent(window, 'keydown', updateState, { capture: true })
   useEvent(window, 'keyup', updateState, { capture: true })
   useEvent(window, 'blur', resetState, { capture: true })
 
+  return useKeyboardApi(state, updateState)
+}
+
+function useEventListener<T extends keyof HTMLElementEventMap>(
+  element: HTMLElement,
+  event: T,
+  handler: (ev: HTMLElementEventMap[T]) => void,
+  onCleanup: (callback: () => void) => void,
+) {
+  element.addEventListener(event, handler)
+  onCleanup(() => element.removeEventListener(event, handler))
+}
+
+/**
+ * Composable containing reactive flags for modifier's press state, considering only keys pressed
+ * while focus was within a certain element.
+ */
+export function useLocalKeyboard(element: ToValue<Opt<HTMLElement>>): KeyboardComposable {
+  const { state, updateState, resetState } = useKeyboardState()
+
+  watch(
+    toRef(element),
+    (element, _prev, onCleanup) => {
+      resetState()
+      if (element) {
+        useEventListener(element, 'keydown', updateState, onCleanup)
+        useEventListener(element, 'focusout', resetState, onCleanup)
+        element.addEventListener('focusout', resetState)
+        onCleanup(() => element.removeEventListener('focusout', resetState))
+      }
+    },
+    { immediate: true },
+  )
+  useEvent(window, 'keyup', updateState, { capture: true })
+
+  return useKeyboardApi(state, updateState)
+}
+
+type ModifierState = Record<'alt' | 'shift' | 'ctrl' | 'meta', Ref<boolean>>
+type UpdateState = (e: MouseEvent | KeyboardEvent) => void
+
+function useKeyboardState() {
+  const state: ModifierState = {
+    alt: ref(false),
+    shift: ref(false),
+    meta: ref(false),
+    ctrl: ref(false),
+  }
+  return {
+    updateState: (e: MouseEvent | KeyboardEvent) => {
+      state.alt.value = e.altKey
+      state.shift.value = e.shiftKey
+      state.meta.value = e.metaKey
+      state.ctrl.value = e.ctrlKey
+    },
+    resetState: () => {
+      state.alt.value = false
+      state.shift.value = false
+      state.meta.value = false
+      state.ctrl.value = false
+    },
+    state,
+  }
+}
+
+function useKeyboardApi({ alt, shift, ctrl, meta }: ModifierState, updateState: UpdateState) {
   return proxyRefs({
-    alt: state.alt,
-    shift: state.shift,
-    meta: state.meta,
-    ctrl: state.ctrl,
-    mod: isMacLike ? state.meta : state.ctrl,
+    alt,
+    shift,
+    ctrl,
+    mod: isMacLike ? meta : ctrl,
     updateState,
   })
 }

--- a/app/gui/src/project-view/providers/keyboard.ts
+++ b/app/gui/src/project-view/providers/keyboard.ts
@@ -1,6 +1,12 @@
-import { useKeyboard } from '@/composables/keyboard'
+import { useGlobalKeyboard, useLocalKeyboard } from '@/composables/keyboard'
 import { createContextStore } from '@/providers'
 
-export const [provideKeyboard, injectKeyboard] = createContextStore('Keyboard watcher', () =>
-  useKeyboard(),
+export const [provideKeyboard, injectKeyboard] = createContextStore(
+  'Global keyboard modifier state',
+  () => useGlobalKeyboard(),
+)
+
+export const [provideBubblingKeyboard, injectBubblingKeyboard] = createContextStore(
+  'Bubbling keyboard modifier state',
+  () => useLocalKeyboard(document.body),
 )

--- a/app/gui/src/project-view/stores/graph/index.ts
+++ b/app/gui/src/project-view/stores/graph/index.ts
@@ -138,6 +138,7 @@ export function createGraphStore(
     nodeHovered: useAssociatedFlag({ onCleanup }),
     nodeExtended: useAssociatedFlag({ onCleanup }),
     nodeOutputVisible: useAssociatedFlag({ onCleanup }),
+    nodeOutputHovered: useAssociatedFlag({ onCleanup }),
     nodeRects: useAssociatedValue<NodeId, Rect>({ onCleanup }),
     vizRects: useAssociatedValue<NodeId, Rect>({ onCleanup }),
     nodeOutputAnimations: useAssociatedValue<NodeId, number>({ onCleanup }),

--- a/app/gui/src/project-view/util/codemirror/keymap.ts
+++ b/app/gui/src/project-view/util/codemirror/keymap.ts
@@ -53,15 +53,23 @@ function bindCommands<T extends string>(
   })
 }
 
+function isNormalPrintableKey(event: KeyboardEvent) {
+  // This condition matches most printable characters, but not Enter or Tab.
+  return event.key.length === 1 && !modKey(event) && !event.altKey
+}
+
+function isModifierKey(key: string) {
+  // This condition matches modifier keys that may be used as part of text editing and should be
+  // stopped from propagating to ancestors.
+  return ['Control', 'Alt', 'Meta', 'Shift'].includes(key)
+}
+
 const stopNormalKeys: KeyBinding[] = [
   {
     any: (_view, event: KeyboardEvent) => {
       // Stop propagation of typical keys that will result in a character being inserted into the
-      // editor.
-      // This condition matches most printable characters, but not Enter or Tab.
-      if (event.key.length === 1 && !modKey(event) && !event.altKey) {
-        event.stopImmediatePropagation()
-      }
+      // editor, and modifier keys occurring alone.
+      if (isNormalPrintableKey(event) || isModifierKey(event.key)) event.stopImmediatePropagation()
       return false
     },
   },


### PR DESCRIPTION
### Pull Request Description

Prevent the modifier key from opening the visualization preview if pressed while a CodeMirror editor is focused. Fixes #13634.

### Important Notes

- Also fix a bug in node hovered state detection

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
