### PR TITLE
Fix Table Visualisation Header Icons

### DIFF
--- a/app/gui/src/project-view/components/SvgIcon.vue
+++ b/app/gui/src/project-view/components/SvgIcon.vue
@@ -1,36 +1,4 @@
 <script lang="ts">
-import iconsSvgUrl from '@/assets/icons.svg'
-import { type URLString } from '@/util/data/urlString'
-import type { Icon } from '@/util/iconMetadata/iconName'
-import { embedSvgSymbols, svgUseHref } from '@/util/icons'
-
-let embeddedSvg: SVGSVGElement | null = null
-
-// Embed icons SVG into the document body, so the symbols can be referenced in SVG `use` element directly by their ID.
-// We used to reference the icons using `icons.svg#symbol-id` format, but that occassionaly causes issues with
-// cross-origin requests. This is impacting the playwright test snapshots, which would end up requesting the svg using
-// the origin used during test run and attempt to resolve it with a service-worker. That request unfortunately gets
-// rejected immediately. To avoid that, we embed the resource directly on page load and use local IDs. That approach
-// also works inside shadow-root, so it is safe to reference the same icon symbols in visualizations.
-function fetchIcons() {
-  fetch(iconsSvgUrl, { cache: 'default', mode: 'same-origin' }).then(
-    async (response) => (embeddedSvg = embedSvgSymbols(await response.text())),
-  )
-}
-
-// Skip fetching icons in unit tests, node's `fetch` there would fail to resolve the URL properly
-// and we don't need the icons to actually be loaded for any purpose anyway.
-if (process.env.NODE_ENV !== 'test') {
-  fetchIcons()
-}
-
-// In case we hot-reload the icons, remove previously embedded SVG.
-if (import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    embeddedSvg?.remove()
-  })
-}
-
 /**
  * A component displaying a SVG icon.
  *
@@ -40,12 +8,18 @@ export default {}
 </script>
 
 <script setup lang="ts">
-const { name } = defineProps<{ name: Icon | URLString }>()
+import icons from '@/assets/icons.svg'
+import type { URLString } from '@/util/data/urlString'
+import type { Icon } from '@/util/iconMetadata/iconName'
+
+const props = defineProps<{
+  name: Icon | URLString
+}>()
 </script>
 
 <template>
   <svg class="SvgIcon" viewBox="0 0 16 16" preserveAspectRatio="xMidYMid slice">
-    <use :href="svgUseHref(name)"></use>
+    <use :href="props.name.includes(':') ? props.name : `${icons}#${props.name}`"></use>
   </svg>
 </template>
 

--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import icons from '@/assets/icons.svg'
 import AgGridTableView, { commonContextMenuActions } from '@/components/shared/AgGridTableView.vue'
 import {
   useTableVizToolbar,
@@ -7,7 +8,6 @@ import {
 import { Ast } from '@/util/ast'
 import { Pattern } from '@/util/ast/match'
 import { Icon } from '@/util/iconMetadata/iconName'
-import { svgUseHref } from '@/util/icons'
 import { useVisualizationConfig } from '@/util/visualizationBuiltins'
 import type {
   CellClassParams,
@@ -184,7 +184,7 @@ const grid = ref<
 >()
 
 const getSvgTemplate = (icon: Icon) =>
-  `<svg viewBox="0 0 16 16" width="16" height="16"> <use xlink:href="${encodeURI(svgUseHref(icon))}"/> </svg>`
+  `<svg viewBox="0 0 16 16" width="16" height="16"> <use xlink:href="${icons}#${icon}"/> </svg>`
 
 const getContextMenuItems = (
   params: GetContextMenuItemsParams,

--- a/app/ide-desktop/client/tests/localWorkflow.spec.ts
+++ b/app/ide-desktop/client/tests/localWorkflow.spec.ts
@@ -64,10 +64,7 @@ test('Local Workflow', async ({ page, app, projectsDir }) => {
 
   // Enter User Defined Component
   // First wait until node is computed. Visualization may be cached, so we look at icon.
-  await expect(page.locator('.GraphNode .WidgetIcon svg use')).toHaveAttribute(
-    'href',
-    /#svgicon:group/,
-  )
+  await expect(page.locator('.GraphNode .WidgetIcon svg use')).toHaveAttribute('href', /#group/)
   await page.locator('.GraphNode').dblclick()
   await expect(page.locator('.GraphNode')).toHaveCount(3)
   await expect(page.locator('.NavBreadcrumb')).toHaveText([


### PR DESCRIPTION
### Pull Request Description

This change was introduced in #13603. I have no idea why, as that story has nothing to do with Table Visualisations and this change is not mentioned in the notes for that MR. It was also clearly not tested in the product.

If it is important we should raise a ticket to reimplement it.

Before:

<img width="1291" height="97" alt="image" src="https://github.com/user-attachments/assets/340e3ab4-94b5-4ae0-8eff-61f3e84b6feb" />

After:

<img width="1281" height="78" alt="image" src="https://github.com/user-attachments/assets/0c0b8ebc-6db0-4f97-a52e-33990a4cbce3" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
