### PR TITLE
Fixing file browser

### DIFF
--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -187,10 +187,11 @@ function acceptFile(name: string) {
 }
 
 function chooseEntry(asset: AnyAsset, close: boolean) {
+  const name = asset.type === AssetType.datalink ? `${asset.title}.datalink` : asset.title
   if (props.writeMode) {
-    setFilename(asset.title)
+    setFilename(name)
   } else {
-    acceptFile(asset.title)
+    acceptFile(name)
     if (close) emit('close')
   }
 }

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -109,15 +109,27 @@ const { currentDirPath, chosenFilename, setPath, enterDir, popTo, append } = use
   home: () => ensoPath(toValue(userFiles.value?.home ?? [])),
   enteredPath,
 })
+// Set initial path when opening the file browser.
 watchEffect(() => setPath(parseEnsoPath(props.choosenPath)))
-watchEffect(() => currentDirPath.value && setBrowsingPath(currentDirPath.value))
+// Set the browsing path when the current directory changes.
+watchEffect(() => {
+  if (currentDirPath.value) {
+    const fullPath =
+      chosenFilename.value ?
+        mapPath(currentDirPath.value, append(chosenFilename.value))
+      : currentDirPath.value
+    setBrowsingPath(fullPath)
+  }
+})
+// Set the filename when the user enters a directory.
 watchEffect(() => {
   if (props.writeMode && unenteredPathSuffix.value) setFilename(unenteredPathSuffix.value)
 })
-
+// Set the filename when the user chooses a file.
 watchEffect(() => {
   if (chosenFilename.value) setFilename(chosenFilename.value)
 })
+
 const highlightedFilename = computed(
   () => (props.writeMode && fullFilePath.value) || chosenFilename.value,
 )

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -9,7 +9,7 @@ import { useBackends } from '$/providers/backends'
 import ActionButton from '@/components/ActionButton.vue'
 import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
 import UpsertSecretPanel from '@/components/UpsertSecretPanel.vue'
