### PR TITLE
Pass extra cloud parameters when opening a hybrid project

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1280,13 +1280,25 @@ export interface UpdateProjectRequestBody {
   readonly projectName: string | null
 }
 
+/**
+ * Extra parameters required when opening the project in hybrid mode.
+ */
+export interface OpenHybridProjectParameters {
+  /** Cloud project directory path. */
+  readonly cloudProjectDirectoryPath: string
+  /** Cloud project id. */
+  readonly cloudProjectId: string
+  /** Cloud project session id. */
+  readonly cloudProjectSessionId: string
+}
+
 /** HTTP request body for the "open project" endpoint. */
 export interface OpenProjectRequestBody {
   readonly executeAsync: boolean
   /** MUST be present on Remote backend; NOT REQUIRED on Local backend. */
   readonly cognitoCredentials: CognitoCredentials | null
-  /** Required when running in hybrid mode. */
-  readonly cloudProjectDirectoryPath: string | null
+  /** Extra parameters required when running in hybrid mode. */
+  readonly openHybridProjectParameters: OpenHybridProjectParameters | null
 }
 
 /** HTTP request body for the "create project execution" endpoint. */

--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1285,11 +1285,11 @@ export interface UpdateProjectRequestBody {
  */
 export interface OpenHybridProjectParameters {
   /** Cloud project directory path. */
-  readonly cloudProjectDirectoryPath: string
+  readonly cloudProjectDirectoryPath: EnsoPath
   /** Cloud project id. */
-  readonly cloudProjectId: string
+  readonly cloudProjectId: ProjectId
   /** Cloud project session id. */
-  readonly cloudProjectSessionId: string
+  readonly cloudProjectSessionId: ProjectSessionId
 }
 
 /** HTTP request body for the "open project" endpoint. */

--- a/app/gui/integration-test/dashboard/actions/api.ts
+++ b/app/gui/integration-test/dashboard/actions/api.ts
@@ -925,11 +925,13 @@ async function mockApiInternal({ page, setupAPI }: MockParams) {
           )
         }
 
+        const projectSessionId = backend.ProjectSessionId('projectsession-0000')
         if (project?.projectState) {
           object.unsafeMutable(project.projectState).type = backend.ProjectState.openInProgress
+          object.unsafeMutable(project.projectState).currentSessionId = projectSessionId
         }
 
