### PR TITLE
Engine Nightly Checks fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4510,7 +4510,9 @@ lazy val `edition-updater` = project
       "org.scalatest"              %% "scalatest"     % scalatestVersion % Test
     ),
     Compile / internalModuleDependencies := Seq(
+      (`cli` / Compile / exportedModule).value,
       (`distribution-manager` / Compile / exportedModule).value,
+      (`downloader` / Compile / exportedModule).value,
       (`editions` / Compile / exportedModule).value
     )
   )

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Visualization_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Visualization_Helpers.enso
@@ -64,7 +64,7 @@ type Visualization_Helpers
        Used for determining which filters should be used.
     check_distinct_values : Boolean
     check_distinct_values self  =
-        (self.count_distinct_values.if_nothing 1000) < 100
+        (self.count_distinct_values.if_nothing 0) < DataQualityMetrics.DISTINCT_THRESHOLD
 
     ## ---
        private: true

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/ProjectSettingsManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/ProjectSettingsManager.scala
@@ -44,7 +44,7 @@ class ProjectSettingsManager(
       updated = pkg.updateConfig { config =>
         config.copy(edition = Some(newEdition))
       }
-      _ <- Try(updated.save())
+      _ <- Try(updated.save(false))
     } yield SettingsUpdated()
 
   private def setPreferLocalLibraries(
@@ -54,7 +54,7 @@ class ProjectSettingsManager(
     updated = pkg.updateConfig { config =>
       config.copy(preferLocalLibraries = preferLocalLibraries)
     }
-    _ <- Try(updated.save())
+    _ <- Try(updated.save(false))
   } yield SettingsUpdated()
 }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -448,8 +448,9 @@ abstract class BaseServerTest
     if (initializeProjectPackage) {
       PackageManager.Default.create(
         config.projectContentRoot.file,
-        name    = "TestProject",
-        edition = customEdition
+        name            = "TestProject",
+        edition         = customEdition,
+        keepDevVersions = true
       )
     }
   }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -28,9 +28,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import scala.concurrent.duration._
 
