### PR TITLE
Making `Builtins.get(...)` the primary accessor for `Builtins`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -16,6 +16,7 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.type.TypesGen;
@@ -51,7 +52,7 @@ public abstract class PrintErrNode extends Node {
       VirtualFrame frame,
       Object message,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings,
-      @Cached("buildSymbol()") UnresolvedSymbol symbol,
+      @Cached("buildToTextSymbol($node)") UnresolvedSymbol symbol,
       @Cached("buildInvokeCallableNode()") InvokeCallableNode invokeCallableNode,
       @Cached ExpectStringNode expectStringNode) {
     var ctx = EnsoContext.get(this);
@@ -79,7 +80,9 @@ public abstract class PrintErrNode extends Node {
   }
 
   @NeverDefault
-  UnresolvedSymbol buildSymbol() {
-    return UnresolvedSymbol.build("to_text", EnsoContext.get(this).getBuiltins().getScope());
+  static UnresolvedSymbol buildToTextSymbol(Node where) {
+    var mod = Builtins.get(where).getModule();
+    var scope = mod.getScope();
+    return UnresolvedSymbol.build("to_text", scope);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -15,6 +15,7 @@ import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.warning.WarningsLibrary;
@@ -56,7 +57,7 @@ public abstract class PrintlnNode extends Node {
       Object nl,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings,
       @CachedLibrary(limit = "10") WarningsLibrary warnings,
-      @Cached("buildSymbol()") UnresolvedSymbol symbol,
+      @Cached("buildToTextSymbol($node)") UnresolvedSymbol symbol,
       @Cached("buildInvokeCallableNode()") InvokeCallableNode invokeCallableNode) {
     var ctx = EnsoContext.get(this);
     var state = ctx.currentState();
@@ -98,8 +99,10 @@ public abstract class PrintlnNode extends Node {
   }
 
   @NeverDefault
-  UnresolvedSymbol buildSymbol() {
-    return UnresolvedSymbol.build("to_text", EnsoContext.get(this).getBuiltins().getScope());
+  static UnresolvedSymbol buildToTextSymbol(Node where) {
+    var mod = Builtins.get(where).getModule();
+    var scope = mod.getScope();
+    return UnresolvedSymbol.build("to_text", scope);
   }
 
   @NeverDefault

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import org.enso.common.LanguageInfo;
@@ -98,7 +99,6 @@ public final class EnsoContext {
   private final boolean isInlineCachingDisabled;
   private final boolean isIrCachingDisabled;
   private final boolean shouldWaitForPendingSerializationJobs;
-  private final Builtins builtins;
   private final CompilerConfig compilerConfig;
   private final NotificationHandler notificationHandler;
   private final TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, EnsoContext.class);
@@ -179,7 +179,6 @@ public final class EnsoContext {
             .isLintingDisabled(getOption(RuntimeOptions.DISABLE_LINTING_KEY))
             .removeUnusedImports(shouldRemoveUnusedImports)
             .build();
-    this.builtins = new Builtins(this);
     this.notificationHandler = notificationHandler;
     this.lockManager = lockManager;
     this.distributionManager = distributionManager;
@@ -208,6 +207,7 @@ public final class EnsoContext {
     var editionOverride = OptionsHelper.getEditionOverride(environment);
     var resourceManager = new org.enso.distribution.locking.ResourceManager(lockManager);
 
+    var builtins = Builtins.get(this);
     packageRepository =
         DefaultPackageRepository.initializeRepository(
             OptionConverters.toScala(projectPackage),
@@ -683,8 +683,8 @@ public final class EnsoContext {
    *
    * @return an object containing the builtin functions
    */
-  public Builtins getBuiltins() {
-    return this.builtins;
+  public final Builtins getBuiltins() {
+    return Builtins.get(this);
   }
 
   /**
@@ -1031,11 +1031,11 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private Object extraValues(int index, Supplier<?> init) {
+  private Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       extraValues = Arrays.copyOf(extraValues, Extra.COUNTER.get());
-      extraValues[index] = init.get();
+      extraValues[index] = init.apply(this);
       assert extraValues[index] != null;
     }
     return extraValues[index];
@@ -1052,7 +1052,7 @@ public final class EnsoContext {
     private static final AtomicInteger COUNTER = new AtomicInteger();
     private final int index;
     private final Class<T> type;
-    private final Supplier<T> init;
+    private final Function<EnsoContext, T> init;
 
     /**
      * Defines new value associated with the context.Use as:
@@ -1064,7 +1064,7 @@ public final class EnsoContext {
      * @param type the type of the value to {@link #set} and {@link #get}.
      * @param initialValue function to use to compute initial value
      */
-    public Extra(Class<T> type, Supplier<T> initialValue) {
+    public Extra(Class<T> type, Function<EnsoContext, T> initialValue) {
       this.type = type;
       this.index = COUNTER.getAndIncrement();
       this.init = initialValue;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import org.enso.common.CompilationStage;
 import org.enso.common.LanguageInfo;
@@ -144,11 +145,17 @@ public final class Module extends EnsoObject {
    * Creates a new module.
    *
    * @param name the qualified name of this module.
+   * @param fillWith a code to run to initialize module scope or {@code null} to leave the module
+   *     scope empty
    * @param pkg the package this module belongs to. May be {@code null}, if the module does not
    *     belong to a package.
    */
   private Module(
-      QualifiedName name, Package<TruffleFile> pkg, boolean synthetic, Rope literalSource) {
+      QualifiedName name,
+      Package<TruffleFile> pkg,
+      boolean synthetic,
+      Consumer<ModuleScopeBuilder> fillWith,
+      Rope literalSource) {
     ensureConsistentName(name, pkg);
     this.sources =
         literalSource == null ? ModuleSources.NONE : ModuleSources.NONE.newWith(literalSource);
@@ -160,10 +167,13 @@ public final class Module extends EnsoObject {
     this.synthetic = synthetic;
     if (synthetic) {
       this.compilationStage = CompilationStage.INITIAL;
-      scopeBuilder.build();
     } else {
+      if (fillWith != null) {
+        fillWith.accept(scopeBuilder);
+      }
       this.compilationStage = CompilationStage.AFTER_CODEGEN;
     }
+    scopeBuilder.build();
   }
 
   private void ensureConsistentName(QualifiedName name, Package<TruffleFile> pkg) {
@@ -203,10 +213,24 @@ public final class Module extends EnsoObject {
    * @param name the qualified name of the newly created module.
    * @param pkg the package this module belongs to. May be {@code null}, if the module does not
    *     belong to a package.
+   * @param fillWith to fill in the scope
+   * @return the module with scope filled by provided with code
+   */
+  public static Module emptyWith(
+      QualifiedName name, Package<TruffleFile> pkg, Consumer<ModuleScopeBuilder> fillWith) {
+    return new Module(name, pkg, false, fillWith, null);
+  }
+
+  /**
+   * Creates an empty module.
+   *
+   * @param name the qualified name of the newly created module.
+   * @param pkg the package this module belongs to. May be {@code null}, if the module does not
+   *     belong to a package.
    * @return the module with empty scope.
    */
   public static Module empty(QualifiedName name, Package<TruffleFile> pkg) {
-    return new Module(name, pkg, false, null);
+    return new Module(name, pkg, false, null, null);
   }
 
   /**
@@ -219,7 +243,7 @@ public final class Module extends EnsoObject {
    * @return the synthetic module
    */
   public static Module synthetic(QualifiedName name, Package<TruffleFile> pkg, Rope source) {
-    return new Module(name, pkg, true, source);
+    return new Module(name, pkg, true, null, source);
   }
 
   /** Clears any literal source set for this module. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime.builtin;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.nodes.Node;
 import java.io.IOException;
 import java.util.Optional;
 import org.enso.common.MethodNames;
@@ -34,7 +35,6 @@ import org.enso.interpreter.node.expression.builtin.text.Text;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.pkg.QualifiedName;
 
 /** Container class for static predefined atoms, methods, and their containing scope. */
@@ -46,7 +46,6 @@ public final class Builtins {
 
   private final Error error;
   private final Module module;
-  private final ModuleScope scope;
   private final Number number;
   private final Boolean bool;
 
@@ -131,16 +130,29 @@ public final class Builtins {
     error = new Error(this, context);
     system = new System(this);
     number = new Number(this);
-    scope = scopeBuilder.build();
+    scopeBuilder.build();
   }
 
   /**
    * Obtains instance of {@link Builtins} for given context.
    *
-   * @param ctx
-   * @return
+   * @param ctx the context to find builtins for
+   * @return the 1:1 instance associated with provided context
    */
   public static Builtins get(EnsoContext ctx) {
+    return KEY.get(ctx);
+  }
+
+  /**
+   * Obtains instance of {@link Builtins} for given node. Uses {@link EnsoContext#get} followed by
+   * {@link #get(org.enso.interpreter.runtime.EnsoContext)}.
+   *
+   * @param node the node to find builtins for
+   * @return instance of builtins for given node
+   */
+  public static Builtins get(Node node) {
+    var ctx = EnsoContext.get(node);
+    assert ctx != null : "No context for " + node;
     return KEY.get(ctx);
   }
 
@@ -452,15 +464,6 @@ public final class Builtins {
    */
   public Type instrumentor() {
     return instrumentor.getType();
-  }
-
-  /**
-   * Returns the builtin module scope.
-   *
-   * @return the builtin module scope
-   */
-  public ModuleScope getScope() {
-    return scope;
   }
 
   public Module getModule() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -39,6 +39,8 @@ import org.enso.pkg.QualifiedName;
 
 /** Container class for static predefined atoms, methods, and their containing scope. */
 public final class Builtins {
+  private static final EnsoContext.Extra<Builtins> KEY =
+      new EnsoContext.Extra<>(Builtins.class, Builtins::new);
   private final EnsoContext context;
   private final BuiltinsRegistry builtins;
 
@@ -85,10 +87,11 @@ public final class Builtins {
    *
    * @param context the current {@link EnsoContext} instance
    */
-  public Builtins(EnsoContext context) {
+  private Builtins(EnsoContext context) {
     this.context = context;
-    EnsoLanguage language = context.getLanguage();
-    module = Module.empty(QualifiedName.fromString(MethodNames.Builtins.MODULE_NAME), null);
+    var language = context.getLanguage();
+    var fqn = QualifiedName.fromString(MethodNames.Builtins.MODULE_NAME);
+    module = Module.empty(fqn, null);
     module.compileScope(context); // Dummy compilation for an empty module
     var scopeBuilder = module.newScopeBuilder();
 
@@ -129,6 +132,16 @@ public final class Builtins {
     system = new System(this);
     number = new Number(this);
     scope = scopeBuilder.build();
+  }
+
+  /**
+   * Obtains instance of {@link Builtins} for given context.
+   *
+   * @param ctx
+   * @return
+   */
+  public static Builtins get(EnsoContext ctx) {
+    return KEY.get(ctx);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -35,17 +35,23 @@ import org.enso.interpreter.node.expression.builtin.text.Text;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.pkg.QualifiedName;
 
 /** Container class for static predefined atoms, methods, and their containing scope. */
 public final class Builtins {
   private static final EnsoContext.Extra<Builtins> KEY =
-      new EnsoContext.Extra<>(Builtins.class, Builtins::new);
+      new EnsoContext.Extra<>(Builtins.class, Builtins::create);
   private final EnsoContext context;
   private final BuiltinsRegistry builtins;
 
+  /**
+   * Module isn't final, as it wasn't possible to assign it in constructor. But it is "effectively
+   * final" - nobody is changing that field.
+   */
+  @CompilerDirectives.CompilationFinal private Module module;
+
   private final Error error;
-  private final Module module;
   private final Number number;
   private final Boolean bool;
 
@@ -81,26 +87,38 @@ public final class Builtins {
   private final AdditionalWarnings additionalWarnings;
   private final Builtin instrumentor;
 
+  /** Factory method to create the builtins. */
+  private static Builtins create(EnsoContext context) {
+    var fqn = QualifiedName.fromString(MethodNames.Builtins.MODULE_NAME);
+    var res = new Builtins[1];
+    var module =
+        Module.emptyWith(
+            fqn,
+            null,
+            (scopeBuilder) -> {
+              res[0] = new Builtins(context, scopeBuilder);
+            });
+    module.compileScope(context); // Dummy compilation for an empty module
+    // module has to be assigned only when constructor is over
+    res[0].module = module;
+    return res[0];
+  }
+
   /**
    * Creates an instance with builtin methods installed.
    *
-   * @param context the current {@link EnsoContext} instance
+   * @param ctx the current {@link EnsoContext} instance
+   * @param sb scope builder to fill
    */
-  private Builtins(EnsoContext context) {
-    this.context = context;
-    var language = context.getLanguage();
-    var fqn = QualifiedName.fromString(MethodNames.Builtins.MODULE_NAME);
-    module = Module.empty(fqn, null);
-    module.compileScope(context); // Dummy compilation for an empty module
-    var scopeBuilder = module.newScopeBuilder();
-
-    builtins = new BuiltinsRegistry(language, scopeBuilder);
+  private Builtins(EnsoContext ctx, ModuleScopeBuilder sb) {
+    context = ctx;
+    builtins = new BuiltinsRegistry(ctx.getLanguage(), sb);
 
     ordering = getBuiltinType(Ordering.class);
     comparable = getBuiltinType(Comparable.class);
     defaultComparator = getBuiltinType(DefaultComparator.class);
-    bool = this.getBuiltinType(Boolean.class);
-    contexts = this.getBuiltinType(Context.class);
+    bool = getBuiltinType(Boolean.class);
+    contexts = getBuiltinType(Context.class);
 
     any = getBuiltinType(Any.class);
     nothing = getBuiltinType(Nothing.class);
@@ -127,10 +145,9 @@ public final class Builtins {
     additionalWarnings = getBuiltinType(AdditionalWarnings.class);
     instrumentor = getBuiltinType(org.enso.interpreter.node.expression.builtin.Instrumentor.class);
 
-    error = new Error(this, context);
+    error = new Error(this, ctx);
     system = new System(this);
     number = new Number(this);
-    scopeBuilder.build();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -84,7 +84,7 @@ public final class Error {
   private static final Text divideByZeroMessage = Text.create("Cannot divide by zero.");
 
   /** Creates builders for error Atom Constructors. */
-  public Error(Builtins builtins, EnsoContext context) {
+  Error(Builtins builtins, EnsoContext context) {
     this.context = context;
     syntaxError = builtins.getBuiltinType(SyntaxError.class);
     typeError = builtins.getBuiltinType(TypeError.class);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Number.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Number.java
@@ -6,13 +6,13 @@ import org.enso.interpreter.node.expression.builtin.number.Integer;
 import org.enso.interpreter.runtime.data.Type;
 
 /** A container for all number-related builtins. */
-public class Number {
+public final class Number {
   private final Builtin integer;
   private final Builtin number;
   private final Builtin ensoFloat;
 
   /** Creates builders for number Atom Constructors. */
-  public Number(Builtins builtins) {
+  Number(Builtins builtins) {
     integer = builtins.getBuiltinType(Integer.class);
     number =
         builtins.getBuiltinType(org.enso.interpreter.node.expression.builtin.number.Number.class);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/State.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/State.java
@@ -23,7 +23,8 @@ public final class State {
   private static final EnsoContext.Extra<Shape> ROOT_STATE_SHAPE =
       new EnsoContext.Extra<>(
           Shape.class,
-          () -> Shape.newBuilder().layout(State.Container.class, State.Container.lookup()).build());
+          (ctx) ->
+              Shape.newBuilder().layout(State.Container.class, State.Container.lookup()).build());
 
   private final Container container;
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -100,6 +100,7 @@ import org.enso.interpreter.runtime.data.Type
 import org.enso.interpreter.runtime.scope.ImportExportScope
 import org.enso.interpreter.runtime.scope.ModuleScopeBuilder
 import org.enso.interpreter.{Constants, EnsoLanguage}
+import org.enso.interpreter.runtime.builtin.Builtins
 
 import java.math.BigInteger
 import java.util.function.Supplier
@@ -129,6 +130,9 @@ class IrToTruffle(
   val scopeBuilder: ModuleScopeBuilder,
   val compilerConfig: CompilerConfig
 ) {
+  private def getBuiltins: Builtins = {
+    Builtins.get(context)
+  }
 
   val language: EnsoLanguage = context.getLanguage
 
@@ -727,7 +731,7 @@ class IrToTruffle(
 
     val staticWrapper = methodDef.isStaticWrapperForInstanceMethod
 
-    val builtinFunction = context.getBuiltins
+    val builtinFunction = getBuiltins
       .getBuiltinFunction(
         methodOwnerName,
         methodName,
@@ -744,7 +748,7 @@ class IrToTruffle(
       .left
       .flatMap { l =>
         // Builtin Types Number and Integer have methods only for documentation purposes
-        val number = context.getBuiltins.number()
+        val number = getBuiltins.number()
         val ok =
           staticWrapper && (cons == number.getNumber.getEigentype || cons == number.getInteger.getEigentype) ||
           !staticWrapper && (cons == number.getNumber             || cons == number.getInteger)
@@ -1300,7 +1304,7 @@ class IrToTruffle(
     def processType(value: Tpe): RuntimeExpression = {
       setLocation(
         ErrorNode.build(
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeSyntaxError(
               "Type operators are not currently supported at runtime"
@@ -1348,7 +1352,7 @@ class IrToTruffle(
 
             val message = invalidBranches.map(_.message).mkString(", ")
 
-            val error = context.getBuiltins
+            val error = getBuiltins
               .error()
               .makeCompileError(message)
 
@@ -1437,13 +1441,13 @@ class IrToTruffle(
                     ) =>
                   val atomCons =
                     asType(tp).getConstructors.get(cons.name)
-                  val r = if (atomCons == context.getBuiltins.bool().getTrue) {
+                  val r = if (atomCons == getBuiltins.bool().getTrue) {
                     BooleanBranchNode.build(
                       true,
                       branchCodeNode.getCallTarget,
                       branch.terminalBranch
                     )
-                  } else if (atomCons == context.getBuiltins.bool().getFalse) {
+                  } else if (atomCons == getBuiltins.bool().getFalse) {
                     BooleanBranchNode.build(
                       false,
                       branchCodeNode.getCallTarget,
@@ -1464,7 +1468,7 @@ class IrToTruffle(
                     ) =>
                   val tpe =
                     asType(binding)
-                  val polyglot = context.getBuiltins.polyglot
+                  val polyglot = getBuiltins.polyglot
                   val branchNode = if (tpe == polyglot) {
                     PolyglotBranchNode.build(
                       tpe,
@@ -1922,7 +1926,7 @@ class IrToTruffle(
             ConstantObjectNode.build(t)
           } else {
             ErrorNode.build(
-              context.getBuiltins
+              getBuiltins
                 .error()
                 .makeSyntaxError(
                   s"Type for $tp is null"
@@ -2009,47 +2013,47 @@ class IrToTruffle(
         case Error.InvalidIR(_, _) =>
           throw new CompilerError("Unexpected Invalid IR during codegen.")
         case err: errors.Syntax =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeSyntaxError(err.message(fileLocationFromSection))
         case err: errors.Redefined.Binding =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.Method =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.MethodClashWithAtom =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.Conversion =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.Type =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.SelfArg =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Redefined.Arg =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Unexpected.TypeSignature =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Resolution =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case err: errors.Conversion =>
-          context.getBuiltins
+          getBuiltins
             .error()
             .makeCompileError(err.message(fileLocationFromSection))
         case _: errors.Pattern =>
@@ -2069,7 +2073,7 @@ class IrToTruffle(
       * @return the Nothing builtin
       */
     private def processEmpty(): RuntimeExpression = {
-      LiteralNode.build(context.getBuiltins.nothing())
+      LiteralNode.build(getBuiltins.nothing())
     }
 
     /** Processes function arguments, generates arguments reads and creates
@@ -2290,7 +2294,7 @@ class IrToTruffle(
         case _: Application.Typeset =>
           setLocation(
             ErrorNode.build(
-              context.getBuiltins
+              getBuiltins
                 .error()
                 .makeSyntaxError(
                   "Typeset literals are not yet supported at runtime"


### PR DESCRIPTION
### Pull Request Description

`Builtins` are an independent concept built on top of `EnsoContext`. It makes little sense for the context itself to initialize them and hold a reference to them from a source code organizational point of view. This PR uses `EnsoContext.Extra` to define a `KEY` for the `Builtins` class.

The straightforward way to access builtins is to use `Builtins.get(ctx)` or even simpler `Builtins.get(node)`. Possibly we could remove `EnsoContext.getBuiltins` now (leaving that after PR review as that will be a huge mechanical change).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
