### PR TITLE
Mini compiler passes are not combined when IR is dumped

### DIFF
--- a/docs/runtime/compiler-ir.md
+++ b/docs/runtime/compiler-ir.md
@@ -30,10 +30,18 @@ enso --no-compile-dependencies --no-global-cache --no-ir-caches --vm.D enso.comp
 ## Dumping IR
 
 The IR can be visualized using the `enso.compiler.dumpIr` system property. The
-value of the property is a substring of a module name to dump. IRs are dumped
-into the [IGV tool](https://www.graalvm.org/latest/tools/igv/) in a similar way
-to how GraalVM graphs are dumped, which is documented in
-[enso4igv](https://github.com/enso-org/enso/blob/2e714a70ddf12456e9f3fa9e132fd2ac43aa3b77/tools/enso4igv/IGV.md#using-the-igv).
+property value has format `<module-name>[:<dump-level>]`, where `module-name` is
+a substring of a module to dump and `dump-level` is an optional integer which
+can be:
+
+- `1` ... the default value.
+- `2` ... Does not chain mini passes. By default, mini passes are _chained_ into
+  a bigger mega pass. Use this if you want to see IR transformation done by all
+  mini passes.
+
+- IRs are dumped into the [IGV tool](https://www.graalvm.org/latest/tools/igv/)
+  in a similar way to how GraalVM graphs are dumped, which is documented in
+  [enso4igv](https://github.com/enso-org/enso/blob/2e714a70ddf12456e9f3fa9e132fd2ac43aa3b77/tools/enso4igv/IGV.md#using-the-igv).
 
 When using the `enso.compiler.dumpIr` property, one has to add
 `--add-exports jdk.graal.compiler/jdk.graal.compiler.graphio=org.enso.runtime.compiler.dump.igv`

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
@@ -447,6 +447,8 @@ final class EnsoModuleAST {
                 "argName", specifiedArg.name().name(),
                 "suspended", specifiedArg.suspended());
         var node = newNode(specifiedArg, props);
+        var nameNode = newNode(specifiedArg.name());
+        createEdge(node, nameNode, "name");
         if (specifiedArg.ascribedType().isDefined()) {
           var ascribedTypeNode = buildTree(specifiedArg.ascribedType().get());
           createEdge(node, ascribedTypeNode, "ascribedType");

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
@@ -233,6 +233,13 @@ final class EnsoModuleAST {
           var argNode = buildTree(arg);
           createEdge(node, argNode, "arg[" + i + "]");
         }
+        for (var i = 0; i < type.body().size(); i++) {
+          var bodyItem = type.body().apply(i);
+          if (bodyItem instanceof Expression bodyItemExpr) {
+            var bodyItemNode = buildTree(bodyItemExpr);
+            createEdge(node, bodyItemNode, "body[" + i + "]");
+          }
+        }
         yield node;
       }
       case Name.GenericAnnotation genericAnnotation -> {

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
@@ -333,12 +333,14 @@ final class EnsoModuleAST {
         }
         yield prefixAppNode;
       }
-      case Function.Lambda lambda -> {
-        var lambdaNode = newNode(lambda);
-        var bodyNode = buildTree(lambda.body());
+      case Function function -> {
+        Map<String, Object> props =
+            Map.of("canBeTCO", function.canBeTCO(), "isPrivate", function.isPrivate());
+        var lambdaNode = newNode(function, props);
+        var bodyNode = buildTree(function.body());
         createEdge(lambdaNode, bodyNode, "body");
-        for (var i = 0; i < lambda.arguments().size(); i++) {
-          var arg = lambda.arguments().apply(i);
+        for (var i = 0; i < function.arguments().size(); i++) {
+          var arg = function.arguments().apply(i);
           var argNode = buildTree(arg);
           createEdge(lambdaNode, argNode, "arg[" + i + "]");
         }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/data/CompilerConfig.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/data/CompilerConfig.java
@@ -24,7 +24,7 @@ public record CompilerConfig(
     boolean privateCheckEnabled,
     boolean staticAnalysisEnabled,
     boolean treatWarningsAsErrors,
-    Option<String> dumpModuleIR,
+    Option<IRDumperConfig> dumpModuleIR,
     boolean isStrictErrors,
     boolean isLintingDisabled,
     Option<PrintStream> outputRedirect,
@@ -44,7 +44,7 @@ public record CompilerConfig(
     private boolean privateCheckEnabled = true;
     private boolean staticAnalysisEnabled = false;
     private boolean treatWarningsAsErrors = false;
-    private Option<String> dumpModuleIR = Option.empty();
+    private Option<IRDumperConfig> dumpModuleIR = Option.empty();
     private boolean isStrictErrors = false;
     private boolean isLintingDisabled = false;
     private Option<PrintStream> outputRedirect = Option.empty();
@@ -76,7 +76,7 @@ public record CompilerConfig(
       return this;
     }
 
-    public Builder dumpModuleIR(Option<String> dumpModuleIR) {
+    public Builder dumpModuleIR(Option<IRDumperConfig> dumpModuleIR) {
       this.dumpModuleIR = dumpModuleIR;
       return this;
     }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/data/IRDumperConfig.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/data/IRDumperConfig.java
@@ -1,0 +1,66 @@
+package org.enso.compiler.data;
+
+public final class IRDumperConfig {
+  public enum DumpLevel {
+    DEFAULT(),
+    NO_MINI_PASS_CHAINING();
+
+    private static DumpLevel fromInt(int level) {
+      return switch (level) {
+        case 1 -> DEFAULT;
+        case 2 -> NO_MINI_PASS_CHAINING;
+        default -> throw new IllegalArgumentException("Unknown dump level: " + level);
+      };
+    }
+  }
+
+  private final String moduleName;
+  private final DumpLevel dumpLevel;
+
+  private IRDumperConfig(String moduleName, DumpLevel dumpLevel) {
+    this.moduleName = moduleName;
+    this.dumpLevel = dumpLevel;
+  }
+
+  /** Shortcut for {@link #forModuleName(String, DumpLevel)}. */
+  public static IRDumperConfig forModuleName(String moduleName) {
+    return forModuleName(moduleName, DumpLevel.DEFAULT);
+  }
+
+  /**
+   * @param moduleName Substring of the module name to dump.
+   */
+  public static IRDumperConfig forModuleName(String moduleName, DumpLevel dumpLevel) {
+    return new IRDumperConfig(moduleName, dumpLevel);
+  }
+
+  public static IRDumperConfig parseFromProperty(String prop) {
+    if (prop != null) {
+      if (prop.contains(":")) {
+        var items = prop.split(":", 2);
+        var modName = items[0];
+        var level = items[1].trim();
+        int numLevel;
+        try {
+          numLevel = Integer.parseInt(level);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+              "Invalid dump level: " + level + " for module: " + modName, e);
+        }
+        var dumpLevel = DumpLevel.fromInt(numLevel);
+        return new IRDumperConfig(modName, dumpLevel);
+      } else {
+        return new IRDumperConfig(prop, DumpLevel.DEFAULT);
+      }
+    }
+    return null;
+  }
+
+  public String getModuleName() {
+    return moduleName;
+  }
+
+  public DumpLevel getDumpLevel() {
+    return dumpLevel;
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/data/IRDumperWithConfig.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/data/IRDumperWithConfig.java
@@ -1,0 +1,5 @@
+package org.enso.compiler.data;
+
+import org.enso.compiler.dump.service.IRDumper;
+
+public record IRDumperWithConfig(IRDumper irDumper, IRDumperConfig config) {}

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -274,30 +274,9 @@ class Compiler(
     generateDocs: Boolean
   ): List[Module] = {
     initialize()
-    modules.foreach(m =>
-      try {
-        parseModule(
-          m,
-          irCachingEnabled && !context.isInteractive(m),
-          generateDocs
-        )
-      } catch {
-        case e: Throwable =>
-          context.log(
-            Level.SEVERE,
-            "Encountered a critical failure while parsing module",
-            e
-          )
-          context.log(
-            Level.SEVERE,
-            "Contents of module {0}: {0}",
-            m.getPath,
-            m.getCharacters.toString
-          )
-      }
-    )
 
     var moduleIrDumpers: HashMap[Module, IRDumper] = new HashMap()
+
     def getOrCreateDumper(module: Module): Option[IRDumper] = {
       config.dumpModuleIR.flatMap(pattern => {
         if (module.getName().toString.contains(pattern)) {
@@ -317,6 +296,30 @@ class Compiler(
     def closeAllDumpers(): Unit = {
       moduleIrDumpers.foreach { case (_, dumper) => dumper.close() }
     }
+
+    modules.foreach(m =>
+      try {
+        parseModule(
+          m,
+          irCachingEnabled && !context.isInteractive(m),
+          generateDocs,
+          irDumper = getOrCreateDumper(m)
+        )
+      } catch {
+        case e: Throwable =>
+          context.log(
+            Level.SEVERE,
+            "Encountered a critical failure while parsing module",
+            e
+          )
+          context.log(
+            Level.SEVERE,
+            "Contents of module {0}: {0}",
+            m.getPath,
+            m.getCharacters.toString
+          )
+      }
+    )
 
     val requiredModules = modules.flatMap { module =>
       val isLoadedFromSource =

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -23,7 +23,7 @@ import org.enso.compiler.core.ir.module.scope.Export
 import org.enso.compiler.core.ir.module.scope.Import
 import org.enso.compiler.core.ir.module.scope.imports
 import org.enso.compiler.core.EnsoParser
-import org.enso.compiler.data.CompilerConfig
+import org.enso.compiler.data.{CompilerConfig, IRDumperWithConfig}
 import org.enso.compiler.pass.PassManager
 import org.enso.compiler.pass.analyse._
 import org.enso.compiler.phase.{ImportResolver, ImportResolverAlgorithm}
@@ -275,17 +275,18 @@ class Compiler(
   ): List[Module] = {
     initialize()
 
-    var moduleIrDumpers: HashMap[Module, IRDumper] = new HashMap()
+    var moduleIrDumpers: HashMap[Module, IRDumperWithConfig] = new HashMap()
 
-    def getOrCreateDumper(module: Module): Option[IRDumper] = {
-      config.dumpModuleIR.flatMap(pattern => {
-        if (module.getName().toString.contains(pattern)) {
+    def getOrCreateDumper(module: Module): Option[IRDumperWithConfig] = {
+      config.dumpModuleIR.flatMap(irDumperConfig => {
+        if (module.getName().toString.contains(irDumperConfig.getModuleName)) {
           moduleIrDumpers.get(module) match {
             case Some(existing) => Some(existing)
             case None =>
-              val dumper = IRDumper.create(module.getName.toString)
-              moduleIrDumpers = moduleIrDumpers.updated(module, dumper)
-              Some(dumper)
+              val dumper        = IRDumper.create(module.getName.toString)
+              val dumperWithCfg = new IRDumperWithConfig(dumper, irDumperConfig)
+              moduleIrDumpers = moduleIrDumpers.updated(module, dumperWithCfg)
+              Some(dumperWithCfg)
           }
         } else {
           None
@@ -294,7 +295,7 @@ class Compiler(
     }
 
     def closeAllDumpers(): Unit = {
-      moduleIrDumpers.foreach { case (_, dumper) => dumper.close() }
+      moduleIrDumpers.foreach { case (_, dumper) => dumper.irDumper().close() }
     }
 
     modules.foreach(m =>
@@ -678,7 +679,7 @@ class Compiler(
     module: Module,
     useCaches: Boolean,
     generateDocs: Boolean,
-    irDumper: Option[IRDumper] = None
+    irDumper: Option[IRDumperWithConfig] = None
   ): Unit = {
     context.log(
       Compiler.defaultLogLevel,
@@ -714,7 +715,7 @@ class Compiler(
   private def uncachedParseModule(
     module: Module,
     generateDocs: Boolean,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): Unit = {
     context.log(
       Compiler.defaultLogLevel,
@@ -899,7 +900,7 @@ class Compiler(
   private def recognizeBindings(
     module: IRModule,
     moduleContext: ModuleContext,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): IRModule = {
     passManager.runPassesOnModule(
       module,
@@ -917,7 +918,7 @@ class Compiler(
   private def runMethodBodyPasses(
     ir: IRModule,
     moduleContext: ModuleContext,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): IRModule = {
     context.log(
       Level.FINEST,
@@ -935,7 +936,7 @@ class Compiler(
   private def runGlobalTypingPasses(
     ir: IRModule,
     moduleContext: ModuleContext,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): IRModule = {
     context.log(
       Level.FINEST,
@@ -957,7 +958,7 @@ class Compiler(
   private def runFinalTypeInferencePasses(
     ir: IRModule,
     moduleContext: ModuleContext,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): IRModule = {
     passManager.runPassesOnModule(
       ir,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/PassManager.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/PassManager.scala
@@ -195,11 +195,24 @@ class PassManager(
     megaPassCompile: (IRPass, IRType, ContextType) => IRType
   ): IRType = {
     val pendingMiniPasses: ListBuffer[MiniPassFactory] = ListBuffer()
+    val shouldCombineMiniPasses                        = irDumper.isEmpty
+    if (!shouldCombineMiniPasses) {
+      logger.trace(
+        "  Mini passes will not be combined - they will be flushed immediately, " +
+        " because IRDumper is set."
+      );
+    }
 
     def flushMiniPasses(in: IRType): IRType = {
       if (pendingMiniPasses.nonEmpty) {
         val miniPasses =
           pendingMiniPasses.map(factory => createMiniPass(factory, context))
+        if (!shouldCombineMiniPasses) {
+          assert(
+            pendingMiniPasses.size <= 1,
+            "Mini passes should be flushed immediately."
+          )
+        }
         val combinedPass = miniPasses.fold(null)(MiniIRPass.combine)
         pendingMiniPasses.clear()
         if (combinedPass != null) {
@@ -224,22 +237,29 @@ class PassManager(
               "  mini collected: {}",
               pass
             )
-            val combiningPreventedByOpt = pendingMiniPasses.find { p =>
-              p.invalidatedPasses.contains(miniFactory)
+            if (shouldCombineMiniPasses) {
+              val combiningPreventedByOpt = pendingMiniPasses.find { p =>
+                p.invalidatedPasses.contains(miniFactory)
+              }
+              val irForRemainingMiniPasses = combiningPreventedByOpt match {
+                case Some(combiningPreventedBy) =>
+                  logger.trace(
+                    "  pass {} forces flush before (invalidates) {}",
+                    combiningPreventedBy,
+                    miniFactory
+                  )
+                  flushMiniPasses(intermediateIR)
+                case None =>
+                  intermediateIR
+              }
+              pendingMiniPasses.addOne(miniFactory)
+              irForRemainingMiniPasses
+            } else {
+              // IRDumper is set - treat mini passes as mega passes.
+              val newIr = flushMiniPasses(intermediateIR)
+              pendingMiniPasses.addOne(miniFactory)
+              newIr
             }
-            val irForRemainingMiniPasses = combiningPreventedByOpt match {
-              case Some(combiningPreventedBy) =>
-                logger.trace(
-                  "  pass {} forces flush before (invalidates) {}",
-                  combiningPreventedBy,
-                  miniFactory
-                )
-                flushMiniPasses(intermediateIR)
-              case None =>
-                intermediateIR
-            }
-            pendingMiniPasses.addOne(miniFactory)
-            irForRemainingMiniPasses
 
           case megaPass: IRPass =>
             // TODO [AA, MK] This is a possible race condition.

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/PassManager.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/PassManager.scala
@@ -5,6 +5,8 @@ import org.enso.compiler.context.{CompilerContext, InlineContext, ModuleContext}
 import org.enso.compiler.core.ir.{Expression, Module}
 import org.enso.compiler.core.{CompilerError, IR}
 import org.enso.compiler.dump.service.IRDumper
+import org.enso.compiler.data.IRDumperConfig.DumpLevel
+import org.enso.compiler.data.IRDumperWithConfig
 import org.enso.compiler.dump.service.IRSource
 
 import scala.collection.mutable.ListBuffer
@@ -72,7 +74,7 @@ class PassManager(
     ir: Module,
     moduleContext: ModuleContext,
     passGroup: PassGroup,
-    irDumper: Option[IRDumper]
+    irDumper: Option[IRDumperWithConfig]
   ): Module = {
     if (!passes.contains(passGroup)) {
       throw new CompilerError("Cannot run an unvalidated pass group.")
@@ -188,15 +190,20 @@ class PassManager(
     context: ContextType,
     passGroup: PassGroup,
     moduleName: Option[String],
-    irDumper: Option[IRDumper],
+    irDumper: Option[IRDumperWithConfig],
     module: CompilerContext.Module,
     createMiniPass: (MiniPassFactory, ContextType) => MiniIRPass,
     miniPassCompile: (MiniIRPass, IRType) => IRType,
     megaPassCompile: (IRPass, IRType, ContextType) => IRType
   ): IRType = {
     val pendingMiniPasses: ListBuffer[MiniPassFactory] = ListBuffer()
-    val shouldCombineMiniPasses                        = irDumper.isEmpty
-    if (!shouldCombineMiniPasses) {
+    val noMiniPassChaining = irDumper match {
+      case Some(dumper)
+          if dumper.config().getDumpLevel == DumpLevel.NO_MINI_PASS_CHAINING =>
+        true
+      case _ => false
+    }
+    if (noMiniPassChaining) {
       logger.trace(
         "  Mini passes will not be combined - they will be flushed immediately, " +
         " because IRDumper is set."
@@ -207,7 +214,7 @@ class PassManager(
       if (pendingMiniPasses.nonEmpty) {
         val miniPasses =
           pendingMiniPasses.map(factory => createMiniPass(factory, context))
-        if (!shouldCombineMiniPasses) {
+        if (noMiniPassChaining) {
           assert(
             pendingMiniPasses.size <= 1,
             "Mini passes should be flushed immediately."
@@ -218,7 +225,13 @@ class PassManager(
         if (combinedPass != null) {
           logger.trace("  flushing pending mini pass: {}", combinedPass)
           val ret = miniPassCompile(combinedPass, in)
-          dump(ret, moduleName, irDumper, combinedPass.toString, module)
+          dump(
+            ret,
+            moduleName,
+            irDumper.map(_.irDumper()),
+            combinedPass.toString,
+            module
+          )
           ret
         } else {
           in
@@ -237,7 +250,7 @@ class PassManager(
               "  mini collected: {}",
               pass
             )
-            if (shouldCombineMiniPasses) {
+            if (!noMiniPassChaining) {
               val combiningPreventedByOpt = pendingMiniPasses.find { p =>
                 p.invalidatedPasses.contains(miniFactory)
               }
@@ -274,7 +287,13 @@ class PassManager(
               megaPass
             )
             val ret = megaPassCompile(megaPass, flushedIR, context)
-            dump(ret, moduleName, irDumper, megaPass.toString, module)
+            dump(
+              ret,
+              moduleName,
+              irDumper.map(_.irDumper()),
+              megaPass.toString,
+              module
+            )
             ret
         }
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -41,6 +41,7 @@ import org.enso.common.RuntimeOptions;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.core.EnsoParser;
 import org.enso.compiler.data.CompilerConfig;
+import org.enso.compiler.data.IRDumperConfig;
 import org.enso.distribution.DistributionManager;
 import org.enso.distribution.locking.LockManager;
 import org.enso.editions.LibraryName;
@@ -170,7 +171,8 @@ public final class EnsoContext {
     this.assertionsEnabled = shouldAssertionsBeEnabled();
     this.shouldWaitForPendingSerializationJobs =
         getOption(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY);
-    var dumpModuleIR = System.getProperty(RuntimeOptions.IR_DUMPER_SYSTEM_PROP);
+    var dumpModuleIR =
+        IRDumperConfig.parseFromProperty(System.getProperty(RuntimeOptions.IR_DUMPER_SYSTEM_PROP));
     var shouldRemoveUnusedImports =
         System.getProperty(RuntimeOptions.REMOVE_UNUSED_IMPORTS_SYSTEM_PROP) != null;
     this.compilerConfig =


### PR DESCRIPTION
### Pull Request Description

When [dumping IR](https://github.com/enso-org/enso/blob/16def77cd6278adc1d74c51311b660e22710c549/docs/runtime/compiler-ir.md#L30), mini IR passes [are not combined](https://github.com/enso-org/enso/blob/0163284e5af861a291423009158509ec52e442a8/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/PassManager.scala#L258-L261). Instead, they are immediately flushed. Effectively making them the same as mega passes.

The impact is that the dumped IR graph will contain separate graphs for every mini pass, as well as mega pass.

The previous dump (mini passes are combined):
<img width="676" height="350" alt="image" src="https://github.com/user-attachments/assets/0743ef14-27e9-4ca7-b1a4-e691400baf89" />


The new dump (mini passes are not combined):
<img width="472" height="476" alt="image" src="https://github.com/user-attachments/assets/9ff1d07a-0dc5-482a-a6ca-7ee9a7c9b793" />


### Important Notes

This probably affects performance. But when we are dumping IRs, we don't care about performance anyway.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
