### PR TITLE
Catch table viz errors

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -833,35 +833,43 @@ function toLinkField(fieldName: string, options: LinkFieldOptions): ColDef {
 }
 
 watchEffect(() => {
+  try {
+    refresh()
+  } catch (error) {
+    console.warn('Error refreshing table.', error)
+  }
+})
+
+const DEFAULT_DATA = {
+  type: typeof props.data,
+  json: props.data,
+  // eslint-disable-next-line camelcase
+  all_rows_count: 1,
+  data: undefined,
+  header: undefined,
+  // eslint-disable-next-line camelcase
+  value_type: undefined,
+  // eslint-disable-next-line camelcase
+  has_index_col: false,
+  links: undefined,
+  // eslint-disable-next-line camelcase
+  get_child_node_action: '',
+  // eslint-disable-next-line camelcase
+  get_child_node_link_name: undefined,
+  // eslint-disable-next-line camelcase
+  child_label: undefined,
+  // eslint-disable-next-line camelcase
+  visualization_header: undefined,
+  // eslint-disable-next-line camelcase
+  is_using_server_sort_and_filter: undefined,
+  // eslint-disable-next-line camelcase
+  requires_number_format: undefined,
+}
+
+// Update state computed from the input `data`.
+function refresh() {
   // If the user switches from one visualization type to another, we can receive the raw object.
-  const data_ =
-    typeof props.data === 'object' ?
-      props.data
-    : {
-        type: typeof props.data,
-        json: props.data,
-        // eslint-disable-next-line camelcase
-        all_rows_count: 1,
-        data: undefined,
-        header: undefined,
-        // eslint-disable-next-line camelcase
-        value_type: undefined,
-        // eslint-disable-next-line camelcase
-        has_index_col: false,
-        links: undefined,
-        // eslint-disable-next-line camelcase
-        get_child_node_action: '',
-        // eslint-disable-next-line camelcase
-        get_child_node_link_name: undefined,
-        // eslint-disable-next-line camelcase
-        child_label: undefined,
-        // eslint-disable-next-line camelcase
-        visualization_header: undefined,
-        // eslint-disable-next-line camelcase
-        is_using_server_sort_and_filter: undefined,
-        // eslint-disable-next-line camelcase
-        requires_number_format: undefined,
-      }
+  const data_ = typeof props.data === 'object' ? props.data : DEFAULT_DATA
   if (isError(data_)) {
     columnDefs.value = [
       {
@@ -1013,7 +1021,7 @@ watchEffect(() => {
   // If data is truncated, we cannot rely on sorting/filtering so will disable.
   defaultColDef.value.filter = !isTruncated.value
   defaultColDef.value.sortable = !isTruncated.value
-})
+}
 
 const colTypeMap = computed(() => {
   const colMap: Map<string, string> = new Map()


### PR DESCRIPTION
### Pull Request Description

The `data` watcher in the table visualization currently throws exceptions sometimes. Uncaught exceptions can abort the reactive tick and cause additional problems. Wrap the logic in a `try/catch` for safety.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
