### PR TITLE
Removes `ModuleScopeBuilder` from `Module`

### DIFF
--- a/engine/runtime-benchmarks/src/main/java/org/enso/compiler/benchmarks/exportimport/ExportImportResolutionBenchmark.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/compiler/benchmarks/exportimport/ExportImportResolutionBenchmark.java
@@ -1,5 +1,7 @@
 package org.enso.compiler.benchmarks.exportimport;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,9 +67,10 @@ public class ExportImportResolutionBenchmark {
     var ensoCtx = ctx.ensoContext();
     this.mainModule = ensoCtx.getPackageRepository().getLoadedModule("local.Proj.Main").get();
     var mainRuntimeMod = Module.fromCompilerModule(mainModule);
+    assertTrue("main module should not yet be compiled", mainRuntimeMod.needsCompilation());
     assertThat(
         "main module should not yet be compiled",
-        mainRuntimeMod.getCompilationStage().equals(CompilationStage.INITIAL));
+        mainModule.getCompilationStage().equals(CompilationStage.INITIAL));
     this.importResolver = new ImportResolver(ensoCtx.getCompiler());
     this.exportsResolution = new ExportsResolution(ensoCtx.getCompiler().context());
   }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.instrument.job;
 
-import org.enso.common.CompilationStage;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.pkg.QualifiedName;
-import org.slf4j.LoggerFactory;
 
 /** The job that serializes module. */
 public final class SerializeModuleJob extends BackgroundJob<Void> {
@@ -31,14 +29,8 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
                   .findModule(moduleName.toString())
                   .ifPresent(
                       module -> {
-                        if (module.getCompilationStage().isBefore(CompilationStage.AFTER_CODEGEN)) {
-                          LoggerFactory.getLogger(SerializeModuleJob.class)
-                              .warn(
-                                  "Attempt to serialize the module [{}] at stage [{}].",
-                                  module.getName(),
-                                  module.getCompilationStage());
-                          return;
-                        }
+                        assert !module.needsCompilation()
+                            : "Attempt to serialize the module that needs compilation: " + module;
                         compiler
                             .context()
                             .serializeModule(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -3,7 +3,7 @@ package org.enso.interpreter.instrument.job
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import org.enso.common.{CachePreferences, CompilationStage}
+import org.enso.common.CachePreferences
 import org.enso.compiler.{data, CompilerResult}
 import org.enso.compiler.context._
 import org.enso.compiler.core.Implicits.AsMetadata
@@ -287,11 +287,7 @@ class EnsureCompiledJob(
     idMapOpt: Option[IdMap] = None
   )(implicit ctx: RuntimeContext): Either[Throwable, CompilerResult] =
     try {
-      val compilationStage = module.getCompilationStage
-      if (
-        !compilationStage.isAtLeast(CompilationStage.AFTER_CODEGEN)
-        || idMapOpt.isDefined
-      ) {
+      if (module.needsCompilation() || idMapOpt.isDefined) {
         logger.trace(s"Compiling ${module.getName}.")
         val compiler = ctx.executionService.getContext.getCompiler
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/LookupServicesNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/LookupServicesNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import java.util.ArrayList;
 import java.util.function.Supplier;
-import org.enso.common.CompilationStage;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -61,8 +60,7 @@ public abstract class LookupServicesNode extends Node {
       throw new PanicException(err, this);
     }
     var scope = module.compileScope(ensoCtx);
-    var stage = module.getCompilationStage();
-    assert stage.isAtLeast(CompilationStage.AFTER_CODEGEN) : "Unsufficient stage " + stage;
+    assert !module.needsCompilation() : "Unsufficient stage of " + module;
 
     var typeName = fqn.item();
     var implType = scope.getType(typeName, true);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/IrTruffleUtils.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/IrTruffleUtils.java
@@ -36,8 +36,8 @@ final class IrTruffleUtils {
 
     @Override
     protected TypeCheckValueNode forName(CompilerContext.Module module, String name) {
-      var m = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
-      var typ = m.getScopeBuilder().getType(name, true);
+      var sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(module);
+      var typ = sb.getType(name, true);
       if (typ == ctx.getBuiltins().any()) {
         if (allTypes) {
           return TypeCheckValueNode.allOf(comment, new TypeCheckValueNode[1]);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -64,7 +64,6 @@ import org.slf4j.LoggerFactory;
 public final class Module extends EnsoObject {
   private ModuleSources sources;
   private QualifiedName name;
-  private ModuleScopeBuilder scopeBuilder;
   private ModuleScope scope;
   private final Package<TruffleFile> pkg;
   private final Cache<ModuleCache.CachedModule, ModuleCache.Metadata> cache;
@@ -565,11 +564,8 @@ public final class Module extends EnsoObject {
    * @return
    */
   final ModuleScopeBuilder getScopeBuilder(boolean reset) {
-    if (reset || scopeBuilder == null) {
-      scopeBuilder =
-          ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
-    }
-    return scopeBuilder;
+    var sb = TruffleCompilerContext.findCompilerModule(this).getScopeBuilder(reset);
+    return sb.unsafeScopeBuilder();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -166,8 +166,7 @@ public final class Module extends EnsoObject {
     this.sources =
         literalSource == null ? ModuleSources.NONE : ModuleSources.NONE.newWith(literalSource);
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
+    var scopeBuilder = TruffleCompilerContext.findCompilerModule(this).newScopeBuilder();
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -176,7 +175,7 @@ public final class Module extends EnsoObject {
       this.compilationStage = CompilationStage.INITIAL;
     } else {
       if (fillWith != null) {
-        fillWith.accept(scopeBuilder);
+        fillWith.accept(scopeBuilder.unsafeScopeBuilder());
       }
       this.compilationStage = CompilationStage.AFTER_CODEGEN;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 public final class Module extends EnsoObject {
   private ModuleSources sources;
   private QualifiedName name;
+  private ModuleScopeBuilder scopeBuilder;
   private ModuleScope scope;
   private final Package<TruffleFile> pkg;
   private final Cache<ModuleCache.CachedModule, ModuleCache.Metadata> cache;
@@ -98,6 +99,8 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(sourceFile);
     this.name = name;
+    this.scopeBuilder =
+        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -105,6 +108,7 @@ public final class Module extends EnsoObject {
   }
 
   final void updateModuleScope(ModuleScope scope) {
+    assert scope == scopeBuilder.asModuleScope();
     this.scope = scope;
   }
 
@@ -120,6 +124,8 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(Rope.apply(literalSource));
     this.name = name;
+    this.scopeBuilder =
+        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -139,6 +145,8 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(literalSource);
     this.name = name;
+    this.scopeBuilder =
+        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -165,7 +173,7 @@ public final class Module extends EnsoObject {
     this.sources =
         literalSource == null ? ModuleSources.NONE : ModuleSources.NONE.newWith(literalSource);
     this.name = name;
-    var scopeBuilder =
+    this.scopeBuilder =
         ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
@@ -390,8 +398,12 @@ public final class Module extends EnsoObject {
       } catch (IOException ignored) {
       }
     }
-    var cm = TruffleCompilerContext.findCompilerModule(this);
-    TruffleCompilerModuleScopeBuilder.fromCompilerModule(cm).finish();
+    //    var cm = TruffleCompilerContext.findCompilerModule(this);
+    //    var sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(cm);
+    //    assert sb == scopeBuilder;
+    //    sb.finish();
+    scopeBuilder.finish();
+    assert scope == scopeBuilder.asModuleScope();
     return scope;
   }
 
@@ -551,6 +563,22 @@ public final class Module extends EnsoObject {
    */
   public final ModuleScope getScope() {
     return scope;
+  }
+
+  final ModuleScopeBuilder getScopeBuilder() {
+    return scopeBuilder;
+  }
+
+  /**
+   * Resets scope builder of this module by a new one. Shall only be called from compiler interface
+   * - {@link TruffleCompilerContext}.
+   *
+   * @return new scope builder - same as {@link #getScopeBuilder()} since now
+   */
+  final ModuleScopeBuilder newScopeBuilder() {
+    this.scopeBuilder =
+        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
+    return this.scopeBuilder;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -99,8 +99,6 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(sourceFile);
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -108,7 +106,6 @@ public final class Module extends EnsoObject {
   }
 
   final void updateModuleScope(ModuleScope scope) {
-    assert scope == scopeBuilder.asModuleScope();
     this.scope = scope;
   }
 
@@ -124,8 +121,6 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(Rope.apply(literalSource));
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -145,8 +140,6 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(literalSource);
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -402,8 +395,8 @@ public final class Module extends EnsoObject {
     //    var sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(cm);
     //    assert sb == scopeBuilder;
     //    sb.finish();
-    scopeBuilder.finish();
-    assert scope == scopeBuilder.asModuleScope();
+    getScopeBuilder().finish();
+    assert scope == getScopeBuilder().asModuleScope();
     return scope;
   }
 
@@ -566,6 +559,10 @@ public final class Module extends EnsoObject {
   }
 
   final ModuleScopeBuilder getScopeBuilder() {
+    if (scopeBuilder == null) {
+      scopeBuilder =
+          ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
+    }
     return scopeBuilder;
   }
 
@@ -576,9 +573,8 @@ public final class Module extends EnsoObject {
    * @return new scope builder - same as {@link #getScopeBuilder()} since now
    */
   final ModuleScopeBuilder newScopeBuilder() {
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
-    return this.scopeBuilder;
+    this.scopeBuilder = null;
+    return this.getScopeBuilder();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -385,7 +385,8 @@ public final class Module extends EnsoObject {
   public ModuleScope compileScope(EnsoContext context) {
     if (!compilationStage.isAtLeast(CompilationStage.AFTER_CODEGEN)) {
       try {
-        compile(context);
+        var cm = TruffleCompilerContext.findCompilerModule(this);
+        cm.compile(context.getCompiler());
       } catch (IOException ignored) {
       }
     }
@@ -464,15 +465,6 @@ public final class Module extends EnsoObject {
     return allSources.containsKey(s);
   }
 
-  private void compile(EnsoContext context) throws IOException {
-    Source source = getSource();
-    if (source == null) return;
-    var cm = asCompilerModule();
-    cm.newScopeBuilder();
-    compilationStage = CompilationStage.INITIAL;
-    context.getCompiler().run(cm);
-  }
-
   /**
    * @return IR defined by this module.
    */
@@ -503,7 +495,7 @@ public final class Module extends EnsoObject {
   /**
    * @return the current compilation stage of this module.
    */
-  public CompilationStage getCompilationStage() {
+  final CompilationStage getCompilationStage() {
     return compilationStage;
   }
 
@@ -694,7 +686,8 @@ public final class Module extends EnsoObject {
       module.disposeInteractive();
       module.wasLoadedFromCache = false;
       try {
-        module.compile(context);
+        var cm = TruffleCompilerContext.findCompilerModule(module);
+        cm.compile(context.getCompiler());
       } catch (IOException ignored) {
       }
       return module;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -55,12 +55,15 @@ import org.enso.polyglot.data.TypeGraph;
 import org.enso.text.buffer.Rope;
 import org.slf4j.LoggerFactory;
 
-/** Represents a source module with a known location. */
+/**
+ * Represents a source module with a known location. The state of {@link Module} may change as the
+ * user manipulates it source in the Enso Studio. The immutable state is captured inside of {@link
+ * ModuleScope}. Snapshot of the scope can be obtained via {@link #getScope()}.
+ */
 @ExportLibrary(InteropLibrary.class)
 public final class Module extends EnsoObject {
   private ModuleSources sources;
   private QualifiedName name;
-  private ModuleScopeBuilder scopeBuilder;
   private ModuleScope scope;
   private final Package<TruffleFile> pkg;
   private final Cache<ModuleCache.CachedModule, ModuleCache.Metadata> cache;
@@ -95,16 +98,13 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(sourceFile);
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
     this.synthetic = false;
   }
 
-  private void updateModuleScope(ModuleScope scope) {
-    assert scope == scopeBuilder.asModuleScope();
+  final void updateModuleScope(ModuleScope scope) {
     this.scope = scope;
   }
 
@@ -120,8 +120,6 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(Rope.apply(literalSource));
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -141,8 +139,6 @@ public final class Module extends EnsoObject {
     ensureConsistentName(name, pkg);
     this.sources = ModuleSources.NONE.newWith(literalSource);
     this.name = name;
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
     this.wasLoadedFromCache = false;
@@ -169,7 +165,7 @@ public final class Module extends EnsoObject {
     this.sources =
         literalSource == null ? ModuleSources.NONE : ModuleSources.NONE.newWith(literalSource);
     this.name = name;
-    this.scopeBuilder =
+    var scopeBuilder =
         ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     this.pkg = pkg;
     this.cache = ModuleCache.create(this);
@@ -394,8 +390,8 @@ public final class Module extends EnsoObject {
       } catch (IOException ignored) {
       }
     }
-    scopeBuilder.finish();
-    assert scope == scopeBuilder.asModuleScope();
+    var cm = TruffleCompilerContext.findCompilerModule(this);
+    TruffleCompilerModuleScopeBuilder.fromCompilerModule(cm).finish();
     return scope;
   }
 
@@ -467,9 +463,10 @@ public final class Module extends EnsoObject {
   private void compile(EnsoContext context) throws IOException {
     Source source = getSource();
     if (source == null) return;
-    scopeBuilder = ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
+    var cm = asCompilerModule();
+    cm.newScopeBuilder();
     compilationStage = CompilationStage.INITIAL;
-    context.getCompiler().run(asCompilerModule());
+    context.getCompiler().run(cm);
   }
 
   /**
@@ -549,26 +546,11 @@ public final class Module extends EnsoObject {
    * scope instance at given time. Over time the scope instance may change as a result of {@link
    * ModuleScopeBuilder#finish()} call.
    *
-   * @return the current runtime scope of this module.
+   * @return the current runtime scope of this module, future calls may yield different instance if
+   *     the code/state of the module was modified
    */
   public final ModuleScope getScope() {
     return scope;
-  }
-
-  final ModuleScopeBuilder getScopeBuilder() {
-    return scopeBuilder;
-  }
-
-  /**
-   * Resets scope builder of this module by a new one. Shall only be called from compiler interface
-   * - {@link TruffleCompilerContext}.
-   *
-   * @return new scope builder - same as {@link #getScopeBuilder()} since now
-   */
-  final ModuleScopeBuilder newScopeBuilder() {
-    this.scopeBuilder =
-        ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
-    return this.scopeBuilder;
   }
 
   /**
@@ -639,7 +621,7 @@ public final class Module extends EnsoObject {
    * @return instance of {@link CompilerContext.Module} that delegates to this module
    */
   public final CompilerContext.Module asCompilerModule() {
-    return new TruffleCompilerContext.Module(this);
+    return TruffleCompilerContext.findCompilerModule(this);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -394,8 +394,9 @@ public final class Module extends EnsoObject {
     //    var sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(cm);
     //    assert sb == scopeBuilder;
     //    sb.finish();
-    getScopeBuilder().finish();
-    assert scope == getScopeBuilder().asModuleScope();
+    var sb = getScopeBuilder(false);
+    sb.finish();
+    assert scope == sb.asModuleScope();
     return scope;
   }
 
@@ -557,23 +558,18 @@ public final class Module extends EnsoObject {
     return scope;
   }
 
-  final ModuleScopeBuilder getScopeBuilder() {
-    if (scopeBuilder == null) {
+  /**
+   * Gets current or reset builder for this module.
+   *
+   * @param reset should any existing builder be reset?
+   * @return
+   */
+  final ModuleScopeBuilder getScopeBuilder(boolean reset) {
+    if (reset || scopeBuilder == null) {
       scopeBuilder =
           ModuleScopeAccessor.getInstance().newScopeBuilder(this, this::updateModuleScope);
     }
     return scopeBuilder;
-  }
-
-  /**
-   * Resets scope builder of this module by a new one. Shall only be called from compiler interface
-   * - {@link TruffleCompilerContext}.
-   *
-   * @return new scope builder - same as {@link #getScopeBuilder()} since now
-   */
-  final ModuleScopeBuilder newScopeBuilder() {
-    this.scopeBuilder = null;
-    return this.getScopeBuilder();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -768,7 +768,7 @@ final class TruffleCompilerContext implements CompilerContext {
     private Module(org.enso.interpreter.runtime.Module module) {
       this.module = module;
       var tmp = newScopeBuilder();
-      assert this.sb == tmp;
+      // assert this.sb == tmp;
     }
 
     @Override
@@ -857,15 +857,14 @@ final class TruffleCompilerContext implements CompilerContext {
 
     @Override
     public CompilerContext.ModuleScopeBuilder getScopeBuilder() {
-      return sb;
+      var sb = module.getScopeBuilder();
+      return new TruffleCompilerModuleScopeBuilder(sb);
     }
 
     @Override
     public ModuleScopeBuilder newScopeBuilder() {
-      var inner =
-          ModuleScopeAccessor.getInstance().newScopeBuilder(module, module::updateModuleScope);
-      sb = new TruffleCompilerModuleScopeBuilder(inner);
-      return sb;
+      var sb = module.newScopeBuilder();
+      return new TruffleCompilerModuleScopeBuilder(sb);
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -853,12 +853,21 @@ final class TruffleCompilerContext implements CompilerContext {
       return module.isPrivate();
     }
 
-  /**
-   * Gets current or reset builder for this module.
-   *
-   * @param reset should any existing builder be reset?
-   * @return
-   */
+    final void compile(Compiler compiler) throws IOException {
+      Source source = module.getSource();
+      if (source != null) {
+        this.newScopeBuilder();
+        module.unsafeSetCompilationStage(CompilationStage.INITIAL);
+        compiler.run(this);
+      }
+    }
+
+    /**
+     * Gets current or reset builder for this module.
+     *
+     * @param reset should any existing builder be reset?
+     * @return
+     */
     final TruffleCompilerModuleScopeBuilder getScopeBuilder(boolean reset) {
       if (reset || sb == null) {
         var scopeBuilder =
@@ -867,7 +876,7 @@ final class TruffleCompilerContext implements CompilerContext {
       }
       return sb;
     }
-    
+
     @Override
     public TruffleCompilerModuleScopeBuilder getScopeBuilder() {
       return getScopeBuilder(false);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -8,12 +8,15 @@ import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.source.Source;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -736,7 +739,7 @@ final class TruffleCompilerContext implements CompilerContext {
         module.module.setLoadedFromCache(loadedFromCache);
       }
       if (resetScope) {
-        module.module.newScopeBuilder();
+        module.newScopeBuilder();
       }
       if (invalidateCache) {
         module.module.getCache().invalidate(context);
@@ -744,13 +747,28 @@ final class TruffleCompilerContext implements CompilerContext {
     }
   }
 
-  public static final class Module extends CompilerContext.Module {
+  private static final Map<org.enso.interpreter.runtime.Module, Reference<Module>>
+      COMPILER_MODULES = new WeakHashMap<>();
 
+  static synchronized Module findCompilerModule(org.enso.interpreter.runtime.Module module) {
+    var ref = COMPILER_MODULES.get(module);
+    var cm = ref == null ? null : ref.get();
+    if (cm == null) {
+      cm = new Module(module);
+      COMPILER_MODULES.put(module, new WeakReference<>(cm));
+    }
+    return cm;
+  }
+
+  public static final class Module extends CompilerContext.Module {
     private final org.enso.interpreter.runtime.Module module;
     private BindingsMap bindings;
+    private ModuleScopeBuilder sb;
 
-    public Module(org.enso.interpreter.runtime.Module module) {
+    private Module(org.enso.interpreter.runtime.Module module) {
       this.module = module;
+      var tmp = newScopeBuilder();
+      assert this.sb == tmp;
     }
 
     @Override
@@ -839,14 +857,15 @@ final class TruffleCompilerContext implements CompilerContext {
 
     @Override
     public CompilerContext.ModuleScopeBuilder getScopeBuilder() {
-      var sb = module.getScopeBuilder();
-      return new TruffleCompilerModuleScopeBuilder(sb);
+      return sb;
     }
 
     @Override
     public ModuleScopeBuilder newScopeBuilder() {
-      var sb = module.newScopeBuilder();
-      return new TruffleCompilerModuleScopeBuilder(sb);
+      var inner =
+          ModuleScopeAccessor.getInstance().newScopeBuilder(module, module::updateModuleScope);
+      sb = new TruffleCompilerModuleScopeBuilder(inner);
+      return sb;
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -856,13 +856,13 @@ final class TruffleCompilerContext implements CompilerContext {
     }
 
     @Override
-    public CompilerContext.ModuleScopeBuilder getScopeBuilder() {
+    public TruffleCompilerModuleScopeBuilder getScopeBuilder() {
       var sb = module.getScopeBuilder();
       return new TruffleCompilerModuleScopeBuilder(sb);
     }
 
     @Override
-    public ModuleScopeBuilder newScopeBuilder() {
+    public TruffleCompilerModuleScopeBuilder newScopeBuilder() {
       var sb = module.newScopeBuilder();
       return new TruffleCompilerModuleScopeBuilder(sb);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -763,12 +763,10 @@ final class TruffleCompilerContext implements CompilerContext {
   public static final class Module extends CompilerContext.Module {
     private final org.enso.interpreter.runtime.Module module;
     private BindingsMap bindings;
-    private ModuleScopeBuilder sb;
+    private TruffleCompilerModuleScopeBuilder sb;
 
     private Module(org.enso.interpreter.runtime.Module module) {
       this.module = module;
-      var tmp = newScopeBuilder();
-      // assert this.sb == tmp;
     }
 
     @Override
@@ -855,16 +853,29 @@ final class TruffleCompilerContext implements CompilerContext {
       return module.isPrivate();
     }
 
+  /**
+   * Gets current or reset builder for this module.
+   *
+   * @param reset should any existing builder be reset?
+   * @return
+   */
+    final TruffleCompilerModuleScopeBuilder getScopeBuilder(boolean reset) {
+      if (reset || sb == null) {
+        var scopeBuilder =
+            ModuleScopeAccessor.getInstance().newScopeBuilder(module, module::updateModuleScope);
+        sb = new TruffleCompilerModuleScopeBuilder(scopeBuilder);
+      }
+      return sb;
+    }
+    
     @Override
     public TruffleCompilerModuleScopeBuilder getScopeBuilder() {
-      var sb = module.getScopeBuilder(false);
-      return new TruffleCompilerModuleScopeBuilder(sb);
+      return getScopeBuilder(false);
     }
 
     @Override
     public TruffleCompilerModuleScopeBuilder newScopeBuilder() {
-      var sb = module.getScopeBuilder(true);
-      return new TruffleCompilerModuleScopeBuilder(sb);
+      return getScopeBuilder(true);
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -857,13 +857,13 @@ final class TruffleCompilerContext implements CompilerContext {
 
     @Override
     public TruffleCompilerModuleScopeBuilder getScopeBuilder() {
-      var sb = module.getScopeBuilder();
+      var sb = module.getScopeBuilder(false);
       return new TruffleCompilerModuleScopeBuilder(sb);
     }
 
     @Override
     public TruffleCompilerModuleScopeBuilder newScopeBuilder() {
-      var sb = module.newScopeBuilder();
+      var sb = module.getScopeBuilder(true);
       return new TruffleCompilerModuleScopeBuilder(sb);
     }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
@@ -19,4 +19,8 @@ final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScop
       CompilerContext.ModuleScopeBuilder scopeBuilder) {
     return ((TruffleCompilerModuleScopeBuilder) scopeBuilder).unsafeScopeBuilder();
   }
+
+  static ModuleScopeBuilder fromCompilerModule(CompilerContext.Module module) {
+    return fromCompilerModuleScopeBuilder(module.getScopeBuilder());
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
@@ -11,10 +11,6 @@ final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScop
     this.scopeBuilder = scopeBuilder;
   }
 
-  org.enso.interpreter.runtime.scope.ModuleScopeBuilder unsafeScopeBuilder() {
-    return scopeBuilder;
-  }
-
   static ModuleScopeBuilder fromCompilerModuleScopeBuilder(
       CompilerContext.ModuleScopeBuilder scopeBuilder) {
     return ((TruffleCompilerModuleScopeBuilder) scopeBuilder).unsafeScopeBuilder();
@@ -22,5 +18,13 @@ final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScop
 
   static ModuleScopeBuilder fromCompilerModule(CompilerContext.Module module) {
     return fromCompilerModuleScopeBuilder(module.getScopeBuilder());
+  }
+
+  org.enso.interpreter.runtime.scope.ModuleScopeBuilder unsafeScopeBuilder() {
+    return scopeBuilder;
+  }
+
+  final void finish() {
+    this.scopeBuilder.finish();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -98,7 +98,6 @@ public final class Builtins {
             (scopeBuilder) -> {
               res[0] = new Builtins(context, scopeBuilder);
             });
-    module.compileScope(context); // Dummy compilation for an empty module
     // module has to be assigned only when constructor is over
     res[0].module = module;
     return res[0];

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -38,7 +38,7 @@ import org.enso.interpreter.runtime.state.State;
 @ImportStatic(PanicException.class)
 public final class DataflowError extends AbstractTruffleException {
   /** Signals (local) values that haven't yet been initialized */
-  public static final DataflowError UNINITIALIZED = new DataflowError(null, (Node) null);
+  public static final DataflowError UNINITIALIZED = new DataflowError();
 
   private final EnsoContext ctx;
   private final Object payload;
@@ -93,6 +93,14 @@ public final class DataflowError extends AbstractTruffleException {
     var result = new DataflowError(payload, prototype);
     TruffleStackTrace.fillIn(result);
     return result;
+  }
+
+  /** Constructor for {@link #UNINITIALIZED} value. */
+  private DataflowError() {
+    super(null, null, 1, null);
+    this.payload = null;
+    this.ownTrace = false;
+    this.ctx = null;
   }
 
   private DataflowError(Object payload, Node location) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.library.ExportMessage;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.enso.common.CompilationStage;
 import org.enso.compiler.common.MethodResolutionAlgorithm;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -80,7 +79,7 @@ public final class ModuleScope extends EnsoObject {
    */
   @CompilerDirectives.TruffleBoundary
   public Function lookupMethodDefinition(Type type, String name) {
-    assert getModule().getCompilationStage().isAtLeast(CompilationStage.AFTER_CODEGEN);
+    assert !getModule().needsCompilation();
     return RuntimeMethodResolution.INSTANCE.lookupMethodDefinition(this, type, name);
   }
 
@@ -171,7 +170,7 @@ public final class ModuleScope extends EnsoObject {
    */
   @CompilerDirectives.TruffleBoundary
   public Function lookupConversionDefinition(Type source, Type target) {
-    assert getModule().getCompilationStage().isAtLeast(CompilationStage.AFTER_CODEGEN);
+    assert !getModule().needsCompilation();
     return RuntimeMethodResolution.INSTANCE.lookupConversionDefinition(this, source, target);
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -144,9 +144,7 @@ class IrToTruffle(
   ) = this(
     context,
     source,
-    org.enso.interpreter.runtime.Module
-      .fromCompilerModule(mod)
-      .getScopeBuilder(),
+    TruffleCompilerModuleScopeBuilder.fromCompilerModule(mod),
     compilerConfig
   )
 
@@ -2562,24 +2560,22 @@ class IrToTruffle(
   }
 
   private def asScope(module: CompilerContext.Module): ModuleScopeBuilder = {
-    val m = org.enso.interpreter.runtime.Module.fromCompilerModule(module)
-    m.getScopeBuilder()
+    TruffleCompilerModuleScopeBuilder.fromCompilerModule(module)
   }
 
   private def asType(
     typ: BindingsMap.ResolvedType
   ): Type = {
-    val m = org.enso.interpreter.runtime.Module
-      .fromCompilerModule(typ.module.unsafeAsModule())
-    val sb = m.getScopeBuilder()
+    val sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(
+      typ.module.unsafeAsModule()
+    )
     sb.getType(typ.tp.name, true)
   }
 
   private def asAssociatedType(
     module: CompilerContext.Module
   ): Type = {
-    val m  = org.enso.interpreter.runtime.Module.fromCompilerModule(module)
-    val sb = m.getScopeBuilder()
+    val sb = TruffleCompilerModuleScopeBuilder.fromCompilerModule(module)
     sb.getAssociatedType()
   }
 


### PR DESCRIPTION
### Pull Request Description

- continuation of #13716
- and #13709
- this time we remove `ModuleScopeBuilder` from `Module`
- the idea is that `Module` has a mutable piece `ModuleScope` reference
- that reference is updated iff `ModuleScopeBuilder.finish()` is called
- 5b36d3b fixes #13776

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
