### PR TITLE
Persist documentation scroll state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 #### Enso Language & Runtime
 
 - [Open type check `Type&Any` lets all visible types thru][13225]
+- [The documentation panel opens to the scroll position at last close][13647]
 
 [13225]: https://github.com/enso-org/enso/pull/13225
+[13647]: https://github.com/enso-org/enso/pull/13647
 
 # Next Release
 

--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -15,62 +15,163 @@ async function goToGraphAndGetDocs(page: Page) {
   return { docsContent, docsScroller }
 }
 
-test('Main method documentation', async ({ page }) => {
-  const { docsContent } = await goToGraphAndGetDocs(page)
-
-  // Right-dock displays main method documentation.
-  await expect(docsContent).toContainText('The main method')
-
-  // All three images are loaded properly
-  await expect(docsContent.getByAltText('Image')).toHaveCount(3)
-  for (const img of await docsContent.getByAltText('Image').all())
-    await expect(img).toHaveJSProperty('naturalWidth', 3)
-
-  // The video was recognized
-  await expect(docsContent.locator('.DocumentationVideo')).toHaveCount(1)
-
-  // Nested lists are rendered with hierarchical indentation
-  const listItemPos = (text: string) =>
-    docsContent
-      .locator('span.cm-BulletList-item span')
-      .getByText(text, { exact: true })
-      .boundingBox()
-  const listLevel0 = await listItemPos('Outer list element')
-  const listLevel1 = await listItemPos('Nested list element')
-  const listLevel2 = await listItemPos('Very nested list element')
-  expect(listLevel0).not.toBeNull()
-  expect(listLevel1).not.toBeNull()
-  expect(listLevel2).not.toBeNull()
-  expect(listLevel0!.x).toBeLessThan(listLevel1!.x)
-  expect(listLevel1!.x).toBeLessThan(listLevel2!.x)
-
-  // Documentation hotkey closes right-dock.
-  await page.keyboard.press(`${CONTROL_KEY}+D`)
-  await expect(docsContent).toBeHidden()
-})
-
-test('Doc panel focus (regression #10471)', async ({ page }) => {
-  const { docsContent } = await goToGraphAndGetDocs(page)
-
-  // Open and focus code editor.
-  const { codeEditor, getCodeEditorContent } = await openCodeEditor(page)
-  await codeEditor.click()
-
-  await page.evaluate(() => {
-    const codeEditorApi = (window as any).__codeEditorApi
-    const docStart = codeEditorApi.indexOf('The main method')
-    codeEditorApi.placeCursor(docStart + 8)
+test.describe('Main method documentation rendering', () => {
+  test('Text', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await expect(docsContent).toContainText('The main method')
   })
-  await page.keyboard.press('Space')
-  await page.keyboard.press('T')
-  await page.keyboard.press('E')
-  await page.keyboard.press('S')
-  await page.keyboard.press('T')
 
-  const content = await getCodeEditorContent()
-  expect(content.includes('The main TEST method')).toBe(true)
-  await expect(docsContent).toContainText('The main TEST method')
+  test('Images', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await expect(docsContent.getByAltText('Image')).toHaveCount(3)
+    for (const img of await docsContent.getByAltText('Image').all())
+      await expect(img).toHaveJSProperty('naturalWidth', 3)
+  })
+
+  test('Video', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await expect(docsContent.locator('.DocumentationVideo')).toHaveCount(1)
+  })
+
+  test('Lists', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+
+    // Nested lists are rendered with hierarchical indentation
+    const listItemPos = (text: string) =>
+      docsContent
+        .locator('span.cm-BulletList-item span')
+        .getByText(text, { exact: true })
+        .boundingBox()
+    const listLevel0 = await listItemPos('Outer list element')
+    const listLevel1 = await listItemPos('Nested list element')
+    const listLevel2 = await listItemPos('Very nested list element')
+    expect(listLevel0).not.toBeNull()
+    expect(listLevel1).not.toBeNull()
+    expect(listLevel2).not.toBeNull()
+    expect(listLevel0!.x).toBeLessThan(listLevel1!.x)
+    expect(listLevel1!.x).toBeLessThan(listLevel2!.x)
+  })
+
+  test('Link (rendered and interactive)', async ({ page, context }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await expect(docsContent.locator('a')).toHaveAccessibleDescription(
+      /Click to edit.*Click to open link/,
+    )
+
+    await expect(docsContent.locator('a')).toHaveText('https://example.com')
+    await docsContent.locator('a').click()
+    await expect(page.locator('.LinkEditPopup')).toBeVisible()
+    await locate.graphEditor(page).click()
+    await expect(page.locator('.LinkEditPopup')).toBeHidden()
+    await context.route('https://example.com', (route) =>
+      route.fulfill({ status: 200, body: 'YAY' }),
+    )
+    const newPagePromise = context.waitForEvent('page', { timeout: 10000 })
+    await docsContent.locator('a').click({ modifiers: ['ControlOrMeta'] })
+    await expect(newPagePromise).resolves.toHaveURL('https://example.com')
+  })
 })
