### PR TITLE
Deduplicate `listDirectory` and `getAssetDetails` requests

### DIFF
--- a/app/gui/src/components/AppContainer.vue
+++ b/app/gui/src/components/AppContainer.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { SHORT_CACHE_TIME_MS } from '#/hooks/backendHooks'
 import { Dashboard as DashboardReact, type DashboardProps } from '#/pages/dashboard/Dashboard'
 import { EnsoPath } from '#/services/Backend'
 import { useBackends } from '$/providers/backends'
@@ -39,7 +40,10 @@ export const dataLoader: DataLoader<DashboardProps> = {
     const typedAsset = resolvedPath && extractTypeFromId(resolvedPath.id)
     if (typedAsset?.type !== AssetType.project) return Ok({})
     const options = backendQueryOptions('getAssetDetails', [typedAsset.id, undefined], backend)
-    const assetResponse: AssetDetailsResponse<ProjectId> = await queryClient.fetchQuery(options)
+    const assetResponse: AssetDetailsResponse<ProjectId> = await queryClient.fetchQuery({
+      ...options,
+      staleTime: SHORT_CACHE_TIME_MS,
+    })
     if (!assetResponse) return Ok({})
     const asset: ProjectAsset = { ...assetResponse, ensoPath: path }
     return Ok({ projectToOpen: { asset, backend: backend.type } })

--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -43,7 +43,8 @@ import { useBackends, useFullUserSession } from '$/providers/react'
 import { useFeatureFlag } from '$/providers/react/featureFlags'
 import { z } from 'zod'
 
-const PROJECT_EXECUTIONS_STALE_TIME = 60_000
+export const SHORT_CACHE_TIME_MS = 5_000
+const PROJECT_EXECUTIONS_STALE_TIME_MS = 60_000
 
 export function backendQueryOptions<Method extends BackendQueryMethod>(
   backend: Backend,
@@ -239,6 +240,8 @@ export function listDirectoryQueryOptions(options: ListDirectoryQueryOptions) {
   } = options
   const rootPath = 'rootPath' in category ? category.rootPath : undefined
   return queryOptions({
+    meta: { persist: false },
+    staleTime: SHORT_CACHE_TIME_MS,
     queryKey: [
       backend.type,
       'listDirectory',
@@ -577,7 +580,7 @@ export function listProjectExecutionsQueryOptions(
   return queryOptions({
     ...backendQueryOptions(backend, 'listProjectExecutions', [id, title]),
     select: (executions) => [...executions].reverse(),
-    staleTime: PROJECT_EXECUTIONS_STALE_TIME,
+    staleTime: PROJECT_EXECUTIONS_STALE_TIME_MS,
   })
 }
 
@@ -589,6 +592,6 @@ export function getProjectExecutionDetailsQueryOptions(
 ) {
   return queryOptions({
     ...backendQueryOptions(backend, 'getProjectExecutionDetails', [id, title]),
-    staleTime: PROJECT_EXECUTIONS_STALE_TIME,
+    staleTime: PROJECT_EXECUTIONS_STALE_TIME_MS,
   })
 }

--- a/app/gui/src/dashboard/layouts/Drive.tsx
+++ b/app/gui/src/dashboard/layouts/Drive.tsx
@@ -153,18 +153,18 @@ function DriveAssetsView() {
             <AssetsTableAssetsUnselector />
           </div>
 
-          <div className="grid-col-1 sm:grid-col-2 flex flex-col gap-3">
-            <DriveBar query={query} setQuery={setQuery} />
+          <Suspense>
+            <div className="grid-col-1 sm:grid-col-2 flex flex-col gap-3">
+              <DriveBar query={query} setQuery={setQuery} />
 
-            {isInaccessible && <OfflineMessage />}
-            {!isInaccessible && (
-              <Suspense>
+              {isInaccessible && <OfflineMessage />}
+              {!isInaccessible && (
                 <ErrorBoundary>
                   <AssetsTable query={query} setQuery={setQuery} />
                 </ErrorBoundary>
-              </Suspense>
-            )}
-          </div>
+              )}
+            </div>
+          </Suspense>
         </div>
       </div>
     </div>

--- a/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarNavigation.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarNavigation.tsx
@@ -9,6 +9,7 @@ import { Popover } from '#/components/Dialog'
 import { Menu } from '#/components/Menu'
 import { Scroller } from '#/components/Scroller/Scroller'
 import { moveAssetsMutationOptions } from '#/hooks/backendBatchedHooks'
+import { SHORT_CACHE_TIME_MS } from '#/hooks/backendHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useSyncRef } from '#/hooks/syncRefHooks'
 import CategorySwitcher from '#/layouts/CategorySwitcher'
@@ -67,6 +68,7 @@ export function DriveBarNavigation() {
         : undefined,
       ),
     meta: { persist: false },
+    staleTime: SHORT_CACHE_TIME_MS,
     retry: (count, error) => {
       if (error instanceof AssetDoesNotExistError || error instanceof NetworkError) {
         if (currentDirectoryId === currentDirectoryIdRef.current) {

--- a/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
@@ -139,11 +139,12 @@ export class ProjectManager {
 
   /** Get the state of a project given its path. */
   async getProject(projectPath: Path) {
-    const projectId = this.projectIds.get(projectPath)
-    if (projectId) {
-      return this.projects.get(projectId)
+    const existingProjectId = this.projectIds.get(projectPath)
+    if (existingProjectId) {
+      return this.projects.get(existingProjectId)
     }
     await this.listDirectory(Path(getFolderPath(projectPath)))
+    const projectId = this.projectIds.get(projectPath)
     invariant(projectId, `Unknown project id for project '${projectPath}'.`)
     return this.projects.get(projectId)
   }

--- a/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
@@ -139,8 +139,11 @@ export class ProjectManager {
 
   /** Get the state of a project given its path. */
   async getProject(projectPath: Path) {
-    await this.listDirectory(Path(getFolderPath(projectPath)))
     const projectId = this.projectIds.get(projectPath)
+    if (projectId) {
+      return this.projects.get(projectId)
+    }
+    await this.listDirectory(Path(getFolderPath(projectPath)))
     invariant(projectId, `Unknown project id for project '${projectPath}'.`)
     return this.projects.get(projectId)
   }

--- a/app/gui/src/router/initialProject.ts
+++ b/app/gui/src/router/initialProject.ts
@@ -84,7 +84,6 @@ async function shouldOpenInitialProject(
     console.error('Cannot read user home directory; will skip launching Welcome Project', err)
     return null
   }
-  console.log(onlineManager.isOnline(), remoteBackend)
   const homeContent = await Promise.all([
     localBackend?.listDirectory(homeDirQuery) ?? [],
     onlineManager.isOnline() && remoteBackend != null ?

--- a/app/gui/src/router/initialProject.ts
+++ b/app/gui/src/router/initialProject.ts
@@ -84,6 +84,7 @@ async function shouldOpenInitialProject(
     console.error('Cannot read user home directory; will skip launching Welcome Project', err)
     return null
   }
+  console.log(onlineManager.isOnline(), remoteBackend)
   const homeContent = await Promise.all([
     localBackend?.listDirectory(homeDirQuery) ?? [],
     onlineManager.isOnline() && remoteBackend != null ?


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/2119
- Deduplicate `listDirectory` and `getAssetDetails` requests that occur on startup
  - This significantly speeds startup (how much of an improvement it is may depend on latency to the backend servers)
  - Also deduplicates unnecessary `listDirectory` called by the Local Backend for `getProjectDetails`

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
