### PR TITLE
Fix removing argument default

### DIFF
--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -125,16 +125,96 @@ test('Component help', async ({ page }) => {
   await expect(locate.rightDock(page)).toHaveText(/Reads a file into Enso/)
 })
 
-test('Documentation reflects entered function', async ({ page }) => {
-  const { docsContent } = await goToGraphAndGetDocs(page)
+test.describe('User-defined component documentation', () => {
+  async function enterUdc(page: Page) {
+    await mockUserDefinedFunctionInfo(page, 'final', 'func1')
+    await locate.graphNodeByBinding(page, 'final').dblclick()
+    await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project', 'func1'])
+  }
 
-  // Enter the User Defined Function function
-  await mockUserDefinedFunctionInfo(page, 'final', 'func1')
-  await locate.graphNodeByBinding(page, 'final').dblclick()
-  await expect(locate.navBreadcrumb(page)).toHaveText(['Mock Project', 'func1'])
+  test('Entering function', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await enterUdc(page)
+    await expect(docsContent).toHaveText('A User Defined Function')
+  })
 
-  // Editor should contain function's docs
-  await expect(docsContent).toHaveText('A User Defined Function')
+  class FunctionSignatureEditor {
+    private constructor(private readonly locator: Locator) {}
+
+    static async new(within: Locator): Promise<FunctionSignatureEditor> {
+      const locator = within.locator('.FunctionSignatureEditor')
+      await locator.waitFor()
+      return new FunctionSignatureEditor(locator)
+    }
+
+    async expectArguments(count: number): Promise<FunctionSignatureEditorArgument[]> {
+      const argLocators = this.locator.locator('.FunctionDefArguments').locator('.ArgumentRow')
+      await expect(argLocators).toHaveCount(count)
+      const args = await argLocators.all()
+      expect(args.length).toBe(count)
+      return args.map(
+        (locator) => new FunctionSignatureEditorArgument(locator, { popoverRoot: this.locator }),
+      )
+    }
+  }
+
+  type MissingBehaviour = 'required' | 'optional' | 'default'
+
+  class FunctionSignatureEditorArgument {
+    public readonly defaultValue: Locator
+    private readonly popoverRoot: Locator
+    private readonly missingBehaviour: Locator
+    constructor(
+      private readonly locator: Locator,
+      { popoverRoot }: { popoverRoot: Locator },
+    ) {
+      this.defaultValue = this.locator.getByTestId('missing-default-value')
+      this.popoverRoot = popoverRoot
+      this.missingBehaviour = locator.getByTestId('missing-behaviour')
+    }
+
+    /** Check that the current missing-argument behaviour is as specified. */
+    expectMissingBehaviour(behaviour: MissingBehaviour): Promise<void> {
+      return expect(this.missingBehaviour).toHaveText(behaviour)
+    }
+
+    /**
+     * Use the dropdown to select a behaviour when the argument is omitted. Verifies that the new
+     * behaviour has been set before returning.
+     */
+    async setMissingBehaviour(behaviour: MissingBehaviour): Promise<void> {
+      await this.missingBehaviour.click()
+      const dropdown = this.popoverRoot.locator('.DropdownWidget')
+      await expect(dropdown).toExist()
+      const items = dropdown.locator('.item')
+      const item = items.getByText(behaviour)
+      await item.click()
+      await this.expectMissingBehaviour(behaviour)
+      await expect(dropdown).not.toBeVisible()
+      await this.expectMissingBehaviour(behaviour)
+    }
+  }
+
+  test('Changing argument default', async ({ page }) => {
+    await goToGraphAndGetDocs(page)
+    await enterUdc(page)
+    const fse = await FunctionSignatureEditor.new(locate.rightDock(page))
+    const [arg] = await fse.expectArguments(1)
+    await arg!.expectMissingBehaviour('optional')
+    await expect(arg!.defaultValue).not.toBeVisible()
+    await arg!.setMissingBehaviour('required')
+    await expect(arg!.defaultValue).not.toBeVisible()
+    await arg!.setMissingBehaviour('optional')
+    await expect(arg!.defaultValue).not.toBeVisible()
+    await arg!.setMissingBehaviour('default')
+    await expect(arg!.defaultValue).toBeVisible()
+
+    // Regression test for #13627: Ensure missing-behaviour can be changed when the default value
+    // widget is focused.
+    await arg!.defaultValue.locator('.WidgetEnsoExpression').click()
+    await expect(arg!.defaultValue.locator('.WidgetEnsoExpression .cm-content')).toBeFocused()
+    await arg!.setMissingBehaviour('optional')
+  })
 })
 
 test('Link in documentation is rendered and interactive', async ({ page, context }) => {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetEnsoExpression.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetEnsoExpression.vue
@@ -10,7 +10,7 @@ import {
 } from '@/providers/widgetRegistry'
 import { Ast } from '@/util/ast'
 import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { BodyBlock, MutableModule } from 'ydoc-shared/ast'
 
 const props = defineProps(widgetProps(widgetDefinition))
@@ -40,6 +40,8 @@ const extensions = [
   syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
   ensoSyntax(moduleRoot),
 ]
+
+const cmWidget = useTemplateRef('cmWidget')
 </script>
 
 <script lang="ts">
@@ -63,8 +65,12 @@ export const widgetDefinition = defineWidget(
 </script>
 
 <template>
-  <div class="WidgetEnsoExpression widgetRounded widgetPill">
+  <div
+    class="WidgetEnsoExpression widgetRounded widgetPill"
+    @click.stop="cmWidget?.focusAndSelect()"
+  >
     <CodeMirrorWidgetBase
+      ref="cmWidget"
       v-model="astCode"
       :widgetTypeId="widgetTypeId"
       :input="input"

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetEnsoExpression.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetEnsoExpression.vue
@@ -10,7 +10,7 @@ import {
 } from '@/providers/widgetRegistry'
 import { Ast } from '@/util/ast'
 import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { BodyBlock, MutableModule } from 'ydoc-shared/ast'
 
 const props = defineProps(widgetProps(widgetDefinition))

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunctionDef/ArgumentRow.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunctionDef/ArgumentRow.vue
@@ -1,33 +1,31 @@
 <script setup lang="ts">
 import { useCurrentProject } from '$/components/WithCurrentProject.vue'
 import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import { EnsoExpression } from '@/components/GraphEditor/widgets/WidgetEnsoExpression.vue'
+import {
+  type ArgumentDefaultKind,
+  createDefaultExpressionOfKind,
+  getArgumentDefaultKind,
+} from '@/components/GraphEditor/widgets/WidgetFunctionDef/argumentAst'
+import SelectionSubmenu from '@/components/GraphEditor/widgets/WidgetSelection/SelectionSubmenu.vue'
+import { EnsoTypeExpression } from '@/components/GraphEditor/widgets/WidgetTypeExpression.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
-import { DropdownEntry } from '@/components/widgets/DropdownWidget.vue'
+import { type DropdownEntry } from '@/components/widgets/DropdownWidget.vue'
 import { PortId, syntheticPortId } from '@/providers/portInfo'
 import {
   rewritePortValueUpdate,
-  UpdateHandler,
+  type UpdateHandler,
   WidgetInput,
-  WidgetUpdate,
+  type WidgetUpdate,
 } from '@/providers/widgetRegistry'
 import { WidgetEditHandler } from '@/providers/widgetRegistry/editHandler'
 import { Ast } from '@/util/ast'
-import { unwrapGroups } from '@/util/ast/abstract'
-import { endOnClick, targetIsOutside } from '@/util/autoBlur'
-import { mapOrUndefined, Opt } from '@/util/data/opt'
+import { mapOrUndefined, type Opt } from '@/util/data/opt'
 import { Err, Ok } from '@/util/data/result'
 import { proxyRefs } from '@/util/reactivity'
 import { computed, useTemplateRef } from 'vue'
-import { ComponentProps } from 'vue-component-type-helpers'
-import { ArgumentDefinition, ConcreteRefs } from 'ydoc-shared/ast'
-import { EnsoExpression } from '../WidgetEnsoExpression.vue'
-import SelectionSubmenu from '../WidgetSelection/SelectionSubmenu.vue'
-import { EnsoTypeExpression } from '../WidgetTypeExpression.vue'
-import {
-  ArgumentDefaultKind,
-  createDefaultExpressionOfKind,
-  getArgumentDefaultKind,
-} from './argumentAst'
+import type { ComponentProps } from 'vue-component-type-helpers'
+import type { ArgumentDefinition, ConcreteRefs } from 'ydoc-shared/ast'
 
 const { definition, onUpdate, portIdBase } = defineProps<{
   root: Opt<HTMLElement>
@@ -111,8 +109,10 @@ function resolveType(typeExpr: Ast.Ast) {
 }
 
 const nodeDefaultPortId = computed(() => syntheticPortId(portIdBase, 'defaultExpr'))
-const nodeDefault = computed((): WidgetProps => {
-  let expr = unwrapGroups(definition.defaultValue?.expression?.node)
+const nodeDefault = computed((): WidgetProps | undefined => {
+  if (defaultKind.value !== 'explicit') return
+
+  let expr = Ast.unwrapGroups(definition.defaultValue?.expression?.node)
   if (expr instanceof Ast.Group || expr instanceof Ast.Invalid) expr = undefined
   const syntheticId = nodeDefaultPortId.value
   const expectedType = mapOrUndefined(definition.type?.type?.node, resolveType)
@@ -120,7 +120,6 @@ const nodeDefault = computed((): WidgetProps => {
     input: {
       ...WidgetInput.FromAstOrPlaceholder(expr, () => syntheticId),
       expectedType,
-      editHandler: defaultValueDropdownInteraction.value,
       [EnsoExpression]: {
         weakMatch: true,
       },
@@ -141,25 +140,27 @@ const nodeDefault = computed((): WidgetProps => {
 
 const submenuRef = useTemplateRef('submenuRef')
 const defaultValueRoot = useTemplateRef<HTMLElement>('defaultValueRoot')
-function isOutsideDropdown(event: Event) {
-  return submenuRef.value?.isTargetOutside(event) ?? false
-}
-
-function isOutsideWidget(event: Event) {
-  return targetIsOutside(event, defaultValueRoot.value)
-}
 
 // Close the dropdown when clicking outside of it, but also end parent interaction when clicking outside of both.
 const defaultValueDropdownInteraction = WidgetEditHandler.NewNested(
   nodeDefaultPortId,
   () => undefined,
-  endOnClick((event) => isOutsideDropdown(event) && !isOutsideWidget(event), {
-    end() {},
-    cancel() {},
-  }),
+  {
+    pointerdown: (ev) => {
+      if (submenuRef.value?.isTargetOutside(ev)) defaultValueDropdownInteraction.value.end()
+    },
+  },
 )
 
 const defaultKind = computed(() => getArgumentDefaultKind(definition))
+const defaultKindText = computed(
+  (): string =>
+    ({
+      required: 'required',
+      optional: 'optional',
+      explicit: 'default',
+    })[defaultKind.value],
+)
 
 function defaultOnClick(entry: (typeof defaultEntries)[number]) {
   if (entry.value !== defaultKind.value) {
@@ -210,17 +211,9 @@ const defaultEntries = [
         :extendUpwards="false"
         @clickedEntry="defaultOnClick"
       />
-      <template v-if="defaultKind == 'optional'">
-        <span class="tokenText">optional</span>
-      </template>
-      <template v-else-if="defaultKind == 'required'">
-        <span class="tokenText">required</span>
-      </template>
-      <template v-else>
-        <span class="tokenText pad-right">default</span>
-        <NodeWidget v-bind="nodeDefault" />
-      </template>
+      <span class="tokenText">{{ defaultKindText }}</span>
     </div>
+    <NodeWidget v-if="nodeDefault" v-bind="nodeDefault" class="pad-left" />
   </div>
 </template>
 
@@ -233,8 +226,8 @@ const defaultEntries = [
   overflow-x: clip;
 }
 
-.pad-right {
-  margin-right: 4px;
+.pad-left {
+  margin-left: 4px;
 }
 
 .defaultValueRoot {
@@ -243,7 +236,7 @@ const defaultEntries = [
 
 svg.dropdownArrow {
   position: absolute;
-  bottom: -8px;
+  bottom: -10px;
   left: 50%;
   transform: translateX(-50%) rotate(90deg) scale(0.7);
   transform-origin: center;

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunctionDef/ArgumentRow.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunctionDef/ArgumentRow.vue
@@ -193,7 +193,7 @@ const defaultEntries = [
     <span class="tokenText">&nbsp;=&nbsp;</span>
     <div
       ref="defaultValueRoot"
-      class="defaultValueRoot"
+      class="defaultValueRoot clickable"
       @click.stop="defaultValueDropdownInteraction.start()"
     >
       <SvgIcon
@@ -211,9 +211,14 @@ const defaultEntries = [
         :extendUpwards="false"
         @clickedEntry="defaultOnClick"
       />
-      <span class="tokenText">{{ defaultKindText }}</span>
+      <span class="tokenText" data-testid="missing-behaviour">{{ defaultKindText }}</span>
     </div>
-    <NodeWidget v-if="nodeDefault" v-bind="nodeDefault" class="pad-left" />
+    <NodeWidget
+      v-if="nodeDefault"
+      v-bind="nodeDefault"
+      class="pad-left"
+      data-testid="missing-default-value"
+    />
   </div>
 </template>
 

--- a/app/gui/src/project-view/util/autoBlur.ts
+++ b/app/gui/src/project-view/util/autoBlur.ts
@@ -2,7 +2,7 @@ import { unrefElement, useEvent } from '@/composables/events'
 import { injectInteractionHandler, type Interaction } from '@/providers/interactionHandler'
 import type { ToValue } from '@/util/reactivity'
 import type { VueInstance } from '@vueuse/core'
-import { onUnmounted, toValue, watchEffect, type Ref } from 'vue'
+import { onUnmounted, toValue, watchEffect } from 'vue'
 import type { Opt } from 'ydoc-shared/util/data/opt'
 
 /**
@@ -50,9 +50,11 @@ export function registerAutoBlurHandler() {
   )
 }
 
-/** Returns true if the target of the event is outside the DOM subtree of the given `area` element. */
-export function targetIsOutside(e: Event, area: Opt<Element>): boolean {
-  return isNodeOutside(e.target, area)
+/**
+ * Returns true if the target of the event is outside the DOM subtree of the given `area` element.
+ */
+export function targetIsOutside(e: Event, area: Opt<Element | VueInstance>): boolean {
+  return isNodeOutside(e.target, unrefElement(area))
 }
 
 /** Returns true if the `element` argument is a node outside the DOM subtree of the given `area`. */
@@ -61,23 +63,19 @@ export function isNodeOutside(element: any, area: Opt<Node>): boolean {
 }
 
 /**
- * Returns a new interaction based on the given `interaction`. The new interaction will be ended if a pointerdown event
- *  occurs outside the given `area` element.
- *
- * See also {@link cancelOnClickOutside}.
+ * Returns a new interaction based on the given `interaction`. The new interaction will be ended if
+ * a pointerdown event occurs outside the given `area` element.
  */
 export function endOnClickOutside(
-  area: Ref<Opt<Element | VueInstance>>,
+  area: ToValue<Opt<Element | VueInstance>>,
   interaction: Interaction,
 ): Interaction {
   return endOnClick(isClickOutside(area), interaction)
 }
 
 /**
- * Returns a new interaction based on the given `interaction`. The new interaction will be ended if a pointerdown event
- *  occurs such as a `condition` returns `true`.
- *
- * See also {@link cancelOnClickOutside}.
+ * Returns a new interaction based on the given `interaction`. The new interaction will be ended if
+ * a pointerdown event occurs such as a `condition` returns `true`.
  */
 export function endOnClick(
   condition: (e: PointerEvent) => boolean,
@@ -87,39 +85,10 @@ export function endOnClick(
   return handleClick(condition, interaction, handler.end.bind(handler))
 }
 
-/**
- * Returns a new interaction based on the given `interaction`. The new interaction will be canceled if a pointerdown event
- *  occurs such as a `condition` returns `true`.
- *
- * See also {@link cancelOnClickOutside}.
- */
-export function cancelOnClick(
-  condition: (e: PointerEvent) => boolean,
-  interaction: Interaction,
-): Interaction {
-  const handler = injectInteractionHandler()
-  return handleClick(condition, interaction, handler.cancel.bind(handler))
+function isClickOutside(area: ToValue<Opt<Element | VueInstance>>) {
+  return (e: PointerEvent) => targetIsOutside(e, toValue(area))
 }
 
-/**
- * Returns a new interaction based on the given `interaction`. The new interaction will be canceled if a pointerdown event
- *  occurs outside the given `area` element.
- *
- * See also {@link endOnClickOutside}.
- */
-export function cancelOnClickOutside(
-  area: Ref<Opt<Element | VueInstance>>,
-  interaction: Interaction,
-) {
-  const handler = injectInteractionHandler()
-  return handleClick(isClickOutside(area), interaction, handler.cancel.bind(handler))
-}
-
-function isClickOutside(area: Ref<Opt<Element | VueInstance>>) {
-  return (e: PointerEvent) => targetIsOutside(e, unrefElement(area))
-}
-
-/** Common part of {@link cancelOnClickOutside} and {@link endOnClickOutside}. */
 function handleClick(
   condition: (e: PointerEvent) => boolean,
   interaction: Interaction,


### PR DESCRIPTION
Fix removing argument default value (fixes #13627)--change the relationship between the required/optional/default dropdown and the default value, so that the default value is treated similarly to how we would treat an argument to a selected constructor.

Also:
- Make Enso Expression Widget easier to click
- Fix closing argument requiredness dropdown on click outside

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
