### PR TITLE
Use custom to_json for Widgets

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Metadata.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Metadata.md
@@ -2,15 +2,18 @@
 ## module Standard.Base.Metadata
 - type Choice
     - Option label:Standard.Base.Data.Text.Text value:(Standard.Base.Data.Text.Text|Standard.Base.Any.Any)= parameters:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any)= icon:Standard.Base.Data.Text.Text=
+    - to_json self -> Standard.Base.Data.Text.Text
 - type Display
     - Always
     - Expanded_Only
     - When_Modified
+    - to_json self -> Standard.Base.Any.Any
 - type File_Action
     - Open
     - Save
+    - to_json self -> Standard.Base.Any.Any
 - type File_Type
-    - Option label:Standard.Base.Data.Text.Text extensions:(Standard.Base.Any.Any|Standard.Base.Any.Any)= icon:Standard.Base.Data.Text.Text=
+    - Option label:Standard.Base.Data.Text.Text extensions:(Standard.Base.Data.Vector.Vector Standard.Base.Data.Text.Text)= icon:Standard.Base.Data.Text.Text=
 - type Widget
     - Boolean_Input label:(Standard.Base.Nothing.Nothing|Standard.Base.Data.Text.Text)= display:Standard.Base.Metadata.Display=
     - File_Browse existing_only:Standard.Base.Data.Boolean.Boolean= label:(Standard.Base.Nothing.Nothing|Standard.Base.Data.Text.Text)= display:Standard.Base.Metadata.Display= action:Standard.Base.Metadata.File_Action= file_types:(Standard.Base.Data.Vector.Vector Standard.Base.Metadata.File_Type)=
@@ -22,4 +25,5 @@
     - Text_Input label:(Standard.Base.Nothing.Nothing|Standard.Base.Data.Text.Text)= display:Standard.Base.Metadata.Display= quote_values:Standard.Base.Data.Boolean.Boolean= suggestions:(Standard.Base.Data.Vector.Vector Standard.Base.Data.Text.Text)= syntax:(Standard.Base.Nothing.Nothing|Standard.Base.Data.Text.Text)=
     - Vector_Editor item_editor:Standard.Base.Metadata.Widget item_default:Standard.Base.Data.Text.Text label:(Standard.Base.Nothing.Nothing|Standard.Base.Data.Text.Text)= display:Standard.Base.Metadata.Display=
     - to_js_object self -> Standard.Base.Any.Any
+    - to_json self -> Standard.Base.Data.Text.Text
 - make_single_choice values:Standard.Base.Data.Vector.Vector display:Standard.Base.Metadata.Display= -> Standard.Base.Metadata.Widget

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -9,7 +9,6 @@ import project.Nothing.Nothing
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Json.Extensions import all
 from project.Data.Range.Extensions import all
-from project.Logging import all
 
 type Display
     ## Parameter is always shown on the collapsed view.
@@ -171,7 +170,6 @@ type Widget
        Override the to_js_object and don't include Nothing.
     to_js_object : JS_Object
     to_js_object self =
-        Widget.log_message ("to_js_object called for "+self.to_text) ..Info
         type_pair = [["type", Meta.type_of self . to_text]]
 
         m = Meta.meta self

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -9,6 +9,7 @@ import project.Nothing.Nothing
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Json.Extensions import all
 from project.Data.Range.Extensions import all
+from project.Logging import all
 
 type Display
     ## Parameter is always shown on the collapsed view.
@@ -20,12 +21,29 @@ type Display
     ## Parameter is only shown on the expanded view.
     Expanded_Only
 
+    ## ---
+       private: true
+       ---
+       In-lined JSON representation of the Display.
+    to_json self = case self of
+        Display.Always -> '{"constructor":"Always"}'
+        Display.When_Modified -> '{"constructor":"When_Modified"}'
+        Display.Expanded_Only -> '{"constructor":"Expanded_Only"}'
+
 type File_Action
     ## The File or Folder is for reading from.
     Open
 
     ## The File or Folder is for writing to.
     Save
+
+    ## ---
+       private: true
+       ---
+       In-lined JSON representation of the Display.
+    to_json self = case self of
+        File_Action.Open -> '{"constructor":"Open"}'
+        File_Action.Save -> '{"constructor":"Save"}'
 
 type Choice
     ## Describes an entry in a Single_Choice or Multiple_Choice widget.
@@ -37,7 +55,16 @@ type Choice
         - `parameters`: A list of parameters for the arguments for the `value`.
           This provides the structure needed for nested widgets.
         - `icon`: The icon to display for the entry. By default, no icon is used.
-    Option label:Text value:(Text | Vector Choice)=label parameters:(Vector (Pair Text Widget))=[] icon:Text=""
+    Option label:Text value:Text=label parameters:(Vector (Pair Text Widget))=[] icon:Text=""
+
+    ## ---
+       private: true
+       ---
+       In-lined JSON representation of the Choice.
+    to_json self -> Text =
+        parameter_json = if self.parameters.length == 0 then '[]' else
+            '[' + ((self.parameters.map p-> '[' + p.first.to_json + ',' + p.second.to_json + ']').join ',') + ']'
+        '{"label":' + self.label.to_json + ',"value":' + self.value.to_json + ',"parameters":' + parameter_json + ',"icon":' + self.icon.to_json + '}'
 
 type File_Type
     ## Describes a file type.