-        route.fulfill()
+        return { projectSessionId }
       },
     )
     await post(paths.getHybridSetOpenedPath(GLOB_PROJECT_ID), async (route, _, [id]) => {

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -519,7 +519,9 @@ function useOpenHybridProject() {
         addOpeningProject(asset.id)
         const projectSessionId = await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)
         const localProject = await remoteBackend.downloadProject(asset.id)
-        const cloudProjectDirectoryPath = asset.ensoPath.slice(0, asset.ensoPath.lastIndexOf('/'))
+        const cloudProjectDirectoryPath = backendModule.EnsoPath(
+          asset.ensoPath.slice(0, asset.ensoPath.lastIndexOf('/')),
+        )
 
         let project
         for (const parentId of [localProject.parentId, localProject.projectRootId]) {

--- a/app/gui/src/dashboard/hooks/projectHooks.ts
+++ b/app/gui/src/dashboard/hooks/projectHooks.ts
@@ -230,8 +230,8 @@ export function useOpenProjectMutation() {
       const backend = type === backendModule.BackendType.remote ? remoteBackend : localBackend
 
       invariant(backend != null, 'Backend is null')
-      const cloudProjectDirectoryPath = hybrid ? hybrid.cloudProjectDirectoryPath : null
 
+      const openHybridProjectParameters = hybrid ? { ...hybrid } : null
       await backend
         .openProject(
           id,
@@ -244,7 +244,7 @@ export function useOpenProjectMutation() {
               expireAt: session.expireAt,
               refreshUrl: session.refreshUrl,
             },
-            cloudProjectDirectoryPath,
+            openHybridProjectParameters,
           },
           title,
         )
@@ -517,7 +517,7 @@ function useOpenHybridProject() {
       try {
         invariant(localBackend != null, 'Local Backend is null')
         addOpeningProject(asset.id)
-        await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)
+        const projectSessionId = await remoteBackend.setHybridOpenInProgress(asset.id, asset.title)
         const localProject = await remoteBackend.downloadProject(asset.id)
         const cloudProjectDirectoryPath = asset.ensoPath.slice(0, asset.ensoPath.lastIndexOf('/'))
 
@@ -545,6 +545,7 @@ function useOpenHybridProject() {
           type: backendModule.BackendType.local,
           hybrid: {
             cloudProjectId: asset.id,
+            cloudProjectSessionId: projectSessionId,
             cloudParentId: asset.parentId,
             parentId: localProject.parentId,
             cloudProjectDirectoryPath,

--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -367,8 +367,8 @@ export default class LocalBackend extends Backend {
       await this.projectManager.openProject({
         projectPath: path,
         missingComponentAction: projectManager.MissingComponentAction.install,
-        ...(body?.cloudProjectDirectoryPath != null ?
-          { cloudProjectDirectoryPath: body.cloudProjectDirectoryPath }
+        ...(body?.openHybridProjectParameters != null ?
+          { cloud: body.openHybridProjectParameters }
         : {}),
       })
       return

--- a/app/gui/src/dashboard/services/ProjectManager/types.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/types.ts
@@ -185,12 +185,21 @@ interface OpenedProjectState {
  */
 export type ProjectState = OpenedProjectState | OpenInProgressProjectState
 
+/**
+ * Extra parameters required for cloud projects.
+ */
+export interface CloudParams {
+  readonly cloudProjectDirectoryPath: string
+  readonly cloudProjectId: string
+  readonly cloudProjectSessionId: string
+}
+
 /** Parameters for the "open project" endpoint. */
 export interface OpenProjectParams {
   readonly projectId: UUID
   readonly missingComponentAction: MissingComponentAction
-  readonly cloudProjectDirectoryPath?: string
   readonly projectsDirectory: Path
+  readonly cloud?: CloudParams
 }
 
 /** Parameters for the "close project" endpoint. */

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -1398,13 +1398,19 @@ export default class RemoteBackend extends Backend {
   }
 
   /** Set state of the project running in Hybrid mode as open in progress. */
-  async setHybridOpenInProgress(id: backend.ProjectId, title: string): Promise<void> {
+  async setHybridOpenInProgress(id: backend.ProjectId, title: string): Promise<backend.ProjectSessionId> {
+    /** The type of the response body of this endpoint. */
+    interface ResponseBody {
+      readonly projectSessionId: backend.ProjectSessionId
+    }
+
     const path = remoteBackendPaths.getHybridSetOpenInProgressPath(id)
-    const response = await this.post(path, {})
+    const response = await this.post<ResponseBody>(path, {})
     if (!response.ok) {
       return await this.throw(response, 'openProjectBackendError', title)
     } else {
-      return
+      const body = await response.json()
+      return body.projectSessionId
     }
   }
 

--- a/app/gui/src/dashboard/services/RemoteBackend.ts
+++ b/app/gui/src/dashboard/services/RemoteBackend.ts
@@ -1398,7 +1398,10 @@ export default class RemoteBackend extends Backend {
   }
 
   /** Set state of the project running in Hybrid mode as open in progress. */
-  async setHybridOpenInProgress(id: backend.ProjectId, title: string): Promise<backend.ProjectSessionId> {
+  async setHybridOpenInProgress(
+    id: backend.ProjectId,
+    title: string,
+  ): Promise<backend.ProjectSessionId> {
     /** The type of the response body of this endpoint. */
     interface ResponseBody {
       readonly projectSessionId: backend.ProjectSessionId

--- a/app/gui/src/providers/container.ts
+++ b/app/gui/src/providers/container.ts
@@ -31,6 +31,7 @@ const PROJECT_SCHEMA = z
     hybrid: z.optional(
       z.object({
         cloudProjectId: PROJECT_ID_SCHEMA,
+        cloudProjectSessionId: z.string(),
         cloudParentId: DIRECTORY_ID_SCHEMA,
         parentId: DIRECTORY_ID_SCHEMA,
         cloudProjectDirectoryPath: z.string(),

--- a/app/gui/src/providers/container.ts
+++ b/app/gui/src/providers/container.ts
@@ -1,4 +1,4 @@
-import { BackendType, DirectoryId, EnsoPath, ProjectId } from '#/services/Backend'
+import { BackendType, DirectoryId, EnsoPath, ProjectId, ProjectSessionId } from '#/services/Backend'
 import LocalStorage from '#/utilities/LocalStorage'
 import { createContextStore } from '@/providers'
 import { proxyRefs } from '@/util/reactivity'
@@ -18,9 +18,13 @@ declare module '#/utilities/LocalStorage' {
 const PROJECT_ID_SCHEMA = z.custom<ProjectId>(
   (x) => typeof x === 'string' && x.startsWith('project-'),
 )
+const PROJECT_SESSION_ID_SCHEMA = z.custom<ProjectSessionId>(
+  (x) => typeof x === 'string' && x.startsWith('projectsession-'),
+)
 const DIRECTORY_ID_SCHEMA = z.custom<DirectoryId>(
   (x) => typeof x === 'string' && x.startsWith('directory-'),
 )
+const ENSO_PATH_SCHEMA = z.custom<EnsoPath>((x) => typeof x === 'string')
 const PROJECT_SCHEMA = z
   .object({
     id: PROJECT_ID_SCHEMA,
@@ -31,10 +35,10 @@ const PROJECT_SCHEMA = z
     hybrid: z.optional(
       z.object({
         cloudProjectId: PROJECT_ID_SCHEMA,
-        cloudProjectSessionId: z.string(),
+        cloudProjectSessionId: PROJECT_SESSION_ID_SCHEMA,
         cloudParentId: DIRECTORY_ID_SCHEMA,
         parentId: DIRECTORY_ID_SCHEMA,
-        cloudProjectDirectoryPath: z.string(),
+        cloudProjectDirectoryPath: ENSO_PATH_SCHEMA,
       }),
     ),
   })

--- a/docs/language-server/protocol-project-manager.md
+++ b/docs/language-server/protocol-project-manager.md
@@ -411,7 +411,16 @@ the action.
 #### Parameters
 
 ```typescript
-{
+/**
+ * Extra parameters required for cloud projects.
+ */
+interface CloudParams {
+  cloudProjectDirectoryPath: string;
+  cloudProjectId: string;
+  cloudProjectSessionId: string;
+}
+
+interface OpenProjectParams {
   projectId: UUID;
 
   /**
@@ -422,16 +431,14 @@ the action.
   missingComponentAction?: MissingComponentAction;
 
   /**
-   * Specifies the cloud project directory.
-   *
-   * Required when running in hybrid mode.
-   */
-  cloudProjectDirectoryPath?: string;
-
-  /**
    * Custom directory with the user projects.
    */
   projectsDirectory?: string;
+
+  /**
+   * Extra cloud parameters required when running in hybrid mode.
+   */
+  cloud?: CloudParams;
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -530,7 +530,9 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     contextSupervisor.close()
     runtimeEventsMonitor.close()
     log.info("Stopped Language Server")
-    MDC.remove("project.id")
+    MDC.remove("projectLocalId")
+    MDC.remove("projectId")
+    MDC.remove("projectSessionId")
   }
 
   private def akkaHttpsConfig(): com.typesafe.config.Config = {

--- a/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
@@ -201,6 +201,16 @@ object LauncherApplication {
     ) {
       val rootId    = Opts.parameter[UUID]("root-id", "UUID", "Content root id.")
       val projectId = Opts.parameter[UUID]("project-id", "UUID", "Project id.")
+      val projectCloudId = Opts.optionalParameter[String](
+        "cloud-project-id",
+        "ID",
+        "Cloud project id (hybrid)."
+      )
+      val projectSessionId = Opts.optionalParameter[String](
+        "cloud-project-session-id",
+        "ID",
+        "Cloud project session id (hybrid)."
+      )
       val path =
         Opts.parameter[Path]("path", "PATH", "Path to the content root.")
       val interface =
@@ -246,6 +256,8 @@ object LauncherApplication {
       (
         rootId,
         projectId,
+        projectCloudId,
+        projectSessionId,
         path,
         interface,
         rpcPort,
@@ -262,6 +274,8 @@ object LauncherApplication {
         (
           rootId,
           projectId,
+          projectCloudId,
+          projectSessionId,
           path,
           interface,
           rpcPort,
@@ -277,14 +291,16 @@ object LauncherApplication {
         ) => (config: Config) =>
           Launcher(config).runLanguageServer(
             options = LanguageServerOptions(
-              rootId         = rootId,
-              projectId      = projectId,
-              interface      = interface,
-              rpcPort        = rpcPort,
-              secureRpcPort  = secureRpcPort,
-              dataPort       = dataPort,
-              secureDataPort = secureDataPort,
-              jvm            = Option(jvm)
+              rootId                = rootId,
+              projectId             = projectId,
+              projectCloudId        = projectCloudId,
+              projectCloudSessionId = projectSessionId,
+              interface             = interface,
+              rpcPort               = rpcPort,
+              secureRpcPort         = secureRpcPort,
+              dataPort              = dataPort,
+              secureDataPort        = secureDataPort,
+              jvm                   = Option(jvm)
             ),
             contentRoot         = path,
             versionOverride     = versionOverride,

--- a/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
@@ -299,14 +299,16 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
       newProject("test", projectPath, version)
 
       val options = LanguageServerOptions(
-        rootId         = UUID.randomUUID(),
-        projectId      = UUID.randomUUID(),
-        interface      = "127.0.0.2",
-        rpcPort        = 1234,
-        secureRpcPort  = None,
-        dataPort       = 4321,
-        secureDataPort = None,
-        jvm            = None
+        rootId                = UUID.randomUUID(),
+        projectId             = UUID.randomUUID(),
+        projectCloudId        = None,
+        projectCloudSessionId = None,
+        interface             = "127.0.0.2",
+        rpcPort               = 1234,
+        secureRpcPort         = None,
+        dataPort              = 4321,
+        secureDataPort        = None,
+        jvm                   = None
       )
       val runSettings = runner
         .languageServer(

--- a/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
+++ b/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
@@ -12,6 +12,8 @@ public abstract class LanguageServerApi {
   public static final String RPC_PORT_OPTION = "rpc-port";
   public static final String DATA_PORT_OPTION = "data-port";
   public static final String PROJECT_ID_OPTION = "project-id";
+  public static final String CLOUD_PROJECT_ID_OPTION = "cloud-project-id";
+  public static final String CLOUD_PROJECT_SESSION_ID_OPTION = "cloud-project-session-id";
   public static final String SECURE_RPC_PORT_OPTION = "secure-rpc-port";
   public static final String SECURE_DATA_PORT_OPTION = "secure-data-port";
   public static final String SKIP_GRAALVM_UPDATER = "skip-graalvm-updater";

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -311,6 +311,22 @@ public class Main {
             .longOpt(LanguageServerApi.PROJECT_ID_OPTION)
             .desc("Project id.")
             .build();
+    var cloudProjectIdOption =
+        cliOptionBuilder()
+            .hasArg(true)
+            .numberOfArgs(1)
+            .argName("id")
+            .longOpt(LanguageServerApi.CLOUD_PROJECT_ID_OPTION)
+            .desc("Cloud project id (hybrid).")
+            .build();
+    var cloudProjectSessionIdOption =
+        cliOptionBuilder()
+            .hasArg(true)
+            .numberOfArgs(1)
+            .argName("id")
+            .longOpt(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION)
+            .desc("Cloud project session id (hybrid).")
+            .build();
     var pathOption =
         cliOptionBuilder()
             .hasArg(true)
@@ -527,6 +543,8 @@ public class Main {
         .addOption(secureDataPortOption)
         .addOption(uuidOption)
         .addOption(projectIdOption)
+        .addOption(cloudProjectIdOption)
+        .addOption(cloudProjectSessionIdOption)
         .addOption(pathOption)
         .addOption(inProjectOption)
         .addOption(version)
@@ -1631,8 +1649,15 @@ public class Main {
     } catch (IllegalArgumentException e) {
       projectId = "00000000-0000-0000-0000-000000000000";
     }
-
-    MDC.put("project.id", projectId);
+    if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_ID_OPTION)) {
+      MDC.put("projectId", line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_ID_OPTION));
+    }
+    if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION)) {
+      MDC.put(
+          "projectSessionId",
+          line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION));
+    }
+    MDC.put("projectLocalId", projectId);
     RunnerLogging.setup(connectionUri, logLevel, logMasking[0]);
     return logLevel;
   }

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/ProxyLoggingEvent.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/ProxyLoggingEvent.java
@@ -1,0 +1,118 @@
+package org.enso.logging.service.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
+
+public final class ProxyLoggingEvent implements ILoggingEvent {
+  private final ILoggingEvent underlying;
+  private final Map<String, String> mdc;
+
+  public ProxyLoggingEvent(ILoggingEvent underlying, Map<String, String> extra) {
+    assert extra != null;
+    this.underlying = underlying;
+    this.mdc = new HashMap<>();
+    if (underlying.getMDCPropertyMap() != null) {
+      this.mdc.putAll(underlying.getMDCPropertyMap());
+    }
+    this.mdc.putAll(extra);
+  }
+
+  @Override
+  public String getThreadName() {
+    return underlying.getThreadName();
+  }
+
+  @Override
+  public Level getLevel() {
+    return underlying.getLevel();
+  }
+
+  @Override
+  public String getMessage() {
+    return underlying.getMessage();
+  }
+
+  @Override
+  public Object[] getArgumentArray() {
+    return underlying.getArgumentArray();
+  }
+
+  @Override
+  public String getFormattedMessage() {
+    return underlying.getFormattedMessage();
+  }
+
+  @Override
+  public String getLoggerName() {
+    return underlying.getLoggerName();
+  }
+
+  @Override
+  public LoggerContextVO getLoggerContextVO() {
+    return underlying.getLoggerContextVO();
+  }
+
+  @Override
+  public IThrowableProxy getThrowableProxy() {
+    return underlying.getThrowableProxy();
+  }
+
+  @Override
+  public StackTraceElement[] getCallerData() {
+    return underlying.getCallerData();
+  }
+
+  @Override
+  public boolean hasCallerData() {
+    return underlying.hasCallerData();
+  }
+
+  @Override
+  public List<Marker> getMarkerList() {
+    return underlying.getMarkerList();
+  }
+
+  @Override
+  public Map<String, String> getMDCPropertyMap() {
+
+    return this.mdc;
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public Map<String, String> getMdc() {
+    return this.mdc;
+  }
+
+  @Override
+  public long getTimeStamp() {
+    return underlying.getTimeStamp();
+  }
+
+  @Override
+  public int getNanoseconds() {
+    return underlying.getNanoseconds();
+  }
+
+  @Override
+  public long getSequenceNumber() {
+    return underlying.getSequenceNumber();
+  }
+
+  @Override
+  public List<KeyValuePair> getKeyValuePairs() {
+    return underlying.getKeyValuePairs();
+  }
+
+  @Override
+  public void prepareForDeferredProcessing() {
+    underlying.prepareForDeferredProcessing();
+  }
+}

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
 // Contributors: Moses Hohman <mmhohman@rainbow.uchicago.edu>
@@ -51,6 +52,7 @@ public class SocketLoggingNode implements Runnable {
   volatile State state = State.NOT_STARTED;
   SocketServer socketServer;
   UUID projectId;
+  Map<String, String> localMdc;
 
   public SocketLoggingNode(SocketServer socketServer, Socket socket, LoggerContext context) {
     this.socketServer = socketServer;
@@ -59,6 +61,7 @@ public class SocketLoggingNode implements Runnable {
     this.context = context;
     logger = context.getLogger(SocketLoggingNode.class);
     projectId = null;
+    localMdc = null;
   }
 
   public void run() {
@@ -80,9 +83,10 @@ public class SocketLoggingNode implements Runnable {
           event = (ILoggingEvent) hardenedLoggingEventInputStream.readObject();
           if (projectId == null) {
             try {
-              var property = event.getMDCPropertyMap().get("project.id");
+              var property = event.getMDCPropertyMap().get("projectLocalId");
               if (property != null) {
                 projectId = UUID.fromString(property);
+                localMdc = event.getMDCPropertyMap();
               }
             } catch (IllegalArgumentException e) {
               // ignore
@@ -93,8 +97,11 @@ public class SocketLoggingNode implements Runnable {
           remoteLogger = context.getLogger(event.getLoggerName());
           // apply the logger-level filter
           if (remoteLogger.isEnabledFor(event.getLevel())) {
+            // Ensure MDC properties are set
+            // event.getMDCPropertyMap() returns an immutable map that can't be updated
+            var event1 = localMdc != null ? new ProxyLoggingEvent(event, localMdc) : event;
             // finally log the event as if was generated locally
-            remoteLogger.callAppenders(event);
+            remoteLogger.callAppenders(event1);
           }
         } catch (IOException e) {
           throw e;

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/CloudParams.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/CloudParams.scala
@@ -1,0 +1,13 @@
+package org.enso.projectmanager.data
+
+/** Extra parameters required to run the project in hybrid mode.
+  *
+  * @param cloudProjectDirectoryPath the cloud project directory
+  * @param cloudProjectId the cloud project id
+  * @param cloudProjectSessionId the cloud project session id
+  */
+case class CloudParams(
+  cloudProjectDirectoryPath: String,
+  cloudProjectId: String,
+  cloudProjectSessionId: String
+)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.enso.logger.masking.Masking
 import org.enso.logging.service.LoggingServiceManager
 import org.enso.projectmanager.boot.Cli.{PROFILING_PATH, PROFILING_TIME}
+import org.enso.projectmanager.service.ProjectService
 import org.enso.projectmanager.service.versionmanagement.RuntimeVersionManagerFactory
 import org.enso.runtimeversionmanager.config.GlobalRunnerConfigurationManager
 import org.enso.runtimeversionmanager.runner.{LanguageServerOptions, Runner}
@@ -83,8 +84,16 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
     val inheritedLogLevel =
       LoggingServiceManager.currentLogLevelForThisApplication()
     val options = LanguageServerOptions(
-      rootId         = descriptor.rootId,
-      projectId      = descriptor.projectId,
+      rootId    = descriptor.rootId,
+      projectId = descriptor.projectId,
+      projectCloudId = findProperty(
+        ProjectService.ENSO_CLOUD_PROJECT_ID_ENV_NAME,
+        descriptor.extraEnv
+      ),
+      projectCloudSessionId = findProperty(
+        ProjectService.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME,
+        descriptor.extraEnv
+      ),
       interface      = descriptor.networkConfig.interface,
       rpcPort        = rpcPort,
       secureRpcPort  = secureRpcPort,
@@ -152,6 +161,12 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
       lifecycleListener.onTerminated(exitCode)
     }
   }
+
+  private def findProperty(
+    key: String,
+    extraEnv: Seq[(String, String)]
+  ): Option[String] =
+    extraEnv.find(_._1 == key).map(_._2)
 
   private class LanguageServerProcessHandle(private val process: Process)
       extends LanguageServerExecutor.ProcessHandle {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -7,6 +7,7 @@ import org.enso.semver.SemVer
 import org.enso.editions.EnsoVersion
 import org.enso.jsonrpc.{Error, HasParams, HasResult, Method, Unused}
 import org.enso.projectmanager.data.{
+  CloudParams,
   EngineVersion,
   MissingComponentActions,
   ProjectMetadata,
@@ -112,7 +113,7 @@ object ProjectManagementApi {
       missingComponentAction: Option[
         MissingComponentActions.MissingComponentAction
       ],
-      cloudProjectDirectoryPath: Option[String]
+      cloud: Option[CloudParams]
     )
 
     case class Result(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
@@ -51,12 +51,12 @@ class ProjectOpenHandler[F[+_, +_]: Exec: CovariantFlatMap: Sync](
       projectsDirectory <-
         Sync[F].effect(params.projectsDirectory.map(Files.getAbsoluteFile))
       server <- projectService.openProject(
-        progressTracker           = self,
-        clientId                  = clientId,
-        projectId                 = params.projectId,
-        missingComponentAction    = missingComponentAction,
-        cloudProjectDirectoryPath = params.cloudProjectDirectoryPath,
-        projectsDirectory         = projectsDirectory
+        progressTracker        = self,
+        clientId               = clientId,
+        projectId              = params.projectId,
+        missingComponentAction = missingComponentAction,
+        cloud                  = params.cloud,
+        projectsDirectory      = projectsDirectory
       )
     } yield ProjectOpen.Result(
       engineVersion                     = server.engineVersion,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -596,7 +596,9 @@ object ProjectService {
   /** The variable is used in stdlib to resolve relative paths. */
   private val ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME =
     "ENSO_CLOUD_PROJECT_DIRECTORY_PATH"
-  private val ENSO_CLOUD_PROJECT_ID_ENV_NAME = "ENSO_CLOUD_PROJECT_ID"
-  private val ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME =
+
+  /** Variables used during startup of a hybrid project */
+  val ENSO_CLOUD_PROJECT_ID_ENV_NAME = "ENSO_CLOUD_PROJECT_ID"
+  val ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME =
     "ENSO_CLOUD_PROJECT_SESSION_ID"
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -12,6 +12,7 @@ import org.enso.projectmanager.control.core.CovariantFlatMap
 import org.enso.projectmanager.control.effect.syntax._
 import org.enso.projectmanager.control.effect.{ErrorChannel, Semaphore, Sync}
 import org.enso.projectmanager.data.{
+  CloudParams,
   LanguageServerStatus,
   MissingComponentActions,
   ProjectMetadata,
@@ -300,7 +301,7 @@ class ProjectService[
     clientId: UUID,
     projectId: UUID,
     missingComponentAction: MissingComponentActions.MissingComponentAction,
-    cloudProjectDirectoryPath: Option[String],
+    cloud: Option[CloudParams],
     projectsDirectory: Option[File]
   ): F[ProjectServiceFailure, RunningLanguageServerInfo] = {
     for {
@@ -312,9 +313,14 @@ class ProjectService[
       _ <- repo.update(updated).mapError(toServiceFailure)
       projectWithDefaultEdition =
         updated.copy(edition = Some(DefaultEdition.getDefaultEdition))
-      extraEnv = cloudProjectDirectoryPath
-        .map(ProjectService.ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME -> _)
-        .toSeq
+      extraEnv = cloud.toSeq
+        .flatMap(c =>
+          Seq(
+            ProjectService.ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME -> c.cloudProjectDirectoryPath,
+            ProjectService.ENSO_CLOUD_PROJECT_ID_ENV_NAME             -> c.cloudProjectId,
+            ProjectService.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME     -> c.cloudProjectSessionId
+          )
+        )
       sockets <- startServer(
         progressTracker,
         clientId,
@@ -590,4 +596,7 @@ object ProjectService {
   /** The variable is used in stdlib to resolve relative paths. */
   private val ENSO_CLOUD_PROJECT_DIRECTORY_PATH_ENV_NAME =
     "ENSO_CLOUD_PROJECT_DIRECTORY_PATH"
+  private val ENSO_CLOUD_PROJECT_ID_ENV_NAME = "ENSO_CLOUD_PROJECT_ID"
+  private val ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME =
+    "ENSO_CLOUD_PROJECT_SESSION_ID"
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 import akka.actor.ActorRef
 import org.enso.semver.SemVer
 import org.enso.projectmanager.data.{
+  CloudParams,
   LanguageServerStatus,
   MissingComponentActions,
   ProjectMetadata,
@@ -65,7 +66,7 @@ trait ProjectServiceApi[F[+_, +_]] {
     * @param clientId the requester id
     * @param projectId the project id
     * @param missingComponentAction specifies how to handle missing components
-    * @param cloudProjectDirectoryPath set cloud project directory when running project in hybrid mode
+    * @param cloud extra parameters required when running project in hybrid mode
     * @return either failure or a socket of the Language Server
     */
   def openProject(
@@ -73,7 +74,7 @@ trait ProjectServiceApi[F[+_, +_]] {
     clientId: UUID,
     projectId: UUID,
     missingComponentAction: MissingComponentActions.MissingComponentAction,
-    cloudProjectDirectoryPath: Option[String],
+    cloud: Option[CloudParams],
     projectsDirectory: Option[File]
   ): F[ProjectServiceFailure, RunningLanguageServerInfo]
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/LanguageServerOptions.scala
@@ -6,6 +6,8 @@ import java.util.UUID
   *
   * @param rootId an id of content root
   * @param projectId an id of the project
+  * @param projectCloudId an id of the cloud project
+  * @param projectCloudSessionId an id of the session in cloud project
   * @param interface a interface that the server listen to
   * @param rpcPort an RPC port that the server listen to
   * @param secureRpcPort an option secure RPC port that the server listen to
@@ -16,6 +18,8 @@ import java.util.UUID
 case class LanguageServerOptions(
   rootId: UUID,
   projectId: UUID,
+  projectCloudId: Option[String],
+  projectCloudSessionId: Option[String],
   interface: String,
   rpcPort: Int,
   secureRpcPort: Option[Int],

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -136,9 +136,15 @@ class Runner(
         options.dataPort.toString,
         "--log-level",
         logLevel.name
-      ) ++ options.secureRpcPort
-        .map(port => Seq("--secure-rpc-port", port.toString))
+      ) ++ options.projectCloudId
+        .map(id => Seq("--cloud-project-id", id))
         .getOrElse(Seq.empty) ++
+        options.projectCloudSessionId
+          .map(id => Seq("--cloud-project-session-id", id))
+          .getOrElse(Seq.empty) ++
+        options.secureRpcPort
+          .map(port => Seq("--secure-rpc-port", port.toString))
+          .getOrElse(Seq.empty) ++
         options.secureDataPort
           .map(port => Seq("--secure-data-port", port.toString))
           .getOrElse(Seq.empty) ++


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #13738

Changelog:
- update: `project/open` api to allow passing extra cloud parameters 
- update: gui to pass extra cloud parameters when starting hybrid projects
- update: project manager to pass extra cloud parameters to the started language server as env variables

### Important Notes

Manually testsed:

```
[TRACE] [2025-08-07T11:00:28.171] [org.enso.projectmanager.infrastructure.languageserver.ExecutorWithUnlimitedPool] Starting Language Server Process [JAVA_HOME="/home/dbushev/.local/share/enso/runtime/graalvm-ce-java24.0.1-24.2.0" ENSO_DATA_DIRECTORY="/home/dbushev/.local/share/enso" ENSO_AUXILIARY_LIBRARY_CACHES="/home/dbushev/.local/share/enso/dist/0.0.0-dev/lib" ENSO_RUNTIME_DIRECTORY="/run/user/1000/enso" ENSO_EDITION_PATH="/home/dbushev/enso/editions" ENSO_CONFIG_DIRECTORY="/home/dbushev/.config/enso" ENSO_HOME="/home/dbushev/enso" ENSO_LOG_DIRECTORY="/home/dbushev/.local/share/enso/log" ENSO_LIBRARY_PATH="/home/dbushev/enso/libraries" ENSO_CLOUD_PROJECT_DIRECTORY_PATH="enso://Users/dmitry.bushev+1871_csd2@enso.org" ENSO_CLOUD_PROJECT_ID="project-30rgh6svpzeNez8OU47ABoGmYtL" ENSO_CLOUD_PROJECT_SESSION_ID="projectsession-30xERUf8IGttPW396caV5xPCidd" "/home/dbushev/.local/share/enso/runtime/graalvm-ce-java24.0.1-24.2.0/bin/java" "-Djdk.graal.PrintGraph=Network" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--add-opens=java.base/java.nio=ALL-UNNAMED" "--sun-misc-unsafe-memory-access=allow" "--enable-native-access=org.graalvm.truffle" "--module-path" "/home/dbushev/.local/share/enso/dist/0.0.0-dev/component" "-m" "org.enso.runner/org.enso.runner.Main" "--logger-connect" "//localhost:6000" "--server" "--root-id" "700ec030-61da-498f-954b-3e64a0a6e8e6" "--project-id" "d2ea1d59-0dd1-4d50-94a6-901260e8006e" "--path" "/home/dbushev/Documents/enso-projects/cloud-project-30rgh6svpzeNez8OU47ABoGmYtL/project_root" "--interface" "127.0.0.1" "--rpc-port" "51264" "--data-port" "61142" "--log-level" "TRACE" "--no-log-masking"]
```

```
ENSO_CLOUD_PROJECT_DIRECTORY_PATH="enso://Users/dmitry.bushev+1871_csd2@enso.org"
ENSO_CLOUD_PROJECT_ID="project-30rgh6svpzeNez8OU47ABoGmYtL" 
ENSO_CLOUD_PROJECT_SESSION_ID="projectsession-30xERUf8IGttPW396caV5xPCidd" 
```

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
