### PR TITLE
Cleaning up std-benchmarks build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2445,7 +2445,7 @@ lazy val `runtime-language-arrow` =
       ),
       javaModuleName := "org.enso.interpreter.arrow",
       Compile / moduleDependencies ++= GraalVM.modules,
-      Test / moduleDependencies += projectID.value,
+      Test / internalModuleDependencies += (Compile / exportedModule).value,
       Test / patchModules := {
         val testClassesDir = (Test / productDirectories).value.head
         Map(javaModuleName.value -> Seq(testClassesDir))

--- a/build.sbt
+++ b/build.sbt
@@ -4205,7 +4205,8 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       "-processor",
       "org.enso.benchmarks.processor.BenchProcessor,org.openjdk.jmh.generators.BenchmarkProcessor",
       // There is no Truffle compiler available for annotation processors. Suppress the warning.
-      "-J-Dpolyglot.engine.WarnInterpreterOnly=false"
+      "-J-Dpolyglot.engine.WarnInterpreterOnly=false",
+      "-J--sun-misc-unsafe-memory-access=allow"
     ),
     Compile / javaOptions ++= Seq(
       // Force killing of alive threads once a benchmark is finished.

--- a/build.sbt
+++ b/build.sbt
@@ -4176,7 +4176,8 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       "org.openjdk.jmh"      % "jmh-core"                 % jmhVersion,
       "org.openjdk.jmh"      % "jmh-generator-annprocess" % jmhVersion,
       "org.graalvm.polyglot" % "polyglot"                 % graalMavenPackagesVersion,
-      "org.slf4j"            % "slf4j-nop"                % slf4jVersion
+      "org.slf4j"            % "slf4j-nop"                % slf4jVersion,
+      "org.netbeans.api"     % "org-openide-util-lookup"  % netbeansApiVersion % "provided"
     ),
     commands += WithDebugCommand.withDebug
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2439,7 +2439,7 @@ lazy val `runtime-language-arrow` =
       libraryDependencies ++= GraalVM.modules ++ slf4jApi.map(_ % Test) ++ Seq(
         "junit"            % "junit"              % junitVersion       % Test,
         "com.github.sbt"   % "junit-interface"    % junitIfVersion     % Test,
-        "org.slf4j"        % "slf4j-nop"          % slf4jVersion       % Test,
+        slf4jNop           % Test,
         "org.apache.arrow" % "arrow-vector"       % apacheArrowVersion % Test,
         "org.apache.arrow" % "arrow-memory-netty" % apacheArrowVersion % Test
       ),
@@ -2826,15 +2826,15 @@ lazy val `runtime-benchmarks` =
       // Note that withDebug command only makes sense if you use `@Fork(0)` in your benchmarks.
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ GraalVM.toolsPkgs ++ helidon ++ logbackPkg ++ slf4jApi ++ Seq(
-        "org.openjdk.jmh"     % "jmh-core"                     % jmhVersion,
-        "org.openjdk.jmh"     % "jmh-generator-annprocess"     % jmhVersion,
-        "jakarta.xml.bind"    % "jakarta.xml.bind-api"         % jaxbVersion,
-        "com.sun.xml.bind"    % "jaxb-impl"                    % jaxbVersion,
-        "org.graalvm.truffle" % "truffle-api"                  % graalMavenPackagesVersion,
-        "org.graalvm.truffle" % "truffle-dsl-processor"        % graalMavenPackagesVersion % "provided",
-        "org.slf4j"           % "slf4j-nop"                    % slf4jVersion,
-        "com.typesafe"        % "config"                       % typesafeConfigVersion,
-        "org.netbeans.api"    % "org-netbeans-modules-sampler" % netbeansApiVersion
+        "org.openjdk.jmh"     % "jmh-core"                 % jmhVersion,
+        "org.openjdk.jmh"     % "jmh-generator-annprocess" % jmhVersion,
+        "jakarta.xml.bind"    % "jakarta.xml.bind-api"     % jaxbVersion,
+        "com.sun.xml.bind"    % "jaxb-impl"                % jaxbVersion,
+        "org.graalvm.truffle" % "truffle-api"              % graalMavenPackagesVersion,
+        "org.graalvm.truffle" % "truffle-dsl-processor"    % graalMavenPackagesVersion % "provided",
+        slf4jNop,
+        "com.typesafe"     % "config"                       % typesafeConfigVersion,
+        "org.netbeans.api" % "org-netbeans-modules-sampler" % netbeansApiVersion
       ),
       mainClass :=
         Some("org.enso.interpreter.bench.benchmarks.RuntimeBenchmarksRunner"),
