### PR TITLE
Keep right panel state per tab

### DIFF
--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -9,7 +9,6 @@ import * as locate from './locate'
 
 async function goToGraphAndGetDocs(page: Page) {
   await actions.goToGraph(page)
-  await page.getByRole('tab', { name: 'Documentation' }).click()
   const docsContent = page.getByTestId('documentation-editor-content')
   const docsScroller = page.getByTestId('documentation-editor-scroller')
   await expect(docsContent.locator('.cm-line')).toExist()

--- a/app/gui/integration-test/project-view/graphNodeVisualization.spec.ts
+++ b/app/gui/integration-test/project-view/graphNodeVisualization.spec.ts
@@ -50,7 +50,7 @@ test('Previewing visualization', async ({ page }) => {
   await expect(locate.anyVisualization(node)).toBeVisible()
   // TODO[ao]: The simple move near top-left corner not always works i.e. not always
   //  `pointerleave` event is emitted. Investigated in https://github.com/enso-org/enso/issues/9478
-  await page.mouse.move(700, 1200, { steps: 20 })
+  await page.mouse.move(500, 1200, { steps: 20 })
   await expect(locate.anyVisualization(page)).toBeHidden()
   await page.keyboard.up('Meta')
   await page.keyboard.up('Control')

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -446,6 +446,8 @@ test('File Browser widget', async ({ page }) => {
 
 test('Manage aggregates in `aggregate` node', async ({ page }) => {
   await actions.goToGraph(page)
+  // Hide docpanel to not obscure long node.
+  await page.getByRole('tab', { name: 'Documentation' }).click()
   await mockMethodCallInfo(page, 'aggregated', {
     methodPointer: {
       module: 'Standard.Table.Table',

--- a/app/gui/src/providers/container.ts
+++ b/app/gui/src/providers/container.ts
@@ -53,6 +53,18 @@ LocalStorage.registerKey('launchedProjects', {
 /** Tab identifier, equal to the path of the view's URL. */
 export type TabId = 'drive' | 'settings' | EnsoPath
 
+/** Check if given {@link TabId} refers to a project tab. */
+export function isProjectTab(tab: TabId): tab is EnsoPath {
+  switch (tab) {
+    case 'drive':
+    case 'settings':
+      return false
+    default:
+      DEV: tab satisfies EnsoPath
+      return true
+  }
+}
+
 export type ContainerData = ReturnType<typeof useContainerData>
 export const [provideContainerData, useContainerData] = createContextStore(
   'gui-container',

--- a/app/gui/src/providers/rightPanel.ts
+++ b/app/gui/src/providers/rightPanel.ts
@@ -1,12 +1,13 @@
 import { type PaywallFeatureName } from '#/hooks/billing/FeaturesConfiguration'
 import { type Category, isCloudCategory } from '#/layouts/CategorySwitcher/Category'
 import { type AnyAsset, AssetType, type ProjectId } from '#/services/Backend'
+import { useSyncLocalStorage } from '@/composables/syncLocalStorage'
 import { createContextStore } from '@/providers'
 import { Err, Ok, type Result } from '@/util/data/result'
 import type { Icon } from '@/util/iconMetadata/iconName'
 import { proxyRefs, type ToValue } from '@/util/reactivity'
-import { useLocalStorage } from '@vueuse/core'
-import { computed, reactive, readonly, type Ref, ref, toRef, toValue } from 'vue'
+import { encoding } from 'lib0'
+import { computed, reactive, readonly, type Ref, ref, toValue } from 'vue'
 import type { SuggestionId } from 'ydoc-shared/languageServerTypes/suggestions'
 import { type TabId } from './container'
 import { type TextStore, useText } from './text'
@@ -42,12 +43,6 @@ interface RightPanelTabInfo {
   enabled: ToValue<Result<void>>
   hidden?: ToValue<boolean>
   title: ToValue<string>
-}
-
-/** Right Panel Data kept in local storage. */
-interface RightPanelStore {
-  tab: RightPanelTabId | undefined
-  width: number | undefined
 }
 
 function useRightPanelTabs(
@@ -151,14 +146,31 @@ function useRightPanel(
   const allTabs = useRightPanelTabs(containerTab, context, isFeatureUnderPaywall, textStore)
   const fullscreen = ref(false)
   const temporaryTab = ref<RightPanelTabId>()
+  const tab = ref<RightPanelTabId>()
+  const width = ref<number>()
 
-  const store = useLocalStorage<RightPanelStore>('rightPanel', {
-    tab: undefined,
-    width: undefined,
+  useSyncLocalStorage({
+    storageKey: 'rightPanel',
+    mapKeyEncoder: (enc) => encoding.writeVarString(enc, toValue(containerTab)),
+    debounce: 200,
+    captureState: () => ({
+      tab: tab.value,
+      width: width.value,
+    }),
+    restoreState: (state) => {
+      if (state) {
+        tab.value = state.tab
+        width.value = state.width
+      } else {
+        const contTab = toValue(containerTab)
+        tab.value = contTab === 'drive' || contTab === 'settings' ? undefined : 'documentation'
+        width.value = undefined
+      }
+    },
   })
 
   const displayedTab = computed(() => {
-    const markedTab = temporaryTab.value ?? store.value.tab
+    const markedTab = temporaryTab.value ?? tab.value
     if (markedTab == null) return undefined
     if (!toValue(allTabs.get(markedTab)?.enabled)?.ok) return undefined
     return markedTab
@@ -201,13 +213,13 @@ function useRightPanel(
     return typeof currentItem === 'object' ? currentItem : undefined
   })
 
-  function setTab(tab: RightPanelTabId | undefined) {
-    store.value.tab = tab
+  function setTab(newTab: RightPanelTabId | undefined) {
+    tab.value = newTab
     temporaryTab.value = undefined
   }
 
   function toggleTab(specificTab?: RightPanelTabId | undefined) {
-    if (specificTab == null || store.value.tab == specificTab) {
+    if (specificTab == null || tab.value == specificTab) {
       setTab(undefined)
     } else {
       setTab(specificTab)
@@ -216,7 +228,7 @@ function useRightPanel(
 
   return proxyRefs({
     allTabs,
-    tab: readonly(toRef(store.value, 'tab')),
+    tab: readonly(tab),
     /** Tab which should be displayed (taking temporary tab into consideration). */
     displayedTab,
     setTab,
@@ -229,7 +241,7 @@ function useRightPanel(
      */
     temporaryTab,
     setTemporaryTab: (tab: RightPanelTabId | undefined) => (temporaryTab.value = tab),
-    width: toRef(store.value, 'width'),
+    width,
     fullscreen,
     context,
     setContext,

--- a/app/gui/src/providers/rightPanel.ts
+++ b/app/gui/src/providers/rightPanel.ts
@@ -9,7 +9,7 @@ import { proxyRefs, type ToValue } from '@/util/reactivity'
 import { encoding } from 'lib0'
 import { computed, reactive, readonly, type Ref, ref, toValue } from 'vue'
 import type { SuggestionId } from 'ydoc-shared/languageServerTypes/suggestions'
-import { type TabId } from './container'
+import { isProjectTab, type TabId } from './container'
 import { type TextStore, useText } from './text'
 
 /** Information about content of "Help" panel. */
@@ -121,10 +121,9 @@ function useRightPanelTabs(
       'help',
       {
         icon: 'help',
-        enabled: computed(() => {
-          const tab = toValue(currentTab)
-          return tab !== 'drive' && tab !== 'settings' ? Ok() : Err('Exclusive to Project view')
-        }),
+        enabled: computed(() =>
+          isProjectTab(toValue(currentTab)) ? Ok() : Err('Exclusive to Project view'),
+        ),
         title: 'Component help',
       },
     ],
@@ -162,8 +161,7 @@ function useRightPanel(
         tab.value = state.tab
         width.value = state.width
       } else {
-        const contTab = toValue(containerTab)
-        tab.value = contTab === 'drive' || contTab === 'settings' ? undefined : 'documentation'
+        tab.value = isProjectTab(toValue(containerTab)) ? 'documentation' : undefined
         width.value = undefined
       }
     },

--- a/app/ide-desktop/client/tests/localWorkflow.spec.ts
+++ b/app/ide-desktop/client/tests/localWorkflow.spec.ts
@@ -73,7 +73,6 @@ test('Local Workflow', async ({ page, app, projectsDir }) => {
   ])
 
   // Rename User Defined component
-  await page.getByRole('tab', { name: 'Documentation' }).click()
   await page
     .locator('.FunctionSignatureEditor')
     .getByTestId('widget-function-name-content')
@@ -135,7 +134,6 @@ test('Local Workflow', async ({ page, app, projectsDir }) => {
   })
 
   // Paste an image in documentation.
-  // (the panel is opened in previous steps)
   await page.locator('.DocumentationEditor').click()
   await page.keyboard.press(`${CONTROL_KEY}+V`)
   const docImageElement = page.locator('.DocumentationEditor').getByTestId('doc-img')


### PR DESCRIPTION
### Pull Request Description

Fixes #13642

The right panel state is now kept per tab. Also, brought back the default of docpanel being opened in case of projects.

https://github.com/user-attachments/assets/7dc5afe5-5bff-4d10-9d04-22d7743c0076

### Important Notes

Not testing yet, as it's prone to change with 3panel design.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