@@ -47,7 +74,7 @@ type File_Type
         - `extensions`: A list of extensions for the file type. Extensions do not
           include the dot, the only supported glob pattern is '*' (all files).
         - `icon`: The icon to display for the file type.
-    Option label:Text extensions:(Vector Text | Vector File_Type)=[label] icon:Text=""
+    Option label:Text extensions:(Vector Text)=[label] icon:Text=""
 
 type Widget
     ## Describes a single value widget (dropdown).
@@ -80,7 +107,14 @@ type Widget
     Boolean_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
 
     ## Describe a numeric parameter.
-    Numeric_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified minimum:Integer|Nothing=Nothing maximum:Integer|Nothing=Nothing step:Number=1 decimal_places:Integer=0 allow_outside:Boolean=True
+    Numeric_Input
+        label:(Nothing | Text)=Nothing
+        display:Display=Display.When_Modified
+        minimum:Integer|Nothing=Nothing
+        maximum:Integer|Nothing=Nothing
+        step:Number=1
+        decimal_places:Integer=0
+        allow_outside:Boolean=True
 
     ## Describes a text widget.
     Text_Input
@@ -97,8 +131,8 @@ type Widget
     File_Browse 
         existing_only:Boolean=True 
         label:(Nothing | Text)=Nothing 
-        display:Display=Display.When_Modified 
-        action:File_Action=File_Action.Open 
+        display:Display=..When_Modified
+        action:File_Action=..Open
         file_types:(Vector File_Type)=[File_Type.Option "All Files" ["*"]]
 
     ## Describes a secret chooser.
@@ -107,9 +141,37 @@ type Widget
     ## ---
        private: true
        ---