@@ -2845,11 +2845,11 @@ lazy val `runtime-benchmarks` =
       parallelExecution := false,
       Compile / moduleDependencies ++= {
         GraalVM.modules ++ GraalVM.langsPkgs ++ GraalVM.insightPkgs ++ logbackPkg ++ helidon ++ scalaReflect ++ slf4jApi ++ Seq(
-          "org.apache.commons"     % "commons-lang3"                % commonsLangVersion,
-          "org.apache.commons"     % "commons-compress"             % commonsCompressVersion,
-          "commons-io"             % "commons-io"                   % commonsIoVersion,
-          "org.apache.tika"        % "tika-core"                    % tikaVersion,
-          "org.slf4j"              % "slf4j-nop"                    % slf4jVersion,
+          "org.apache.commons" % "commons-lang3"    % commonsLangVersion,
+          "org.apache.commons" % "commons-compress" % commonsCompressVersion,
+          "commons-io"         % "commons-io"       % commonsIoVersion,
+          "org.apache.tika"    % "tika-core"        % tikaVersion,
+          slf4jNop,
           "org.netbeans.api"       % "org-openide-util-lookup"      % netbeansApiVersion,
           "org.netbeans.api"       % "org-netbeans-modules-sampler" % netbeansApiVersion,
           "com.ibm.icu"            % "icu4j"                        % icuVersion,
@@ -2911,7 +2911,7 @@ lazy val `runtime-benchmarks` =
       Compile / addModules := Seq(
         (`runtime` / javaModuleName).value,
         (`benchmarks-common` / javaModuleName).value,
-        "org.slf4j.nop"
+        slf4jNopModule
       ),
       // Benchmark sources are patched into the `org.enso.runtime` module
       Compile / patchModules := {
@@ -2948,7 +2948,7 @@ lazy val `runtime-benchmarks` =
         }.toMap
 
         pkgsExports ++ Map(
-          "org.slf4j.nop/org.slf4j.nop" -> Seq("org.slf4j")
+          s"$slf4jNopModule/$slf4jNopModule" -> Seq(slf4jNop.organization)
         )
       },
       javaOptions ++= {
@@ -4226,7 +4226,8 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
     Compile / addModules := Seq(
       (`runtime` / javaModuleName).value,
       (`bench-processor` / javaModuleName).value,
-      (`benchmarks-common` / javaModuleName).value
+      (`benchmarks-common` / javaModuleName).value,
+      slf4jNopModule
     ),
     // std benchmark sources are patch into the `org.enso.runtime` module
     Compile / patchModules := {
@@ -4260,7 +4261,7 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       }.toMap
 
       pkgsExports ++ Map(
-        "org.slf4j.nop/org.slf4j.nop" -> Seq("org.slf4j")
+        s"$slf4jNopModule/$slf4jNopModule" -> Seq(slf4jNop.organization)
       )
     },
     javaOptions ++= testLogProviderOptions,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -930,7 +930,7 @@ class RuntimeAsyncCommandsTest
           ) =>
         data
     }
-    repliesData.map(new String(_)) shouldEqual List("42", "85")
+    repliesData.map(new String(_)).sorted shouldEqual List("42", "85")
   }
 
 }