-class LibrariesTest
-    extends BaseServerTest
-    with ReportLogsOnFailure {
+class LibrariesTest extends BaseServerTest with ReportLogsOnFailure {
   private val libraryRepositoryPort: Int = 47308
   private val defaultTimeout             = 30.seconds
 
@@ -327,7 +325,10 @@ class LibrariesTest
             componentGroups =
               Some(TestComponentGroups.testLibraryComponentGroups)
           )
-      Files.writeString(packageFile, packageConfig.toYaml)
+      Files.writeString(
+        packageFile,
+        packageConfig.toYaml(keepDevVersions = true)
+      )
 
       client.send(json"""
           { "jsonrpc": "2.0",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -20,7 +20,7 @@ import org.enso.librarymanager.test.published.repository.{
   ExampleRepository
 }
 import org.enso.pkg.{Config, Contact, Package, PackageManager}
-import org.enso.testkit.{FlakySpec, ReportLogsOnFailure}
+import org.enso.testkit.ReportLogsOnFailure
 import org.enso.version.BuildVersion
 import org.enso.yaml.YamlHelper
 
@@ -30,8 +30,7 @@ import scala.concurrent.duration._
 
 class LibrariesTest
     extends BaseServerTest
-    with ReportLogsOnFailure
-    with FlakySpec {
+    with ReportLogsOnFailure {
   private val libraryRepositoryPort: Int = 47308
   private val defaultTimeout             = 30.seconds
 
@@ -60,7 +59,7 @@ class LibrariesTest
   )
 
   "LocalLibraryManager" should {
-    "create a library project and include it on the list of local projects" taggedAs SkipOnFailure in {
+    "create a library project and include it on the list of local projects" in {
       val client          = getInitialisedWsClient()
       val testLibraryName = LibraryName("user", "My_Local_Lib")
 

--- a/engine/launcher/src/test/resources/org/enso/launcher/components/fake-releases/launcher/enso-1.0.2/enso-launcher-1.0.2-macos-aarch64.tar.gz/enso/README.md
+++ b/engine/launcher/src/test/resources/org/enso/launcher/components/fake-releases/launcher/enso-1.0.2/enso-launcher-1.0.2-macos-aarch64.tar.gz/enso/README.md
@@ -1,0 +1,1 @@
+Content

--- a/engine/launcher/src/test/resources/org/enso/launcher/components/fake-releases/launcher/enso-1.0.2/enso-launcher-1.0.2-macos-aarch64.tar.gz/enso/THIRD-PARTY/test-license.txt
+++ b/engine/launcher/src/test/resources/org/enso/launcher/components/fake-releases/launcher/enso-1.0.2/enso-launcher-1.0.2-macos-aarch64.tar.gz/enso/THIRD-PARTY/test-license.txt
@@ -1,0 +1,1 @@
+Test license

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -662,7 +662,8 @@ public class Main {
             "",
             Option$.MODULE$.empty(),
             nil(),
-            Option$.MODULE$.empty());
+            Option$.MODULE$.empty(),
+            false);
     throw exitSuccess();
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
@@ -105,7 +105,6 @@ public class RuntimeProgressTest {
                 true)));
 
     var reply1 = context.receiveNIgnoreStdLib(9, 60);
-    assertEquals(9, reply1.size());
     assertSameElements(
         reply1,
         Response(requestId, new Runtime$Api$PushContextResponse(contextId)),
@@ -176,7 +175,6 @@ public class RuntimeProgressTest {
                 true)));
 
     var reply1 = context.receiveNIgnoreStdLib(11, 60);
-    assertEquals(11, reply1.size());
     assertSameElements(
         reply1,
         Response(requestId, new Runtime$Api$PushContextResponse(contextId)),

--- a/lib/scala/edition-updater/src/main/java/module-info.java
+++ b/lib/scala/edition-updater/src/main/java/module-info.java
@@ -1,6 +1,8 @@
 module org.enso.editions.updater {
   requires scala.library;
+  requires org.enso.cli;
   requires org.enso.distribution;
+  requires org.enso.downloader;
   requires org.enso.editions;
 
   exports org.enso.editions.updater;

--- a/lib/scala/editions/src/main/scala/org/enso/editions/Editions.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/Editions.scala
@@ -322,14 +322,14 @@ trait Editions {
         value.engineVersion
           .map(semverEncoder.encode)
           .foreach(n => elements.add((Fields.EngineVersion, n)))
-        if (value.libraries.nonEmpty)
+        if (value.repositories.nonEmpty)
           elements.add(
             (
               Fields.Repositories,
               repositoriesEncoder.encode(value.repositories.values.toSeq)
             )
           )
-        if (value.repositories.nonEmpty)
+        if (value.libraries.nonEmpty)
           elements.add(
             (
               Fields.Libraries,

--- a/lib/scala/library-manager/src/test/scala/org/enso/librarymanager/test/published/repository/DummyRepository.scala
+++ b/lib/scala/library-manager/src/test/scala/org/enso/librarymanager/test/published/repository/DummyRepository.scala
@@ -97,7 +97,7 @@ abstract class DummyRepository(toolsRootDirectory: Path) {
       namespace = lib.libraryName.namespace,
       version   = lib.version.toString()
     )
-    pkg.save()
+    pkg.save(true)
     pkg
   }
 

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -168,21 +168,23 @@ case class Config(
   jvm: Option[Boolean]
 ) {
 
-  /** Converts the configuration into a YAML representation. */
-  def toYaml: String = {
-    val config: Config = this
-    val noDevEdition: Config =
+  /** Converts the configuration into a YAML representation.
+    *
+    * @param keepDevVersion true if default dev versions should be stored
+    */
+  def toYaml(keepDevVersions: Boolean): String = {
+    val config: Config =
       if (
-        config.edition.exists(
+        !keepDevVersions && edition.exists(
           _.parent
-            .exists(p => p.toString == BuildVersion.defaultDevEnsoVersion())
+            .exists(p => p == BuildVersion.defaultDevEnsoVersion())
         )
       ) {
-        config.copy(edition = None)
+        copy(edition = None)
       } else {
-        config
+        this
       }
-    val node          = implicitly[YamlEncoder[Config]].encode(noDevEdition)
+    val node          = implicitly[YamlEncoder[Config]].encode(config)
     val dumperOptions = new DumperOptions()
     dumperOptions.setIndent(2)
     dumperOptions.setPrettyFlow(true)
@@ -350,7 +352,6 @@ object Config {
             (JsonFields.Maintainer, contactsEncoder.encode(value.maintainers))
           )
         }
-
         value.edition.foreach { edition =>
           if (edition.isDerivingWithoutOverrides)
             elements.add((JsonFields.Edition, edition.parent.get))

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -172,7 +172,7 @@ case class Config(
     *
     * @param keepDevVersion true if default dev versions should be stored
     */
-  def toYaml(keepDevVersions: Boolean): String = {
+  def toYaml(keepDevVersions: Boolean = false): String = {
     val config: Config =
       if (
         !keepDevVersions && edition.exists(

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -93,8 +93,10 @@ final class Package[F](
 
   /** Stores the package metadata on the hard drive. If the package does not exist,
     * creates the required directory structure.
+    *
+    * @param keepDevVersion true if default dev versions should be stored
     */
-  def save(): Unit = {
+  def save(keepDevVersions: Boolean): Unit = {
     try {
       if (!root.exists) root.createDirectories()
       if (!sourceDir.exists) sourceDir.createDirectories()
@@ -102,7 +104,7 @@ final class Package[F](
       case NonFatal(e) => throw CouldNotCreateDirectory(e)
     }
 
-    saveConfig()
+    saveConfig(keepDevVersions)
   }
 
   /** Gets the cache root location within this package for a given Enso version.
@@ -164,15 +166,17 @@ final class Package[F](
     */
   def updateConfig(update: Config => Config): Package[F] = {
     val newPkg = new Package(root, update(config), fileSystem)
-    newPkg.saveConfig()
+    newPkg.saveConfig(false)
     newPkg
   }
 
   /** Saves the config metadata into the package configuration file.
+    *
+    * @param keepDevVersion true if default dev versions should be stored
     */
-  private def saveConfig(): Unit =
+  private def saveConfig(keepDevVersions: Boolean): Unit =
     Using(configFile.newBufferedWriter) { writer =>
-      writer.write(config.toYaml)
+      writer.write(config.toYaml(keepDevVersions))
     }
 
   /** Gets the location of the package's Main file.
@@ -269,17 +273,20 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
 
   /** Creates a new Package in a given location and with config file.
     *
-    * @param root the root location of the package.
-    * @param config the config for the new package.
-    * @return a package object representing the newly created package.
+    * @param root the root location of the package
+    * @param config the config for the new package
+    * @param template defines a template to use for the new package
+    * @param keepDevVersion true if default dev versions should be stored
+    * @return a package object representing the newly created package
     */
   def create(
     root: F,
     config: Config,
-    template: Template
+    template: Template,
+    keepDevVersions: Boolean
   ): Package[F] = {
     val pkg = new Package(root, config, fileSystem)
-    pkg.save()
+    pkg.save(keepDevVersions)
     copyResources(pkg, template)
     pkg
   }
@@ -296,6 +303,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
     *                will not specify any, meaning that the current default one
     *                will be used
     * @param jvm should JVM mode be set for the package
+    * @param keepDevVersion true if default dev versions should be stored
     * @return a package object representing the newly created package.
     */
   def create(
@@ -311,7 +319,8 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
     license: String                          = "",
     componentGroups: Option[ComponentGroups] = None,
     services: List[ProvidesWith]             = List(),
-    jvm: Option[Boolean]                     = None
+    jvm: Option[Boolean]                     = None,
+    keepDevVersions: Boolean                 = false
   ): Package[F] = {
     val config = Config(
       name                 = name,
@@ -327,7 +336,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
       services             = services,
       jvm                  = jvm
     )
-    create(root, config, template)
+    create(root, config, template, keepDevVersions)
   }
 
   /** Tries to parse package structure from a given root location.

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -105,7 +105,7 @@ class ConfigSpec
       parsed.moduleName shouldEqual "FooBar"
 
       val ser = parsed.toYaml(keepDevVersions = true)
-      ser shouldEqual "name: fooBar\nnamespace: local\n"
+      ser shouldEqual "name: fooBar\nnamespace: local\nedition: 0.0.0-dev\n"
     }
 
     "correctly de-serialize and serialize back the shortened edition syntax " +

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -98,7 +98,7 @@ class ConfigSpec
       ser shouldEqual "name: fooBar\nnamespace: local\nedition: 2024.4.2\n"
     }
 
-    "don't persist dev edition" in {
+    "persist dev edition if requested" in {
       val parsed = Config.fromYaml("name: fooBar\nedition: 0.0.0-dev").get
       parsed.name shouldEqual "fooBar"
       parsed.normalizedName shouldEqual None
@@ -106,6 +106,16 @@ class ConfigSpec
 
       val ser = parsed.toYaml(keepDevVersions = true)
       ser shouldEqual "name: fooBar\nnamespace: local\nedition: 0.0.0-dev\n"
+    }
+
+    "don't persist dev edition by default" in {
+      val parsed = Config.fromYaml("name: fooBar\nedition: 0.0.0-dev").get
+      parsed.name shouldEqual "fooBar"
+      parsed.normalizedName shouldEqual None
+      parsed.moduleName shouldEqual "FooBar"
+
+      val ser = parsed.toYaml()
+      ser shouldEqual "name: fooBar\nnamespace: local\n"
     }
 
     "correctly de-serialize and serialize back the shortened edition syntax " +

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -36,7 +36,8 @@ class ConfigSpec
         services             = List(),
         jvm                  = None
       )
-      val deserialized = Config.fromYaml(config.toYaml).get
+      val deserialized =
+        Config.fromYaml(config.toYaml(keepDevVersions = true)).get
       deserialized shouldEqual config
     }
 
@@ -93,7 +94,7 @@ class ConfigSpec
       parsed.normalizedName shouldEqual None
       parsed.moduleName shouldEqual "FooBar"
 
-      val ser = parsed.toYaml
+      val ser = parsed.toYaml(keepDevVersions = true)
       ser shouldEqual "name: fooBar\nnamespace: local\nedition: 2024.4.2\n"
     }
 
@@ -103,7 +104,7 @@ class ConfigSpec
       parsed.normalizedName shouldEqual None
       parsed.moduleName shouldEqual "FooBar"
 
-      val ser = parsed.toYaml
+      val ser = parsed.toYaml(keepDevVersions = true)
       ser shouldEqual "name: fooBar\nnamespace: local\n"
     }
 
@@ -117,7 +118,7 @@ class ConfigSpec
 
       parsed.edition.get.parent should contain("2020.1")
 
-      val serialized = parsed.toYaml
+      val serialized = parsed.toYaml(keepDevVersions = true)
       serialized should include("edition: '2020.1'")
     }
 
@@ -182,7 +183,7 @@ class ConfigSpec
       )
       parsed.componentGroups shouldEqual Some(expectedComponentGroups)
 
-      val serialized = parsed.toYaml
+      val serialized = parsed.toYaml(keepDevVersions = true)
       serialized should include(
         """component-groups:
           |  new:

--- a/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/DataQualityMetrics.java
@@ -62,6 +62,9 @@ public abstract class DataQualityMetrics {
   public static final String NEEDS_FORMATTING = "_Needs Formatting";
   public static final String TYPE_RECORD = "Types and Counts";
 
+  // Default threshold for checking distinct values count.
+  public static final int DISTINCT_THRESHOLD = 100;
+
   // Default seed for random number generation (no specific reason for this value, just stability on
   // results).
   public static final long RANDOM_SEED = 677280131;
@@ -200,7 +203,7 @@ public abstract class DataQualityMetrics {
 
       public Result getResult() {
         String distinctJson = null;
-        if (distinct.size() < 100) {
+        if (distinct.size() < DISTINCT_THRESHOLD) {
           distinctJson =
               "["
                   + distinct.stream()
@@ -308,13 +311,11 @@ public abstract class DataQualityMetrics {
     }
 
     public T getMinimum() {
-      var current = result.getNow(null);
-      return current != null ? current.minimum : null;
+      return result.thenApply(Result::minimum).getNow(null);
     }
 
     public T getMaximum() {
-      var current = result.getNow(null);
-      return current != null ? current.maximum : null;
+      return result.thenApply(Result::maximum).getNow(null);
     }
 
     @Override


### PR DESCRIPTION
### Pull Request Description

An attempt to fix remaining failures in our extra tests running nightly.
Partial revert of #11805 was needed as some of our tests use the dev version and broke in the process.
Regular CI builds didn't complain, apparently, since the problematic test used the "skip-on-failure" exception but locally it was problematic.

### Important Notes

This is an attempt to make [Engine Nightly Checks](https://github.com/enso-org/enso/actions/workflows/engine-checks-nightly.yml) pass.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
