### PR TITLE
Stop dumping modules on visualization failure

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -771,7 +771,8 @@ object ProgramExecutionSupport {
               p.getLocation().getEncapsulatingSourceSection() match {
                 case ss: SourceSection =>
                   logger.warn(
-                    s"Error at ${ss.getCharIndex()}-${ss.getCharEndIndex()} (e.g. `${ss
+                    s"Error at ${ss.getCharIndex()}-${ss
+                      .getCharEndIndex()} in ${ss.getSource.getPath} (e.g. `${ss
                       .getCharacters()}`) of visualization $visualizationId",
                     p
                   )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -771,12 +771,9 @@ object ProgramExecutionSupport {
               p.getLocation().getEncapsulatingSourceSection() match {
                 case ss: SourceSection =>
                   logger.warn(
-                    "Error at {}-{} (e.g. `{}`) of {} with text:\n{}",
-                    ss.getCharIndex(),
-                    ss.getCharEndIndex(),
-                    ss.getCharacters(),
-                    visualizationId,
-                    ss.getSource().getCharacters()
+                    s"Error at ${ss.getCharIndex()}-${ss.getCharEndIndex()} (e.g. `${ss
+                      .getCharacters()}`) of visualization $visualizationId",
+                    p
                   )
                 case _ =>
               }


### PR DESCRIPTION
Logs are being polluted by modules' sources.

Initially introduced as part of #13352.