--- a/lib/java/jna-wrapper/src/main/java/com/sun/jna/Native.java
+++ b/lib/java/jna-wrapper/src/main/java/com/sun/jna/Native.java
@@ -301,6 +301,7 @@ public final class Native implements Version {
   private static final Object finalizer =
       new Object() {
         @Override
+        @SuppressWarnings("deprecation")
         protected void finalize() throws Throwable {
           dispose();
           super.finalize();
@@ -791,6 +792,7 @@ public final class Native implements Version {
    * @param type The type class
    * @return The options map
    */
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> getLibraryOptions(Class<?> type) {
     Map<String, Object> libraryOptions;
     // cached already ?
@@ -815,6 +817,7 @@ public final class Native implements Version {
     try {
       Field field = mappingClass.getField("OPTIONS");
       field.setAccessible(true);
+
       libraryOptions = (Map<String, Object>) field.get(null);
       if (libraryOptions == null) {
         throw new IllegalStateException("Null options field");
@@ -1329,6 +1332,7 @@ public final class Native implements Version {
     try {
 
       final ClassLoader cl = Native.class.getClassLoader();
+      @SuppressWarnings("removal")
       Method m =
           AccessController.doPrivileged(
               new PrivilegedAction<Method>() {
@@ -1459,7 +1463,9 @@ public final class Native implements Version {
     }
     if (Structure.class.isAssignableFrom(type)
         && !Structure.ByReference.class.isAssignableFrom(type)) {
-      return Structure.size((Class<Structure>) type, (Structure) value);
+      @SuppressWarnings("unchecked")
+      Class<Structure> tpe = (Class<Structure>) type;
+      return Structure.size(tpe, (Structure) value);
     }
     try {
       return getNativeSize(type);
@@ -1476,6 +1482,7 @@ public final class Native implements Version {
    * @param cls The Java class
    * @return The native size for the class
    */
+  @SuppressWarnings("unchecked")
   public static int getNativeSize(Class<?> cls) {
     if (NativeMapped.class.isAssignableFrom(cls)) {
       cls = NativeMappedConverter.getInstance(cls).nativeType();
@@ -1580,6 +1587,7 @@ public final class Native implements Version {
 
   /** Try to determine the class context in which a {@link #register(String)} call was made. */
   static Class<?> getCallingClass() {
+    @SuppressWarnings("removal")
     Class<?>[] context =
         new SecurityManager() {
           @Override

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -271,6 +271,8 @@ object Dependencies {
   val slf4jApi = Seq(
     "org.slf4j" % "slf4j-api" % slf4jVersion
   )
+  val slf4jNop       = "org.slf4j" % "slf4j-nop" % slf4jVersion
+  val slf4jNopModule = "org.slf4j.nop"
 
   // === Other ==================================================================
 


### PR DESCRIPTION
### Pull Request Description

It's hard to see real warnings/errors beyond what `std-benchmarks` reports during regular build.

### Important Notes

Fixed in `sbt:enso> std-benchmarks/compile`
```
[warn] WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
[warn] WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.oracle.truffle.api.dsl.InlineSupport$UnsafeField (file:/home/hubert/.cache/coursier/v1/https/repo1.maven.org/maven2/org/graalvm/truffle/truffle-api/24.2.0/truffle-api-24.2.0.jar)
[warn] WARNING: Please consider reporting this to the maintainers of class com.oracle.truffle.api.dsl.InlineSupport$UnsafeField
[warn] WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

```
[error] [JPMSUtils/std-benchmarks] Not all modules from classpath were found
[error] [JPMSUtils/std-benchmarks] Ensure libraryDependencies and moduleDependencies are correct (79 != 80): List(org-openide-util-lookup)
```

```
[warn] warning: [options] module name in --add-exports option not found: org.slf4j.nop
```

Additionally,
```
[warn] [JPMSPlugin/runtime-language-arrow] ModuleID org.enso:runtime-language-arrow:0.0.0-dev specified inside `moduleDependencies` task. This is and internal dependency and should be specified in `internalModuleDependencies`.
```

Still remaining in `std-benchmarks` but it requires some module magic:
```
[warn] WARNING: A restricted method in java.lang.System has been called
[warn] WARNING: java.lang.System::load has been called by com.oracle.truffle.polyglot.JDKSupport in module org.graalvm.truffle (file:/home/hubert/.cache/coursier/v1/https/repo1.maven.org/maven2/org/graalvm/truffle/truffle-api/24.2.0/truffle-api-24.2.0.jar)
[warn] WARNING: Use --enable-native-access=org.graalvm.truffle to avoid a warning for callers in this module
[warn] WARNING: Restricted methods will be blocked in a future release unless native access is enabled
[warn] 
[warn] SLF4J(W): No SLF4J providers were found.
[warn] SLF4J(W): Defaulting to no-operation (NOP) logger implementation
[warn] SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
[warn] Jul 30, 2025 9:54:20 AM enso.org.enso.interpreter.runtime.EnsoContext
[warn] WARNING: Initializing the context in a different working directory than the one containing the project root. This may lead to relative paths not behaving as advertised by `File.new`. Please run the engine inside of `/home/hubert/tmp/enso/test` directory.
[warn] Jul 30, 2025 9:54:31 AM enso.org.enso.interpreter.runtime.EnsoContext
[warn] WARNING: Unknown identifier: org.enso.base.Environment_Utils
[warn] 1 warning.
[info] BenchProcessor: org.enso.benchmarks.processor.BenchProcessor.modulePath system property set. Creating truffle module layer for benchmark collection.
```

Also fixed random failures in our tests:
```
 INFO ide_ci::program::command: sbt ℹ️ [info] - should execute mutliple expressions in the local scope *** FAILED *** (565 milliseconds)
 INFO ide_ci::program::command: sbt ℹ️ [info]   List("85", "42") did not equal List("42", "85") (RuntimeAsyncCommandsTest.scala:933)
 INFO ide_ci::program::command: sbt ℹ️ [info]   Analysis:
 INFO ide_ci::program::command: sbt ℹ️ [info]   List(0: "85" -> "42", 1: "42" -> "85")
 ```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.