-import { mapPath, useEnsoPaths } from '@/components/widgets/FileBrowserWidget/ensoPath'
+import { useEnsoPaths } from '@/components/widgets/FileBrowserWidget/ensoPath'
 import {
   listDirectoryArgs,
   useCurrentPath,
@@ -26,6 +26,7 @@ import {
   usePathBrowsing,
   type Directory,
 } from '@/components/widgets/FileBrowserWidget/pathBrowsing'
+import { useAcceptCurrentFile } from '@/components/widgets/FileBrowserWidget/useAcceptCurrentFile'
 import { useFileBrowserSync } from '@/components/widgets/FileBrowserWidget/useFileBrowserSync'
 import { useUserFiles } from '@/components/widgets/FileBrowserWidget/userFiles'
 import { useBackend } from '@/composables/backend'
@@ -129,8 +130,6 @@ const highlightedFilename = computed(
 
 // === Status ===
 
-const overwriteFilename = ref<string | null>(null)
-const warningText = ref<string | null>(null)
 const isBusy = computed(
   () => isBrowsingPending.value || isPending.value || commitSecretPending.value,
 )
@@ -150,46 +149,21 @@ async function createSecret(value: string, name: string) {
 
 // === Accepting Chosen File ===
 
-async function tryAcceptCurrentFile() {
-  if (!enteredPath.value) {
-    // We can only reach this if there was a root previously, but there isn't now. This might be
-    // possible if the session is lost.
-    warningText.value = 'Unable to access files'
-    return
-  }
-  const path = mapPath(enteredPath.value, append(...fullFilePath.value.split('/')))
-  const enteringResult = await setBrowsingPath(path)
-  currentDirPath.value = path
-  if (!enteringResult.ok) {
-    warningText.value = `${enteringResult.error.payload.toString()}`
-    return
-  }
-  setFilename(unenteredPathSuffix.value)
-  const assetInfo = await assetExists(fullFilePath.value)
-  if (
-    assetInfo.exists &&
-    assetInfo.type === AssetType.file &&
-    props.writeMode &&
-    !props.allowOverride
-  ) {
-    overwriteFilename.value = fullFilePath.value
-  } else if (assetInfo.exists && assetInfo.type === AssetType.directory) {
-    warningText.value = `'${fullFilePath.value}' is a directory, not a file`
-  } else {
-    acceptCurrentFile()
-    return
-  }
-}
-
-function acceptCurrentFile() {
-  acceptFile(fullFilePath.value)
-}
-
-function acceptFile(name: string) {
-  if (!enteredPath.value) return
-  const currentFilePath = printEnsoPath(mapPath(enteredPath.value, append(...name.split('/'))))
-  emit('pathAccepted', currentFilePath)
-}
+const { overwriteFilename, warningText, tryAcceptCurrentFile, acceptCurrentFile, acceptFile } =
+  useAcceptCurrentFile({
+    enteredPath,
+    fullFilePath,
+    currentDirPath,
+    setBrowsingPath,
+    append,
+    setFilename,
+    unenteredPathSuffix,
+    assetExists,
+    writeMode: () => props.writeMode,
+    allowOverride: () => props.allowOverride,
+    printEnsoPath,
+    pathAcceptedCallback: (p) => emit('pathAccepted', p),
+  })
 
 function chooseEntry(asset: AnyAsset, close: boolean) {
   const name = asset.type === AssetType.datalink ? `${asset.title}.datalink` : asset.title

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -26,6 +26,7 @@ import {
   usePathBrowsing,
   type Directory,
 } from '@/components/widgets/FileBrowserWidget/pathBrowsing'
+import { useFileBrowserSync } from '@/components/widgets/FileBrowserWidget/useFileBrowserSync'
 import { useUserFiles } from '@/components/widgets/FileBrowserWidget/userFiles'
 import { useBackend } from '@/composables/backend'
 import { registerHandlers } from '@/providers/action'
@@ -33,7 +34,7 @@ import { providePopoverRoot } from '@/providers/popoverRoot'
 import { FileType } from '@/providers/widgetRegistry/configuration'
 import type { AnyAsset } from 'enso-common/src/services/Backend'
 import { assetIsDirectory, AssetType } from 'enso-common/src/services/Backend'
-import { computed, ref, toValue, useTemplateRef, watch, watchEffect } from 'vue'
+import { computed, ref, toValue, useTemplateRef, watch } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -109,25 +110,17 @@ const { currentDirPath, chosenFilename, setPath, enterDir, popTo, append } = use
   home: () => ensoPath(toValue(userFiles.value?.home ?? [])),
   enteredPath,
 })
-// Sync opened directory with the passed property.
-watchEffect(() => setPath(parseEnsoPath(props.choosenPath)))
-// Sync the browsing path with the current directory (usually when navigating).
-watchEffect(() => {
-  if (currentDirPath.value) {
-    const fullPath =
-      chosenFilename.value ?
-        mapPath(currentDirPath.value, append(chosenFilename.value))
-      : currentDirPath.value
-    setBrowsingPath(fullPath)
-  }
-})
-// Sync the filename with entered path (usually when openening the file browser).
-watchEffect(() => {
-  if (props.writeMode && unenteredPathSuffix.value) setFilename(unenteredPathSuffix.value)
-})
-// Set the filename with the chosen file.
-watchEffect(() => {
-  if (chosenFilename.value) setFilename(chosenFilename.value)
+useFileBrowserSync({
+  writeMode: () => props.writeMode,
+  choosenPath: () => props.choosenPath,
+  parseEnsoPath,
+  currentDirPath,
+  chosenFilename,
+  setPath,
+  setBrowsingPath,
+  append,
+  setFilename,
+  unenteredPathSuffix,
 })
 
 const highlightedFilename = computed(

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -109,9 +109,9 @@ const { currentDirPath, chosenFilename, setPath, enterDir, popTo, append } = use
   home: () => ensoPath(toValue(userFiles.value?.home ?? [])),
   enteredPath,
 })
-// Set initial path when opening the file browser.
+// Sync opened directory with the passed property.
 watchEffect(() => setPath(parseEnsoPath(props.choosenPath)))
-// Set the browsing path when the current directory changes.
+// Sync the browsing path with the current directory (usually when navigating).
 watchEffect(() => {
   if (currentDirPath.value) {
     const fullPath =
@@ -121,11 +121,11 @@ watchEffect(() => {
     setBrowsingPath(fullPath)
   }
 })
-// Set the filename when the user enters a directory.
+// Sync the filename with entered path (usually when openening the file browser).
 watchEffect(() => {
   if (props.writeMode && unenteredPathSuffix.value) setFilename(unenteredPathSuffix.value)
 })
-// Set the filename when the user chooses a file.
+// Set the filename with the chosen file.
 watchEffect(() => {
   if (chosenFilename.value) setFilename(chosenFilename.value)
 })

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/ensoPath.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/ensoPath.test.ts
@@ -1,7 +1,7 @@
 import { DirectoryId } from '#/services/Backend'
 import { uuidv4 } from 'lib0/random.js'
-import { expect, test } from 'vitest'
-import { useEnsoPaths } from '../ensoPath'
+import { describe, expect, test } from 'vitest'
+import { pathToSegments, useEnsoPaths } from '../ensoPath'
 
 test.each`
   userRootPath           | fromUserRoot | segments           | expected
@@ -29,3 +29,59 @@ test.each`
     expect(paths.printEnsoPath(path)).toBe(expected)
   },
 )
+
+describe('pathToSegments', () => {
+  test('rejects non-enso scheme', () => {
+    const res = pathToSegments('file:///tmp')
+    expect(res.ok).toBe(false)
+  })
+
+  test('parses empty enso root', () => {
+    const res = pathToSegments('enso://')
+    expect(res.ok).toBe(true)
+    expect(res.ok && res.value).toEqual([])
+  })
+
+  test('parses segments without trailing slash', () => {
+    const res = pathToSegments('enso://a/b/c')
+    expect(res.ok).toBe(true)
+    expect(res.ok && res.value).toEqual(['a', 'b', 'c'])
+  })
+
+  test('keeps empty last segment for trailing slash', () => {
+    const res = pathToSegments('enso://a/b/c/')
+    expect(res.ok).toBe(true)
+    expect(res.ok && res.value).toEqual(['a', 'b', 'c', ''])
+  })
+})
+
+describe('useEnsoPaths.parseEnsoPath', () => {
+  test.each`
+    userRootPath           | inputPath                        | expectedSegments
+    ${'enso://'}           | ${'enso://Users/user/input.csv'} | ${['Users', 'user', 'input.csv']}
+    ${'enso://Users/user'} | ${'enso://Users/user/input.csv'} | ${['input.csv']}
+    ${'enso://Users/user'} | ${'enso://Other/dir/file.txt'}   | ${[]}
+  `(
+    'parses $inputPath relative to $userRootPath',
+    ({ userRootPath, inputPath, expectedSegments }) => {
+      const files = {
+        rootDirectoryId: DirectoryId(`directory-${uuidv4()}`),
+        rootPath: userRootPath as string,
+      }
+      const { parseEnsoPath } = useEnsoPaths(files)
+      const res = parseEnsoPath(inputPath as string)
+      expect(res.ok).toBe(true)
+      expect(res.ok && res.value.segments).toEqual(expectedSegments)
+    },
+  )
+
+  test('parse rejects invalid scheme', () => {
+    const files = {
+      rootDirectoryId: DirectoryId(`directory-${uuidv4()}`),
+      rootPath: 'enso://',
+    }
+    const { parseEnsoPath } = useEnsoPaths(files)
+    const res = parseEnsoPath('http://example.com')
+    expect(res.ok).toBe(false)
+  })
+})

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/mockData.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/mockData.ts
@@ -1,5 +1,5 @@
 import { AnyAsset, AssetType } from '#/services/Backend'
-import type { Directory } from '../fileBrowsing'
+import type { Directory } from '../pathBrowsing'
 
 interface MockAssetSpec {
   type: AssetType

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
@@ -4,35 +4,48 @@ import { useEnsoPaths } from '../ensoPath'
 import { usePathBrowsing } from '../pathBrowsing'
 import { MOCK_FS, mockListDirectory } from './mockData'
 
-function pathSegments(initialPath: string, rootPath: string, rootId: DirectoryId): string[] {
+function deriveRootId(rootPath: string): DirectoryId {
+  switch (rootPath) {
+    case 'enso://':
+      return '0' as DirectoryId
+    case 'enso://Users/user':
+      return '3' as DirectoryId
+    default:
+      throw new Error(`Unknown rootPath: ${rootPath}`)
+  }
+}
+
+function pathSegments(initialPath: string, rootPath: string): string[] {
+  const rootId = deriveRootId(rootPath)
   const { parseEnsoPath } = useEnsoPaths({
     rootDirectoryId: rootId,
     rootPath,
   })
   const path = parseEnsoPath(initialPath)
-  return path.ok ? path.value.segments : ['Users', 'user']
+  return path.ok ? path.value.segments : []
 }
 
 test.each`
-  initialPath                                       | rootPath               | rootId | expectedStack           | unenteredPath
-  ${''}                                             | ${'enso://'}           | ${'0'} | ${['0', '1', '3']}      | ${''}
-  ${''}                                             | ${'enso://Users/user'} | ${'3'} | ${['3']}                | ${''}
-  ${'enso://'}                                      | ${'enso://'}           | ${'0'} | ${['0']}                | ${''}
-  ${'enso://'}                                      | ${'enso://Users/user'} | ${'3'} | ${['3']}                | ${''}
-  ${'enso://Users/user'}                            | ${'enso://'}           | ${'0'} | ${['0', '1', '3']}      | ${''}
-  ${'enso://Users/user'}                            | ${'enso://Users/user'} | ${'3'} | ${['3']}                | ${''}
-  ${'enso://Users/user/input.csv'}                  | ${'enso://'}           | ${'0'} | ${['0', '1', '3']}      | ${'input.csv'}
-  ${'enso://Users/user/input.csv'}                  | ${'enso://Users/user'} | ${'3'} | ${['3']}                | ${'input.csv'}
-  ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://'}           | ${'0'} | ${['0', '1', '3', '4']} | ${'input.csv'}
-  ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://Users/user'} | ${'3'} | ${['3', '4']}           | ${'input.csv'}
-  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://'}           | ${'0'} | ${['0', '1', '3']}      | ${''}
-  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://Users/user'} | ${'3'} | ${['3']}                | ${''}
-  ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://'}           | ${'0'} | ${['0', '1', '3', '4']} | ${''}
-  ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://Users/user'} | ${'3'} | ${['3', '4']}           | ${''}
+  initialPath                                       | rootPath               | expectedStack           | unenteredPath
+  ${''}                                             | ${'enso://'}           | ${['0']}                | ${''}
+  ${''}                                             | ${'enso://Users/user'} | ${['3']}                | ${''}
+  ${'enso://'}                                      | ${'enso://'}           | ${['0']}                | ${''}
+  ${'enso://'}                                      | ${'enso://Users/user'} | ${['3']}                | ${''}
+  ${'enso://Users/user'}                            | ${'enso://'}           | ${['0', '1', '3']}      | ${''}
+  ${'enso://Users/user'}                            | ${'enso://Users/user'} | ${['3']}                | ${''}
+  ${'enso://Users/user/input.csv'}                  | ${'enso://'}           | ${['0', '1', '3']}      | ${'input.csv'}
+  ${'enso://Users/user/input.csv'}                  | ${'enso://Users/user'} | ${['3']}                | ${'input.csv'}
+  ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://'}           | ${['0', '1', '3', '4']} | ${'input.csv'}
+  ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://Users/user'} | ${['3', '4']}           | ${'input.csv'}
+  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://'}           | ${['0', '1', '3']}      | ${'New Folder 2/input.csv'}
+  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://Users/user'} | ${['3']}                | ${'New Folder 2/input.csv'}
+  ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://'}           | ${['0', '1', '3', '4']} | ${'dir/input.csv'}
+  ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://Users/user'} | ${['3', '4']}           | ${'dir/input.csv'}
 `(
   'Initializing dir stack: initial path: $initialPath, root path: $rootPath',
-  async ({ initialPath, rootPath, rootId, expectedStack, unenteredPath }) => {
-    const segments = pathSegments(initialPath, rootPath, rootId)
+  async ({ initialPath, rootPath, expectedStack, unenteredPath }) => {
+    const segments = pathSegments(initialPath, rootPath)
+    const rootId = deriveRootId(rootPath)
     const { setBrowsingPath, enteredPath, unenteredPathSuffix, currentDirectory, isPending } =
       usePathBrowsing({
         listDirectory: mockListDirectory,

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
@@ -86,5 +86,5 @@ test('does not re-traverse unchanged prefix when entering overlapping path', asy
 
   // Reset to Users/user
   await setBrowsingPath({ root: rootId, segments: ['Users', 'user'] })
-  expect(calls).toBe(5)
+  expect(calls).toBe(4)
 })

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/pathBrowsing.test.ts
@@ -1,7 +1,7 @@
 import { type DirectoryId } from '#/services/Backend'
 import { expect, test } from 'vitest'
 import { useEnsoPaths } from '../ensoPath'
-import { usePathBrowsing } from '../pathBrowsing'
+import { Directory, usePathBrowsing } from '../pathBrowsing'
 import { MOCK_FS, mockListDirectory } from './mockData'
 
 function deriveRootId(rootPath: string): DirectoryId {
@@ -37,8 +37,8 @@ test.each`
   ${'enso://Users/user/input.csv'}                  | ${'enso://Users/user'} | ${['3']}                | ${'input.csv'}
   ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://'}           | ${['0', '1', '3', '4']} | ${'input.csv'}
   ${'enso://Users/user/New Folder 1/input.csv'}     | ${'enso://Users/user'} | ${['3', '4']}           | ${'input.csv'}
-  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://'}           | ${['0', '1', '3']}      | ${'New Folder 2/input.csv'}
-  ${'enso://Users/user/New Folder 2/input.csv'}     | ${'enso://Users/user'} | ${['3']}                | ${'New Folder 2/input.csv'}
+  ${'enso://Users/user/DOES_NOT_EXIST/input.csv'}   | ${'enso://'}           | ${['0', '1', '3']}      | ${'DOES_NOT_EXIST/input.csv'}
+  ${'enso://Users/user/DOES_NOT_EXIST/input.csv'}   | ${'enso://Users/user'} | ${['3']}                | ${'DOES_NOT_EXIST/input.csv'}
   ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://'}           | ${['0', '1', '3', '4']} | ${'dir/input.csv'}
   ${'enso://Users/user/New Folder 1/dir/input.csv'} | ${'enso://Users/user'} | ${['3', '4']}           | ${'dir/input.csv'}
 `(
@@ -61,3 +61,30 @@ test.each`
     expect(currentDirectory.value?.id).toBe(expectedStack[expectedStack.length - 1])
   },
 )
+
+test('does not re-traverse unchanged prefix when entering overlapping path', async () => {
+  const rootPath = 'enso://'
+  const rootId = deriveRootId(rootPath)
+  let calls = 0
+  const countingListDirectory = async (dir: Directory) => {
+    calls += 1
+    return mockListDirectory(dir)
+  }
+
+  const { setBrowsingPath } = usePathBrowsing({ listDirectory: countingListDirectory })
+  // First enter Users/user
+  await setBrowsingPath({ root: rootId, segments: ['Users', 'user'] })
+  expect(calls).toBe(2) // Users, then user
+
+  // Extend to Users/user/New Folder 1
+  await setBrowsingPath({ root: rootId, segments: ['Users', 'user', 'New Folder 1'] })
+  expect(calls).toBe(3)
+
+  // Extend with a new segment
+  await setBrowsingPath({ root: rootId, segments: ['Users', 'user', 'New Folder 1', 'input.csv'] })
+  expect(calls).toBe(4)
+
+  // Reset to Users/user
+  await setBrowsingPath({ root: rootId, segments: ['Users', 'user'] })
+  expect(calls).toBe(5)
+})

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/useAcceptCurrentFile.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/useAcceptCurrentFile.test.ts
@@ -1,0 +1,101 @@
+import { AssetType, DirectoryId } from '#/services/Backend'
+import { Err, Ok, Result } from '@/util/data/result'
+import { uuidv4 } from 'lib0/random'
+import { describe, expect, test, vi } from 'vitest'
+import { ref, type Ref } from 'vue'
+import type { EnsoPath } from '../ensoPath'
+import { useAcceptCurrentFile, type AssetExists } from '../useAcceptCurrentFile'
+
+const rootId = DirectoryId(`directory-${uuidv4()}`)
+function path(segments: string[] = []): EnsoPath {
+  return { root: rootId, segments }
+}
+
+describe('useAcceptCurrentFile', () => {
+  function setupAccept(options?: {
+    enteredPath?: Ref<EnsoPath | undefined>
+    fullFilePath?: Ref<string>
+    currentDirPath?: Ref<EnsoPath | undefined>
+    setBrowsingPath?: () => Promise<Result<void, any>>
+    assetExists?: () => Promise<AssetExists>
+    writeMode?: boolean
+    allowOverride?: boolean
+    printEnsoPath?: (p: EnsoPath) => string
+    pathAcceptedCallback?: (p: string) => void
+  }) {
+    const enteredPath = options?.enteredPath ?? ref(path([]))
+    const fullFilePath = options?.fullFilePath ?? ref('file.txt')
+    const currentDirPath = options?.currentDirPath ?? ref(undefined)
+    const setBrowsing = options?.setBrowsingPath ?? (async () => Ok())
+    const exists = options?.assetExists ?? (async () => ({ exists: false }))
+    const writeMode = options?.writeMode ?? true
+    const allowOverride = options?.allowOverride ?? false
+    const print = options?.printEnsoPath ?? (() => '')
+    const emit = options?.pathAcceptedCallback ?? (() => {})
+
+    const api = useAcceptCurrentFile({
+      enteredPath,
+      fullFilePath,
+      currentDirPath,
+      setBrowsingPath: setBrowsing,
+      append: (n: string) => (s: string[]) => [...s, n],
+      setFilename: () => {},
+      unenteredPathSuffix: ref(''),
+      assetExists: exists,
+      writeMode: () => writeMode,
+      allowOverride: () => allowOverride,
+      printEnsoPath: print,
+      pathAcceptedCallback: emit,
+    })
+
+    return { enteredPath, fullFilePath, currentDirPath, api }
+  }
+
+  test('warns if enteredPath is missing', async () => {
+    const { api } = setupAccept({
+      enteredPath: ref(undefined),
+      printEnsoPath: () => 'enso://file.txt',
+    })
+    await api.tryAcceptCurrentFile()
+    expect(api.warningText.value).toBe('Unable to access files')
+  })
+
+  test('accepts when asset does not exist', async () => {
+    const onPathAccepted = vi.fn()
+    const print = vi.fn(() => 'enso://dir/file.txt')
+    const { api } = setupAccept({
+      enteredPath: ref(path(['dir'])),
+      fullFilePath: ref('file.txt'),
+      pathAcceptedCallback: onPathAccepted,
+      printEnsoPath: print,
+    })
+    await api.tryAcceptCurrentFile()
+    expect(print).toHaveBeenCalledWith(path(['dir', 'file.txt']))
+    expect(onPathAccepted).toHaveBeenCalledWith('enso://dir/file.txt')
+  })
+
+  test('sets overwrite dialog when file exists in write mode without override', async () => {
+    const { api } = setupAccept({
+      enteredPath: ref(path(['dir'])),
+      assetExists: async () => ({ exists: true, type: AssetType.file }),
+    })
+    await api.tryAcceptCurrentFile()
+    expect(api.overwriteFilename.value).toBe('file.txt')
+  })
+
+  test("warns when chosen path is a directory (can't accept)", async () => {
+    const { api } = setupAccept({
+      enteredPath: ref(path(['dir'])),
+      fullFilePath: ref('subdir'),
+      assetExists: async () => ({ exists: true, type: AssetType.directory }),
+    })
+    await api.tryAcceptCurrentFile()
+    expect(api.warningText.value).toContain('is a directory, not a file')
+  })
+
+  test('propagates entering error into warning text', async () => {
+    const { api } = setupAccept({ setBrowsingPath: async () => Err('Directory not found') })
+    await api.tryAcceptCurrentFile()
+    expect(api.warningText.value).toBe('Directory not found')
+  })
+})

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/useFileBrowserSync.test.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/__tests__/useFileBrowserSync.test.ts
@@ -1,0 +1,142 @@
+import { DirectoryId } from '#/services/Backend'
+import { Ok, type Result } from '@/util/data/result'
+import { uuidv4 } from 'lib0/random'
+import { describe, expect, test, vi } from 'vitest'
+import { nextTick, ref, type Ref } from 'vue'
+import type { EnsoPath } from '../ensoPath'
+import { useFileBrowserSync } from '../useFileBrowserSync'
+
+const rootId = DirectoryId(`directory-${uuidv4()}`)
+function path(segments: string[] = []): EnsoPath {
+  return { root: rootId, segments }
+}
+
+describe('useFileBrowserSync', () => {
+  function setupSync(options?: {
+    writeMode?: Ref<boolean>
+    choosenPath?: Ref<string>
+    currentDirPath?: Ref<EnsoPath | undefined>
+    chosenFilename?: Ref<string | null>
+    unenteredPathSuffix?: Ref<string>
+    parseEnsoPath?: (p: string) => Result<EnsoPath, string>
+    setPath?: (path: Result<EnsoPath>) => void
+    setBrowsingPath?: (path: EnsoPath) => Promise<Result<void, any>>
+    append?: (name: string) => (segments: string[]) => string[]
+    setFilename?: (name: string) => void
+  }) {
+    const writeMode = options?.writeMode ?? ref(false)
+    const choosenPath = options?.choosenPath ?? ref('')
+    const currentDirPath = options?.currentDirPath ?? ref(undefined)
+    const chosenFilename = options?.chosenFilename ?? ref(null)
+    const unenteredPathSuffix = options?.unenteredPathSuffix ?? ref('')
+
+    const parseEnsoPath = options?.parseEnsoPath ?? ((p: string) => Ok(path([p])))
+    const setPath = options?.setPath ?? vi.fn()
+    const setBrowsingPath = options?.setBrowsingPath ?? vi.fn()
+    const append =
+      options?.append ?? ((name: string) => (segments: string[]) => [...segments, name])
+    const setFilename = options?.setFilename ?? vi.fn()
+
+    useFileBrowserSync({
+      writeMode,
+      choosenPath,
+      parseEnsoPath,
+      currentDirPath,
+      chosenFilename,
+      setPath,
+      setBrowsingPath,
+      append,
+      setFilename,
+      unenteredPathSuffix,
+    })
+
+    return {
+      writeMode,
+      choosenPath,
+      currentDirPath,
+      chosenFilename,
+      unenteredPathSuffix,
+      parseEnsoPath,
+      setPath,
+      setBrowsingPath,
+      append,
+      setFilename,
+    }
+  }
+
+  test('syncs setPath from choosenPath', async () => {
+    const choosenPath = ref('enso://dir/file')
+    const { setPath, parseEnsoPath } = setupSync({
+      choosenPath,
+      parseEnsoPath: vi.fn((_: string) => Ok(path(['dir', 'file']))),
+    })
+
+    await nextTick()
+    expect(parseEnsoPath).toHaveBeenCalledWith('enso://dir/file')
+    expect(setPath).toHaveBeenCalledTimes(1)
+
+    // Changing the choosenPath should trigger again
+    choosenPath.value = 'enso://another'
+    await nextTick()
+    expect(parseEnsoPath).toHaveBeenCalledWith('enso://another')
+    expect(setPath).toHaveBeenCalledTimes(2)
+  })
+
+  test('updates browsing path when currentDirPath or chosenFilename changes', async () => {
+    const currentDirPath = ref(path(['dir']))
+    const chosenFilename = ref('')
+    const { setBrowsingPath } = setupSync({
+      currentDirPath,
+      chosenFilename,
+      parseEnsoPath: (p) => Ok(path([p])),
+    })
+
+    await nextTick()
+    // With only dir set, it should set browsing path to that dir
+    expect(setBrowsingPath).toHaveBeenLastCalledWith(path(['dir']))
+
+    // When a filename is chosen, it should append it
+    chosenFilename.value = 'file.txt'
+    await nextTick()
+    expect(setBrowsingPath).toHaveBeenLastCalledWith(path(['dir', 'file.txt']))
+
+    // When the directory changes again, it should recompute
+    currentDirPath.value = path(['another'])
+    await nextTick()
+    expect(setBrowsingPath).toHaveBeenLastCalledWith(path(['another', 'file.txt']))
+  })
+
+  test('syncs filename from unenteredPathSuffix only in writeMode', async () => {
+    const writeMode = ref(false)
+    const unenteredPathSuffix = ref('draft.csv')
+    const { setFilename } = setupSync({
+      writeMode,
+      unenteredPathSuffix,
+      parseEnsoPath: (p) => Ok(path([p])),
+    })
+
+    await nextTick()
+    expect(setFilename).not.toHaveBeenCalled()
+
+    writeMode.value = true
+    await nextTick()
+    expect(setFilename).toHaveBeenCalledWith('draft.csv')
+
+    // Changing suffix should invoke again
+    unenteredPathSuffix.value = 'new.csv'
+    await nextTick()
+    expect(setFilename).toHaveBeenLastCalledWith('new.csv')
+  })
+
+  test('sets filename when chosenFilename is provided', async () => {
+    const chosenFilename = ref('picked.txt')
+    const { setFilename } = setupSync({ chosenFilename, parseEnsoPath: (p) => Ok(path([p])) })
+
+    await nextTick()
+    expect(setFilename).toHaveBeenCalledWith('picked.txt')
+
+    chosenFilename.value = 'another.txt'
+    await nextTick()
+    expect(setFilename).toHaveBeenLastCalledWith('another.txt')
+  })
+})

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/fileBrowser.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/fileBrowser.ts
@@ -91,7 +91,7 @@ export function useCurrentPath({
 
   const chosenFilename = computed(
     () =>
-      (!!chosenFile.value &&
+      (chosenFile.value != null &&
         ensoPathEqual(currentDirPath.value, chosenFile.value.path) &&
         chosenFile.value.name) ||
       null,

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/nameBar.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/nameBar.ts
@@ -20,8 +20,13 @@ export function useNameBar() {
     fileExtensionFilter,
     setFilename: (filename: string) => {
       const [name, extension] = splitFilename(filename)
-      filenameInput.value = name
-      extensionInput.value = extension
+      // Filtering datalinks does not make much sense, and we should probably change behavior for other extensions as well in the future.
+      if (extension === 'datalink') {
+        filenameInput.value = filename
+      } else {
+        filenameInput.value = name
+        extensionInput.value = extension
+      }
     },
   }
 }

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/pathBrowsing.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/pathBrowsing.ts
@@ -94,11 +94,8 @@ export function usePathBrowsing({
         const result = await getChildDirectory(title, prevDir)
         if (!result.ok) {
           const breakReason = result.error.payload.reason
-          if (
-            breakReason === 'notDir' ||
-            (breakReason === 'notFound' && i === path.segments.length - 1)
-          ) {
-            unenteredPathSuffix.value = title
+          if (breakReason === 'notDir' || breakReason === 'notFound') {
+            unenteredPathSuffix.value = path.segments.slice(i).join('/')
             break
           } else {
             return result

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/useAcceptCurrentFile.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/useAcceptCurrentFile.ts
@@ -1,0 +1,87 @@
+/** @file Encapsulates the logic for accepting the currently selected file in the File Browser. */
+import { mapPath, type EnsoPath } from '@/components/widgets/FileBrowserWidget/ensoPath'
+import type { Result } from '@/util/data/result'
+import type { ToValue } from '@/util/reactivity'
+import { AssetType } from 'enso-common/src/services/Backend'
+import { ref, toValue, type Ref } from 'vue'
+
+export type AssetExists = { exists: true; type: AssetType } | { exists: false }
+
+export interface AcceptCurrentFileOptions {
+  enteredPath: Readonly<Ref<EnsoPath | undefined>>
+  fullFilePath: Readonly<Ref<string>>
+  currentDirPath: Ref<EnsoPath | undefined>
+  setBrowsingPath: (path: EnsoPath) => Promise<Result<void, any>>
+  append: (...values: string[]) => (segments: string[]) => string[]
+  setFilename: (name: string) => void
+  unenteredPathSuffix: Readonly<Ref<string>>
+  assetExists: (name: string) => Promise<AssetExists>
+  writeMode: ToValue<boolean>
+  allowOverride: ToValue<boolean>
+  printEnsoPath: (path: EnsoPath) => string
+  pathAcceptedCallback: (path: string) => void
+}
+
+/**
+ * Encapsulates the logic for accepting the currently selected file in the File Browser.
+ */
+export function useAcceptCurrentFile(options: AcceptCurrentFileOptions) {
+  const {
+    enteredPath,
+    fullFilePath,
+    currentDirPath,
+    setBrowsingPath,
+    append,
+    setFilename,
+    unenteredPathSuffix,
+    assetExists,
+    writeMode,
+    allowOverride,
+    printEnsoPath,
+    pathAcceptedCallback,
+  } = options
+
+  const overwriteFilename = ref<string | null>(null)
+  const warningText = ref<string | null>(null)
+
+  async function tryAcceptCurrentFile() {
+    if (!enteredPath.value) {
+      warningText.value = 'Unable to access files'
+      return
+    }
+    const path = mapPath(enteredPath.value, append(...fullFilePath.value.split('/')))
+    const enteringResult = await setBrowsingPath(path)
+    currentDirPath.value = path
+    if (!enteringResult.ok) {
+      warningText.value = `${(enteringResult as any).error?.payload?.toString?.() ?? enteringResult}`
+      return
+    }
+    setFilename(unenteredPathSuffix.value)
+    const assetInfo = await assetExists(fullFilePath.value)
+    if (
+      assetInfo.exists &&
+      assetInfo.type === AssetType.file &&
+      toValue(writeMode) &&
+      !toValue(allowOverride)
+    ) {
+      overwriteFilename.value = fullFilePath.value
+    } else if (assetInfo.exists && assetInfo.type === AssetType.directory) {
+      warningText.value = `'${fullFilePath.value}' is a directory, not a file`
+    } else {
+      acceptCurrentFile()
+      return
+    }
+  }
+
+  function acceptCurrentFile() {
+    acceptFile(fullFilePath.value)
+  }
+
+  function acceptFile(name: string) {
+    if (!enteredPath.value) return
+    const currentFilePath = printEnsoPath(mapPath(enteredPath.value, append(...name.split('/'))))
+    pathAcceptedCallback(currentFilePath)
+  }
+
+  return { overwriteFilename, warningText, tryAcceptCurrentFile, acceptCurrentFile, acceptFile }
+}

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/useFileBrowserSync.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/useFileBrowserSync.ts
@@ -1,0 +1,73 @@
+/** @file Orchestrates reactive synchronization for the File Browser widget. */
+import { mapPath, type EnsoPath } from '@/components/widgets/FileBrowserWidget/ensoPath'
+import type { Result } from '@/util/data/result'
+import type { ToValue } from '@/util/reactivity'
+import { toValue, watchEffect, type Ref } from 'vue'
+
+export interface FileBrowserSyncOptions {
+  /** Whether the widget is in write mode (affects filename syncing). */
+  writeMode: ToValue<boolean>
+  /** The externally chosen path (enso://...) to sync into the browser. */
+  choosenPath: ToValue<string>
+  /** Parses enso:// strings into EnsoPath results (already unit-tested separately). */
+  parseEnsoPath: (path: string) => Result<EnsoPath, string>
+
+  /** The currently selected directory path in the UI. */
+  currentDirPath: Readonly<Ref<EnsoPath | undefined>>
+  /** The currently chosen filename in the UI (if any). */
+  chosenFilename: Readonly<Ref<string | null>>
+
+  /** Called to update the browser's path from an external input. */
+  setPath: (path: Result<EnsoPath, string>) => void
+  /** Called to update the browsing path to reflect the current UI state. */
+  setBrowsingPath: (path: EnsoPath) => void
+  /** Function that appends a value to path segments. */
+  append: (name: string) => (segments: string[]) => string[]
+
+  /** Called to update the filename input. */
+  setFilename: (name: string) => void
+  /** Suffix of the path that couldn't be entered (e.g., a filename). */
+  unenteredPathSuffix: Readonly<Ref<string>>
+}
+
+/**
+ * Installs watchers that keep the browser state synchronized with incoming props and
+ * user interactions. Extracted from `FileBrowserWidget.vue` for independent testing.
+ */
+export function useFileBrowserSync(options: FileBrowserSyncOptions) {
+  const {
+    writeMode,
+    choosenPath,
+    parseEnsoPath,
+    currentDirPath,
+    chosenFilename,
+    setPath,
+    setBrowsingPath,
+    append,
+    setFilename,
+    unenteredPathSuffix,
+  } = options
+
+  // Sync opened directory with the passed property.
+  watchEffect(() => setPath(parseEnsoPath(toValue(choosenPath))))
+
+  // Sync the browsing path with the current directory (usually when navigating).
+  watchEffect(() => {
+    const dirPath = currentDirPath.value
+    if (dirPath) {
+      const name = chosenFilename.value
+      const fullPath = name ? mapPath(dirPath, append(name)) : dirPath
+      setBrowsingPath(fullPath)
+    }
+  })
+
+  // Sync the filename with entered path (usually when opening the file browser).
+  watchEffect(() => {
+    if (toValue(writeMode) && unenteredPathSuffix.value) setFilename(unenteredPathSuffix.value)
+  })
+
+  // Set the filename with the chosen file.
+  watchEffect(() => {
+    if (chosenFilename.value) setFilename(chosenFilename.value)
+  })
+}

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget/userFiles.ts
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget/userFiles.ts
@@ -22,7 +22,7 @@ interface QueryResult<T> {
 export interface UserFiles {
   rootPath: ToValue<string>
   rootDirectoryId: ToValue<DirectoryId>
-  /** Path to the user's home, relative to `rootPath`. */
+  /** Path to the user's home. */
   home: ToValue<string[]>
 }
 


### PR DESCRIPTION
### Pull Request Description

Closes #13693 #13332

Although I didn’t reproduce #13693, these code changes can fix the issue. Also adjusting behavior to insert datalink extension (and avoid filtering by `.datalink` extension).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
