### PR TITLE
Fix spurious tooltip

### DIFF
--- a/app/gui/src/components/AppContainer/SelectableTab.vue
+++ b/app/gui/src/components/AppContainer/SelectableTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import CloseButton from '$/components/CloseButton.vue'
+import { isOverflowing } from '$/utils/dom'
 import SvgIcon from '@/components/SvgIcon.vue'
 import TooltipTrigger from '@/components/TooltipTrigger.vue'
 import type { Icon } from '@/util/iconMetadata/iconName'
@@ -30,7 +31,9 @@ const emit = defineEmits<{ 'update:selected': [value: boolean] }>()
 const labelElement = useTemplateRef('label')
 
 const tooltipPlacement = computed(() => (orientation === 'horizontal' ? 'top' : 'left'))
-const tooltipOverflowElement = computed(() => (tooltip ? null : labelElement.value))
+const tooltipEnabled = computed(
+  (): boolean => !!tooltip || !labelElement.value || isOverflowing(labelElement.value),
+)
 
 const VARIANTS = {
   hidden: { opacity: 0 },
@@ -39,7 +42,7 @@ const VARIANTS = {
 </script>
 
 <template>
-  <TooltipTrigger :placement="tooltipPlacement" :whenOverflow="tooltipOverflowElement">
+  <TooltipTrigger :placement="tooltipPlacement" :enabled="tooltipEnabled">
     <template #default="triggerProps">
       <div class="SelectableTab" :class="orientation" @click="emit('update:selected', !selected)">
         <AnimatePresence :initial="selected != null">

--- a/app/gui/src/components/AppContainer/SelectableTab.vue
+++ b/app/gui/src/components/AppContainer/SelectableTab.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
+import CloseButton from '$/components/CloseButton.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import TooltipTrigger from '@/components/TooltipTrigger.vue'
-import { Icon } from '@/util/iconMetadata/iconName'
+import type { Icon } from '@/util/iconMetadata/iconName'
 import { AnimatePresence, motion } from 'motion-v'
-import { computed } from 'vue'
-import CloseButton from '../CloseButton.vue'
+import { computed, useTemplateRef } from 'vue'
 
 const {
   selected,
@@ -27,8 +27,10 @@ const {
 // change.
 const emit = defineEmits<{ 'update:selected': [value: boolean] }>()
 
+const labelElement = useTemplateRef('label')
+
 const tooltipPlacement = computed(() => (orientation === 'horizontal' ? 'top' : 'left'))
-const whenTooltip = computed(() => (label && !tooltip ? 'whenOverflow' : 'always'))
+const tooltipOverflowElement = computed(() => (tooltip ? null : labelElement.value))
 
 const VARIANTS = {
   hidden: { opacity: 0 },
@@ -37,7 +39,7 @@ const VARIANTS = {
 </script>
 
 <template>
-  <TooltipTrigger :placement="tooltipPlacement" :when="whenTooltip">
+  <TooltipTrigger :placement="tooltipPlacement" :whenOverflow="tooltipOverflowElement">
     <template #default="triggerProps">
       <div class="SelectableTab" :class="orientation" @click="emit('update:selected', !selected)">
         <AnimatePresence :initial="selected != null">
@@ -55,14 +57,15 @@ const VARIANTS = {
         <button
           role="tab"
           :aria-label="tooltip ?? label ?? ''"
-          class="tabContent"
+          class="tabContent tabLayout"
           :class="{ enabled, selected }"
           :disabled="!enabled"
-          v-bind="triggerProps"
         >
-          <SvgIcon v-if="icon" :name="icon" />
-          <slot />
-          <span v-if="label" class="label">{{ label }}</span>
+          <span class="tabLayout" v-bind="triggerProps">
+            <SvgIcon v-if="icon" :name="icon" />
+            <slot />
+            <span v-if="label" ref="label" class="label">{{ label }}</span>
+          </span>
           <CloseButton v-if="onClose" @click="onClose" />
         </button>
       </div>
@@ -143,14 +146,17 @@ const VARIANTS = {
   }
 }
 
-.tabContent {
-  height: 100%;
-  padding: 8px;
+.tabLayout {
   display: flex;
-  border-radius: var(--radius-full);
   flex-direction: row;
   align-items: center;
   gap: 12px;
+}
+
+.tabContent {
+  height: 100%;
+  padding: 8px;
+  border-radius: var(--radius-full);
   transition: background-color 0.3s;
   cursor: not-allowed;
   opacity: 0.2;

--- a/app/gui/src/dashboard/components/VisualTooltip/useVisualTooltip.tsx
+++ b/app/gui/src/dashboard/components/VisualTooltip/useVisualTooltip.tsx
@@ -4,6 +4,7 @@ import Portal from '#/components/Portal'
 import { TOOLTIP_STYLES, type TooltipProps } from '#/components/Tooltip'
 import * as eventCallback from '#/hooks/eventCallbackHooks'
 import { unsafeWriteValue } from '#/utilities/write'
+import { isOverflowing } from '$/utils/dom'
 import * as React from 'react'
 
 /** Props for {@link useVisualTooltip}. */
@@ -238,6 +239,5 @@ function TooltipInner(props: TooltipInnerProps) {
 
 const DISPLAY_STRATEGIES: Record<DisplayStrategy, (target: HTMLElement) => boolean> = {
   always: () => true,
-  whenOverflowing: (target) =>
-    target.scrollWidth > target.clientWidth || target.scrollHeight > target.clientHeight,
+  whenOverflowing: isOverflowing,
 }

--- a/app/gui/src/dashboard/utilities/scrollContainers.ts
+++ b/app/gui/src/dashboard/utilities/scrollContainers.ts
@@ -2,6 +2,8 @@
  * @file Functions for working with scroll containers.
  */
 
+import { elementHierarchy, isOverflowing } from '$/utils/dom'
+
 /**
  * A type that represents an HTML or SVG element.
  */
@@ -51,20 +53,12 @@ export function findScrollContainers(element: HTMLOrSVGElement | null): HTMLOrSV
 }
 
 /**
- * Finds all containers that possbly have overflow (when scrollWidth/scrollHeight > clientWidth/clientHeight)
+ * Finds all containers that possibly have overflow (when scrollWidth/scrollHeight > clientWidth/clientHeight)
  * @param element - The element to start searching from
- * @returns An array of containers that possbly have overflow
+ * @returns An array of containers that possibly have overflow
  */
 export function findOverflowContainers(element: HTMLOrSVGElement | null): HTMLOrSVGElement[] {
-  const result: HTMLOrSVGElement[] = []
-
-  if (!element || element === document.body) return result
-
-  if (hasPossibleOverflow(element)) {
-    result.push(element)
-  }
-
-  return [...result, ...findOverflowContainers(element.parentElement)]
+  return elementHierarchy(element).filter((el) => el !== document.body && isOverflowing(el))
 }
 
 /**
@@ -148,16 +142,6 @@ export function hasTailwindOverflow(element: HTMLOrSVGElement): boolean {
     element.classList.contains('overflow-x-scroll') ||
     element.classList.contains('overflow-y-scroll')
   )
-}
-
-/**
- * Checks if the element has possible overflow, when scrollWidth/scrollHeight > clientWidth/clientHeight.
- * @param element - The element to check
- * @returns True if the element has possible overflow, false otherwise
- */
-export function hasPossibleOverflow(element: HTMLOrSVGElement): boolean {
-  const { scrollHeight, scrollWidth, clientHeight, clientWidth } = element
-  return scrollHeight > clientHeight || scrollWidth > clientWidth
 }
 
 /**

--- a/app/gui/src/project-view/components/TooltipDisplayer.vue
+++ b/app/gui/src/project-view/components/TooltipDisplayer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { unrefElement } from '@/composables/events'
 import { HoveredElement, type TooltipRegistry } from '@/providers/tooltipRegistry'
 import { Opt } from '@/util/data/opt'
 import { autoUpdate, flip, FloatingElement, offset, shift, useFloating } from '@floating-ui/vue'
@@ -56,17 +57,18 @@ const isDisplayed = (tooltip: Opt<HoveredElement>) => {
   if (tooltip.entry.isHidden) return false
   if (tooltip.entry.forceShow) return true
   if (!tooltip.element.isConnected) return false
-  switch (toValue(tooltip.entry.props.when)) {
-    case 'always':
-      return true
-    case 'whenOverflow':
-      return (
-        tooltip.element.scrollWidth > tooltip.element.clientWidth ||
-        tooltip.element.scrollHeight > tooltip.element.clientHeight
-      )
-    default:
-      return false
+  const whenOverflow = toValue(tooltip.entry.props.whenOverflow)
+  if (!whenOverflow) return true
+  const overflowElement = whenOverflow === true ? tooltip.element : unrefElement(whenOverflow)
+  if (!overflowElement) {
+    DEV: console.warn('Tooltip overflow element could not be resolved.')
+    return true
   }
+  return isOverflowing(overflowElement)
+}
+
+function isOverflowing(element: HTMLElement) {
+  return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight
 }
 
 const displayedTooltip = computed(() => {

--- a/app/gui/src/project-view/components/TooltipDisplayer.vue
+++ b/app/gui/src/project-view/components/TooltipDisplayer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { unrefElement } from '@/composables/events'
 import { HoveredElement, type TooltipRegistry } from '@/providers/tooltipRegistry'
 import { Opt } from '@/util/data/opt'
 import { autoUpdate, flip, FloatingElement, offset, shift, useFloating } from '@floating-ui/vue'
@@ -57,18 +56,7 @@ const isDisplayed = (tooltip: Opt<HoveredElement>) => {
   if (tooltip.entry.isHidden) return false
   if (tooltip.entry.forceShow) return true
   if (!tooltip.element.isConnected) return false
-  const whenOverflow = toValue(tooltip.entry.props.whenOverflow)
-  if (!whenOverflow) return true
-  const overflowElement = whenOverflow === true ? tooltip.element : unrefElement(whenOverflow)
-  if (!overflowElement) {
-    DEV: console.warn('Tooltip overflow element could not be resolved.')
-    return true
-  }
-  return isOverflowing(overflowElement)
-}
-
-function isOverflowing(element: HTMLElement) {
-  return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight
+  return toValue(tooltip.entry.props.enabled)
 }
 
 const displayedTooltip = computed(() => {

--- a/app/gui/src/project-view/components/TooltipTrigger.vue
+++ b/app/gui/src/project-view/components/TooltipTrigger.vue
@@ -2,22 +2,15 @@
 import { useTooltipRegistry } from '@/providers/tooltipRegistry'
 import { usePropagateScopesToAllRoots } from '@/util/patching'
 import type { Placement } from '@floating-ui/vue'
-import type { VueInstance } from '@vueuse/core'
 import { toRef } from 'vue'
-import type { Opt } from '@/util/data/opt'
 
 const {
   placement = 'top',
-  whenOverflow = undefined,
+  enabled = true,
   showOnClick = false,
 } = defineProps<{
   placement?: Placement
-  /**
-   * If set, the tooltip is inhibited unless the reference element is overflowing. If `true`, the
-   * element in the default slot is the reference element; if an element is explicitly provided, it
-   * will be used as the reference element.
-   */
-  whenOverflow?: Opt<true | HTMLElement | VueInstance>
+  enabled?: boolean
   showOnClick?: boolean
 }>()
 
@@ -33,7 +26,7 @@ const tooltipSlot = toRef(slots, 'tooltip')
 const registered = registry.registerTooltip(tooltipSlot)
 function onEnter(e: PointerEvent) {
   if (e.target instanceof HTMLElement && tooltipSlot.value != null) {
-    registered.onTargetEnter(e.target, { placement: () => placement, whenOverflow: () => whenOverflow })
+    registered.onTargetEnter(e.target, { placement: () => placement, enabled: () => enabled })
   }
 }
 

--- a/app/gui/src/project-view/components/TooltipTrigger.vue
+++ b/app/gui/src/project-view/components/TooltipTrigger.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
-import { useTooltipRegistry, type TooltipDisplayStrategy } from '@/providers/tooltipRegistry'
+import { useTooltipRegistry } from '@/providers/tooltipRegistry'
 import { usePropagateScopesToAllRoots } from '@/util/patching'
-import { Placement } from '@floating-ui/vue'
+import type { Placement } from '@floating-ui/vue'
+import type { VueInstance } from '@vueuse/core'
 import { toRef } from 'vue'
+import type { Opt } from '@/util/data/opt'
 
 const {
   placement = 'top',
-  when = 'always',
+  whenOverflow = undefined,
   showOnClick = false,
 } = defineProps<{
   placement?: Placement
-  when?: TooltipDisplayStrategy
+  /**
+   * If set, the tooltip is inhibited unless the reference element is overflowing. If `true`, the
+   * element in the default slot is the reference element; if an element is explicitly provided, it
+   * will be used as the reference element.
+   */
+  whenOverflow?: Opt<true | HTMLElement | VueInstance>
   showOnClick?: boolean
 }>()
 
@@ -26,7 +33,7 @@ const tooltipSlot = toRef(slots, 'tooltip')
 const registered = registry.registerTooltip(tooltipSlot)
 function onEnter(e: PointerEvent) {
   if (e.target instanceof HTMLElement && tooltipSlot.value != null) {
-    registered.onTargetEnter(e.target, { placement: () => placement, when: () => when })
+    registered.onTargetEnter(e.target, { placement: () => placement, whenOverflow: () => whenOverflow })
   }
 }
 

--- a/app/gui/src/project-view/providers/tooltipRegistry.ts
+++ b/app/gui/src/project-view/providers/tooltipRegistry.ts
@@ -1,7 +1,6 @@
 import { createContextStore } from '@/providers'
 import type { ToValue } from '@/util/reactivity'
 import type { Placement } from '@floating-ui/vue'
-import type { VueInstance } from '@vueuse/core'
 import * as iter from 'enso-common/src/utilities/data/iter'
 import {
   computed,
@@ -12,11 +11,10 @@ import {
   type Slot,
 } from 'vue'
 import { assert } from 'ydoc-shared/util/assert'
-import type { Opt } from '@/util/data/opt'
 
 interface TooltipProps {
   placement: ToValue<Placement>
-  whenOverflow: ToValue<Opt<true | HTMLElement | VueInstance>>
+  enabled: ToValue<boolean>
 }
 
 interface TooltipEntry {

--- a/app/gui/src/project-view/providers/tooltipRegistry.ts
+++ b/app/gui/src/project-view/providers/tooltipRegistry.ts
@@ -1,6 +1,7 @@
 import { createContextStore } from '@/providers'
-import { ToValue } from '@/util/reactivity'
-import { Placement } from '@floating-ui/vue'
+import type { ToValue } from '@/util/reactivity'
+import type { Placement } from '@floating-ui/vue'
+import type { VueInstance } from '@vueuse/core'
 import * as iter from 'enso-common/src/utilities/data/iter'
 import {
   computed,
@@ -11,12 +12,11 @@ import {
   type Slot,
 } from 'vue'
 import { assert } from 'ydoc-shared/util/assert'
-
-export type TooltipDisplayStrategy = 'always' | 'whenOverflow'
+import type { Opt } from '@/util/data/opt'
 
 interface TooltipProps {
   placement: ToValue<Placement>
-  when: ToValue<TooltipDisplayStrategy>
+  whenOverflow: ToValue<Opt<true | HTMLElement | VueInstance>>
 }
 
 interface TooltipEntry {

--- a/app/gui/src/utils/dom.ts
+++ b/app/gui/src/utils/dom.ts
@@ -1,0 +1,19 @@
+/**
+ * Checks if the element's scroll size exceeds its client size.
+ * @param element - The element to check
+ * @returns Whether the element overflows.
+ */
+export function isOverflowing(element: HTMLElement | SVGElement): boolean {
+  const { scrollHeight, scrollWidth, clientHeight, clientWidth } = element
+  return scrollHeight > clientHeight || scrollWidth > clientWidth
+}
+
+/** Collects the `parentElement` hierarchy starting from `element`. */
+export function elementHierarchy<T extends { parentElement: T | null }>(element: T | null): T[] {
+  const elements: T[] = []
+  while (element != null) {
+    elements.push(element)
+    element = element.parentElement
+  }
+  return elements
+}


### PR DESCRIPTION
Fix spurious tooltip (Fixes #13612)

UI:
- Tab name tooltip is no longer shown when name is not truncated.
- Tab name tooltip is no longer triggered by hovering tab close button.

APIs:
- TooltipTrigger: Add support for specifying an overflow element other than the trigger element.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
