### PR TITLE
Properly register Enso_File type and not its module

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File_System_Impl.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File_System_Impl.enso
@@ -1,7 +1,7 @@
 private
 
 import project.System.File.File_System_SPI
-import project.Enso_Cloud.Enso_File
+import project.Enso_Cloud.Enso_File.Enso_File
 
 type Enso_File_System_Impl
 

--- a/test/Base_Tests/src/System/File_Spec.enso
+++ b/test/Base_Tests/src/System/File_Spec.enso
@@ -426,6 +426,13 @@ add_specs suite_builder =
         group_builder.specify "will resolve empty path to the current working directory" <|
             File.new "" . should_equal File.current_directory
 
+        group_builder.specify "try enso:// URL" <|
+            f = File.new 'enso://'
+            # got some value
+            f.is_nothing . should_be_false
+            # the value is of type Enso_File(!?) currently
+            f.should_be_a Standard.Base.Enso_Cloud.Enso_File.Enso_File
+
     suite_builder.group "read_text" group_builder->
         group_builder.specify "should allow reading a UTF-8 file" <|
             contents = sample_file.read_text


### PR DESCRIPTION
### Pull Request Description

Fixes #13766 by properly registering `Enso_File` type and not its module.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