+
+test.describe('Panels', () => {
+  test('Doc panel: Close with hotkey', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+    await page.keyboard.press(`${CONTROL_KEY}+D`)
+    await expect(docsContent).toBeHidden()
+  })
+
+  test('Doc panel focus (regression #10471)', async ({ page }) => {
+    const { docsContent } = await goToGraphAndGetDocs(page)
+
+    // Open and focus code editor.
+    const { codeEditor, getCodeEditorContent } = await openCodeEditor(page)
+    await codeEditor.click()
+
+    await page.evaluate(() => {
+      const codeEditorApi = (window as any).__codeEditorApi
+      const docStart = codeEditorApi.indexOf('The main method')
+      codeEditorApi.placeCursor(docStart + 8)
+    })
+    await page.keyboard.press('Space')
+    await page.keyboard.press('T')
+    await page.keyboard.press('E')
+    await page.keyboard.press('S')
+    await page.keyboard.press('T')
+
+    const content = await getCodeEditorContent()
+    expect(content.includes('The main TEST method')).toBe(true)
+    await expect(docsContent).toContainText('The main TEST method')
+  })
+
+  test('Code editor with wide content does not take space from doc editor (#12476)', async ({
+    page,
+  }) => {
+    await goToGraphAndGetDocs(page)
+    const rightDock = locate.rightDock(page)
+
+    const getDocX = async () => {
+      await rightDock.elementHandle().then((el) => el!.waitForElementState('stable'))
+      return (await rightDock.boundingBox())!.x
+    }
+    const docPosWithoutCodeEditor = await getDocX()
+    await page.keyboard.press(`${CONTROL_KEY}+\``)
+    const codeEditor = page.locator('.CodeEditor')
+    await expect(codeEditor).toBeVisible()
+    const docPosWithCodeEditor = await getDocX()
+
+    // Note that we compare `x` instead of `width`: This will catch either a change in width, or the
+    // viewport becoming larger than the page (causing a change in *apparent* width).
+    expect(docPosWithCodeEditor).toBe(docPosWithoutCodeEditor)
+  })
+
+  test('Remember scroll position when closed and reopened', async ({ page }) => {
+    const { docsContent, docsScroller } = await goToGraphAndGetDocs(page)
+    const { getCodeEditorContent } = await openCodeEditor(page)
+
+    await setDocumentationText('Some text\n'.repeat(200), {
+      docsContent,
+      getCodeEditorContent,
+      page,
+    })
+    await docsContent.hover()
+    await page.mouse.wheel(0, -2000)
+    await docsContent.elementHandle().then((el) => el!.waitForElementState('stable'))
+    await page.mouse.wheel(0, 400)
+    await docsContent.elementHandle().then((el) => el!.waitForElementState('stable'))
+    await expect.poll(() => docsScroller.evaluate((e) => e.scrollTop)).toBe(400)
+
+    await page.keyboard.press(`${CONTROL_KEY}+D`)
+    await expect(docsContent).toBeHidden()
+
+    await page.keyboard.press(`${CONTROL_KEY}+D`)
+    await expect(docsContent).toBeVisible()
+    await expect
+      .poll(async () => Math.abs(400 - (await docsScroller.evaluate((e) => e.scrollTop))))
+      .toBeLessThan(10)
+  })
+})
+
+async function setDocumentationText(
+  text: string,
+  {
+    docsContent,
+    getCodeEditorContent,
+    page,
+  }: {
+    docsContent: Locator
+    getCodeEditorContent: () => Promise<string>
+    page: Page
+  },
+) {
+  await docsContent.focus()
+  await page.keyboard.press(`${CONTROL_KEY}+A`)
+  await page.keyboard.press(DELETE_KEY)
+  await docsContent.fill(text)
+  const codeAfterSettingNewDocs = await getCodeEditorContent()
+  // Wrapping-aware comparison; not correct for all inputs, but it only needs to work for test
+  // cases.
+  const normalizeWhitespace = (text: string) => text.replaceAll(/\s+/g, ' ')
+  expect(normalizeWhitespace(codeAfterSettingNewDocs)).toContain(normalizeWhitespace(text))
+}
 
 async function openCodeEditor(page: Page) {
   await page.keyboard.press(`${CONTROL_KEY}+\``)
@@ -81,27 +182,6 @@ async function openCodeEditor(page: Page) {
   const codeScroller = codeEditor.locator('.cm-scroller')
   return { codeEditor, getCodeEditorContent, codeScroller }
 }
-
-test('Code editor with wide content does not take space from doc editor (#12476)', async ({
-  page,
-}) => {
-  await goToGraphAndGetDocs(page)
-  const rightDock = locate.rightDock(page)
-
-  const getDocX = async () => {
-    await rightDock.elementHandle().then((el) => el!.waitForElementState('stable'))
-    return (await rightDock.boundingBox())!.x
-  }
-  const docPosWithoutCodeEditor = await getDocX()
-  await page.keyboard.press(`${CONTROL_KEY}+\``)
-  const codeEditor = page.locator('.CodeEditor')
-  await expect(codeEditor).toBeVisible()
-  const docPosWithCodeEditor = await getDocX()
-
-  // Note that we compare `x` instead of `width`: This will catch either a change in width, or the
-  // viewport becoming larger than the page (causing a change in *apparent* width).
-  expect(docPosWithCodeEditor).toBe(docPosWithoutCodeEditor)
-})
 
 test('Component help', async ({ page }) => {
   await actions.goToGraph(page)
@@ -214,23 +294,6 @@ test.describe('User-defined component documentation', () => {
     await expect(arg!.defaultValue.locator('.WidgetEnsoExpression .cm-content')).toBeFocused()
     await arg!.setMissingBehaviour('optional')
   })
-})
-
-test('Link in documentation is rendered and interactive', async ({ page, context }) => {
-  const { docsContent } = await goToGraphAndGetDocs(page)
-  await expect(docsContent.locator('a')).toHaveAccessibleDescription(
-    /Click to edit.*Click to open link/,
-  )
-
-  await expect(docsContent.locator('a')).toHaveText('https://example.com')
-  await docsContent.locator('a').click()
-  await expect(page.locator('.LinkEditPopup')).toBeVisible()
-  await locate.graphEditor(page).click()
-  await expect(page.locator('.LinkEditPopup')).toBeHidden()
-  context.route('https://example.com', (route) => route.fulfill({ status: 200, body: 'YAY' }))
-  const newPagePromise = context.waitForEvent('page', { timeout: 10000 })
-  await docsContent.locator('a').click({ modifiers: ['ControlOrMeta'] })
-  await expect(newPagePromise).resolves.toHaveURL('https://example.com')
 })
 
 test('Insert link button inserts link and focuses editor', async ({ page }) => {

--- a/app/gui/package.json
+++ b/app/gui/package.json
@@ -52,7 +52,7 @@
     "@codemirror/lint": "^6.8.4",
     "@codemirror/search": "^6.5.10",
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.4",
+    "@codemirror/view": "^6.38.1",
     "@floating-ui/vue": "^1.1.5",
     "@hookform/resolvers": "^3.9.1",
     "@internationalized/date": "3.7.0",

--- a/app/gui/src/project-view/components/DocumentationEditor.vue
+++ b/app/gui/src/project-view/components/DocumentationEditor.vue
@@ -2,11 +2,13 @@
 import { useCurrentProject } from '$/components/WithCurrentProject.vue'
 import { useBackends } from '$/providers/backends'
 import { useRightPanelData } from '$/providers/rightPanel'
+import { useDocumentViewId } from '@/components/DocumentationEditor/documentViewId'
 import FunctionSignatureEditor from '@/components/FunctionSignatureEditor.vue'
 import MarkdownEditor from '@/components/MarkdownEditor.vue'
 import { Ast } from '@/util/ast'
 import { parseModule } from '@/util/ast/abstract'
 import { useYTextSync } from '@/util/codemirror'
+import { editorPersistence } from '@/util/codemirror/persistence'
 import { Err, mapOk, Ok, unwrapOr } from '@/util/data/result'
 import { methodPointerEquals } from '@/util/methodPointer'
 import { ResultComponent } from '@/util/react'
@@ -80,13 +82,21 @@ const editorMarkdown = computed(() =>
 const editorContent = computed(() => unwrapOr(editorMarkdown.value, undefined))
 
 const { syncExt, connectSync } = useYTextSync(editorContent)
+const editorPersistenceExt = editorPersistence({
+  documentViewId: useDocumentViewId({
+    projectId,
+    methodPointer: () => unwrapOr(currentProject.ref.value?.graph.currentMethod.pointer, undefined),
+    view: 'DocumentationEditor',
+  }),
+  scroll: { y: true, x: false },
+})
 </script>
 
 <template>
   <div class="DocumentationEditor">
     <MarkdownEditor
       v-if="currentMethodAst.ok"
-      :extensions="syncExt"
+      :extensions="[syncExt, editorPersistenceExt]"
       :readonly="currentMethodAst.value.readOnly"
       contentTestId="documentation-editor-content"
       scrollerTestId="documentation-editor-scroller"

--- a/app/gui/src/project-view/components/DocumentationEditor.vue
+++ b/app/gui/src/project-view/components/DocumentationEditor.vue
@@ -90,13 +90,15 @@ const editorPersistenceExt = editorPersistence({
   }),
   scroll: { y: true, x: false },
 })
+
+const extensions = [syncExt, editorPersistenceExt]
 </script>
 
 <template>
   <div class="DocumentationEditor">
     <MarkdownEditor
       v-if="currentMethodAst.ok"
-      :extensions="[syncExt, editorPersistenceExt]"
+      :extensions="extensions"
       :readonly="currentMethodAst.value.readOnly"
       contentTestId="documentation-editor-content"
       scrollerTestId="documentation-editor-scroller"

--- a/app/gui/src/project-view/components/DocumentationEditor/documentViewId.ts
+++ b/app/gui/src/project-view/components/DocumentationEditor/documentViewId.ts
@@ -1,0 +1,48 @@
+import type { MethodPointer } from '@/util/methodPointer'
+import type { ToValue } from '@/util/reactivity'
+import type { ProjectId } from 'enso-common/src/services/Backend'
+import { computed, type Ref, toRef, toValue } from 'vue'
+import type { Opt } from 'ydoc-shared/util/data/opt'
+
+export interface DocumentViewIdOptions {
+  /** The project to which the method belongs. */
+  projectId: ToValue<Opt<ProjectId>>
+  /** The method whose documentation is being viewed. */
+  methodPointer: ToValue<Opt<MethodPointer>>
+  /** Distinguishes between different views of the same method. */
+  view: ToValue<string>
+}
+
+/** Returns a value that uniquely identifies a view of a method's documentation. */
+export function useDocumentViewId(
+  options: DocumentViewIdOptions,
+): Readonly<Ref<string | undefined>> {
+  const methodPointer = toRef(options.methodPointer)
+  return computed((): string | undefined =>
+    methodDocumentViewId({
+      project: toValue(options.projectId),
+      method: methodPointer.value ? methodPointerKey(methodPointer.value) : '$.main',
+      view: toValue(options.view),
+    }),
+  )
+}
+
+function methodDocumentViewId({
+  project,
+  method,
+  view,
+}: {
+  project: Opt<string>
+  method: Opt<string>
+  view: string
+}): string | undefined {
+  if (project == null || method == null) return
+  return JSON.stringify({ project, method, view })
+}
+
+function methodPointerKey(methodPointer: MethodPointer): string
+function methodPointerKey(methodPointer: MethodPointer | undefined): string | undefined {
+  if (!methodPointer) return
+  const { definedOnType, name } = methodPointer
+  return definedOnType.append(name).key() satisfies string
+}

--- a/app/gui/src/project-view/composables/syncLocalStorage.ts
+++ b/app/gui/src/project-view/composables/syncLocalStorage.ts
@@ -1,7 +1,7 @@
 import { useAbortScope } from '@/util/net'
 import { debouncedWatch, useLocalStorage } from '@vueuse/core'
 import { encoding } from 'lib0'
-import { computed, getCurrentInstance, ref, watch, withCtx } from 'vue'
+import { computed, getCurrentInstance, onBeforeUnmount, ref, watch, withCtx } from 'vue'
 import { xxHash128 } from 'ydoc-shared/ast/ffi'
 import { AbortScope } from 'ydoc-shared/util/net'
 
@@ -35,8 +35,6 @@ export interface SyncLocalStorageOptions<StoredState> {
     state: Partial<StoredState> | undefined,
     abort: AbortSignal,
   ) => Promise<void> | void
-  /** When to commit updates to the local storage. Defaults to 'pre'. */
-  flush?: 'pre' | 'post' | 'sync' | undefined
 }
 
 /**
@@ -58,7 +56,9 @@ export function useSyncLocalStorage<StoredState extends object>(
   ) as typeof options.restoreState
 
   const storageMap = useLocalStorage<Map<string, StoredState>>(options.storageKey, new Map(), {
-    flush: options.flush ?? 'pre',
+    // The default (`pre`) cannot be used because state captured during `beforeMount` would never
+    // be flushed.
+    flush: 'sync',
   })
 
   /**
@@ -106,6 +106,10 @@ export function useSyncLocalStorage<StoredState extends object>(
       debounce: options.debounce,
     },
   )
+  onBeforeUnmount(() => {
+    if (restoreIdInProgress.value == null)
+      saveState(graphViewportStorageKey.value, serializedState.value)
+  })
 
   function saveState(storageKey: string, state: StoredState) {
     storageMap.value.set(storageKey, state)
@@ -151,7 +155,5 @@ export function useSyncLocalStorage<StoredState extends object>(
         storageMap.value.set(newKey, stateBlob)
       }
     },
-    /** Save the current state immediately, independently of the debounce timer. */
-    saveState: () => saveState(graphViewportStorageKey.value, serializedState.value),
   }
 }

