### PR TITLE
Make passphrase a secret or text

### DIFF
--- a/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/docs/api/Generic_JDBC_Connection.md
+++ b/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/docs/api/Generic_JDBC_Connection.md
@@ -1,0 +1,21 @@
+## Enso Signatures 1.0
+## module Standard.Generic_JDBC.Generic_JDBC_Connection
+- type Generic_JDBC_Connection
+    - close self -> Standard.Base.Nothing.Nothing
+    - connect url:Standard.Base.Data.Text.Text= properties:Standard.Base.Data.Vector.Vector= quote_char:Standard.Base.Data.Text.Text= -> Standard.Generic_JDBC.Generic_JDBC_Connection.Generic_JDBC_Connection
+    - database self -> (Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)
+    - database_product self -> Standard.Base.Data.Text.Text
+    - databases self -> (Standard.Base.Data.Vector.Vector Standard.Base.Data.Text.Text)
+    - driver self -> Standard.Base.Data.Text.Text
+    - execute self sql:Standard.Base.Data.Text.Text= -> Standard.Base.Data.Numbers.Integer
+    - quote_identifier self identifier:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
+    - quote_literal self literal:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
+    - read self sql_query:Standard.Database.SQL_Query.SQL_Query= limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Table.Table.Table
+    - schema self -> Standard.Base.Any.Any
+    - schemas self -> Standard.Base.Data.Vector.Vector
+    - table_types self -> Standard.Base.Any.Any
+    - tables self name_like:Standard.Base.Data.Text.Text= database:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)= schema:Standard.Base.Data.Text.Text= table_types:Standard.Base.Data.Vector.Vector= -> Standard.Table.Table.Table
+- type Generic_JDBC_Details
+    - Value url:Standard.Base.Data.Text.Text
+    - connect self options:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - resolve constructor:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/docs/api/Main.md
+++ b/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/docs/api/Main.md
@@ -1,0 +1,2 @@
+## Enso Signatures 1.0
+## module Standard.Generic_JDBC.Main

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Connection/Key_Pair_Credentials.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Connection/Key_Pair_Credentials.md
@@ -7,7 +7,7 @@
     - to_js_object self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Data.Text.Text
 - type Key_Pair_Credentials
-    - Key_Pair username:Standard.Base.Data.Text.Text= private_key:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_File.Enso_File)= passphrase:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)=
+    - Key_Pair username:Standard.Base.Data.Text.Text= private_key:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_File.Enso_File)= passphrase:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Data.Text.Text)=
     - generate_key_pair location:Standard.Base.Enso_Cloud.Enso_File.Enso_File= name:Standard.Base.Data.Text.Text if_exists:Standard.Snowflake.Connection.Key_Pair_Credentials.On_Existing_Key_Pair= -> Standard.Snowflake.Connection.Key_Pair_Credentials.Generated_Key_Pair
 - type On_Existing_Key_Pair
     - Error

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Key_Pair_Credentials.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Key_Pair_Credentials.enso
@@ -16,7 +16,7 @@ type Key_Pair_Credentials
           located on the local machine.
         - `passphrase`: The passphrase for the private key file. Only applicable
           if the private key is a file.
-    Key_Pair username:Text=(Missing_Argument.throw "username") private_key:Enso_Secret|File|Enso_File=(Missing_Argument.throw "private_key") passphrase:Text|Nothing=Nothing
+    Key_Pair username:Text=(Missing_Argument.throw "username") private_key:Enso_Secret|File|Enso_File=(Missing_Argument.throw "private_key") passphrase:Enso_Secret|Text=""
 
     ## ---
        group: Standard.Base.Database

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -426,15 +426,15 @@ private auth_jdbc_properties credentials = case credentials of
     Credentials.Username_And_Password username password ->
         [Pair.new 'user' username, Pair.new 'password' password]
     Key_Pair_Credentials.Key_Pair username private_key passphrase ->
-        resolved_passphase = _resolve_passphase passphrase
+        resolved_passphrase = _resolve_passphrase passphrase
         key_part = case private_key of
             local_file : File ->
