### PR TITLE
Revert "Remove cache invalidation for visualizations (#13608)"

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -44,7 +44,7 @@ logging-service {
     org.enso.languageserver.protocol.json.JsonConnectionController = debug
     org.enso.jsonrpc.JsonRpcServer = debug
     org.enso.languageserver.runtime.RuntimeConnector = debug
-    org.enso.interpreter.runtime.HostClassLoader = error
+    org.enso.interpreter.epb.HostClassLoader = error
     java.lang.ProcessBuilder = warn
     Standard.Base.Logging.Progress = error
   }

--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -44,7 +44,7 @@ logging-service {
     org.enso.languageserver.protocol.json.JsonConnectionController = debug
     org.enso.jsonrpc.JsonRpcServer = debug
     org.enso.languageserver.runtime.RuntimeConnector = debug
-    org.enso.interpreter.epb.HostClassLoader = error
+    org.enso.interpreter.runtime.HostClassLoader = error
     java.lang.ProcessBuilder = warn
     Standard.Base.Logging.Progress = error
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -5,7 +5,11 @@ import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Name
 import org.enso.compiler.core.ir.module.scope.{definition, Definition}
-import org.enso.compiler.pass.analyse.CachePreferenceAnalysis
+import org.enso.compiler.refactoring.IRUtils
+import org.enso.compiler.pass.analyse.{
+  CachePreferenceAnalysis,
+  DataflowAnalysis
+}
 import org.enso.interpreter.instrument.execution.{Executable, RuntimeContext}
 import org.enso.interpreter.instrument.job.UpsertVisualizationJob.{
   EvaluationFailed,
@@ -222,6 +226,20 @@ class UpsertVisualizationJob(
 object UpsertVisualizationJob {
   private lazy val logger =
     LoggerFactory.getLogger(classOf[UpsertVisualizationJob])
+
+  /** Invalidate caches for a particular expression id. */
+  sealed private case class InvalidateCaches(
+    expressionId: Api.ExpressionId
+  )(implicit ctx: RuntimeContext)
+      extends Runnable {
+
+    override def run(): Unit = {
+      ctx.locking.withWriteCompilationLock(
+        classOf[UpsertVisualizationJob],
+        () => invalidateCaches(expressionId)
+      )
+    }
+  }
 
   /** The number of times to retry the expression evaluation. */
   private val MaxEvaluationRetryCount: Int = 5
@@ -573,7 +591,7 @@ object UpsertVisualizationJob {
     * @param ctx the runtime context
     * @return the re-evaluated visualization
     */
-  private def updateAttachedVisualization(
+  def updateAttachedVisualization(
     visualizationId: Api.VisualizationId,
     expressionId: Api.ExpressionId,
     module: Module,
@@ -595,6 +613,7 @@ object UpsertVisualizationJob {
         arguments
       )
     setCacheWeights(visualization)
+    ctx.state.executionHooks.add(InvalidateCaches(expressionId))
     ctx.contextManager.upsertVisualization(
       visualizationConfig.executionContextId,
       visualization
@@ -645,6 +664,44 @@ object UpsertVisualizationJob {
     }
   }
 
+  /** Update the caches. */
+  private def invalidateCaches(
+    expressionId: Api.ExpressionId
+  )(implicit ctx: RuntimeContext): Unit = {
+    val stacks = ctx.contextManager.getAllContexts.values
+    /* The invalidation of the first cached dependent node is required for
+     * attaching the visualizations to sub-expressions. Consider the example
+     * ```
+     * op = target.foo arg
+     * ```
+     * The result of expression `target.foo arg` is cached. If you attach the
+     * visualization to say `target`, the sub-expression `target` won't be
+     * executed because the whole expression is cached. And the visualization
+     * won't be computed.
+     * To workaround this issue, the logic below tries to identify if the
+     * visualized expression is a sub-expression and invalidate the first parent
+     * expression accordingly.
+     */
+    if (!stacks.exists(isExpressionCached(expressionId, _))) {
+      invalidateFirstDependent(expressionId)
+    }
+  }
+
+  /** Check if the expression is cached in the execution stack.
+    *
+    * @param expressionId the expression id to check
+    * @param stack the execution stack
+    * @return `true` if the expression exists in the frame cache
+    */
+  private def isExpressionCached(
+    expressionId: Api.ExpressionId,
+    stack: Iterable[InstrumentFrame]
+  ): Boolean = {
+    stack.headOption.exists { frame =>
+      frame.cache.get(expressionId) ne null
+    }
+  }
+
   /** Set the cache weights for the provided visualization.
     *
     * @param visualization the visualization to update
@@ -657,6 +714,52 @@ object UpsertVisualizationJob {
           Seq(visualization),
           CacheInvalidation.Command.SetMetadata(metadata)
         )
+      }
+  }
+
+  /** Invalidate the first cached dependent node of the provided expression.
+    *
+    * @param expressionId the expression id
+    */
+  private def invalidateFirstDependent(
+    expressionId: Api.ExpressionId
+  )(implicit ctx: RuntimeContext): Unit = {
+    ctx.executionService.getContext
+      .findModuleByExpressionId(expressionId)
+      .ifPresent { module =>
+        module.getIr
+          .getMetadata(DataflowAnalysis)
+          .foreach { metadata =>
+            val externalId = expressionId
+            IRUtils
+              .findByExternalId(module.getIr, externalId)
+              .map { ir =>
+                DataflowAnalysis.DependencyInfo.Type
+                  .Static(ir.getId, ir.getExternalId)
+              }
+              .flatMap { expressionKey =>
+                metadata.dependents.getExternal(expressionKey)
+              }
+              .foreach { dependents =>
+                val stacks = ctx.contextManager.getAllContexts.values
+                stacks.foreach { stack =>
+                  stack.headOption.foreach { frame =>
+                    dependents
+                      .find { id => frame.cache.get(id) ne null }
+                      .foreach { firstDependent =>
+                        CacheInvalidation.run(
+                          stack,
+                          CacheInvalidation(
+                            CacheInvalidation.StackSelector.Top,
+                            CacheInvalidation.Command
+                              .InvalidateKeys(Seq(firstDependent))
+                          )
+                        )
+                      }
+                  }
+                }
+              }
+          }
       }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -4487,15 +4487,19 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
         Vector()
       )
       context.send(
-        Api.Request(
-          requestId,
-          Api.PushContextRequest(contextId, item1, execute = false)
-        )
+        Api.Request(requestId, Api.PushContextRequest(contextId, item1))
       )
       context.receiveNIgnorePendingExpressionUpdates(
-        1
+        3
       ) should contain theSameElementsAs Seq(
-        Api.Response(requestId, Api.PushContextResponse(contextId))
+        Api.Response(requestId, Api.PushContextResponse(contextId)),
+        TestMessages.update(
+          contextId,
+          idY,
+          ConstantsGen.INTEGER,
+          Api.MethodCall(Api.MethodPointer(moduleName, s"$moduleName.T", "inc"))
+        ),
+        context.executionComplete(contextId)
       )
 
       // Send IdMap
@@ -4505,11 +4509,9 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
           Api.EditFileNotification(
             mainFile,
             Seq(),
-            execute = true,
+            execute = false,
             idMap = Some(
-              model.IdMap(
-                Vector(model.Span(100, 101) -> idYX, model.Span(65, 72) -> idY)
-              )
+              model.IdMap(Vector(model.Span(100, 101) -> idYX))
             )
           )
         )
@@ -4535,15 +4537,9 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
         )
       )
       val attachVisualizationResponses =
-        context.receiveNIgnoreStdLib(5)
+        context.receiveNIgnoreExpressionUpdates(3)
       attachVisualizationResponses should contain allOf (
         Api.Response(requestId, Api.VisualizationAttached()),
-        TestMessages.update(
-          contextId,
-          idY,
-          ConstantsGen.INTEGER,
-          Api.MethodCall(Api.MethodPointer(moduleName, s"$moduleName.T", "inc"))
-        ),
         context.executionComplete(contextId)
       )
       val Some(data) = attachVisualizationResponses.collectFirst {


### PR DESCRIPTION
### Pull Request Description

This reverts commit 834f08b88629dd331106d6eca591af02a8b99019.
Turns out GUI has be making some esoteric requests with expression ID for something inside a cached value. Neither did we anticipate nor prevent such requests.

As cache invalidation logic is too intertwined with execution, any changes to cache invalidation logic are rather fragile. This is the source of the problem for #13747. The sad consequence of this revert is that some executions will be done twice.

### Important Notes

Re-opens #13580.