--- a/app/gui/src/project-view/composables/syncLocalStorage.ts
+++ b/app/gui/src/project-view/composables/syncLocalStorage.ts
@@ -35,6 +35,8 @@ export interface SyncLocalStorageOptions<StoredState> {
     state: Partial<StoredState> | undefined,
     abort: AbortSignal,
   ) => Promise<void> | void
+  /** When to commit updates to the local storage. Defaults to 'pre'. */
+  flush?: 'pre' | 'post' | 'sync' | undefined
 }
 
 /**
@@ -55,7 +57,9 @@ export function useSyncLocalStorage<StoredState extends object>(
     getCurrentInstance(),
   ) as typeof options.restoreState
 
-  const storageMap = useLocalStorage<Map<string, StoredState>>(options.storageKey, new Map())
+  const storageMap = useLocalStorage<Map<string, StoredState>>(options.storageKey, new Map(), {
+    flush: options.flush ?? 'pre',
+  })
 
   /**
    * Maximum number of graph states stored in localStorage. When it is exceeded, least recently used
@@ -147,5 +151,7 @@ export function useSyncLocalStorage<StoredState extends object>(
         storageMap.value.set(newKey, stateBlob)
       }
     },
+    /** Save the current state immediately, independently of the debounce timer. */
+    saveState: () => saveState(graphViewportStorageKey.value, serializedState.value),
   }
 }