-                passphrase_part = if resolved_passphase.is_empty . not then [Pair.new 'private_key_file_pwd' resolved_passphase] else []
+                passphrase_part = if resolved_passphrase != Nothing then [Pair.new 'private_key_file_pwd' resolved_passphrase] else []
                 [Pair.new 'private_key_file' local_file.absolute.path] + passphrase_part
             _ : Enso_File ->
                 Error.throw (Illegal_Argument.Error "Currently only local files can be used as private keys. In Cloud, consider using a Secret instead of a file.")
             secret : Enso_Secret ->
-                if resolved_passphase.is_empty . not then
+                if resolved_passphrase != Nothing then
                     Error.throw (Illegal_Argument.Error "Passphrase is not applicable when using a secret as a private key.")
                 secret_as_private_key = InterpretAsPrivateKey.new (as_hideable_value secret)
                 [Pair.new 'privateKey' secret_as_private_key]
@@ -442,9 +442,9 @@ private auth_jdbc_properties credentials = case credentials of
     _ : Enso_Secret ->
         Panic.throw (Illegal_Argument.Error "Cannot extract `auth_jdbc_properties` from a Cloud Credential. This is a bug in Snowflake library.")
 
-private _resolve_passphase passphrase:Text|Enso_Secret =
+private _resolve_passphrase passphrase:Text|Enso_Secret =
     case passphrase of
-      _ : Text -> passphrase
+      _ : Text -> if passphrase.is_empty then Nothing else passphrase
       secret : Enso_Secret -> as_hideable_value secret
 ## ---
    private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -426,14 +426,15 @@ private auth_jdbc_properties credentials = case credentials of
     Credentials.Username_And_Password username password ->
         [Pair.new 'user' username, Pair.new 'password' password]
     Key_Pair_Credentials.Key_Pair username private_key passphrase ->
+        resolved_passphase = _resolve_passphase passphrase
         key_part = case private_key of
             local_file : File ->
-                passphrase_part = if passphrase != Nothing then [Pair.new 'private_key_file_pwd' passphrase] else []
+                passphrase_part = if resolved_passphase.is_empty . not then [Pair.new 'private_key_file_pwd' resolved_passphase] else []
                 [Pair.new 'private_key_file' local_file.absolute.path] + passphrase_part
             _ : Enso_File ->
                 Error.throw (Illegal_Argument.Error "Currently only local files can be used as private keys. In Cloud, consider using a Secret instead of a file.")
             secret : Enso_Secret ->
-                if passphrase != Nothing then
+                if resolved_passphase.is_empty . not then
                     Error.throw (Illegal_Argument.Error "Passphrase is not applicable when using a secret as a private key.")
                 secret_as_private_key = InterpretAsPrivateKey.new (as_hideable_value secret)
                 [Pair.new 'privateKey' secret_as_private_key]
@@ -441,6 +442,10 @@ private auth_jdbc_properties credentials = case credentials of
     _ : Enso_Secret ->
         Panic.throw (Illegal_Argument.Error "Cannot extract `auth_jdbc_properties` from a Cloud Credential. This is a bug in Snowflake library.")
 
+private _resolve_passphase passphrase:Text|Enso_Secret =
+    case passphrase of
+      _ : Text -> passphrase
+      secret : Enso_Secret -> as_hideable_value secret
 ## ---
    private: true
    ---

