### PR TITLE
When double click enso-project discover name from path

### DIFF
--- a/app/ide-desktop/client/src/fileAssociations.ts
+++ b/app/ide-desktop/client/src/fileAssociations.ts
@@ -166,7 +166,8 @@ export function setOpenFileEventHandler(setProjectToOpen: (path: string) => void
  */
 export function handleOpenFile(openedFile: string): project.ProjectInfo {
   try {
-    return project.importProjectFromPath(openedFile)
+    const title = openedFile.split(pathModule.sep).pop()?.replace('.enso-project', '')
+    return project.importProjectFromPath(openedFile, null, title)
   } catch (error) {
     // Since the user has explicitly asked us to open a file, in case of an error, we should
     // display a message box with the error details.

--- a/app/ide-desktop/client/src/fileAssociations.ts
+++ b/app/ide-desktop/client/src/fileAssociations.ts
@@ -166,7 +166,10 @@ export function setOpenFileEventHandler(setProjectToOpen: (path: string) => void
  */
 export function handleOpenFile(openedFile: string): project.ProjectInfo {
   try {
-    const title = openedFile.split(pathModule.sep).pop()?.replace('.enso-project', '')
+    const title = openedFile
+      .split(pathModule.sep)
+      .pop()
+      ?.replace(`.${BUNDLED_PROJECT_EXTENSION}`, '')
     return project.importProjectFromPath(openedFile, null, title)
   } catch (error) {
     // Since the user has explicitly asked us to open a file, in case of an error, we should


### PR DESCRIPTION
### Pull Request Description

We handle double-click and drag n drop projects differently. If use `handleOpenFile` double clicking `enso-project`s we need to discover the project name from path because of some edge cases when downloaded from cloud 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