--- a/app/gui/src/project-view/util/codemirror/persistence/index.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/index.ts
@@ -1,0 +1,133 @@
+import { useSyncLocalStorage, type SyncLocalStorageOptions } from '@/composables/syncLocalStorage'
+import {
+  scrollStatePlugin,
+  type ScrollState,
+  type ScrollStatePluginOptions,
+} from '@/util/codemirror/persistence/scroll'
+import type { Opt } from '@/util/data/opt'
+import type { ToValue } from '@/util/reactivity'
+import { type Extension } from '@codemirror/state'
+import { EditorView, ViewPlugin, type PluginValue } from '@codemirror/view'
+import { encoding } from 'lib0'
+import { nextTick, onBeforeUnmount, readonly, shallowRef, toValue, type ShallowRef } from 'vue'
+import { z } from 'zod'
+
+const editorSchema = z.object({
+  scroll: z.unknown(),
+})
+
+interface EditorState extends z.infer<typeof editorSchema> {
+  scroll?: ScrollState
+}
+
+interface EditorPersistencePluginOptions {
+  documentViewId: ToValue<Opt<string>>
+}
+/**
+ * Plugin that synchronizes editor state with local storage; the state is aggregated from any
+ * {@link PersistableStatePlugin}s (such as {@link scrollStatePlugin}) present in the view.
+ */
+class EditorPersistencePluginValue implements PluginValue {
+  private readonly documentViewId: ToValue<Opt<string>>
+  /**
+   * This will be changed to `true` when the `isConnected` state is first observed and the
+   * ready-callback scheduled.
+   */
+  private connected: boolean = false
+  /**
+   * This will be changed to `true` once the editor view is ready to be used. This prevents
+   * attempting to read or write DOM state, such as scroll position, before the editor DOM has been
+   * rendered.
+   */
+  private readonly ready: ShallowRef<boolean> = shallowRef(false)
+  /**
+   * Stores the last update attempted before the editor became ready, to be applied when the editor
+   * becomes ready.
+   */
+  private deferredUpdate: (() => void) | undefined = undefined
+  constructor(
+    private readonly view: EditorView,
+    { documentViewId }: EditorPersistencePluginOptions,
+  ) {
+    const { saveState } = useSyncLocalStorage(this.syncLocalStorageOptions())
+    onBeforeUnmount(saveState)
+
+    this.documentViewId = documentViewId
+  }
+
+  syncLocalStorageOptions(): SyncLocalStorageOptions<object> {
+    return {
+      storageKey: 'textEditor',
+      mapKeyEncoder: (enc) =>
+        encoding.writeVarString(enc, this.ready.value ? (toValue(this.documentViewId) ?? '') : ''),
+      debounce: 200,
+      captureState: this.captureState.bind(this),
+      restoreState: this.restoreState.bind(this),
+      // The default (`pre`) cannot be used because state captured during `beforeMount` would never
+      // be flushed.
+      flush: 'sync',
+    } satisfies SyncLocalStorageOptions<EditorState>
+  }
+
+  private onReady() {
+    this.ready.value = true
+    this.deferredUpdate?.()
+    this.deferredUpdate = undefined
+  }
+
+  update() {
+    if (this.view.contentDOM.isConnected && !this.connected) {
+      this.connected = true
+      nextTick(this.onReady.bind(this)).then()
+    }
+  }
+
+  private captureState(): EditorState {
+    if (!this.ready.value || !toValue(this.documentViewId)) return {}
+    const scrollState = this.view.plugin(scrollStatePlugin)?.captureState()
+    const scroll = scrollState ? readonly(scrollState) : undefined
+    return {
+      ...(scroll ? { scroll } : {}),
+    }
+  }
+
+  private restoreState(rawState: unknown) {
+    if (!toValue(this.documentViewId)) return
+    if (!this.ready.value) {
+      this.deferredUpdate = () => this.restoreState(rawState)
+      return
+    }
+    this.deferredUpdate = undefined
+
+    if (!rawState) return
+
+    const state = editorSchema.safeParse(rawState)
+    if (state.success) {
+      if (state.data.scroll) this.view.plugin(scrollStatePlugin)?.restoreState(state.data.scroll)
+    } else {
+      console.warn('Failed to restore editor state', rawState, 'because', state.error.message)
+    }
+  }
+}
+const editorPersistencePlugin = ViewPlugin.fromClass<
+  EditorPersistencePluginValue,
+  EditorPersistencePluginOptions
+>(EditorPersistencePluginValue)
+
+export interface EditorPersistenceOptions {
+  documentViewId: ToValue<Opt<string>>
+  scroll?: ScrollStatePluginOptions
+}
+
+const NULL_EXTENSION: Extension = []
+
+/**
+ * Returns an extension that persists the specified aspects of the editor's state, associated with
+ * the provided ID.
+ */
+export function editorPersistence({ documentViewId, scroll }: EditorPersistenceOptions): Extension {
+  return [
+    scroll ? scrollStatePlugin.of(scroll) : NULL_EXTENSION,
+    editorPersistencePlugin.of({ documentViewId }),
+  ]
+}

