### PR TITLE
`JAVA_TOOL_OPTIONS` need `=` to specify `--add-exports`

### DIFF
--- a/docs/runtime/compiler-ir.md
+++ b/docs/runtime/compiler-ir.md
@@ -43,7 +43,7 @@ package of GraalVM JDK's module which is not exported by default.
 Usage example:
 
 ```
-$ env JAVA_TOOL_OPTIONS='--add-exports jdk.graal.compiler/jdk.graal.compiler.graphio=org.enso.runtime.compiler.dump.igv -Denso.compiler.dumpIr=Vector' ./built-distribution/*/bin/enso --no-ir-caches --run tmp.enso
+$ env JAVA_TOOL_OPTIONS='--add-exports=jdk.graal.compiler/jdk.graal.compiler.graphio=org.enso.runtime.compiler.dump.igv -Denso.compiler.dumpIr=Vector' ./built-distribution/*/bin/enso --no-ir-caches --run tmp.enso
 ```
 
 The IR graphs are dumped directly to IGV, if it is running, or to the `ir-dumps`

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumper.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumper.java
@@ -15,12 +15,11 @@ import jdk.graal.compiler.graphio.GraphOutput;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
-import org.enso.compiler.dump.service.IRDumper;
 import org.enso.compiler.dump.service.IRSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class IGVDumper implements IRDumper {
+final class IGVDumper {
 
   private static final String DEFAULT_DUMP_DIR = "ir-dumps";
   private static final Logger LOGGER = LoggerFactory.getLogger(IGVDumper.class);
@@ -73,13 +72,11 @@ public final class IGVDumper implements IRDumper {
     return channel;
   }
 
-  @Override
   public void dumpModule(IRSource<Module> ctx) {
     assert ctx.name().equals(this.moduleName);
     dumpTask(ctx);
   }
 
-  @Override
   public void dumpExpression(IRSource<Expression> ctx) {
     dumpTask(ctx);
   }
@@ -121,7 +118,6 @@ public final class IGVDumper implements IRDumper {
     return props;
   }
 
-  @Override
   public void close() {
     if (groupCreated) {
       assert graphOutput != null;

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumperFactory.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/IGVDumperFactory.java
@@ -1,11 +1,13 @@
 package org.enso.compiler.dump.igv;
 
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Module;
 import org.enso.compiler.dump.service.IRDumpFactoryService;
-import org.enso.compiler.dump.service.IRDumper;
+import org.enso.compiler.dump.service.IRSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IGVDumperFactory implements IRDumpFactoryService {
+public final class IGVDumperFactory extends IRDumpFactoryService<IGVDumper> {
   private static final Logger LOGGER = LoggerFactory.getLogger(IGVDumperFactory.class);
   private static final String GRAPHIO_PKG = "jdk.graal.compiler.graphio";
   private static final String COMPILER_MOD = "jdk.graal.compiler";
@@ -32,11 +34,26 @@ public class IGVDumperFactory implements IRDumpFactoryService {
   }
 
   @Override
-  public IRDumper create(String moduleName) {
+  protected IGVDumper create(String moduleName) {
     LOGGER.trace("Creating IGV dumper for module {}", moduleName);
     return IGVDumper.createForModule(moduleName);
   }
 
   @Override
-  public void shutdown() {}
+  protected void shutdown() {}
+
+  @Override
+  protected void dumpModule(IGVDumper group, IRSource<Module> src) {
+    group.dumpModule(src);
+  }
+
+  @Override
+  protected void dumpExpression(IGVDumper group, IRSource<Expression> src) {
+    group.dumpExpression(src);
+  }
+
+  @Override
+  protected void close(IGVDumper group) {
+    group.close();
+  }
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpFactoryService.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpFactoryService.java
@@ -1,13 +1,45 @@
 package org.enso.compiler.dump.service;
 
-/** A service that creates {@link org.enso.compiler.core.IR} dumpers for modules. */
-public interface IRDumpFactoryService {
-  static final IRDumpFactoryService DEFAULT = IRDumpSingleton.DEFAULT;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Module;
 
-  String SYSTEM_PROP = "enso.compiler.dumpIr";
-  String DEFAULT_DUMP_DIR = "ir-dumps";
+/**
+ * A service provider interface to implement to handler dumping of {@link Module} and {@link
+ * Expression} IRs. Contains methods that create and deal with {@link org.enso.compiler.core.IR}
+ * dumpers. Don't call directly. Use {@link IRDumper} which contains the API for perform the
+ * dumping.
+ *
+ * @param <Dump> type to use for grouping of dumpings
+ */
+public abstract class IRDumpFactoryService<Dump> {
+  public static final String SYSTEM_PROP = "enso.compiler.dumpIr";
+  public static final String DEFAULT_DUMP_DIR = "ir-dumps";
 
-  IRDumper create(String moduleName);
+  protected abstract Dump create(String moduleName);
 
-  void shutdown();
+  protected abstract void shutdown();
+
+  /**
+   * Dumps module IR.
+   *
+   * @param group
+   * @param src what to dump
+   */
+  protected abstract void dumpModule(Dump group, IRSource<Module> src);
+
+  /**
+   * Dumps a single expression IR.
+   *
+   * @param group
+   * @param src
+   */
+  protected abstract void dumpExpression(Dump group, IRSource<Expression> src);
+
+  /**
+   * Close and flush all the underlying resources. There will be no more dumps for the module after
+   * this call.
+   *
+   * @param group
+   */
+  protected abstract void close(Dump group);
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpSingleton.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumpSingleton.java
@@ -1,12 +1,13 @@
 package org.enso.compiler.dump.service;
 
 import java.util.ServiceLoader;
+import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
 
 final class IRDumpSingleton {
-  static final IRDumpFactoryService DEFAULT = find();
+  static final IRDumpFactoryService<?> DEFAULT = find();
 
-  private static IRDumpFactoryService find() {
+  private static IRDumpFactoryService<?> find() {
     IRDumpFactoryService service = new NoDumping();
     var loader = ServiceLoader.load(IRDumpFactoryService.class);
     var it = loader.iterator();
@@ -18,19 +19,22 @@ final class IRDumpSingleton {
     return service;
   }
 
-  private static final class NoDumping implements IRDumpFactoryService, IRDumper {
+  private static final class NoDumping extends IRDumpFactoryService<Void> {
     @Override
-    public IRDumper create(String moduleName) {
-      return this;
+    public Void create(String moduleName) {
+      return null;
     }
 
     @Override
     public void shutdown() {}
 
     @Override
-    public void dumpModule(IRSource<Module> ir) {}
+    public void dumpModule(Void group, IRSource<Module> ir) {}
 
     @Override
-    public void close() {}
+    public void dumpExpression(Void group, IRSource<Expression> ir) {}
+
+    @Override
+    public void close(Void group) {}
   }
 }

--- a/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumper.java
+++ b/engine/runtime-compiler-dump/src/main/java/org/enso/compiler/dump/service/IRDumper.java
@@ -3,23 +3,71 @@ package org.enso.compiler.dump.service;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
 
-public interface IRDumper {
+/** Main entry point to dumping of IR graphs. */
+public abstract class IRDumper {
+  IRDumper() {}
 
   /**
-   * Dumps module IR.
+   * Creates new dumping group.
    *
-   * @param dump what to dump
+   * @param name name of the dumping group
+   * @return
    */
-  void dumpModule(IRSource<Module> dump);
-
-  /** Dumps a single expression IR. */
-  default void dumpExpression(IRSource<Expression> dump) {
-    // nop
+  public static IRDumper create(String name) {
+    return Impl.create(name, IRDumpSingleton.DEFAULT);
   }
+
+  /**
+   * Dumps provide source into this group.
+   *
+   * @param src info about the data to dump
+   */
+  public abstract void dumpModule(IRSource<Module> src);
+
+  /**
+   * Dumps provide source into this group.
+   *
+   * @param src info about the data to dump
+   */
+  public abstract void dumpExpression(IRSource<Expression> src);
 
   /**
    * Close and flush all the underlying resources. There will be no more dumps for the module after
    * this call.
    */
-  void close();
+  public abstract void close();
+
+  /**
+   * Open class to hold service and a dumper.
+   *
+   * @param <D> the type shared by service and dumper.
+   */
+  private static final class Impl<D> extends IRDumper {
+    final IRDumpFactoryService<D> service;
+    final D dumper;
+
+    private Impl(IRDumpFactoryService<D> service, D dumper) {
+      this.service = service;
+      this.dumper = dumper;
+    }
+
+    static <D> IRDumper create(String name, IRDumpFactoryService<D> factory) {
+      return new Impl<>(factory, factory.create(name));
+    }
+
+    @Override
+    public void close() {
+      service.close(dumper);
+    }
+
+    @Override
+    public void dumpModule(IRSource<Module> src) {
+      service.dumpModule(dumper, src);
+    }
+
+    @Override
+    public void dumpExpression(IRSource<Expression> src) {
+      service.dumpExpression(dumper, src);
+    }
+  }
 }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -387,11 +387,17 @@ class Compiler(
           isGeneratingDocs = generateDocs
         )
         val compilerOutput =
-          runGlobalTypingPasses(
-            module.getIr(),
-            moduleContext,
-            irDumper = getOrCreateDumper(module)
-          )
+          try {
+            runGlobalTypingPasses(
+              module.getIr(),
+              moduleContext,
+              irDumper = getOrCreateDumper(module)
+            )
+          } catch {
+            case err: CompilerError =>
+              err.attachInfo("At " + moduleContext.getName())
+              throw err
+          }
 
         context.updateModule(
           module,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -31,7 +31,7 @@ import org.enso.editions.LibraryName
 import org.enso.pkg.QualifiedName
 import org.enso.common.CompilationStage
 import org.enso.compiler.docs.{DocsGenerate, DocsVisit}
-import org.enso.compiler.dump.service.{IRDumpFactoryService, IRDumper}
+import org.enso.compiler.dump.service.IRDumper
 import org.enso.compiler.pass.lint.unusedimports.UnusedImportsRemover
 import org.enso.compiler.phase.exports.{
   ExportCycleException,
@@ -304,8 +304,7 @@ class Compiler(
           moduleIrDumpers.get(module) match {
             case Some(existing) => Some(existing)
             case None =>
-              val dumper =
-                IRDumpFactoryService.DEFAULT.create(module.getName.toString)
+              val dumper = IRDumper.create(module.getName.toString)
               moduleIrDumpers = moduleIrDumpers.updated(module, dumper)
               Some(dumper)
           }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerError.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerError.java
@@ -1,11 +1,27 @@
 package org.enso.compiler.core;
 
 public class CompilerError extends RuntimeException {
+  private final StringBuilder info = new StringBuilder();
+
   public CompilerError(String message) {
-    this(message, null);
+    super();
+    info.append(message);
   }
 
   public CompilerError(String message, Throwable cause) {
-    super("Compiler Internal Error: " + message, cause);
+    super(null, cause);
+    info.append("Compiler Internal Error: ").append(message);
+  }
+
+  public final void attachInfo(CharSequence seq) {
+    if (!info.isEmpty()) {
+      info.append("\n");
+    }
+    info.append(seq);
+  }
+
+  @Override
+  public final String getMessage() {
+    return info.toString();
   }
 }

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/IRDumperTestWrapper.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/IRDumperTestWrapper.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Module;
-import org.enso.compiler.dump.service.IRDumpFactoryService;
+import org.enso.compiler.dump.service.IRDumper;
 import org.enso.compiler.dump.service.IRSource;
 
 /** Utility class for {@link org.enso.compiler.dump.service.IRDumper}. */
@@ -21,7 +21,7 @@ public final class IRDumperTestWrapper implements AutoCloseable {
   public void dump(IR ir, String moduleName, String passName) {
     var dumper = dumpers.get(moduleName);
     if (dumper == null) {
-      dumper = IRDumpFactoryService.DEFAULT.create(moduleName);
+      dumper = IRDumper.create(moduleName);
       dumpers.put(moduleName, dumper);
     }
     if (ir instanceof Module modIr) {


### PR DESCRIPTION
### Pull Request Description

- `JAVA_TOOL_OPTIONS` aren't exactly the same as JVM CLI parameters  as explained in [JDK-8320860](https://bugs.openjdk.org/browse/JDK-8320860)
- extracted from #13648
- refactored to adhere to [singletonizer](http://wiki.apidesign.org/wiki/Singletonizer) pattern

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually dumped IR graph to IGV