+       Inlined JSON representation specifically paired with `app/gui/src/project-view/providers/widgetRegistry/configuration.ts`.
+    to_json self -> Text = case self of
+        Widget.Single_Choice values label display _ ->
+            values_json = if values.length == 0 then '[]' else '[' + (values.map v-> v.to_json).join ',' + ']'
+            '{"constructor":"Single_Choice","values":' + values_json + (if label.is_nothing then '' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
+        Widget.Vector_Editor item_editor item_default _ display ->
+            '{"constructor":"Vector_Editor","item_editor":' + item_editor.to_json + (if item_default.is_nothing then '' else ',"item_default":' + item_default.to_json) + ',"display":' + display.to_json + '}'
+        Widget.Multiple_Choice values label display _ ->
+            values_json = if values.length == 0 then '[]' else '[' + (values.map v-> v.to_json).join ',' + ']'
+            '{"constructor":"Multiple_Choice","values":' + values_json + (if label.is_nothing then '' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
+        Widget.Boolean_Input _ display ->
+            '{"constructor":"Boolean_Input","display":' + display.to_json + '}'
+        Widget.Numeric_Input _ display minimum maximum _ _ _ ->
+            '{"constructor":"Numeric_Input","display":' + display.to_json + (if minimum.is_nothing then '' else ',"minimum":' + minimum.to_json) + (if maximum.is_nothing then '' else ',"maximum":' + maximum.to_json) + '}'
+        Widget.Text_Input _ display _ _ syntax ->
+            '{"constructor":"Text_Input"' + ',"display":' + display.to_json + (if syntax.is_nothing then '' else ',"syntax":' + syntax.to_json) + '}'
+        Widget.Folder_Browse _ display ->
+            '{"constructor":"Folder_Browse","display":' + display.to_json + '}'
+        Widget.File_Browse existing_only _ display _ file_types ->
+            '{"constructor":"File_Browse","existing_only":' + (if existing_only then "true" else "false") + ',"display":' + display.to_json + ',"file_types":' + file_types.to_json + '}'
+        Widget.Secret_Browse display ->
+            '{"constructor":"Secret_Browse","display":' + display.to_json + '}'
+        _ -> self.to_js_object.to_json
+
+    ## ---
+       private: true
+       ---
        Override the to_js_object and don't include Nothing.
     to_js_object : JS_Object
     to_js_object self =
+        Widget.log_message ("to_js_object called for "+self.to_text) ..Info
         type_pair = [["type", Meta.type_of self . to_text]]
 
         m = Meta.meta self

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -144,12 +144,12 @@ type Widget
     to_json self -> Text = case self of
         Widget.Single_Choice values label display _ ->
             values_json = if values.length == 0 then '[]' else '[' + (values.map v-> v.to_json).join ',' + ']'
-            '{"constructor":"Single_Choice","values":' + values_json + (if label.is_nothing then '' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
+            '{"constructor":"Single_Choice","values":' + values_json + (if label.is_nothing then ',"label":null' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
         Widget.Vector_Editor item_editor item_default _ display ->
-            '{"constructor":"Vector_Editor","item_editor":' + item_editor.to_json + (if item_default.is_nothing then '' else ',"item_default":' + item_default.to_json) + ',"display":' + display.to_json + '}'
+            '{"constructor":"Vector_Editor","item_editor":' + item_editor.to_json + (if item_default.is_nothing then ',"item_default":"_"' else ',"item_default":' + item_default.to_json) + ',"display":' + display.to_json + '}'
         Widget.Multiple_Choice values label display _ ->
             values_json = if values.length == 0 then '[]' else '[' + (values.map v-> v.to_json).join ',' + ']'
-            '{"constructor":"Multiple_Choice","values":' + values_json + (if label.is_nothing then '' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
+            '{"constructor":"Multiple_Choice","values":' + values_json + (if label.is_nothing then ',"label":null' else ',"label":' + label.to_json) + ',"display":' + display.to_json + '}'
         Widget.Boolean_Input _ display ->
             '{"constructor":"Boolean_Input","display":' + display.to_json + '}'
         Widget.Numeric_Input _ display minimum maximum _ _ _ ->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -54,7 +54,7 @@ type Choice
         - `parameters`: A list of parameters for the arguments for the `value`.
           This provides the structure needed for nested widgets.
         - `icon`: The icon to display for the entry. By default, no icon is used.
-    Option label:Text value:Text=label parameters:(Vector (Pair Text Widget))=[] icon:Text=""
+    Option label:Text value:(Text | Vector Choice)=label parameters:(Vector (Pair Text Widget))=[] icon:Text=""
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -40,5 +40,5 @@ get_widget_json value call_name argument_names uuids="{}" = time_visualization W
             # The annotation is a constant, so we just return it.
             _ -> annotation
 
-    annotations = argument_names.map (arg -> [arg, read_annotation arg])
-    annotations.to_json
+    annotations = argument_names.map (arg -> '[' + arg.to_json + ',' + (read_annotation arg).to_json + ']')
+    '[' + (annotations.join ',') + ']'

--- a/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
@@ -30,7 +30,7 @@ add_specs suite_builder =
         group_builder.specify "works for `query` and `read`" <|
             table_choices = ['a_table', 'another', 'mock_table'] . map n-> Choice.Option n n.pretty
             choices = table_choices + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
-            expect = [["query", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["query",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json connection .query ["query"] . should_equal expect
             Widgets.get_widget_json connection .read ["query"] . should_equal expect
 
@@ -39,13 +39,13 @@ add_specs suite_builder =
 
         group_builder.specify "works for `get` and `at`" <|
             choices = mock_table.column_names . map n-> Choice.Option n n.pretty
-            expect = [["selector", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["selector",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json mock_table .get ["selector"] . should_equal expect
             Widgets.get_widget_json mock_table .at ["selector"] . should_equal expect
 
         group_builder.specify "works for `filter`" <|
             choices = [Choice.Option "<Expression>" "(expr '[A]')"] + mock_table.column_names . map n-> Choice.Option n n.pretty
-            expect = [["column", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["column",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json mock_table .filter ["column"] . should_equal expect
 
     suite_builder.group "Widgets for Database" group_builder->

--- a/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
@@ -18,13 +18,13 @@ add_specs suite_builder =
 
         group_builder.specify "works for `get` and `at`" <|
             choices = mock_table.column_names . map n-> Choice.Option n n.pretty
-            expect = [["selector", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["selector",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json mock_table .get ["selector"] . should_equal expect
             Widgets.get_widget_json mock_table .at ["selector"] . should_equal expect
 
         group_builder.specify "works for `filter`" <|
             choices = [Choice.Option "<Expression>" "(expr '[A]')"] + mock_table.column_names . map n-> Choice.Option n n.pretty
-            expect = [["column", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["column",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json mock_table .filter ["column"] . should_equal expect
 
         group_builder.specify "works for `join` with `right` table" <|
@@ -62,7 +62,7 @@ add_specs suite_builder =
 
         group_builder.specify "works for `geo_distance`" <|
             choices = [Choice.Option "<Number Value>" "0", Choice.Option "<Expression>" "(expr '[A]')"]
-            expect = [["lat1", Widget.Single_Choice choices Nothing Display.Always]] . to_json
+            expect = '[["lat1",' + Widget.Single_Choice choices Nothing Display.Always . to_json + ']]'
             Widgets.get_widget_json mock_table .geo_distance ["lat1"] . should_equal expect
 
 main filter=Nothing =

--- a/test/Visualization_Tests/src/Widgets/Text_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Text_Widgets_Spec.enso
@@ -12,7 +12,7 @@ add_specs suite_builder =
         group_builder.specify "works for `take` and `drop`" <|
             mock_text = "abc def"
             default_widget = Text_Sub_Range.default_widget
-            expect = [["range", default_widget]] . to_json
+            expect = '[["range",' + default_widget . to_json + ']]'
             json = Widgets.get_widget_json mock_text .take ["range"]
             json . should_equal expect
             Widgets.get_widget_json mock_text .drop ["range"] . should_equal expect


### PR DESCRIPTION
### Pull Request Description

- Bespoke JSON code to speed widgets up.
- Uses more fixed format and more aligned with what the GUI is using.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