--- a/app/gui/src/project-view/util/codemirror/persistence/index.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/index.ts
@@ -9,7 +9,7 @@ import type { ToValue } from '@/util/reactivity'
 import { type Extension } from '@codemirror/state'
 import { EditorView, ViewPlugin, type PluginValue } from '@codemirror/view'
 import { encoding } from 'lib0'
-import { nextTick, onBeforeUnmount, readonly, shallowRef, toValue, type ShallowRef } from 'vue'
+import { nextTick, readonly, shallowRef, toValue, type ShallowRef } from 'vue'
 import { z } from 'zod'
 
 const editorSchema = z.object({
@@ -49,13 +49,12 @@ class EditorPersistencePluginValue implements PluginValue {
     private readonly view: EditorView,
     { documentViewId }: EditorPersistencePluginOptions,
   ) {
-    const { saveState } = useSyncLocalStorage(this.syncLocalStorageOptions())
-    onBeforeUnmount(saveState)
+    useSyncLocalStorage(this.syncLocalStorageOptions())
 
     this.documentViewId = documentViewId
   }
 
-  syncLocalStorageOptions(): SyncLocalStorageOptions<object> {
+  syncLocalStorageOptions(): SyncLocalStorageOptions<EditorState> {
     return {
       storageKey: 'textEditor',
       mapKeyEncoder: (enc) =>
@@ -63,10 +62,7 @@ class EditorPersistencePluginValue implements PluginValue {
       debounce: 200,
       captureState: this.captureState.bind(this),
       restoreState: this.restoreState.bind(this),
-      // The default (`pre`) cannot be used because state captured during `beforeMount` would never
-      // be flushed.
-      flush: 'sync',
-    } satisfies SyncLocalStorageOptions<EditorState>
+    }
   }
 
   private onReady() {

--- a/app/gui/src/project-view/util/codemirror/persistence/index.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/index.ts
@@ -1,4 +1,4 @@
-import { useSyncLocalStorage, type SyncLocalStorageOptions } from '@/composables/syncLocalStorage'
+import { useSyncLocalStorage } from '@/composables/syncLocalStorage'
 import {
   scrollStatePlugin,
   type ScrollState,

--- a/app/gui/src/project-view/util/codemirror/persistence/index.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/index.ts
@@ -49,20 +49,16 @@ class EditorPersistencePluginValue implements PluginValue {
     private readonly view: EditorView,
     { documentViewId }: EditorPersistencePluginOptions,
   ) {
-    useSyncLocalStorage(this.syncLocalStorageOptions())
-
-    this.documentViewId = documentViewId
-  }
-
-  syncLocalStorageOptions(): SyncLocalStorageOptions<EditorState> {
-    return {
+    useSyncLocalStorage({
       storageKey: 'textEditor',
       mapKeyEncoder: (enc) =>
         encoding.writeVarString(enc, this.ready.value ? (toValue(this.documentViewId) ?? '') : ''),
       debounce: 200,
       captureState: this.captureState.bind(this),
       restoreState: this.restoreState.bind(this),
-    }
+    })
+
+    this.documentViewId = documentViewId
   }
 
   private onReady() {

--- a/app/gui/src/project-view/util/codemirror/persistence/persistableStatePlugin.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/persistableStatePlugin.ts
@@ -1,0 +1,4 @@
+export interface PersistableStatePlugin<T> {
+  captureState: () => T
+  restoreState: (rawState: unknown) => void
+}

--- a/app/gui/src/project-view/util/codemirror/persistence/scroll.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/scroll.ts
@@ -1,41 +1,31 @@
 import type { PersistableStatePlugin } from '@/util/codemirror/persistence/persistableStatePlugin'
 import { EditorSelection, StateEffect } from '@codemirror/state'
 import { EditorView, type PluginValue, ViewPlugin, type ViewUpdate } from '@codemirror/view'
+import type { Mutable } from 'enso-common/src/utilities/data/object'
 import { shallowRef, type ShallowRef, triggerRef } from 'vue'
 import { z } from 'zod'
 
-const scrollModeSchema = z.union([
-  z.literal('nearest'),
-  z.literal('start'),
-  z.literal('end'),
-  z.literal('center'),
-])
-const scrollAxisSchema = z.object({
-  mode: scrollModeSchema,
-  margin: z.number(),
+const documentRange = z.object({
+  anchor: z.number(),
+  head: z.number().optional(),
 })
+
 const scrollSchema = z.object({
-  range: z.object({
-    anchor: z.number(),
-    head: z.number().optional(),
-  }),
-  x: scrollAxisSchema.optional(),
-  y: scrollAxisSchema.optional(),
+  range: documentRange,
+  x: z.number().optional(),
+  y: z.number().optional(),
 })
 
 export type ScrollState = z.infer<typeof scrollSchema>
 
+type DocumentRange = z.infer<typeof documentRange>
 type ScrollTarget = ReturnType<EditorView['scrollSnapshot']>['value']
 const scrollRestoreStateEffect = StateEffect.define()
 
 export interface ScrollStatePluginOptions {
   /** Whether to persist the scroll position along the y-axis. */
   y: boolean
-  /**
-   * Whether to persist the scroll position along the x-axis. Note that, if the view is not
-   * scrollable on the x-axis, this MUST be `false`. If it is `true` but the editor's element is not
-   * horizontally scrollable, restoring state may result in scrolling an ancestor of the editor.
-   */
+  /** Whether to persist the scroll position along the x-axis. */
   x: boolean
 }
 
@@ -75,58 +65,26 @@ class ScrollStatePlugin implements PluginValue, PersistableStatePlugin<ScrollSta
   }
 
   private serializeState(snapshot: ScrollTarget): ScrollState {
-    const { range, y, x, yMargin, xMargin } = snapshot
+    const { range, yMargin, xMargin } = snapshot
     return {
       range: {
         anchor: range.anchor,
         head: range.head,
       },
-      ...(this.y ?
-        {
-          y: {
-            mode: y,
-            margin: yMargin,
-          },
-        }
-      : {}),
-      ...(this.x ?
-        {
-          x: {
-            mode: x,
-            margin: xMargin,
-          },
-        }
-      : {}),
+      y: this.y ? yMargin : undefined,
+      x: this.x ? xMargin : undefined,
     }
   }
 
   restoreState(rawState: unknown) {
     const state = ScrollStatePlugin.parseState(rawState)
     if (!state) return
-    const { range, y, x } = state
+    const scrollTo = this.scrollSnapshotAt(state.range, state.y, state.x)
+    if (!scrollTo) return
     this.restoringScroll = true
     try {
-      const selectionRange = EditorSelection.range(range.anchor, range.head ?? range.anchor)
-      const scrollOptions = {
-        isSnapshot: true,
-        ...(this.y && y ?
-          {
-            y: y.mode,
-            yMargin: y.margin,
-          }
-        : {}),
-        ...(this.x && x ?
-          {
-            x: x.mode,
-            xMargin: x.margin,
-          }
-        : {}),
-      }
       this.view.dispatch({
-        effects: [
-          EditorView.scrollIntoView(selectionRange, scrollOptions),
-          scrollRestoreStateEffect.of(null),
-        ],
+        effects: [scrollTo, scrollRestoreStateEffect.of(null)],
       })
     } finally {
       this.restoringScroll = false
@@ -140,6 +98,21 @@ class ScrollStatePlugin implements PluginValue, PersistableStatePlugin<ScrollSta
     } else {
       console.warn('Failed to restore scroll state', rawState, 'because', state.error.message)
     }
+  }
+
+  private scrollSnapshotAt(
+    range: DocumentRange,
+    y: number | undefined,
+    x: number | undefined,
+  ): StateEffect<unknown> {
+    // CM does not offer a public API to create a "snapshot" scroll target with specific values; get
+    // a current snapshot and overwrite its contents.
+    const snapshot = this.view.scrollSnapshot()
+    const snapshotValue = snapshot.value as Mutable<typeof snapshot.value>
+    snapshotValue.range = EditorSelection.range(range.anchor, range.head ?? range.anchor)
+    if (y != null) snapshotValue.yMargin = y
+    if (x != null) snapshotValue.xMargin = x
+    return snapshot
   }
 }
 

--- a/app/gui/src/project-view/util/codemirror/persistence/scroll.ts
+++ b/app/gui/src/project-view/util/codemirror/persistence/scroll.ts
@@ -1,0 +1,149 @@
+import type { PersistableStatePlugin } from '@/util/codemirror/persistence/persistableStatePlugin'
+import { EditorSelection, StateEffect } from '@codemirror/state'
+import { EditorView, type PluginValue, ViewPlugin, type ViewUpdate } from '@codemirror/view'
+import { shallowRef, type ShallowRef, triggerRef } from 'vue'
+import { z } from 'zod'
+
+const scrollModeSchema = z.union([
+  z.literal('nearest'),
+  z.literal('start'),
+  z.literal('end'),
+  z.literal('center'),
+])
+const scrollAxisSchema = z.object({
+  mode: scrollModeSchema,
+  margin: z.number(),
+})
+const scrollSchema = z.object({
+  range: z.object({
+    anchor: z.number(),
+    head: z.number().optional(),
+  }),
+  x: scrollAxisSchema.optional(),
+  y: scrollAxisSchema.optional(),
+})
+
+export type ScrollState = z.infer<typeof scrollSchema>
+
+type ScrollTarget = ReturnType<EditorView['scrollSnapshot']>['value']
+const scrollRestoreStateEffect = StateEffect.define()
+
+export interface ScrollStatePluginOptions {
+  /** Whether to persist the scroll position along the y-axis. */
+  y: boolean
+  /**
+   * Whether to persist the scroll position along the x-axis. Note that, if the view is not
+   * scrollable on the x-axis, this MUST be `false`. If it is `true` but the editor's element is not
+   * horizontally scrollable, restoring state may result in scrolling an ancestor of the editor.
+   */
+  x: boolean
+}
+
+/** {@link PersistableStatePlugin} for editor scroll position. */
+class ScrollStatePlugin implements PluginValue, PersistableStatePlugin<ScrollState> {
+  private readonly scrollEffectRef: ShallowRef<undefined> = shallowRef()
+  private restoringScroll: boolean = false
+  private readonly x: boolean
+  private readonly y: boolean
+  constructor(
+    private readonly view: EditorView,
+    { x, y }: ScrollStatePluginOptions,
+  ) {
+    this.x = x
+    this.y = y
+  }
+
+  update(update: ViewUpdate) {
+    if (
+      (update.docChanged || update.viewportChanged) &&
+      !update.transactions.every((tr) => tr.effects.some((e) => e.is(scrollRestoreStateEffect)))
+    )
+      this.scrolled()
+  }
+
+  onScroll() {
+    this.scrolled()
+  }
+
+  private scrolled() {
+    if (!this.restoringScroll) triggerRef(this.scrollEffectRef)
+  }
+
+  captureState(): ScrollState {
+    const _scrollEffect = this.scrollEffectRef.value
+    return this.serializeState(this.view.scrollSnapshot().value)
+  }
+
+  private serializeState(snapshot: ScrollTarget): ScrollState {
+    const { range, y, x, yMargin, xMargin } = snapshot
+    return {
+      range: {
+        anchor: range.anchor,
+        head: range.head,
+      },
+      ...(this.y ?
+        {
+          y: {
+            mode: y,
+            margin: yMargin,
+          },
+        }
+      : {}),
+      ...(this.x ?
+        {
+          x: {
+            mode: x,
+            margin: xMargin,
+          },
+        }
+      : {}),
+    }
+  }
+
+  restoreState(rawState: unknown) {
+    const state = ScrollStatePlugin.parseState(rawState)
+    if (!state) return
+    const { range, y, x } = state
+    this.restoringScroll = true
+    try {
+      const selectionRange = EditorSelection.range(range.anchor, range.head ?? range.anchor)
+      const scrollOptions = {
+        isSnapshot: true,
+        ...(this.y && y ?
+          {
+            y: y.mode,
+            yMargin: y.margin,
+          }
+        : {}),
+        ...(this.x && x ?
+          {
+            x: x.mode,
+            xMargin: x.margin,
+          }
+        : {}),
+      }
+      this.view.dispatch({
+        effects: [
+          EditorView.scrollIntoView(selectionRange, scrollOptions),
+          scrollRestoreStateEffect.of(null),
+        ],
+      })
+    } finally {
+      this.restoringScroll = false
+    }
+  }
+
+  private static parseState(rawState: unknown): ScrollState | undefined {
+    const state = scrollSchema.safeParse(rawState)
+    if (state.success) {
+      return state.data
+    } else {
+      console.warn('Failed to restore scroll state', rawState, 'because', state.error.message)
+    }
+  }
+}
+
+export const scrollStatePlugin = ViewPlugin.fromClass(ScrollStatePlugin, {
+  // CM doesn't run `scrollEnd`, so we have to use `scroll` even though it's inefficient.
+  eventObservers: { scroll: ScrollStatePlugin.prototype.onScroll },
+})

--- a/app/lang-markdown/package.json
+++ b/app/lang-markdown/package.json
@@ -30,7 +30,7 @@
     "@codemirror/lang-html": "^6.0.0",
     "@codemirror/language": "^6.11.0",
     "@codemirror/state": "^6.5.2",
-    "@codemirror/view": "^6.36.4",
+    "@codemirror/view": "^6.38.1",
     "@lezer/markdown": "workspace:*",
     "@lezer/common": "^1.2.1"
   },

--- a/app/ydoc-shared/src/util/data/result.ts
+++ b/app/ydoc-shared/src/util/data/result.ts
@@ -60,10 +60,18 @@ export function unwrap<T, E>(result: Result<T, E>): T {
   else throw result.error
 }
 
+export function unwrapOr<T, A>(result: Result<T, unknown>, alternative: A): T | A
+export function unwrapOr<T, A>(
+  result: Result<T, unknown> | undefined,
+  alternative: A,
+): T | A | undefined
 /** Unwraps the {@link Result} value. If the result is error, an alternative is returned. */
-export function unwrapOr<T, A>(result: Result<T, unknown>, alternative: A): T | A {
-  if (result.ok) return result.value
-  else return alternative
+export function unwrapOr<T, A>(
+  result: Result<T, unknown> | undefined,
+  alternative: A,
+): T | A | undefined {
+  if (!result) return
+  return (result.ok ? result.value : alternative) satisfies T | A
 }
 
 /** Unwraps the {@link Result} value. If the result is error, it is logged and alternative is returned. */
@@ -83,6 +91,21 @@ export function unwrapOrWithLog<T, A>(
 export function mapOk<T, U, E>(result: Result<T, E>, f: (value: T) => U): Result<U, E> {
   if (result.ok) return Ok(f(result.value))
   else return result
+}
+
+export function mapOkOr<T, U, A>(result: Opt<Result<T>>, f: (value: T) => U, alternative: A): U | A
+export function mapOkOr<T, U, A>(
+  result: Opt<Result<T>>,
+  f: (value: T) => U,
+  alternative?: A,
+): U | A | undefined
+/** Maps the {@link Result} value if present, otherwise returns `alternative`. */
+export function mapOkOr<T, U, A>(
+  result: Opt<Result<T>>,
+  f: (value: T) => U,
+  alternative?: A,
+): U | A | undefined {
+  return result && result.ok ? f(result.value) : alternative
 }
 
 /** Maps the {@link Result} value with a function that returns a result. */

--- a/app/ydoc-shared/src/util/data/result.ts
+++ b/app/ydoc-shared/src/util/data/result.ts
@@ -60,18 +60,9 @@ export function unwrap<T, E>(result: Result<T, E>): T {
   else throw result.error
 }
 
-export function unwrapOr<T, A>(result: Result<T, unknown>, alternative: A): T | A
-export function unwrapOr<T, A>(
-  result: Result<T, unknown> | undefined,
-  alternative: A,
-): T | A | undefined
 /** Unwraps the {@link Result} value. If the result is error, an alternative is returned. */
-export function unwrapOr<T, A>(
-  result: Result<T, unknown> | undefined,
-  alternative: A,
-): T | A | undefined {
-  if (!result) return
-  return (result.ok ? result.value : alternative) satisfies T | A
+export function unwrapOr<T, A>(result: Result<T> | undefined, alternative: A): T | A {
+  return result?.ok ? result.value : alternative
 }
 
 /** Unwraps the {@link Result} value. If the result is error, it is logged and alternative is returned. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@codemirror/view':
-        specifier: ^6.36.4
-        version: 6.36.4
+        specifier: ^6.38.1
+        version: 6.38.1
       '@floating-ui/vue':
         specifier: ^1.1.5
         version: 1.1.5(vue@3.5.13(typescript@5.7.2))
@@ -770,8 +770,8 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@codemirror/view':
-        specifier: ^6.36.4
-        version: 6.36.4
+        specifier: ^6.38.1
+        version: 6.38.1
       '@lezer/common':
         specifier: ^1.2.1
         version: 1.2.3
@@ -1450,8 +1450,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.2':
     resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
 
-  '@codemirror/view@6.36.4':
-    resolution: {integrity: sha512-ZQ0V5ovw/miKEXTvjgzRyjnrk9TwriUB1k4R5p7uNnHR9Hus+D1SXHGdJshijEzPFjU25xea/7nhIeSqYFKdbA==}
+  '@codemirror/view@6.38.1':
+    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -8458,7 +8458,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
 
   '@codemirror/buildhelper@1.0.2':
@@ -8475,7 +8475,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
 
   '@codemirror/lang-css@6.3.1':
@@ -8493,7 +8493,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.2
       '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
       '@lezer/css': 1.1.9
       '@lezer/html': 1.3.10
@@ -8504,14 +8504,14 @@ snapshots:
       '@codemirror/language': 6.11.0
       '@codemirror/lint': 6.8.4
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.4.21
 
   '@codemirror/language@6.11.0':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -8520,13 +8520,13 @@ snapshots:
   '@codemirror/lint@6.8.4':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       crelt: 1.0.6
 
   '@codemirror/search@6.5.10':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
@@ -8537,12 +8537,13 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
       '@lezer/highlight': 1.2.1
 
-  '@codemirror/view@6.36.4':
+  '@codemirror/view@6.38.1':
     dependencies:
       '@codemirror/state': 6.5.2
+      crelt: 1.0.6
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
@@ -11816,7 +11817,7 @@ snapshots:
       '@codemirror/lint': 6.8.4
       '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.4
+      '@codemirror/view': 6.38.1
 
   color-convert@1.9.3:
     dependencies:


### PR DESCRIPTION
### Pull Request Description

Persist documentation scroll state

Fixes #13647.

### Important Notes

The CM APIs are not perfect for this. I think the current behaviour is accurate enough for an initial implementation, but I've opened a bug for possible improvements: #13734.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