--- a/test/Snowflake_Tests/polyglot-sources/snowflake-test-java-helpers/src/main/java/org/enso/snowflake_helpers/TestKeyGenerator.java
+++ b/test/Snowflake_Tests/polyglot-sources/snowflake-test-java-helpers/src/main/java/org/enso/snowflake_helpers/TestKeyGenerator.java
@@ -37,7 +37,7 @@ public class TestKeyGenerator {
     keyPairGenerator.initialize(2048);
     KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
-    if (passphrase == null) {
+    if (passphrase.isEmpty()) {
       savePrivateKey(keyPair.getPrivate(), privateKeyFile);
     } else {
       savePrivateKeyEncrypted(keyPair.getPrivate(), privateKeyFile, passphrase);

--- a/test/Snowflake_Tests/src/Auth_Spec.enso
+++ b/test/Snowflake_Tests/src/Auth_Spec.enso
@@ -55,7 +55,7 @@ add_specs suite_builder ~default_connection =
 
             table = with_temp_user default_connection user_name->
                 default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
-
+                IO.println private_key_file
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=passphrase
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|
@@ -74,6 +74,26 @@ add_specs suite_builder ~default_connection =
                 default_connection.execute_update (generated_key.alter_user_query user_name) . should_succeed
 
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=generated_key
+                new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
+                Panic.with_finalizer new_connection.close <|
+                    new_connection.query (..Raw_SQL "SELECT 2+3") . read
+            table.at 0 . at 0 . should_equal 5
+
+        group_builder.specify "using local private key encrypted with passphrase stored in secret" pending=cloud_setup.real_cloud_pending <| cloud_setup.with_prepared_environment <|
+            passphrase = "not-a-safe-passphrase-1234"
+            key_pair = generate_local_key_pair passphrase=passphrase
+            private_key_file = key_pair.first
+            
+            existing_secret = Enso_Secret.get "snowflake-passphrase" test_root.get
+            secret_exists = existing_secret.is_error.not
+            secret = case secret_exists of
+                True -> existing_secret.update_value passphrase
+                False -> Enso_Secret.create "snowflake-passphrase" passphrase test_root.get
+
+            table = with_temp_user default_connection user_name->
+                default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
+                IO.println private_key_file
+                key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=secret
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|
                     new_connection.query (..Raw_SQL "SELECT 2+3") . read

--- a/test/Snowflake_Tests/src/Auth_Spec.enso
+++ b/test/Snowflake_Tests/src/Auth_Spec.enso
@@ -55,7 +55,6 @@ add_specs suite_builder ~default_connection =
 
             table = with_temp_user default_connection user_name->
                 default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
-                IO.println private_key_file
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=passphrase
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|
@@ -92,7 +91,6 @@ add_specs suite_builder ~default_connection =
 
             table = with_temp_user default_connection user_name->
                 default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
-                IO.println private_key_file
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=secret
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|

--- a/test/Snowflake_Tests/src/Auth_Spec.enso
+++ b/test/Snowflake_Tests/src/Auth_Spec.enso
@@ -55,6 +55,7 @@ add_specs suite_builder ~default_connection =
 
             table = with_temp_user default_connection user_name->
                 default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
+
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=passphrase
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|
@@ -91,6 +92,7 @@ add_specs suite_builder ~default_connection =
 
             table = with_temp_user default_connection user_name->
                 default_connection.execute_update (generate_alter_user_query user_name key_pair.second.read_text) . should_succeed
+                
                 key_credentials = Key_Pair_Credentials.Key_Pair username=user_name private_key=private_key_file passphrase=secret
                 new_connection = Database.connect (make_connection_details_with_credentials key_credentials)
                 Panic.with_finalizer new_connection.close <|

--- a/test/Snowflake_Tests/src/Auth_Spec.enso
+++ b/test/Snowflake_Tests/src/Auth_Spec.enso
@@ -24,7 +24,7 @@ with_temp_user base_connection callback =
      Panic.with_finalizer (base_connection.execute_update ('DROP USER "' + user_name + '"')) <|
          callback user_name
 
-generate_local_key_pair passphrase:Text|Nothing =
+generate_local_key_pair passphrase:Text =
     public_key_file = File.create_temporary_file "snowflake-key" ".pub"
     private_key_file = File.create_temporary_file "snowflake-key" ".p8"
     TestKeyGenerator.generateKeyPairForTest private_key_file.path public_key_file.path passphrase
@@ -37,7 +37,7 @@ make_connection_details_with_credentials credentials =
 add_specs suite_builder ~default_connection =
     suite_builder.group "[Snowflake] Key-pair authentication" group_builder->
         group_builder.specify "using local private key" <|
-            key_pair = generate_local_key_pair passphrase=Nothing
+            key_pair = generate_local_key_pair passphrase=""
             private_key_file = key_pair.first
 
             with_temp_user default_connection user_name->


### PR DESCRIPTION
### Pull Request Description

Adds the ability for a Snowflake passphrase to be stored in an Enso Secret

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
https://github.com/enso-org/enso/actions/runs/16642159982
