### PR TITLE
Refactor usage of Java IR types

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/MiniIRPass.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/MiniIRPass.java
@@ -14,8 +14,8 @@ import org.enso.compiler.core.ir.Module;
  * IR#mapExpressions(Function)}. Hence, the additional method {@link #transformModule(Module)}.
  *
  * <p>In the first, <b>prepare</b> phase, the compiler traverses from the root to the leaves and
- * calls the {@link #prepare(Expression)} method on the mini pass. During this phase, the mini pass
- * can gather information about the current IR element, but not modify it.
+ * calls the {@link #prepare(IR, Expression)} method on the mini pass. During this phase, the mini
+ * pass can gather information about the current IR element, but not modify it.
  *
  * <p>In the second, <b>transform</b> phase, the compiler returns from the leaves to the root and
  * calls the {@link #transformExpression(Expression)} method on the mini pass. During this phase,
@@ -25,13 +25,13 @@ import org.enso.compiler.core.ir.Module;
  * <p>For each IR element:
  *
  * <ol>
- *   <li>The {@link #prepare(Expression)} method is called to prepare the pass for the current IR
- *       element. This method is called when the {@link org.enso.compiler.Compiler} traverses the IR
- *       tree from top to bottom. This is useful for mini passes that need to build some information
- *       about the current IR element before transforming it. The mini pass must not modify the IR
- *       element neither attach any metadata to it in this method. By returning {@code null} from
- *       this method, the mini pass signals to the compiler that it wishes to not process the
- *       subtree of the current IR element.
+ *   <li>The {@link #prepare(IR, Expression)} method is called to prepare the pass for the current
+ *       IR element. This method is called when the {@link org.enso.compiler.Compiler} traverses the
+ *       IR tree from top to bottom. This is useful for mini passes that need to build some
+ *       information about the current IR element before transforming it. The mini pass must not
+ *       modify the IR element neither attach any metadata to it in this method. By returning {@code
+ *       null} from this method, the mini pass signals to the compiler that it wishes to not process
+ *       the subtree of the current IR element.
  *   <li>The {@link #transformExpression(Expression)} method is called to transform the current IR
  *       element. This method is called when the {@link org.enso.compiler.Compiler} traverses the
  *       element from bottom to top. All the children of the current IR element are already

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/TailCall.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/TailCall.java
@@ -378,7 +378,7 @@ public final class TailCall implements MiniPassFactory {
     private void collectTailCandicateFunction(
         Function function, java.util.Map<IR, Boolean> tailCandidates) {
       var canBeTCO = function.canBeTCO();
-      var markAsTail = (!canBeTCO && isInTailPos) || canBeTCO;
+      var markAsTail = canBeTCO || isInTailPos;
       switch (function) {
         case Function.Lambda l -> {
           if (markAsTail) {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/OperatorToFunctionMini.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/OperatorToFunctionMini.java
@@ -17,13 +17,14 @@ public class OperatorToFunctionMini extends MiniIRPass {
       ListBuffer<CallArgument> args = new ListBuffer<>();
       args.addOne(binOp.left());
       args.addOne(binOp.right());
-      return new Application.Prefix(
-          binOp.operator(),
-          args.toList(),
-          false,
-          binOp.location().isDefined() ? binOp.location().get() : null,
-          binOp.passData(),
-          binOp.diagnostics());
+      return Application.Prefix.builder()
+          .function(binOp.operator())
+          .arguments(args.toList())
+          .hasDefaultsSuspended(false)
+          .location(binOp.location().isDefined() ? binOp.location().get() : null)
+          .passData(binOp.passData())
+          .diagnostics(binOp.diagnostics())
+          .build();
     }
     return ir;
   }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
@@ -77,42 +77,43 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionLeft.location().isDefined() ? sectionLeft.location().get() : null;
           var passData = sectionLeft.passData();
           var rightArgName = freshNameSupply.newName(false, Option.empty());
-          var rightCallArg = CallArgument.Specified.builder()
-              .name(Option.empty())
-              .value(rightArgName)
-              .isSynthetic(true)
-              .build();
-          var rightDefArg = DefinitionArgument.Specified.builder()
-              .name(
-                  rightArgName.duplicate(true, true, true, false)
-              )
-              .ascribedType(Option.empty())
-              .defaultValue(Option.empty())
-              .suspended(false)
-              .build();
+          var rightCallArg =
+              CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(rightArgName)
+                  .isSynthetic(true)
+                  .build();
+          var rightDefArg =
+              DefinitionArgument.Specified.builder()
+                  .name(rightArgName.duplicate(true, true, true, false))
+                  .ascribedType(Option.empty())
+                  .defaultValue(Option.empty())
+                  .suspended(false)
+                  .build();
 
           if (arg.value() instanceof Name.Blank) {
             var leftArgName = freshNameSupply.newName(false, Option.empty());
-            var leftCallArg = CallArgument.Specified.builder()
-                .name(Option.empty())
-                .value(leftArgName)
-                .isSynthetic(true)
-                .build();
-            var leftDefArg = DefinitionArgument.Specified.builder()
-                .name(
-                    leftArgName.duplicate(true, true, true, false)
-                )
-                .ascribedType(Option.empty())
-                .defaultValue(Option.empty())
-                .suspended(false)
-                .build();
-            var opCall = Application.Prefix.builder()
-                .function(op)
-                .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
-                .hasDefaultsSuspended(false)
-                .passData(passData)
-                .diagnostics(sectionLeft.diagnostics())
-                .build();
+            var leftCallArg =
+                CallArgument.Specified.builder()
+                    .name(Option.empty())
+                    .value(leftArgName)
+                    .isSynthetic(true)
+                    .build();
+            var leftDefArg =
+                DefinitionArgument.Specified.builder()
+                    .name(leftArgName.duplicate(true, true, true, false))
+                    .ascribedType(Option.empty())
+                    .defaultValue(Option.empty())
+                    .suspended(false)
+                    .build();
+            var opCall =
+                Application.Prefix.builder()
+                    .function(op)
+                    .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+                    .hasDefaultsSuspended(false)
+                    .passData(passData)
+                    .diagnostics(sectionLeft.diagnostics())
+                    .build();
 
             var rightLam =
                 new Function.Lambda(cons(rightDefArg, nil()), opCall, null, true, meta());
@@ -135,42 +136,43 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionSides.location().isDefined() ? sectionSides.location().get() : null;
           var passData = sectionSides.passData();
           var leftArgName = freshNameSupply.newName(false, Option.empty());
-          var leftCallArg = CallArgument.Specified.builder()
-              .name(Option.empty())
-              .value(leftArgName)
-              .isSynthetic(true)
-              .build();
-          var leftDefArg = DefinitionArgument.Specified.builder()
-              .name(
-                  leftArgName.duplicate(true, true, true, false)
-              )
-              .ascribedType(Option.empty())
-              .defaultValue(Option.empty())
-              .suspended(false)
-              .build();
+          var leftCallArg =
+              CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(leftArgName)
+                  .isSynthetic(true)
+                  .build();
+          var leftDefArg =
+              DefinitionArgument.Specified.builder()
+                  .name(leftArgName.duplicate(true, true, true, false))
+                  .ascribedType(Option.empty())
+                  .defaultValue(Option.empty())
+                  .suspended(false)
+                  .build();
 
           var rightArgName = freshNameSupply.newName(false, Option.empty());
-          var rightCallArg = CallArgument.Specified.builder()
-              .name(Option.empty())
-              .value(rightArgName)
-              .isSynthetic(true)
-              .build();
-          var rightDefArg = DefinitionArgument.Specified.builder()
-              .name(
-                  rightArgName.duplicate(true, true, true, false)
-              )
-              .ascribedType(Option.empty())
-              .defaultValue(Option.empty())
-              .suspended(false)
-              .build();
+          var rightCallArg =
+              CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(rightArgName)
+                  .isSynthetic(true)
+                  .build();
+          var rightDefArg =
+              DefinitionArgument.Specified.builder()
+                  .name(rightArgName.duplicate(true, true, true, false))
+                  .ascribedType(Option.empty())
+                  .defaultValue(Option.empty())
+                  .suspended(false)
+                  .build();
 
-          var opCall = Application.Prefix.builder()
-              .function(op)
-              .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
-              .hasDefaultsSuspended(false)
-              .passData(passData)
-              .diagnostics(sectionSides.diagnostics())
-              .build();
+          var opCall =
+              Application.Prefix.builder()
+                  .function(op)
+                  .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+                  .hasDefaultsSuspended(false)
+                  .passData(passData)
+                  .diagnostics(sectionSides.diagnostics())
+                  .build();
 
           var rightLambda =
               new Function.Lambda(cons(rightDefArg, nil()), opCall, null, true, meta());
@@ -203,56 +205,58 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionRight.location().isDefined() ? sectionRight.location().get() : null;
           var passData = sectionRight.passData();
           var leftArgName = freshNameSupply.newName(false, Option.empty());
-          var leftCallArg = CallArgument.Specified.builder()
-              .name(Option.empty())
-              .value(leftArgName)
-              .isSynthetic(true)
-              .build();
-          var leftDefArg = DefinitionArgument.Specified.builder()
-              .name(
-                  leftArgName.duplicate(true, true, true, false)
-              )
-              .ascribedType(Option.empty())
-              .defaultValue(Option.empty())
-              .suspended(false)
-              .build();
+          var leftCallArg =
+              CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(leftArgName)
+                  .isSynthetic(true)
+                  .build();
+          var leftDefArg =
+              DefinitionArgument.Specified.builder()
+                  .name(leftArgName.duplicate(true, true, true, false))
+                  .ascribedType(Option.empty())
+                  .defaultValue(Option.empty())
+                  .suspended(false)
+                  .build();
 
           if (arg.value() instanceof Name.Blank) {
             // Note [Blanks in Sections]
             var rightArgName = freshNameSupply.newName(false, Option.empty());
-            var rightCallArg = CallArgument.Specified.builder()
-                .name(Option.empty())
-                .value(rightArgName)
-                .isSynthetic(true)
-                .build();
-            var rightDefArg = DefinitionArgument.Specified.builder()
-                .name(
-                    rightArgName.duplicate(true, true, true, false)
-                )
-                .ascribedType(Option.empty())
-                .defaultValue(Option.empty())
-                .suspended(false)
-                .build();
+            var rightCallArg =
+                CallArgument.Specified.builder()
+                    .name(Option.empty())
+                    .value(rightArgName)
+                    .isSynthetic(true)
+                    .build();
+            var rightDefArg =
+                DefinitionArgument.Specified.builder()
+                    .name(rightArgName.duplicate(true, true, true, false))
+                    .ascribedType(Option.empty())
+                    .defaultValue(Option.empty())
+                    .suspended(false)
+                    .build();
 
-            var opCall = Application.Prefix.builder()
-                .function(op)
-                .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
-                .hasDefaultsSuspended(false)
-                .passData(passData)
-                .diagnostics(sectionRight.diagnostics())
-                .build();
+            var opCall =
+                Application.Prefix.builder()
+                    .function(op)
+                    .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+                    .hasDefaultsSuspended(false)
+                    .passData(passData)
+                    .diagnostics(sectionRight.diagnostics())
+                    .build();
 
             var leftLam = new Function.Lambda(cons(leftDefArg, nil()), opCall, null, true, meta());
 
             yield new Function.Lambda(cons(rightDefArg, nil()), leftLam, loc, true, meta());
           } else {
-            var opCall = Application.Prefix.builder()
-                .function(op)
-                .arguments(cons(leftCallArg, cons(arg, nil())))
-                .hasDefaultsSuspended(false)
-                .passData(passData)
-                .diagnostics(sectionRight.diagnostics())
-                .build();
+            var opCall =
+                Application.Prefix.builder()
+                    .function(op)
+                    .arguments(cons(leftCallArg, cons(arg, nil())))
+                    .hasDefaultsSuspended(false)
+                    .passData(passData)
+                    .diagnostics(sectionRight.diagnostics())
+                    .build();
 
             yield new Function.Lambda(cons(leftDefArg, nil()), opCall, loc, true, meta());
           }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
@@ -86,8 +86,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var rightDefArg =
               DefinitionArgument.Specified.builder()
                   .name(rightArgName.duplicate(true, true, true, false))
-                  .ascribedType(Option.empty())
-                  .defaultValue(Option.empty())
                   .suspended(false)
                   .build();
 
@@ -102,8 +100,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
             var leftDefArg =
                 DefinitionArgument.Specified.builder()
                     .name(leftArgName.duplicate(true, true, true, false))
-                    .ascribedType(Option.empty())
-                    .defaultValue(Option.empty())
                     .suspended(false)
                     .build();
             var opCall =
@@ -145,8 +141,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var leftDefArg =
               DefinitionArgument.Specified.builder()
                   .name(leftArgName.duplicate(true, true, true, false))
-                  .ascribedType(Option.empty())
-                  .defaultValue(Option.empty())
                   .suspended(false)
                   .build();
 
@@ -160,8 +154,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var rightDefArg =
               DefinitionArgument.Specified.builder()
                   .name(rightArgName.duplicate(true, true, true, false))
-                  .ascribedType(Option.empty())
-                  .defaultValue(Option.empty())
                   .suspended(false)
                   .build();
 
@@ -214,8 +206,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var leftDefArg =
               DefinitionArgument.Specified.builder()
                   .name(leftArgName.duplicate(true, true, true, false))
-                  .ascribedType(Option.empty())
-                  .defaultValue(Option.empty())
                   .suspended(false)
                   .build();
 
@@ -231,8 +221,6 @@ public final class SectionsToBinOp implements MiniPassFactory {
             var rightDefArg =
                 DefinitionArgument.Specified.builder()
                     .name(rightArgName.duplicate(true, true, true, false))
-                    .ascribedType(Option.empty())
-                    .defaultValue(Option.empty())
                     .suspended(false)
                     .build();
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/desugar/SectionsToBinOp.java
@@ -77,45 +77,56 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionLeft.location().isDefined() ? sectionLeft.location().get() : null;
           var passData = sectionLeft.passData();
           var rightArgName = freshNameSupply.newName(false, Option.empty());
-          var rightCallArg =
-              new CallArgument.Specified(Option.empty(), rightArgName, true, null, meta());
-          var rightDefArg =
-              new DefinitionArgument.Specified(
-                  rightArgName.duplicate(true, true, true, false),
-                  Option.empty(),
-                  Option.empty(),
-                  false,
-                  null,
-                  meta());
+          var rightCallArg = CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(rightArgName)
+              .isSynthetic(true)
+              .build();
+          var rightDefArg = DefinitionArgument.Specified.builder()
+              .name(
+                  rightArgName.duplicate(true, true, true, false)
+              )
+              .ascribedType(Option.empty())
+              .defaultValue(Option.empty())
+              .suspended(false)
+              .build();
 
           if (arg.value() instanceof Name.Blank) {
             var leftArgName = freshNameSupply.newName(false, Option.empty());
-            var leftCallArg =
-                new CallArgument.Specified(Option.empty(), leftArgName, true, null, meta());
-            var leftDefArg =
-                new DefinitionArgument.Specified(
-                    leftArgName.duplicate(true, true, true, false),
-                    Option.empty(),
-                    Option.empty(),
-                    false,
-                    null,
-                    meta());
-            var opCall =
-                new Application.Prefix(
-                    op,
-                    cons(leftCallArg, cons(rightCallArg, nil())),
-                    false,
-                    null,
-                    passData,
-                    sectionLeft.diagnostics());
+            var leftCallArg = CallArgument.Specified.builder()
+                .name(Option.empty())
+                .value(leftArgName)
+                .isSynthetic(true)
+                .build();
+            var leftDefArg = DefinitionArgument.Specified.builder()
+                .name(
+                    leftArgName.duplicate(true, true, true, false)
+                )
+                .ascribedType(Option.empty())
+                .defaultValue(Option.empty())
+                .suspended(false)
+                .build();
+            var opCall = Application.Prefix.builder()
+                .function(op)
+                .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+                .hasDefaultsSuspended(false)
+                .passData(passData)
+                .diagnostics(sectionLeft.diagnostics())
+                .build();
 
             var rightLam =
                 new Function.Lambda(cons(rightDefArg, nil()), opCall, null, true, meta());
 
             yield new Function.Lambda(cons(leftDefArg, nil()), rightLam, loc, true, meta());
           } else {
-            yield new Application.Prefix(
-                op, cons(arg, nil()), false, loc, passData, sectionLeft.diagnostics());
+            yield Application.Prefix.builder()
+                .function(op)
+                .arguments(cons(arg, nil()))
+                .hasDefaultsSuspended(false)
+                .location(loc)
+                .passData(passData)
+                .diagnostics(sectionLeft.diagnostics())
+                .build();
           }
         }
 
@@ -124,37 +135,42 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionSides.location().isDefined() ? sectionSides.location().get() : null;
           var passData = sectionSides.passData();
           var leftArgName = freshNameSupply.newName(false, Option.empty());
-          var leftCallArg =
-              new CallArgument.Specified(Option.empty(), leftArgName, true, null, meta());
-          var leftDefArg =
-              new DefinitionArgument.Specified(
-                  leftArgName.duplicate(true, true, true, false),
-                  Option.empty(),
-                  Option.empty(),
-                  false,
-                  null,
-                  meta());
+          var leftCallArg = CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(leftArgName)
+              .isSynthetic(true)
+              .build();
+          var leftDefArg = DefinitionArgument.Specified.builder()
+              .name(
+                  leftArgName.duplicate(true, true, true, false)
+              )
+              .ascribedType(Option.empty())
+              .defaultValue(Option.empty())
+              .suspended(false)
+              .build();
 
           var rightArgName = freshNameSupply.newName(false, Option.empty());
-          var rightCallArg =
-              new CallArgument.Specified(Option.empty(), rightArgName, true, null, meta());
-          var rightDefArg =
-              new DefinitionArgument.Specified(
-                  rightArgName.duplicate(true, true, true, false),
-                  Option.empty(),
-                  Option.empty(),
-                  false,
-                  null,
-                  meta());
+          var rightCallArg = CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(rightArgName)
+              .isSynthetic(true)
+              .build();
+          var rightDefArg = DefinitionArgument.Specified.builder()
+              .name(
+                  rightArgName.duplicate(true, true, true, false)
+              )
+              .ascribedType(Option.empty())
+              .defaultValue(Option.empty())
+              .suspended(false)
+              .build();
 
-          var opCall =
-              new Application.Prefix(
-                  op,
-                  cons(leftCallArg, cons(rightCallArg, nil())),
-                  false,
-                  null,
-                  passData,
-                  sectionSides.diagnostics());
+          var opCall = Application.Prefix.builder()
+              .function(op)
+              .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+              .hasDefaultsSuspended(false)
+              .passData(passData)
+              .diagnostics(sectionSides.diagnostics())
+              .build();
 
           var rightLambda =
               new Function.Lambda(cons(rightDefArg, nil()), opCall, null, true, meta());
@@ -187,52 +203,56 @@ public final class SectionsToBinOp implements MiniPassFactory {
           var loc = sectionRight.location().isDefined() ? sectionRight.location().get() : null;
           var passData = sectionRight.passData();
           var leftArgName = freshNameSupply.newName(false, Option.empty());
-          var leftCallArg =
-              new CallArgument.Specified(Option.empty(), leftArgName, true, null, meta());
-          var leftDefArg =
-              new DefinitionArgument.Specified(
-                  leftArgName.duplicate(true, true, true, false),
-                  Option.empty(),
-                  Option.empty(),
-                  false,
-                  null,
-                  meta());
+          var leftCallArg = CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(leftArgName)
+              .isSynthetic(true)
+              .build();
+          var leftDefArg = DefinitionArgument.Specified.builder()
+              .name(
+                  leftArgName.duplicate(true, true, true, false)
+              )
+              .ascribedType(Option.empty())
+              .defaultValue(Option.empty())
+              .suspended(false)
+              .build();
 
           if (arg.value() instanceof Name.Blank) {
             // Note [Blanks in Sections]
             var rightArgName = freshNameSupply.newName(false, Option.empty());
-            var rightCallArg =
-                new CallArgument.Specified(Option.empty(), rightArgName, true, null, meta());
-            var rightDefArg =
-                new DefinitionArgument.Specified(
-                    rightArgName.duplicate(true, true, true, false),
-                    Option.empty(),
-                    Option.empty(),
-                    false,
-                    null,
-                    meta());
+            var rightCallArg = CallArgument.Specified.builder()
+                .name(Option.empty())
+                .value(rightArgName)
+                .isSynthetic(true)
+                .build();
+            var rightDefArg = DefinitionArgument.Specified.builder()
+                .name(
+                    rightArgName.duplicate(true, true, true, false)
+                )
+                .ascribedType(Option.empty())
+                .defaultValue(Option.empty())
+                .suspended(false)
+                .build();
 
-            var opCall =
-                new Application.Prefix(
-                    op,
-                    cons(leftCallArg, cons(rightCallArg, nil())),
-                    false,
-                    null,
-                    passData,
-                    sectionRight.diagnostics());
+            var opCall = Application.Prefix.builder()
+                .function(op)
+                .arguments(cons(leftCallArg, cons(rightCallArg, nil())))
+                .hasDefaultsSuspended(false)
+                .passData(passData)
+                .diagnostics(sectionRight.diagnostics())
+                .build();
 
             var leftLam = new Function.Lambda(cons(leftDefArg, nil()), opCall, null, true, meta());
 
             yield new Function.Lambda(cons(rightDefArg, nil()), leftLam, loc, true, meta());
           } else {
-            var opCall =
-                new Application.Prefix(
-                    op,
-                    cons(leftCallArg, cons(arg, nil())),
-                    false,
-                    null,
-                    passData,
-                    sectionRight.diagnostics());
+            var opCall = Application.Prefix.builder()
+                .function(op)
+                .arguments(cons(leftCallArg, cons(arg, nil())))
+                .hasDefaultsSuspended(false)
+                .passData(passData)
+                .diagnostics(sectionRight.diagnostics())
+                .build();
 
             yield new Function.Lambda(cons(leftDefArg, nil()), opCall, loc, true, meta());
           }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
@@ -205,9 +205,7 @@ public final class MethodDefinitions implements MiniPassFactory {
         // added to avoid modifying the dispatch mechanism.
         var syntheticModuleSelfArg =
             DefinitionArgument.Specified.builder()
-                .name(
-                    new Name.Self(null, true, new MetadataStorage())
-                )
+                .name(new Name.Self(null, true, new MetadataStorage()))
                 .ascribedType(Option.empty())
                 .defaultValue(Option.empty())
                 .suspended(false)

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
@@ -206,8 +206,6 @@ public final class MethodDefinitions implements MiniPassFactory {
         var syntheticModuleSelfArg =
             DefinitionArgument.Specified.builder()
                 .name(new Name.Self(null, true, new MetadataStorage()))
-                .ascribedType(Option.empty())
-                .defaultValue(Option.empty())
                 .suspended(false)
                 .build();
         var newBody =

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/resolve/MethodDefinitions.java
@@ -204,13 +204,14 @@ public final class MethodDefinitions implements MiniPassFactory {
         // is
         // added to avoid modifying the dispatch mechanism.
         var syntheticModuleSelfArg =
-            new DefinitionArgument.Specified(
-                new Name.Self(null, true, new MetadataStorage()),
-                Option.empty(),
-                Option.empty(),
-                false,
-                null,
-                new MetadataStorage());
+            DefinitionArgument.Specified.builder()
+                .name(
+                    new Name.Self(null, true, new MetadataStorage())
+                )
+                .ascribedType(Option.empty())
+                .defaultValue(Option.empty())
+                .suspended(false)
+                .build();
         var newBody =
             new Function.Lambda(
                 // This is the synthetic Self argument that gets the static module

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -178,14 +178,14 @@ case object AliasAnalysis extends IRPass {
             case Some(meta) =>
               val newMeta = meta match {
                 case root: alias.AliasMetadata.RootScope =>
-                  root.copy(graph = copyRootScopeGraph)
+                  root.copy(copyRootScopeGraph)
                 case child: alias.AliasMetadata.ChildScope =>
                   child.copy(
-                    graph = copyRootScopeGraph,
-                    scope = child.scope.deepCopy(scopeMapping)
+                    copyRootScopeGraph,
+                    child.scope.deepCopy(scopeMapping)
                   )
                 case occ: alias.AliasMetadata.Occurrence =>
-                  occ.copy(graph = copyRootScopeGraph)
+                  occ.copy(copyRootScopeGraph)
               }
               alias.AliasMetadata.updateMetadata(copyNode, newMeta)
             case None =>
@@ -602,8 +602,8 @@ case object AliasAnalysis extends IRPass {
     application match {
       case app: Application.Prefix =>
         app.copy(
-          function  = analyseExpression(app.function, builder),
-          arguments = analyseCallArguments(app.arguments, builder)
+          analyseExpression(app.function, builder),
+          analyseCallArguments(app.arguments, builder)
         )
       case app: Application.Force =>
         app.copyWithTarget(analyseExpression(app.target, builder))

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
@@ -306,10 +306,10 @@ object AutomaticParallelism extends IRPass {
       Expression
         .Binding(
           _,
-          new Application.Prefix(
-            Name.Special(Name.Special.NewRef, null),
-            List()
-          ),
+          Application.Prefix.builder()
+            .function(Name.Special(Name.Special.NewRef, null))
+            .arguments(List())
+            .build(),
           null
         )
         .updateMetadata(
@@ -321,37 +321,36 @@ object AutomaticParallelism extends IRPass {
       val blockBody =
         exprs.map(_.ir).flatMap {
           case bind: Expression.Binding =>
-            val refWrite = new Application.Prefix(
-              Name.Special(Name.Special.WriteRef, null),
-              List(
-                new CallArgument.Specified(
-                  None,
-                  refVars(bind.name).duplicate(),
-                  true,
-                  null
-                ),
-                new CallArgument.Specified(
-                  None,
-                  bind.name.duplicate(),
-                  true,
-                  null
+            val refWrite = Application.Prefix.builder()
+              .function(Name.Special(Name.Special.WriteRef, null))
+              .arguments(
+                List(
+                  CallArgument.Specified.builder()
+                    .name(None)
+                    .value(refVars(bind.name).duplicate())
+                    .isSynthetic(true)
+                    .build(),
+                  CallArgument.Specified.builder()
+                    .name(None)
+                    .value(bind.name.duplicate())
+                    .isSynthetic(true)
+                    .build()
                 )
               )
-            )
+              .build()
             List(bind, refWrite)
           case other => List(other)
         }
-      val spawn = new Application.Prefix(
-        Name.Special(Name.Special.RunThread, null),
-        List(
-          new CallArgument.Specified(
-            None,
-            Expression.Block(blockBody.init, blockBody.last, null),
-            true,
-            null
-          )
-        )
-      )
+      val spawn = Application.Prefix.builder()
+        .function(Name.Special(Name.Special.RunThread, null))
+        .arguments(List(
+          CallArgument.Specified.builder()
+            .name(None)
+            .value(Expression.Block(blockBody.init, blockBody.last, null))
+            .isSynthetic(true)
+            .build()
+        ))
+        .build()
       Expression
         .Binding(freshNameSupply.newName(), spawn, null)
         .updateMetadata(
@@ -360,22 +359,32 @@ object AutomaticParallelism extends IRPass {
     }
 
     val threadJoins = threadSpawns.map { bind =>
-      new Application.Prefix(
-        Name.Special(Name.Special.JoinThread, null),
-        List(
-          new CallArgument.Specified(None, bind.name.duplicate(), true, null)
-        )
-      )
+      Application.Prefix.builder()
+        .function(Name.Special(Name.Special.JoinThread, null))
+        .arguments(List(
+          CallArgument.Specified.builder()
+            .name(None)
+            .value(bind.name.duplicate())
+            .isSynthetic(true)
+            .build()
+        ))
+        .build()
     }
 
     val varReads = refVars.map { case (name, ref) =>
       Expression
         .Binding(
           name.duplicate(),
-          new Application.Prefix(
-            Name.Special(Name.Special.ReadRef, null),
-            List(new CallArgument.Specified(None, ref.duplicate(), true, null))
-          ),
+          Application.Prefix.builder()
+            .function(Name.Special(Name.Special.ReadRef, null))
+            .arguments(List(
+              CallArgument.Specified.builder()
+                .name(None)
+                .value(ref.duplicate())
+                .isSynthetic(true)
+                .build()
+            ))
+            .build(),
           null
         )
         .updateMetadata(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
@@ -306,7 +306,8 @@ object AutomaticParallelism extends IRPass {
       Expression
         .Binding(
           _,
-          Application.Prefix.builder()
+          Application.Prefix
+            .builder()
             .function(Name.Special(Name.Special.NewRef, null))
             .arguments(List())
             .build(),
@@ -321,16 +322,19 @@ object AutomaticParallelism extends IRPass {
       val blockBody =
         exprs.map(_.ir).flatMap {
           case bind: Expression.Binding =>
-            val refWrite = Application.Prefix.builder()
+            val refWrite = Application.Prefix
+              .builder()
               .function(Name.Special(Name.Special.WriteRef, null))
               .arguments(
                 List(
-                  CallArgument.Specified.builder()
+                  CallArgument.Specified
+                    .builder()
                     .name(None)
                     .value(refVars(bind.name).duplicate())
                     .isSynthetic(true)
                     .build(),
-                  CallArgument.Specified.builder()
+                  CallArgument.Specified
+                    .builder()
                     .name(None)
                     .value(bind.name.duplicate())
                     .isSynthetic(true)
@@ -341,15 +345,19 @@ object AutomaticParallelism extends IRPass {
             List(bind, refWrite)
           case other => List(other)
         }
-      val spawn = Application.Prefix.builder()
+      val spawn = Application.Prefix
+        .builder()
         .function(Name.Special(Name.Special.RunThread, null))
-        .arguments(List(
-          CallArgument.Specified.builder()
-            .name(None)
-            .value(Expression.Block(blockBody.init, blockBody.last, null))
-            .isSynthetic(true)
-            .build()
-        ))
+        .arguments(
+          List(
+            CallArgument.Specified
+              .builder()
+              .name(None)
+              .value(Expression.Block(blockBody.init, blockBody.last, null))
+              .isSynthetic(true)
+              .build()
+          )
+        )
         .build()
       Expression
         .Binding(freshNameSupply.newName(), spawn, null)
@@ -359,15 +367,19 @@ object AutomaticParallelism extends IRPass {
     }
 
     val threadJoins = threadSpawns.map { bind =>
-      Application.Prefix.builder()
+      Application.Prefix
+        .builder()
         .function(Name.Special(Name.Special.JoinThread, null))
-        .arguments(List(
-          CallArgument.Specified.builder()
-            .name(None)
-            .value(bind.name.duplicate())
-            .isSynthetic(true)
-            .build()
-        ))
+        .arguments(
+          List(
+            CallArgument.Specified
+              .builder()
+              .name(None)
+              .value(bind.name.duplicate())
+              .isSynthetic(true)
+              .build()
+          )
+        )
         .build()
     }
 
@@ -375,15 +387,19 @@ object AutomaticParallelism extends IRPass {
       Expression
         .Binding(
           name.duplicate(),
-          Application.Prefix.builder()
+          Application.Prefix
+            .builder()
             .function(Name.Special(Name.Special.ReadRef, null))
-            .arguments(List(
-              CallArgument.Specified.builder()
-                .name(None)
-                .value(ref.duplicate())
-                .isSynthetic(true)
-                .build()
-            ))
+            .arguments(
+              List(
+                CallArgument.Specified
+                  .builder()
+                  .name(None)
+                  .value(ref.duplicate())
+                  .isSynthetic(true)
+                  .build()
+              )
+            )
             .build(),
           null
         )

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -345,8 +345,8 @@ case object DataflowAnalysis extends IRPass {
 
         prefix
           .copy(
-            function  = analyseExpression(prefix.function, info),
-            arguments = prefix.arguments.map(analyseCallArgument(_, info))
+            analyseExpression(prefix.function, info),
+            prefix.arguments.map(analyseCallArgument(_, info))
           )
           .updateMetadata(new MetadataPair(this, info))
       case force: Application.Force =>

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -229,8 +229,8 @@ case object DemandAnalysis extends IRPass {
           case e       => analyseExpression(e, isInsideCallArgument = false)
         }
         pref.copy(
-          function  = newFun,
-          arguments = pref.arguments.map(analyseCallArgument)
+          newFun,
+          pref.arguments.map(analyseCallArgument)
         )
       case force: Application.Force =>
         force.copyWithTarget(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -190,11 +190,10 @@ case object DemandAnalysis extends IRPass {
           val newNameLocation =
             name.location.map(l => new IdentifiedLocation(l.location()))
           val newName = lit.copy(location = newNameLocation)
-          new Application.Force(
-            newName,
-            name.identifiedLocation(),
-            new MetadataStorage()
-          )
+          Application.Force.builder()
+            .target(newName)
+            .location(name.identifiedLocation())
+            .build()
         case _ => name
       }
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -190,7 +190,8 @@ case object DemandAnalysis extends IRPass {
           val newNameLocation =
             name.location.map(l => new IdentifiedLocation(l.location()))
           val newName = lit.copy(location = newNameLocation)
-          Application.Force.builder()
+          Application.Force
+            .builder()
             .target(newName)
             .location(name.identifiedLocation())
             .build()

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -10,7 +10,6 @@ import org.enso.compiler.core.ir.{
   Function,
   IdentifiedLocation,
   Literal,
-  MetadataStorage,
   Module,
   Name,
   Type

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -265,13 +265,12 @@ case object GenerateMethodBodies extends IRPass {
     * @return the `self` argument
     */
   private def genSyntheticSelf(): DefinitionArgument.Specified = {
-    new DefinitionArgument.Specified(
-      Name.Self(identifiedLocation = null, synthetic = true),
-      None,
-      None,
-      false,
-      null
-    )
+    DefinitionArgument.Specified.builder()
+      .name(Name.Self(identifiedLocation = null, synthetic = true))
+      .ascribedType(None)
+      .defaultValue(None)
+      .suspended(false)
+      .build()
   }
 
   /** Executes the pass on an expression.

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -268,8 +268,6 @@ case object GenerateMethodBodies extends IRPass {
     DefinitionArgument.Specified
       .builder()
       .name(Name.Self(identifiedLocation = null, synthetic = true))
-      .ascribedType(None)
-      .defaultValue(None)
       .suspended(false)
       .build()
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -268,8 +268,8 @@ case object GenerateMethodBodies extends IRPass {
     new DefinitionArgument.Specified(
       Name.Self(identifiedLocation = null, synthetic = true),
       None,
-      defaultValue = None,
-      suspended    = false,
+      None,
+      false,
       null
     )
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -265,7 +265,8 @@ case object GenerateMethodBodies extends IRPass {
     * @return the `self` argument
     */
   private def genSyntheticSelf(): DefinitionArgument.Specified = {
-    DefinitionArgument.Specified.builder()
+    DefinitionArgument.Specified
+      .builder()
       .name(Name.Self(identifiedLocation = null, synthetic = true))
       .ascribedType(None)
       .defaultValue(None)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
@@ -86,8 +86,6 @@ class LambdaShorthandToLambdaMini(
                   null
                 )
               )
-              .ascribedType(None)
-              .defaultValue(None)
               .suspended(false)
               .build()
           ),
@@ -167,8 +165,6 @@ class LambdaShorthandToLambdaMini(
                       p.function.location.orNull
                     )
                 )
-                .defaultValue(None)
-                .ascribedType(None)
                 .build()
             ),
             appResult,
@@ -203,8 +199,6 @@ class LambdaShorthandToLambdaMini(
           val defArg = DefinitionArgument.Specified
             .builder()
             .name(bindingName)
-            .ascribedType(None)
-            .defaultValue(None)
             .suspended(false)
             .build();
           new Function.Lambda(List(defArg), body, locWithoutId.orNull)
@@ -293,8 +287,6 @@ class LambdaShorthandToLambdaMini(
             DefinitionArgument.Specified
               .builder()
               .name(defArgName)
-              .ascribedType(None)
-              .defaultValue(None)
               .suspended(false)
               .passData(specified.passData.duplicate)
               .diagnostics(specified.diagnosticsCopy())
@@ -336,8 +328,6 @@ class LambdaShorthandToLambdaMini(
         val lambdaArg = DefinitionArgument.Specified
           .builder()
           .name(scrutineeName.copy(id = null))
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
@@ -140,8 +140,8 @@ class LambdaShorthandToLambdaMini(
         }
 
         val processedApp = p.copy(
-          function  = updatedFn,
-          arguments = updatedArgs
+          updatedFn,
+          updatedArgs
         )
 
         // Wrap the app in lambdas from right to left, 1 lambda per shorthand
@@ -248,7 +248,7 @@ class LambdaShorthandToLambdaMini(
               diagnostics = s.value.diagnostics
             )
 
-          s.copy(value = newName)
+          s.copy(newName)
         } else s
     }
   }
@@ -281,7 +281,7 @@ class LambdaShorthandToLambdaMini(
               defArgName,
               None,
               None,
-              suspended = false,
+              false,
               null,
               specified.passData.duplicate,
               specified.diagnosticsCopy
@@ -324,7 +324,7 @@ class LambdaShorthandToLambdaMini(
           scrutineeName.copy(id = null),
           None,
           None,
-          suspended = false,
+          false,
           null
         )
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
@@ -77,17 +77,19 @@ class LambdaShorthandToLambdaMini(
 
         new Function.Lambda(
           List(
-            DefinitionArgument.Specified.builder()
-              .name(Name.Literal(
-                newName.name,
-                isMethod = false,
-                null
-              ))
+            DefinitionArgument.Specified
+              .builder()
+              .name(
+                Name.Literal(
+                  newName.name,
+                  isMethod = false,
+                  null
+                )
+              )
               .ascribedType(None)
               .defaultValue(None)
               .suspended(false)
               .build()
-
           ),
           newName,
           blank.location.orNull
@@ -155,7 +157,8 @@ class LambdaShorthandToLambdaMini(
         val resultExpr = if (functionIsShorthand) {
           new Function.Lambda(
             List(
-              DefinitionArgument.Specified.builder()
+              DefinitionArgument.Specified
+                .builder()
                 .name(
                   Name
                     .Literal(
@@ -197,7 +200,8 @@ class LambdaShorthandToLambdaMini(
         val locWithoutId =
           newVec.location.map(l => new IdentifiedLocation(l.location()))
         bindings.foldLeft(newVec: Expression) { (body, bindingName) =>
-          val defArg = DefinitionArgument.Specified.builder()
+          val defArg = DefinitionArgument.Specified
+            .builder()
             .name(bindingName)
             .ascribedType(None)
             .defaultValue(None)
@@ -286,7 +290,8 @@ class LambdaShorthandToLambdaMini(
             )
 
           Some(
-            DefinitionArgument.Specified.builder()
+            DefinitionArgument.Specified
+              .builder()
               .name(defArgName)
               .ascribedType(None)
               .defaultValue(None)
@@ -328,7 +333,8 @@ class LambdaShorthandToLambdaMini(
               diagnostics = nameBlank.diagnostics
             )
 
-        val lambdaArg = DefinitionArgument.Specified.builder()
+        val lambdaArg = DefinitionArgument.Specified
+          .builder()
           .name(scrutineeName.copy(id = null))
           .ascribedType(None)
           .defaultValue(None)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambdaMini.scala
@@ -77,17 +77,17 @@ class LambdaShorthandToLambdaMini(
 
         new Function.Lambda(
           List(
-            new DefinitionArgument.Specified(
-              Name.Literal(
+            DefinitionArgument.Specified.builder()
+              .name(Name.Literal(
                 newName.name,
                 isMethod = false,
                 null
-              ),
-              None,
-              None,
-              false,
-              null
-            )
+              ))
+              .ascribedType(None)
+              .defaultValue(None)
+              .suspended(false)
+              .build()
+
           ),
           newName,
           blank.location.orNull
@@ -155,14 +155,18 @@ class LambdaShorthandToLambdaMini(
         val resultExpr = if (functionIsShorthand) {
           new Function.Lambda(
             List(
-              new DefinitionArgument.Specified(
-                Name
-                  .Literal(
-                    updatedName.get,
-                    isMethod = false,
-                    p.function.location.orNull
-                  )
-              )
+              DefinitionArgument.Specified.builder()
+                .name(
+                  Name
+                    .Literal(
+                      updatedName.get,
+                      isMethod = false,
+                      p.function.location.orNull
+                    )
+                )
+                .defaultValue(None)
+                .ascribedType(None)
+                .build()
             ),
             appResult,
             null
@@ -193,7 +197,12 @@ class LambdaShorthandToLambdaMini(
         val locWithoutId =
           newVec.location.map(l => new IdentifiedLocation(l.location()))
         bindings.foldLeft(newVec: Expression) { (body, bindingName) =>
-          val defArg = new DefinitionArgument.Specified(bindingName)
+          val defArg = DefinitionArgument.Specified.builder()
+            .name(bindingName)
+            .ascribedType(None)
+            .defaultValue(None)
+            .suspended(false)
+            .build();
           new Function.Lambda(List(defArg), body, locWithoutId.orNull)
         }
 
@@ -277,15 +286,14 @@ class LambdaShorthandToLambdaMini(
             )
 
           Some(
-            new DefinitionArgument.Specified(
-              defArgName,
-              None,
-              None,
-              false,
-              null,
-              specified.passData.duplicate,
-              specified.diagnosticsCopy
-            )
+            DefinitionArgument.Specified.builder()
+              .name(defArgName)
+              .ascribedType(None)
+              .defaultValue(None)
+              .suspended(false)
+              .passData(specified.passData.duplicate)
+              .diagnostics(specified.diagnosticsCopy())
+              .build()
           )
       }
     } else None
@@ -320,13 +328,12 @@ class LambdaShorthandToLambdaMini(
               diagnostics = nameBlank.diagnostics
             )
 
-        val lambdaArg = new DefinitionArgument.Specified(
-          scrutineeName.copy(id = null),
-          None,
-          None,
-          false,
-          null
-        )
+        val lambdaArg = DefinitionArgument.Specified.builder()
+          .name(scrutineeName.copy(id = null))
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
 
         val newCaseExpr = caseExpr.copy(
           scrutineeName,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -206,7 +206,7 @@ case object UnusedBindings extends IRPass {
             case _ => name
           }
           s.copyWithDefaultValue(
-            defaultValue = default.map(runExpression(_, context))
+            default.map(runExpression(_, context))
           ).addDiagnostic(warnings.Unused.FunctionArgument(nameToReport))
         } else s
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
@@ -89,7 +89,7 @@ case object ExpressionAnnotations extends IRPass {
               }
               val recurArgs = args.map(_.mapExpressions(doExpression))
               app
-                .copy(function = finalFun, arguments = preArgs ++ recurArgs)
+                .copy(finalFun, preArgs ++ recurArgs)
                 .updateMetadata(new MetadataPair(this, Annotations(Seq(ann))))
           }
         } else {

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
@@ -58,7 +58,8 @@ object FullyAppliedFunctionUses extends IRPass {
         meta match {
           case Some(Resolution(ResolvedConstructor(_, cons)))
               if cons.allFieldsDefaulted && cons.arity > 0 =>
-            Application.Prefix.builder()
+            Application.Prefix
+              .builder()
               .function(name)
               .arguments(List())
               .build()

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
@@ -58,10 +58,10 @@ object FullyAppliedFunctionUses extends IRPass {
         meta match {
           case Some(Resolution(ResolvedConstructor(_, cons)))
               if cons.allFieldsDefaulted && cons.arity > 0 =>
-            new Application.Prefix(
-              name,
-              List()
-            );
+            Application.Prefix.builder()
+              .function(name)
+              .arguments(List())
+              .build()
           case _ => name
         }
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
@@ -343,7 +343,7 @@ case object FullyQualifiedNames extends IRPass {
     }
 
     processedApp.getOrElse(
-      app.copy(function = processedFun, arguments = processedArgs)
+      app.copy(processedFun, processedArgs)
     )
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -373,12 +373,12 @@ case object GlobalNames extends IRPass {
             )
           processedFun.passData.remove(this) // Necessary for IrToTruffle
           app.copy(
-            function  = processedFun,
-            arguments = selfArg :: processedArgs
+            processedFun,
+            selfArg :: processedArgs
           )
         }
       case _ =>
-        app.copy(function = processedFun, arguments = processedArgs)
+        app.copy(processedFun, processedArgs)
     }
   }
 
@@ -431,7 +431,7 @@ case object GlobalNames extends IRPass {
       case _ => None
     }
     newApp.getOrElse(
-      app.copy(function = processedFun, arguments = processedArgs)
+      app.copy(processedFun, processedArgs)
     )
   }
 
@@ -446,7 +446,7 @@ case object GlobalNames extends IRPass {
     ) {
       newFun
     } else {
-      originalApp.copy(function = newFun, arguments = newArgs)
+      originalApp.copy(newFun, newArgs)
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -222,20 +222,20 @@ case object GlobalNames extends IRPass {
                         name     = resolvedModuleMethod.method.name,
                         location = None
                       )
-                      val app = new Application.Prefix(
-                        fun,
-                        List(
-                          new CallArgument.Specified(
-                            None,
-                            self,
-                            true,
-                            identifiedLocation = null
+                      val app = Application.Prefix.builder()
+                        .function(fun)
+                        .arguments(
+                          List(
+                            CallArgument.Specified.builder()
+                              .name(None)
+                              .value(self)
+                              .isSynthetic(true)
+                              .build()
                           )
-                        ),
-                        hasDefaultsSuspended = false,
-                        lit.identifiedLocation,
-                        new MetadataStorage()
-                      )
+                        )
+                        .hasDefaultsSuspended(false)
+                        .location(lit.identifiedLocation)
+                        .build()
                       fun
                         .getMetadata(ExpressionAnnotations)
                         .foreach(annotationsMeta =>
@@ -364,13 +364,10 @@ case object GlobalNames extends IRPass {
                 )
               )
             )
-          val selfArg =
-            new CallArgument.Specified(
-              None,
-              self,
-              true,
-              identifiedLocation = null
-            )
+          val selfArg = CallArgument.Specified.builder()
+            .value(self)
+            .isSynthetic(true)
+            .name(None)
           processedFun.passData.remove(this) // Necessary for IrToTruffle
           app.copy(
             processedFun,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -7,7 +7,6 @@ import org.enso.compiler.core.ir.{
   CallArgument,
   DefinitionArgument,
   Expression,
-  MetadataStorage,
   Module,
   Name,
   Type
@@ -371,6 +370,7 @@ case object GlobalNames extends IRPass {
             .value(self)
             .isSynthetic(true)
             .name(None)
+            .build()
           processedFun.passData.remove(this) // Necessary for IrToTruffle
           app.copy(
             processedFun,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -222,11 +222,13 @@ case object GlobalNames extends IRPass {
                         name     = resolvedModuleMethod.method.name,
                         location = None
                       )
-                      val app = Application.Prefix.builder()
+                      val app = Application.Prefix
+                        .builder()
                         .function(fun)
                         .arguments(
                           List(
-                            CallArgument.Specified.builder()
+                            CallArgument.Specified
+                              .builder()
                               .name(None)
                               .value(self)
                               .isSynthetic(true)
@@ -364,7 +366,8 @@ case object GlobalNames extends IRPass {
                 )
               )
             )
-          val selfArg = CallArgument.Specified.builder()
+          val selfArg = CallArgument.Specified
+            .builder()
             .value(self)
             .isSynthetic(true)
             .name(None)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -230,9 +230,8 @@ case object IgnoredBindings extends IRPass {
 
           spec
             .copy(
-              name = newName,
-              defaultValue =
-                spec.defaultValue.map(resolveExpression(_, freshNameSupply))
+              newName,
+              spec.defaultValue.map(resolveExpression(_, freshNameSupply))
             )
             .updateMetadata(new MetadataPair(this, State.Ignored))
         } else {
@@ -281,8 +280,8 @@ case object IgnoredBindings extends IRPass {
     cse match {
       case expr: Case.Expr =>
         expr.copy(
-          scrutinee = resolveExpression(expr.scrutinee, supply),
-          branches  = expr.branches.map(resolveCaseBranch(_, supply))
+          resolveExpression(expr.scrutinee, supply),
+          expr.branches.map(resolveCaseBranch(_, supply))
         )
       case _: Case.Branch =>
         throw new CompilerError(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/MethodCalls.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/MethodCalls.scala
@@ -103,7 +103,7 @@ object MethodCalls extends IRPass {
                         app.arguments.map(
                           _.mapExpressions(doExpression(_))
                         )
-                      app.copy(function = newName, arguments = newArgs)
+                      app.copy(newName, newArgs)
                     case _ => fallback
                   }
                 case _ => fallback

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
@@ -140,8 +140,8 @@ case object TypeFunctions extends IRPass {
             )
           case _ =>
             pre.copy(
-              function  = resolveExpression(pre.function),
-              arguments = pre.arguments.map(resolveCallArgument)
+              resolveExpression(pre.function),
+              pre.arguments.map(resolveCallArgument)
             )
         }
       case force: Application.Force =>

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -222,14 +222,13 @@ trait CompilerRunner {
       Definition.Data(
         Name.Literal("TestAtom", isMethod = false, identifiedLocation = null),
         List(
-          new DefinitionArgument.Specified(
-            Name
-              .Literal("arg", isMethod = false, identifiedLocation = null),
-            None,
-            Some(ir),
-            suspended          = false,
-            identifiedLocation = null
-          )
+          DefinitionArgument.Specified.builder()
+            .name(Name
+              .Literal("arg", isMethod = false, identifiedLocation = null))
+            .ascribedType(None)
+            .defaultValue(Some(ir))
+            .suspended(false)
+            .build()
         ),
         List(),
         false,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -228,7 +228,6 @@ trait CompilerRunner {
               Name
                 .Literal("arg", isMethod = false, identifiedLocation = null)
             )
-            .ascribedType(None)
             .defaultValue(Some(ir))
             .suspended(false)
             .build()

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -222,9 +222,12 @@ trait CompilerRunner {
       Definition.Data(
         Name.Literal("TestAtom", isMethod = false, identifiedLocation = null),
         List(
-          DefinitionArgument.Specified.builder()
-            .name(Name
-              .Literal("arg", isMethod = false, identifiedLocation = null))
+          DefinitionArgument.Specified
+            .builder()
+            .name(
+              Name
+                .Literal("arg", isMethod = false, identifiedLocation = null)
+            )
             .ascribedType(None)
             .defaultValue(Some(ir))
             .suspended(false)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -23,26 +23,28 @@ class GatherDiagnosticsTest extends CompilerTest {
   "Error Gathering" should {
     val error1 = errors.Syntax(null, errors.Syntax.UnrecognizedToken)
     val plusOp = Name.Literal("+", isMethod = true, identifiedLocation = null)
-    val plusApp = new Application.Prefix(
-      plusOp,
-      List(
-        new CallArgument.Specified(
-          None,
-          error1,
-          false,
-          identifiedLocation = null
+    val plusApp = Application.Prefix
+      .builder()
+      .function(plusOp)
+      .arguments(
+        List(
+          CallArgument.Specified
+            .builder()
+            .name(None)
+            .value(error1)
+            .isSynthetic(false)
+            .build()
         )
       )
-    )
+      .build()
     val lam = new Function.Lambda(
       List(
-        new DefinitionArgument.Specified(
-          Name.Literal("bar", isMethod = false, identifiedLocation = null),
-          None,
-          None,
-          false,
-          null
-        )
+        DefinitionArgument.Specified.builder()
+          .name(Name.Literal("bar", isMethod = false, identifiedLocation = null))
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
       ),
       plusApp,
       identifiedLocation = null
@@ -90,13 +92,13 @@ class GatherDiagnosticsTest extends CompilerTest {
           Definition.Type(
             typeName,
             List(
-              new DefinitionArgument.Specified(
-                fooName,
-                None,
-                Some(error2),
-                suspended          = false,
-                identifiedLocation = null
-              )
+              DefinitionArgument.Specified
+                .builder()
+                .name(fooName)
+                .ascribedType(None)
+                .defaultValue(Some(error2))
+                .suspended(false)
+                .build()
             ),
             List(),
             identifiedLocation = null

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -39,8 +39,11 @@ class GatherDiagnosticsTest extends CompilerTest {
       .build()
     val lam = new Function.Lambda(
       List(
-        DefinitionArgument.Specified.builder()
-          .name(Name.Literal("bar", isMethod = false, identifiedLocation = null))
+        DefinitionArgument.Specified
+          .builder()
+          .name(
+            Name.Literal("bar", isMethod = false, identifiedLocation = null)
+          )
           .ascribedType(None)
           .defaultValue(None)
           .suspended(false)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -44,8 +44,6 @@ class GatherDiagnosticsTest extends CompilerTest {
           .name(
             Name.Literal("bar", isMethod = false, identifiedLocation = null)
           )
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
       ),
@@ -98,7 +96,6 @@ class GatherDiagnosticsTest extends CompilerTest {
               DefinitionArgument.Specified
                 .builder()
                 .name(fooName)
-                .ascribedType(None)
                 .defaultValue(Some(error2))
                 .suspended(false)
                 .build()

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -40,8 +40,8 @@ class GatherDiagnosticsTest extends CompilerTest {
           Name.Literal("bar", isMethod = false, identifiedLocation = null),
           None,
           None,
-          suspended          = false,
-          identifiedLocation = null
+          false,
+          null
         )
       ),
       plusApp,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallMegaPass.scala
@@ -269,9 +269,8 @@ case object TailCallMegaPass extends IRPass {
       case app: Application.Prefix =>
         app
           .copy(
-            function =
-              analyseExpression(app.function, isInTailPosition = false),
-            arguments = app.arguments.map(analyseCallArg)
+            analyseExpression(app.function, isInTailPosition = false),
+            app.arguments.map(analyseCallArg)
           )
       case force: Application.Force =>
         force
@@ -361,11 +360,9 @@ case object TailCallMegaPass extends IRPass {
       case caseExpr: Case.Expr =>
         caseExpr
           .copy(
-            scrutinee =
-              analyseExpression(caseExpr.scrutinee, isInTailPosition = false),
+            analyseExpression(caseExpr.scrutinee, isInTailPosition = false),
             // Note [Analysing Branches in Case Expressions]
-            branches =
-              caseExpr.branches.map(analyseCaseBranch(_, isInTailPosition))
+            caseExpr.branches.map(analyseCaseBranch(_, isInTailPosition))
           )
       case _: Case.Branch =>
         throw new CompilerError("Unexpected case branch.")

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
@@ -159,8 +159,6 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
                   null
                 )
               )
-              .ascribedType(None)
-              .defaultValue(None)
               .suspended(false)
               .build()
           ),
@@ -280,8 +278,6 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
           val defArg = DefinitionArgument.Specified
             .builder()
             .name(bindingName)
-            .ascribedType(None)
-            .defaultValue(None)
             .suspended(false)
             .build()
           new Function.Lambda(List(defArg), body, locWithoutId.orNull)
@@ -374,8 +370,6 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
             DefinitionArgument.Specified
               .builder()
               .name(defArgName)
-              .ascribedType(None)
-              .defaultValue(None)
               .suspended(false)
               .passData(specified.passData().duplicate())
               .diagnostics(specified.diagnosticsCopy())
@@ -423,8 +417,6 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         val lambdaArg = DefinitionArgument.Specified
           .builder()
           .name(scrutineeName.copy(id = null))
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
@@ -219,8 +219,8 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         }
 
         val processedApp = p.copy(
-          function  = updatedFn,
-          arguments = updatedArgs
+          updatedFn,
+          updatedArgs
         )
 
         // Wrap the app in lambdas from right to left, 1 lambda per shorthand
@@ -342,7 +342,7 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
               diagnostics = s.value.diagnostics
             )
 
-          s.copy(value = newName)
+          s.copy(newName)
         } else s
     }
   }
@@ -429,8 +429,8 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         )
 
         val newCaseExpr = caseExpr.copy(
-          scrutinee = scrutineeName,
-          branches  = newBranches
+          scrutineeName,
+          newBranches
         )
 
         new Function.Lambda(
@@ -441,8 +441,8 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         )
       case x =>
         caseExpr.copy(
-          scrutinee = desugarExpression(x, freshNameSupply),
-          branches  = newBranches
+          desugarExpression(x, freshNameSupply),
+          newBranches
         )
     }
   }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaMegaPass.scala
@@ -150,17 +150,19 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
 
         new Function.Lambda(
           List(
-            new DefinitionArgument.Specified(
-              name = Name.Literal(
-                newName.name,
-                isMethod = false,
-                null
-              ),
-              ascribedType       = None,
-              defaultValue       = None,
-              suspended          = false,
-              identifiedLocation = null
-            )
+            DefinitionArgument.Specified
+              .builder()
+              .name(
+                Name.Literal(
+                  newName.name,
+                  isMethod = false,
+                  null
+                )
+              )
+              .ascribedType(None)
+              .defaultValue(None)
+              .suspended(false)
+              .build()
           ),
           newName,
           blank.location.orNull
@@ -234,18 +236,16 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         val resultExpr = if (functionIsShorthand) {
           new Function.Lambda(
             List(
-              new DefinitionArgument.Specified(
-                Name
-                  .Literal(
+              DefinitionArgument.Specified
+                .builder()
+                .name(
+                  Name.Literal(
                     updatedName.get,
                     isMethod = false,
                     p.function.location.orNull
-                  ),
-                None,
-                None,
-                suspended = false,
-                null
-              )
+                  )
+                )
+                .build()
             ),
             appResult,
             null
@@ -277,13 +277,13 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
         val locWithoutId =
           newVec.location.map(l => new IdentifiedLocation(l.location()))
         bindings.foldLeft(newVec: Expression) { (body, bindingName) =>
-          val defArg = new DefinitionArgument.Specified(
-            bindingName,
-            ascribedType       = None,
-            defaultValue       = None,
-            suspended          = false,
-            identifiedLocation = null
-          )
+          val defArg = DefinitionArgument.Specified
+            .builder()
+            .name(bindingName)
+            .ascribedType(None)
+            .defaultValue(None)
+            .suspended(false)
+            .build()
           new Function.Lambda(List(defArg), body, locWithoutId.orNull)
         }
       case tSet: Application.Typeset =>
@@ -371,15 +371,15 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
             )
 
           Some(
-            new DefinitionArgument.Specified(
-              defArgName,
-              None,
-              None,
-              suspended = false,
-              null,
-              specified.passData.duplicate,
-              specified.diagnosticsCopy
-            )
+            DefinitionArgument.Specified
+              .builder()
+              .name(defArgName)
+              .ascribedType(None)
+              .defaultValue(None)
+              .suspended(false)
+              .passData(specified.passData().duplicate())
+              .diagnostics(specified.diagnosticsCopy())
+              .build()
           )
       }
     } else None
@@ -420,13 +420,13 @@ case object LambdaShorthandToLambdaMegaPass extends IRPass {
               diagnostics = nameBlank.diagnostics
             )
 
-        val lambdaArg = new DefinitionArgument.Specified(
-          scrutineeName.copy(id = null),
-          None,
-          None,
-          suspended = false,
-          null
-        )
+        val lambdaArg = DefinitionArgument.Specified
+          .builder()
+          .name(scrutineeName.copy(id = null))
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
 
         val newCaseExpr = caseExpr.copy(
           scrutineeName,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
@@ -8,7 +8,6 @@ import org.enso.compiler.core.ir.{
   Expression,
   IdentifiedLocation,
   Location,
-  MetadataStorage,
   Module,
   Name
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
@@ -65,7 +65,8 @@ class OperatorToFunctionTest extends MiniPassTest {
   ): (Operator.Binary, Application.Prefix) = {
     val loc = new IdentifiedLocation(new Location(1, 33))
 
-    val leftArg = CallArgument.Specified.builder()
+    val leftArg = CallArgument.Specified
+      .builder()
       .name(None)
       .value(left)
       .isSynthetic(false)
@@ -73,7 +74,8 @@ class OperatorToFunctionTest extends MiniPassTest {
       .build()
 
     val rightArg =
-      CallArgument.Specified.builder()
+      CallArgument.Specified
+        .builder()
         .name(None)
         .value(right)
         .isSynthetic(false)
@@ -82,7 +84,8 @@ class OperatorToFunctionTest extends MiniPassTest {
 
     val binOp =
       Operator.Binary(leftArg, name, rightArg, loc)
-    val opFn = Application.Prefix.builder()
+    val opFn = Application.Prefix
+      .builder()
       .function(name)
       .arguments(List(leftArg, rightArg))
       .hasDefaultsSuspended(false)
@@ -95,9 +98,10 @@ class OperatorToFunctionTest extends MiniPassTest {
   // === The Tests ============================================================
   val opName =
     Name.Literal("=:=", isMethod = true, null)
-  val left     = new Empty(null)
-  val right    = new Empty(null)
-  val rightArg =  CallArgument.Specified.builder()
+  val left  = new Empty(null)
+  val right = new Empty(null)
+  val rightArg = CallArgument.Specified
+    .builder()
     .name(None)
     .value(new Empty(null))
     .isSynthetic(false)
@@ -106,13 +110,15 @@ class OperatorToFunctionTest extends MiniPassTest {
   val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
   val oprArg =
-    CallArgument.Specified.builder()
+    CallArgument.Specified
+      .builder()
       .name(None)
       .value(operator)
       .isSynthetic(false)
       .build()
   val oprFnArg =
-    CallArgument.Specified.builder()
+    CallArgument.Specified
+      .builder()
       .name(None)
       .value(operatorFn)
       .isSynthetic(false)
@@ -124,7 +130,8 @@ class OperatorToFunctionTest extends MiniPassTest {
     val left  = new Empty(null)
     val right = new Empty(null)
     val rightArg =
-      CallArgument.Specified.builder()
+      CallArgument.Specified
+        .builder()
         .name(None)
         .value(new Empty(null))
         .isSynthetic(false)
@@ -133,13 +140,15 @@ class OperatorToFunctionTest extends MiniPassTest {
     val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
     val oprArg =
-      CallArgument.Specified.builder()
+      CallArgument.Specified
+        .builder()
         .name(None)
         .value(operator)
         .isSynthetic(false)
         .build()
     val oprFnArg =
-      CallArgument.Specified.builder()
+      CallArgument.Specified
+        .builder()
         .name(None)
         .value(operatorFn)
         .isSynthetic(false)
@@ -155,7 +164,8 @@ class OperatorToFunctionTest extends MiniPassTest {
     "be translated recursively in synthetic IR" in {
       val recursiveIR =
         Operator.Binary(oprArg, opName, rightArg, null)
-      val recursiveIRResult = Application.Prefix.builder()
+      val recursiveIRResult = Application.Prefix
+        .builder()
         .function(opName)
         .arguments(List(oprFnArg, rightArg))
         .build()
@@ -201,7 +211,8 @@ class OperatorToFunctionTest extends MiniPassTest {
     "be translated recursively" in {
       val recursiveIR =
         Operator.Binary(oprArg, opName, rightArg, identifiedLocation = null)
-      val recursiveIRResult = Application.Prefix.builder()
+      val recursiveIRResult = Application.Prefix
+        .builder()
         .function(opName)
         .arguments(List(oprFnArg, rightArg))
         .build()
@@ -276,7 +287,8 @@ case object OperatorToFunctionTestPass extends IRPass {
     inlineContext: InlineContext
   ): Expression = {
     ir.transformExpressions { case operatorBinary: Operator.Binary =>
-      Application.Prefix.builder()
+      Application.Prefix
+        .builder()
         .function(operatorBinary.operator)
         .arguments(
           List(

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/OperatorToFunctionTest.scala
@@ -65,20 +65,29 @@ class OperatorToFunctionTest extends MiniPassTest {
   ): (Operator.Binary, Application.Prefix) = {
     val loc = new IdentifiedLocation(new Location(1, 33))
 
-    val leftArg =
-      new CallArgument.Specified(None, left, false, left.identifiedLocation())
+    val leftArg = CallArgument.Specified.builder()
+      .name(None)
+      .value(left)
+      .isSynthetic(false)
+      .location(left.identifiedLocation())
+      .build()
+
     val rightArg =
-      new CallArgument.Specified(None, right, false, right.identifiedLocation())
+      CallArgument.Specified.builder()
+        .name(None)
+        .value(right)
+        .isSynthetic(false)
+        .location(right.identifiedLocation())
+        .build()
 
     val binOp =
       Operator.Binary(leftArg, name, rightArg, loc)
-    val opFn = new Application.Prefix(
-      name,
-      List(leftArg, rightArg),
-      false,
-      loc,
-      new MetadataStorage()
-    )
+    val opFn = Application.Prefix.builder()
+      .function(name)
+      .arguments(List(leftArg, rightArg))
+      .hasDefaultsSuspended(false)
+      .location(loc)
+      .build()
 
     (binOp, opFn)
   }
@@ -88,41 +97,53 @@ class OperatorToFunctionTest extends MiniPassTest {
     Name.Literal("=:=", isMethod = true, null)
   val left     = new Empty(null)
   val right    = new Empty(null)
-  val rightArg = new CallArgument.Specified(None, new Empty(null), false, null)
+  val rightArg =  CallArgument.Specified.builder()
+    .name(None)
+    .value(new Empty(null))
+    .isSynthetic(false)
+    .build()
 
   val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
-  val oprArg   = new CallArgument.Specified(None, operator, false, null)
-  val oprFnArg = new CallArgument.Specified(None, operatorFn, false, null)
+  val oprArg =
+    CallArgument.Specified.builder()
+      .name(None)
+      .value(operator)
+      .isSynthetic(false)
+      .build()
+  val oprFnArg =
+    CallArgument.Specified.builder()
+      .name(None)
+      .value(operatorFn)
+      .isSynthetic(false)
+      .build()
 
   "Operators" should {
     val opName =
       Name.Literal("=:=", isMethod = true, identifiedLocation = null)
     val left  = new Empty(null)
     val right = new Empty(null)
-    val rightArg = new CallArgument.Specified(
-      None,
-      new Empty(null),
-      false,
-      identifiedLocation = null
-    )
+    val rightArg =
+      CallArgument.Specified.builder()
+        .name(None)
+        .value(new Empty(null))
+        .isSynthetic(false)
+        .build()
 
     val (operator, operatorFn) = genOprAndFn(opName, left, right)
 
     val oprArg =
-      new CallArgument.Specified(
-        None,
-        operator,
-        false,
-        identifiedLocation = null
-      )
+      CallArgument.Specified.builder()
+        .name(None)
+        .value(operator)
+        .isSynthetic(false)
+        .build()
     val oprFnArg =
-      new CallArgument.Specified(
-        None,
-        operatorFn,
-        false,
-        identifiedLocation = null
-      )
+      CallArgument.Specified.builder()
+        .name(None)
+        .value(operatorFn)
+        .isSynthetic(false)
+        .build()
 
     "be translated to functions" in {
       OperatorToFunctionTestPass.runExpression(
@@ -134,10 +155,10 @@ class OperatorToFunctionTest extends MiniPassTest {
     "be translated recursively in synthetic IR" in {
       val recursiveIR =
         Operator.Binary(oprArg, opName, rightArg, null)
-      val recursiveIRResult = new Application.Prefix(
-        opName,
-        List(oprFnArg, rightArg)
-      )
+      val recursiveIRResult = Application.Prefix.builder()
+        .function(opName)
+        .arguments(List(oprFnArg, rightArg))
+        .build()
 
       OperatorToFunctionTestPass.runExpression(
         recursiveIR,
@@ -180,10 +201,10 @@ class OperatorToFunctionTest extends MiniPassTest {
     "be translated recursively" in {
       val recursiveIR =
         Operator.Binary(oprArg, opName, rightArg, identifiedLocation = null)
-      val recursiveIRResult = new Application.Prefix(
-        opName,
-        List(oprFnArg, rightArg)
-      )
+      val recursiveIRResult = Application.Prefix.builder()
+        .function(opName)
+        .arguments(List(oprFnArg, rightArg))
+        .build()
 
       val miniPass = OperatorToFunction.createForInlineCompilation(ctx)
       val miniRes =
@@ -255,17 +276,19 @@ case object OperatorToFunctionTestPass extends IRPass {
     inlineContext: InlineContext
   ): Expression = {
     ir.transformExpressions { case operatorBinary: Operator.Binary =>
-      new Application.Prefix(
-        operatorBinary.operator,
-        List(
-          operatorBinary.left.mapExpressions(runExpression(_, inlineContext)),
-          operatorBinary.right.mapExpressions(runExpression(_, inlineContext))
-        ),
-        hasDefaultsSuspended = false,
-        operatorBinary.location.orNull,
-        operatorBinary.passData,
-        operatorBinary.diagnostics
-      )
+      Application.Prefix.builder()
+        .function(operatorBinary.operator)
+        .arguments(
+          List(
+            operatorBinary.left.mapExpressions(runExpression(_, inlineContext)),
+            operatorBinary.right.mapExpressions(runExpression(_, inlineContext))
+          )
+        )
+        .hasDefaultsSuspended(false)
+        .location(operatorBinary.location().orNull)
+        .passData(operatorBinary.passData)
+        .diagnostics(operatorBinary.diagnostics)
+        .build()
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
@@ -113,8 +113,6 @@ case object SectionsToBinOpMegaPass extends IRPass {
         val rightDefArg = DefinitionArgument.Specified
           .builder()
           .name(rightArgName.duplicate())
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
 
@@ -129,8 +127,6 @@ case object SectionsToBinOpMegaPass extends IRPass {
           val leftDefArg = DefinitionArgument.Specified
             .builder()
             .name(leftArgName.duplicate())
-            .ascribedType(None)
-            .defaultValue(None)
             .suspended(false)
             .build()
           val opCall = Application.Prefix
@@ -178,8 +174,6 @@ case object SectionsToBinOpMegaPass extends IRPass {
         val leftDefArg = DefinitionArgument.Specified
           .builder()
           .name(leftArgName.duplicate())
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
 
@@ -247,8 +241,6 @@ case object SectionsToBinOpMegaPass extends IRPass {
         val leftDefArg = DefinitionArgument.Specified
           .builder()
           .name(leftArgName.duplicate())
-          .ascribedType(None)
-          .defaultValue(None)
           .suspended(false)
           .build()
 
@@ -264,8 +256,6 @@ case object SectionsToBinOpMegaPass extends IRPass {
           val rightDefArg = DefinitionArgument.Specified
             .builder()
             .name(rightArgName.duplicate())
-            .ascribedType(None)
-            .defaultValue(None)
             .suspended(false)
             .build()
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpMegaPass.scala
@@ -104,45 +104,43 @@ case object SectionsToBinOpMegaPass extends IRPass {
     section match {
       case sectionLeft @ Section.Left(arg, op, loc, passData) =>
         val rightArgName = freshNameSupply.newName()
-        val rightCallArg =
-          new CallArgument.Specified(
-            None,
-            rightArgName,
-            true,
-            identifiedLocation = null
-          )
-        val rightDefArg = new DefinitionArgument.Specified(
-          rightArgName.duplicate(),
-          None,
-          None,
-          suspended = false,
-          null
-        )
+        val rightCallArg = CallArgument.Specified
+          .builder()
+          .name(None)
+          .value(rightArgName)
+          .isSynthetic(true)
+          .build()
+        val rightDefArg = DefinitionArgument.Specified
+          .builder()
+          .name(rightArgName.duplicate())
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
 
         if (arg.value.isInstanceOf[Name.Blank]) {
           val leftArgName = freshNameSupply.newName()
-          val leftCallArg =
-            new CallArgument.Specified(
-              None,
-              leftArgName,
-              true,
-              identifiedLocation = null
-            )
-          val leftDefArg = new DefinitionArgument.Specified(
-            leftArgName.duplicate(),
-            None,
-            None,
-            suspended = false,
-            null
-          )
-          val opCall = new Application.Prefix(
-            function             = op,
-            arguments            = List(leftCallArg, rightCallArg),
-            hasDefaultsSuspended = false,
-            identifiedLocation   = null,
-            passData             = passData,
-            diagnostics          = sectionLeft.diagnostics
-          )
+          val leftCallArg = CallArgument.Specified
+            .builder()
+            .name(None)
+            .value(leftArgName)
+            .isSynthetic(true)
+            .build()
+          val leftDefArg = DefinitionArgument.Specified
+            .builder()
+            .name(leftArgName.duplicate())
+            .ascribedType(None)
+            .defaultValue(None)
+            .suspended(false)
+            .build()
+          val opCall = Application.Prefix
+            .builder()
+            .function(op)
+            .arguments(List(leftCallArg, rightCallArg))
+            .hasDefaultsSuspended(false)
+            .passData(passData)
+            .diagnostics(sectionLeft.diagnostics)
+            .build()
 
           val rightLam = new Function.Lambda(
             List(rightDefArg),
@@ -158,57 +156,54 @@ case object SectionsToBinOpMegaPass extends IRPass {
         } else {
           val newArg = arg.mapExpressions(runExpression(_, inlineContext))
 
-          new Application.Prefix(
-            function             = op,
-            arguments            = List(newArg),
-            hasDefaultsSuspended = false,
-            identifiedLocation   = loc,
-            passData             = passData,
-            diagnostics          = sectionLeft.diagnostics
-          )
+          Application.Prefix
+            .builder()
+            .function(op)
+            .arguments(List(newArg))
+            .hasDefaultsSuspended(false)
+            .location(loc)
+            .passData(passData)
+            .diagnostics(sectionLeft.diagnostics)
+            .build()
         }
 
       case sectionSides @ Section.Sides(op, loc, passData) =>
         val leftArgName = freshNameSupply.newName()
-        val leftCallArg =
-          new CallArgument.Specified(
-            None,
-            leftArgName,
-            true,
-            identifiedLocation = null
-          )
-        val leftDefArg = new DefinitionArgument.Specified(
-          leftArgName.duplicate(),
-          None,
-          None,
-          suspended = false,
-          null
-        )
+        val leftCallArg = CallArgument.Specified
+          .builder()
+          .name(None)
+          .value(leftArgName)
+          .isSynthetic(true)
+          .build()
+        val leftDefArg = DefinitionArgument.Specified
+          .builder()
+          .name(leftArgName.duplicate())
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
 
         val rightArgName = freshNameSupply.newName()
-        val rightCallArg =
-          new CallArgument.Specified(
-            None,
-            rightArgName,
-            true,
-            identifiedLocation = null
-          )
-        val rightDefArg = new DefinitionArgument.Specified(
-          rightArgName.duplicate(),
-          None,
-          None,
-          suspended = false,
-          null
-        )
+        val rightCallArg = CallArgument.Specified
+          .builder()
+          .name(None)
+          .value(rightArgName)
+          .isSynthetic(true)
+          .build()
+        val rightDefArg = DefinitionArgument.Specified
+          .builder()
+          .name(rightArgName.duplicate())
+          .suspended(false)
+          .build()
 
-        val opCall = new Application.Prefix(
-          function             = op,
-          arguments            = List(leftCallArg, rightCallArg),
-          hasDefaultsSuspended = false,
-          identifiedLocation   = null,
-          passData             = passData,
-          diagnostics          = sectionSides.diagnostics
-        )
+        val opCall = Application.Prefix
+          .builder()
+          .function(op)
+          .arguments(List(leftCallArg, rightCallArg))
+          .hasDefaultsSuspended(false)
+          .passData(passData)
+          .diagnostics(sectionSides.diagnostics)
+          .build()
 
         val rightLambda = new Function.Lambda(
           List(rightDefArg),
@@ -243,48 +238,45 @@ case object SectionsToBinOpMegaPass extends IRPass {
 
       case sectionRight @ Section.Right(op, arg, loc, passData) =>
         val leftArgName = freshNameSupply.newName()
-        val leftCallArg =
-          new CallArgument.Specified(
-            None,
-            leftArgName,
-            true,
-            identifiedLocation = null
-          )
-        val leftDefArg =
-          new DefinitionArgument.Specified(
-            leftArgName.duplicate(),
-            None,
-            None,
-            suspended = false,
-            null
-          )
+        val leftCallArg = CallArgument.Specified
+          .builder()
+          .name(None)
+          .value(leftArgName)
+          .isSynthetic(true)
+          .build()
+        val leftDefArg = DefinitionArgument.Specified
+          .builder()
+          .name(leftArgName.duplicate())
+          .ascribedType(None)
+          .defaultValue(None)
+          .suspended(false)
+          .build()
 
         if (arg.value.isInstanceOf[Name.Blank]) {
           // Note [Blanks in Sections]
           val rightArgName = freshNameSupply.newName()
-          val rightCallArg =
-            new CallArgument.Specified(
-              None,
-              rightArgName,
-              true,
-              identifiedLocation = null
-            )
-          val rightDefArg = new DefinitionArgument.Specified(
-            rightArgName.duplicate(),
-            None,
-            None,
-            suspended = false,
-            null
-          )
+          val rightCallArg = CallArgument.Specified
+            .builder()
+            .name(None)
+            .value(rightArgName)
+            .isSynthetic(true)
+            .build()
+          val rightDefArg = DefinitionArgument.Specified
+            .builder()
+            .name(rightArgName.duplicate())
+            .ascribedType(None)
+            .defaultValue(None)
+            .suspended(false)
+            .build()
 
-          val opCall = new Application.Prefix(
-            function             = op,
-            arguments            = List(leftCallArg, rightCallArg),
-            hasDefaultsSuspended = false,
-            identifiedLocation   = null,
-            passData             = passData,
-            diagnostics          = sectionRight.diagnostics
-          )
+          val opCall = Application.Prefix
+            .builder()
+            .function(op)
+            .arguments(List(leftCallArg, rightCallArg))
+            .hasDefaultsSuspended(false)
+            .passData(passData)
+            .diagnostics(sectionRight.diagnostics)
+            .build()
 
           val leftLam = new Function.Lambda(
             List(leftDefArg),
@@ -300,14 +292,14 @@ case object SectionsToBinOpMegaPass extends IRPass {
         } else {
           val newArg = arg.mapExpressions(runExpression(_, inlineContext))
 
-          val opCall = new Application.Prefix(
-            function             = op,
-            arguments            = List(leftCallArg, newArg),
-            hasDefaultsSuspended = false,
-            identifiedLocation   = null,
-            passData             = passData,
-            diagnostics          = sectionRight.diagnostics
-          )
+          val opCall = Application.Prefix
+            .builder()
+            .function(op)
+            .arguments(List(leftCallArg, newArg))
+            .hasDefaultsSuspended(false)
+            .passData(passData)
+            .diagnostics(sectionRight.diagnostics)
+            .build()
 
           new Function.Lambda(
             List(leftDefArg),

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/optimise/LambdaConsolidateTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/optimise/LambdaConsolidateTest.scala
@@ -229,32 +229,37 @@ class LambdaConsolidateTest extends CompilerTest {
 
       val ir: Function.Lambda = new Function.Lambda(
         List(
-          new DefinitionArgument.Specified(
-            Name
-              .Literal("a", isMethod = false, identifiedLocation = null),
-            None,
-            None,
-            suspended          = false,
-            identifiedLocation = null
-          ),
-          new DefinitionArgument.Specified(
-            Name.Literal("b", isMethod = false, identifiedLocation = null),
-            None,
-            None,
-            suspended          = false,
-            identifiedLocation = null
-          )
+          DefinitionArgument.Specified
+            .builder()
+            .name(
+              Name
+                .Literal("a", isMethod = false, identifiedLocation = null)
+            )
+            .suspended(false)
+            .build(),
+          DefinitionArgument.Specified
+            .builder()
+            .name(
+              Name
+                .Literal("b", isMethod = false, identifiedLocation = null)
+            )
+            .suspended(false)
+            .build()
         ),
         new Function.Lambda(
           List(
-            new DefinitionArgument.Specified(
-              Name
-                .Literal("c", isMethod = false, identifiedLocation = null),
-              None,
-              None,
-              suspended          = false,
-              identifiedLocation = null
-            )
+            DefinitionArgument.Specified
+              .builder()
+              .name(
+                Name
+                  .Literal(
+                    "c",
+                    isMethod           = false,
+                    identifiedLocation = null
+                  )
+              )
+              .suspended(false)
+              .build()
           ),
           Name.Literal("c", isMethod = false, identifiedLocation = null),
           identifiedLocation = null

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
@@ -48,7 +48,6 @@ final class IRNodeClassGenerator {
       Set.of(
           "java.util.UUID",
           "java.util.ArrayList",
-          "java.util.function.Function",
           "java.util.Objects",
           "java.util.stream.Collectors",
           "org.enso.compiler.core.Identifier",

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
@@ -50,7 +50,7 @@ public final class MapExpressionsMethodGenerator {
         .append(" ")
         .append(METHOD_NAME)
         .append("(")
-        .append("Function<Expression, Expression> fn")
+        .append("java.util.function.Function<Expression, Expression> fn")
         .append(") {")
         .append(System.lineSeparator());
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
@@ -65,10 +65,14 @@ public interface IR {
 
   /**
    * Maps the provided function over any expression defined as a child of the node this is called
-   * on.
+   * on. The child does not have to be a <emph>direct</emph> child, it can have an arbitrary number
+   * of intermediate non-expression nodes. The mapping traverses in DFS order, and it stops on first
+   * (non-direct) child that is an {@link Expression}.
+   *
+   * <p>The function is not applied on this IR, even if it is {@link Expression}.
    *
    * @param fn the function to transform the expressions
-   * @return `this`, potentially having had its children transformed by `fn`
+   * @return `this`, potentially having had its (non-direct) children transformed by `fn`
    */
   IR mapExpressions(Function<Expression, Expression> fn);
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
@@ -7,25 +7,59 @@ import org.enso.compiler.core.ir.DiagnosticStorage;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.IdentifiedLocation;
 import org.enso.compiler.core.ir.MetadataStorage;
+import org.enso.compiler.core.ir.ProcessingPass.Metadata;
 import org.enso.compiler.debug.Debug;
 import scala.Option;
 import scala.collection.immutable.List;
 
 /**
- * [[IR]] is a temporary and fairly unsophisticated internal representation format for Enso
+ * {@link IR} is a temporary and fairly unsophisticated internal representation format for Enso
  * programs.
  *
  * <p>It is a purely tree-based representation to support basic desugaring and analysis passes that
- * do not rely on the ability to create cycles in the IR itself. Its existence is the natural
- * evolution of the older AstExpression format used during the initial development of the
- * interpreter.
+ * do not rely on the ability to create cycles in the IR itself.
  *
- * <p>Please note that all extensions of [[IR]] must reimplement `copy` to keep the id intact when
- * copying nodes. The copy implementation should provide a way to set the id for the copy, but
- * should default to being copied. Care must be taken to not end up with two nodes with the same ID.
- * When using `copy` to duplicate nodes, please ensure that a new ID is provided.
+ * <p>IR AST is generally immutable with the exception of {@link IR#passData() metadata} and {@link
+ * IR#diagnostics() diagnostics} that are mutable.
  *
- * <p>See also: Note [IR Equality and hashing]
+ * <p>The current IR hierarchy consist of old Scala case classes (for example {@link
+ * org.enso.compiler.core.ir.Name.Qualified}) and of new Java classes annotated with {@link
+ * org.enso.runtime.parser.dsl.GenerateIR} for which superclasses are generated. See {@link
+ * org.enso.runtime.parser.dsl.GenerateIR} javadoc for more information on the generation of IR
+ * classes. The desired state is to have the whole hierarchy in Java only.
+ *
+ * <h2>Copy</h2>
+ *
+ * The immutable nature of IR elements means that they cannot be modified in place. Modifications to
+ * IR are done by copying the old element and returning a new one. Usually, <i>shallow</i> copies
+ * are preferred.
+ *
+ * <h3>Shallow copy</h3>
+ *
+ * On old Scala case classes, various {@code copy} methods exist, like {@link
+ * org.enso.compiler.core.ir.Name.Qualified#copy(List, Option, MetadataStorage, DiagnosticStorage,
+ * UUID) Name.Qualified#copy}. The new Java classes also have generated {@code copy} methods as well
+ * as generated copy builders.
+ *
+ * <p>All the fields that are not changed in the {@code copy} methods will contain references to the
+ * original IR element. It the original IR element is not disposed and still referenced somewhere,
+ * all the mutable structures on the subtree will potentially be modified from two places.
+ * Therefore, <b>if you intend to keep the original IR element, use deep copy instead</b>.
+ *
+ * <p>When manually implementing {@code copy} methods (which is now discouraged with the
+ * introduction of {@link org.enso.runtime.parser.dsl.GenerateIR}), special care must be taken to
+ * keep the {@link IR#getId() UUID} intact. The copy implementation should provide a way to set the
+ * UUID for the copy, but should default to being copied from the original element. <b>There should
+ * never be two nodes with the same UUID</b>.
+ *
+ * <h3>Deep copy</h3>
+ *
+ * Deep copy is implemented by the {@link IR#duplicate(boolean, boolean, boolean, boolean)
+ * duplicate} method. Note that special care must be taken when duplicating {@link IR#passData()
+ * metadata}, as some {@link org.enso.compiler.core.ir.ProcessingPass compiler passes} may decide to
+ * not duplicate the metadata at all by returning {@code None} from {@link Metadata#duplicate()}
+ * method. In these cases, the newly duplicated IR element will have just a portion of the original
+ * metadata.
  */
 public interface IR {
   /**
@@ -151,6 +185,11 @@ public interface IR {
    *
    * <p>You can choose to keep the location, metadata and diagnostic information in the duplicated
    * copy, as well as whether you want to generate new node identifiers or not.
+   *
+   * <p>Note that even with {@code keepMetadata} set to {@code true}, some compiler passes may
+   * choose to not duplicate their metadata, returning {@code None} from their {@link
+   * Metadata#duplicate()} method. In these cases, the newly duplicated IR will have just a portion
+   * of the original metadata.
    *
    * @param keepLocations whether locations should be kept in the duplicated IR
    * @param keepMetadata whether the pass metadata should be kept in the duplicated IR

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.enso.compiler.core.ir.AscriptionReason;
 import org.enso.compiler.core.ir.CallArgument;
 import org.enso.compiler.core.ir.DefinitionArgument;
+import org.enso.compiler.core.ir.DefinitionArgument.Specified;
 import org.enso.compiler.core.ir.Diagnostic;
 import org.enso.compiler.core.ir.DiagnosticStorage;
 import org.enso.compiler.core.ir.Empty;
@@ -446,15 +447,30 @@ final class TreeToIr {
         } else {
           arg = new Name.Qualified(tail, loc, meta());
         }
-        var ca = new CallArgument.Specified(Option.empty(), arg, false, loc, meta());
+        var ca = CallArgument.Specified.builder()
+            .name(Option.empty())
+            .value(arg)
+            .isSynthetic(false)
+            .location(loc)
+            .build();
         args = join(ca, args);
         yield name;
       }
     };
     if (in == null) {
-      return new Application.Prefix(type, args, false, getIdentifiedLocation(app), meta());
+      return Application.Prefix.builder()
+          .function(type)
+          .arguments(args)
+          .hasDefaultsSuspended(false)
+          .location(getIdentifiedLocation(app))
+          .build();
     } else {
-      var fn = new CallArgument.Specified(Option.empty(), type, false, getIdentifiedLocation(app), meta());
+      var fn = CallArgument.Specified.builder()
+          .name(Option.empty())
+          .value(type)
+          .isSynthetic(false)
+          .location(getIdentifiedLocation(app))
+          .build();
       return new Operator.Binary(fn, in, args.head(), getIdentifiedLocation(app), meta());
     }
   }
@@ -652,14 +668,25 @@ final class TreeToIr {
         case Tree.App app -> {
           var expr = translateExpression(app.getArg(), false);
           var loc = getIdentifiedLocation(app.getArg());
-          args.add(new CallArgument.Specified(Option.empty(), expr, false, loc, meta()));
+          args.add(CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(expr)
+              .isSynthetic(false)
+              .location(loc)
+              .build());
           tree = app.getFunc();
         }
         case Tree.NamedApp app -> {
           var expr = translateExpression(app.getArg(), false);
           var loc = getIdentifiedLocation(app.getArg());
           var id = buildName(app, app.getName());
-          args.add(new CallArgument.Specified(Option.apply(id), expr, false, loc, meta()));
+          var arg = CallArgument.Specified.builder()
+              .name(Option.apply(id))
+              .value(expr)
+              .isSynthetic(false)
+              .location(loc)
+              .build();
+          args.add(arg);
           tree = app.getFunc();
         }
         case Tree.OperatorBlockApplication app -> {
@@ -675,16 +702,42 @@ final class TreeToIr {
             }
             var expr = switch (translateExpression(l.getExpression().getExpression(), true)) {
               case Application.Prefix pref -> {
-                var arg = new CallArgument.Specified(Option.empty(), self, false, self.identifiedLocation(), meta());
-                yield new Application.Prefix(pref.function(), join(arg, pref.arguments()), false, pref.identifiedLocation(), meta());
+                var arg = CallArgument.Specified.builder()
+                    .name(Option.empty())
+                    .value(self)
+                    .isSynthetic(false)
+                    .location(self.identifiedLocation())
+                    .build();
+                yield Application.Prefix.builder()
+                    .function(pref.function())
+                    .arguments(join(arg, pref.arguments()))
+                    .hasDefaultsSuspended(false)
+                    .location(pref.identifiedLocation())
+                    .build();
               }
               case Expression any -> {
-                var arg = new CallArgument.Specified(Option.empty(), self, false, self.identifiedLocation(), meta());
-                yield new Application.Prefix(any, join(arg, nil()), false, any.identifiedLocation(), meta());
+                var arg = CallArgument.Specified.builder()
+                    .name(Option.empty())
+                    .value(self)
+                    .isSynthetic(false)
+                    .location(self.identifiedLocation())
+                    .build();
+                yield Application.Prefix.builder()
+                    .function(any)
+                    .arguments(join(arg, nil()))
+                    .hasDefaultsSuspended(false)
+                    .location(any.identifiedLocation())
+                    .build();
               }
             };
             var loc = getIdentifiedLocation(l.getExpression().getExpression());
-            args.add(at, new CallArgument.Specified(Option.empty(), expr, false, loc, meta()));
+            var arg = CallArgument.Specified.builder()
+                .name(Option.empty())
+                .value(expr)
+                .isSynthetic(false)
+                .location(loc)
+                .build();
+            args.add(at, arg);
             self = expr;
           }
           return self;
@@ -701,7 +754,13 @@ final class TreeToIr {
             if (oprApp.getLhs() != null) {
               var self = translateExpression(oprApp.getLhs(), isMethod);
               var loc = getIdentifiedLocation(oprApp.getLhs());
-              args.add(new CallArgument.Specified(Option.empty(), self, false, loc, meta()));
+              var arg = CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(self)
+                  .isSynthetic(false)
+                  .location(loc)
+                  .build();
+              args.add(arg);
             }
           } else if (args.isEmpty()) {
             return null;
@@ -710,12 +769,12 @@ final class TreeToIr {
           }
           java.util.Collections.reverse(args);
           var argsList = CollectionConverters.asScala(args.iterator()).toList();
-          return new Application.Prefix(
-              func, argsList,
-              hasDefaultsSuspended,
-              getIdentifiedLocation(ast),
-              meta()
-          );
+          return Application.Prefix.builder()
+              .function(func)
+              .arguments(argsList)
+              .hasDefaultsSuspended(hasDefaultsSuspended)
+              .location(getIdentifiedLocation(ast))
+              .build();
         }
       }
     }
@@ -830,14 +889,13 @@ final class TreeToIr {
             }
             var defaultValue = new Expression[1];
             Name name = translateOldStyleLambdaArgumentName(arg, isSuspended, defaultValue);
-            var arg_ = new DefinitionArgument.Specified(
-                name,
-                Option.empty(),
-                Option.apply(defaultValue[0]),
-                isSuspended[0],
-                getIdentifiedLocation(arg),
-                meta()
-            );
+            var arg_ = Specified.builder()
+                .name(name)
+                .ascribedType(Option.empty())
+                .defaultValue(Option.apply(defaultValue[0]))
+                .suspended(isSuspended[0])
+                .location(getIdentifiedLocation(arg))
+                .build();
             List<DefinitionArgument> args = join(arg_, nil());
             var body = translateExpression(app.getRhs(), false);
             if (body == null) {
@@ -878,7 +936,12 @@ final class TreeToIr {
           var loc = getIdentifiedLocation(app);
           var both = applyOperator(op, lhs, rhs, loc);
           expr = both;
-          lhs = new CallArgument.Specified(Option.empty(), expr, false, loc, meta());
+          lhs = CallArgument.Specified.builder()
+              .name(Option.empty())
+              .value(expr)
+              .isSynthetic(false)
+              .location(loc)
+              .build();
         }
         yield expr;
       }
@@ -895,10 +958,10 @@ final class TreeToIr {
             items = join(exp, items);
           }
         }
-        yield new Application.Sequence(
-            items.reverse(),
-            getIdentifiedLocation(arr),
-            meta());
+        yield Application.Sequence.builder()
+            .items(items.reverse())
+            .location(getIdentifiedLocation(arr))
+            .build();
       }
       case Tree.Number n -> translateNumber(n);
       case Tree.Ident id -> translateIdent(id, isMethod);
@@ -928,7 +991,12 @@ final class TreeToIr {
         if (!checkArgs(args)) {
           yield translateSyntaxError(app, Syntax.UnexpectedExpression$.MODULE$);
         }
-        yield new Application.Prefix(fn, args.reverse(), false, getIdentifiedLocation(tree), meta());
+        yield Application.Prefix.builder()
+            .function(fn)
+            .arguments(args.reverse())
+            .hasDefaultsSuspended(false)
+            .location(getIdentifiedLocation(tree))
+            .build();
       }
       case Tree.BodyBlock body -> translateBodyBlock(body, false);
       case Tree.Assignment assign -> translateAssignment(assign);
@@ -1039,8 +1107,18 @@ final class TreeToIr {
             );
             case Expression expr -> {
               var negate = new Name.Literal("negate", true, null, Option.empty(), meta());
-              var arg = new CallArgument.Specified(Option.empty(), expr, false, expr.identifiedLocation(), meta());
-              yield new Application.Prefix(negate, join(arg, nil()), false, getIdentifiedLocation(un), meta());
+              var arg = CallArgument.Specified.builder()
+                  .name(Option.empty())
+                  .value(expr)
+                  .isSynthetic(false)
+                  .location(expr.identifiedLocation())
+                  .build();
+              yield Application.Prefix.builder()
+                  .function(negate)
+                  .arguments(join(arg, nil()))
+                  .hasDefaultsSuspended(false)
+                  .location(getIdentifiedLocation(un))
+                  .build();
             }
             case null ->
                 translateSyntaxError(tree, new Syntax.UnsupportedSyntax("Strange unary -"));
@@ -1057,7 +1135,12 @@ final class TreeToIr {
         var fn = translateExpression(app.getFunc(), isMethod);
         var loc = getIdentifiedLocation(app);
         if (app.getArg() instanceof Tree.SuspendedDefaultArguments) {
-          yield new Application.Prefix(fn, nil(), true, loc, meta());
+          yield Application.Prefix.builder()
+              .function(fn)
+              .arguments(nil())
+              .hasDefaultsSuspended(true)
+              .location(loc)
+              .build();
         } else {
           yield fn.setLocation(Option.apply(loc));
         }
@@ -1083,13 +1166,12 @@ final class TreeToIr {
     } catch (SyntaxException ex) {
       return ex.toError();
     }
-    var methodReference = new CallArgument.Specified(
-            Option.empty(),
-            methodName,
-            false,
-            methodName.identifiedLocation(),
-            meta()
-    );
+    var methodReference = CallArgument.Specified.builder()
+        .name(Option.empty())
+        .value(methodName)
+        .isSynthetic(false)
+        .location(methodName.identifiedLocation())
+        .build();
     var opName = buildName(null, sig.getOperator(), true);
     var signature = translateTypeCallArgument(sig.getType());
     return new Operator.Binary(methodReference, opName, signature, getIdentifiedLocation(sig), meta());
@@ -1352,11 +1434,10 @@ final class TreeToIr {
             items = join(exp, items);
           }
         }
-        yield new Application.Literal.Sequence(
-            items.reverse(),
-            getIdentifiedLocation(arr),
-            meta()
-        );
+        yield Application.Sequence.builder()
+            .items(items.reverse())
+            .location(getIdentifiedLocation(arr))
+            .build();
       }
       case Tree.Ident id -> buildName(getIdentifiedLocation(id), id.getToken(), false);
       case Tree.Group group -> translateType(group.getBody());
@@ -1401,12 +1482,22 @@ final class TreeToIr {
       args = (List<CallArgument>) args.tail();
     }
     List<CallArgument> allArgs = (List<CallArgument>) pref.arguments().appendedAll(args.reverse());
-    final CallArgument.Specified blockArg = new CallArgument.Specified(Option.empty(), block, false, block.identifiedLocation(), meta());
+    final CallArgument.Specified blockArg = CallArgument.Specified.builder()
+        .name(Option.empty())
+        .value(block)
+        .isSynthetic(false)
+        .location(block.identifiedLocation())
+        .build();
     List<CallArgument> withBlockArgs = (List<CallArgument>) allArgs.appended(blockArg);
     if (!checkArgs(withBlockArgs)) {
       return translateSyntaxError(pref.location().get(), Syntax.UnexpectedExpression$.MODULE$);
     }
-    return new Application.Prefix(pref.function(), withBlockArgs, pref.hasDefaultsSuspended(), pref.identifiedLocation(), meta());
+    return Application.Prefix.builder()
+        .function(pref.function())
+        .arguments(withBlockArgs)
+        .hasDefaultsSuspended(pref.hasDefaultsSuspended())
+        .location(pref.identifiedLocation())
+        .build();
   }
 
   private Application.Prefix translateBuiltinAnnotation(Name.BuiltinAnnotation ir, Tree expr,
@@ -1427,7 +1518,12 @@ final class TreeToIr {
         yield translateBuiltinAnnotation(ir, null, callArgs);
       }
       case null -> {
-        yield new Application.Prefix(ir, callArgs, false, ir.identifiedLocation(), meta());
+        Application.Prefix.builder()
+            .function(ir)
+            .arguments(callArgs)
+            .hasDefaultsSuspended(false)
+            .location(ir.identifiedLocation())
+            .build();
       }
       default -> {
         var arg = translateCallArgument(expr);
@@ -1519,14 +1615,13 @@ final class TreeToIr {
         .map(ascription -> translateType(ascription.getType()));
     var defaultValue = Option.apply(def.getDefault())
         .map(default_ -> translateExpression(default_.getExpression(), false));
-    return new DefinitionArgument.Specified(
-        name,
-        ascribedType,
-        defaultValue,
-        isSuspended,
-        getIdentifiedLocation(def.getPattern()),
-        meta()
-    );
+    return DefinitionArgument.Specified.builder()
+        .name(name)
+        .ascribedType(ascribedType)
+        .defaultValue(defaultValue)
+        .suspended(isSuspended)
+        .location(getIdentifiedLocation(def.getPattern()))
+        .build();
   }
 
   /**
@@ -1541,12 +1636,22 @@ final class TreeToIr {
       case Tree.NamedApp app -> {
         var expr = translateExpression(app.getArg(), false);
         var id = sanitizeName(buildName(app, app.getName()));
-        yield new CallArgument.Specified(Option.apply(id), expr, false, loc, meta());
+        yield CallArgument.Specified.builder()
+            .name(Option.apply(id))
+            .value(expr)
+            .isSynthetic(false)
+            .location(loc)
+            .build();
       }
       case null -> null;
       default -> {
         var expr = translateExpression(arg, false);
-        yield new CallArgument.Specified(Option.empty(), expr, false, loc, meta());
+        yield CallArgument.Specified.builder()
+            .name(Option.empty())
+            .value(expr)
+            .isSynthetic(false)
+            .location(loc)
+            .build();
       }
     };
   }
@@ -1554,7 +1659,12 @@ final class TreeToIr {
   CallArgument.Specified translateTypeCallArgument(Tree arg) {
     var loc = getIdentifiedLocation(arg);
     var expr = translateType(arg);
-    return new CallArgument.Specified(Option.empty(), expr, false, loc, meta());
+    return CallArgument.Specified.builder()
+        .name(Option.empty())
+        .value(expr)
+        .isSynthetic(false)
+        .location(loc)
+        .build();
   }
 
   CallArgument.Specified unnamedCallArgument(Tree arg) {
@@ -1563,7 +1673,12 @@ final class TreeToIr {
     }
     var loc = getIdentifiedLocation(arg);
     var expr = translateExpression(arg);
-    return new CallArgument.Specified(Option.empty(), expr, false, loc, meta());
+    return CallArgument.Specified.builder()
+        .name(Option.empty())
+        .value(expr)
+        .isSynthetic(false)
+        .location(loc)
+        .build();
   }
 
   /**

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -1517,14 +1517,12 @@ final class TreeToIr {
         callArgs = join(fnAsArg, join(arg, callArgs));
         yield translateBuiltinAnnotation(ir, null, callArgs);
       }
-      case null -> {
-        Application.Prefix.builder()
-            .function(ir)
-            .arguments(callArgs)
-            .hasDefaultsSuspended(false)
-            .location(ir.identifiedLocation())
-            .build();
-      }
+      case null -> Application.Prefix.builder()
+          .function(ir)
+          .arguments(callArgs)
+          .hasDefaultsSuspended(false)
+          .location(ir.identifiedLocation())
+          .build();
       default -> {
         var arg = translateCallArgument(expr);
         callArgs = join(arg, callArgs);

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/CallArgument.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/CallArgument.java
@@ -54,21 +54,8 @@ public interface CallArgument extends IR {
       super(name, value, isSynthetic, identifiedLocation, passData, diagnostics);
     }
 
-    public Specified(
-        Option<Name> name,
-        Expression value,
-        boolean isSynthetic,
-        IdentifiedLocation identifiedLocation,
-        MetadataStorage passData) {
-      this(name, value, isSynthetic, identifiedLocation, passData, null);
-    }
-
-    public Specified(
-        Option<Name> name,
-        Expression value,
-        boolean isSynthetic,
-        IdentifiedLocation identifiedLocation) {
-      this(name, value, isSynthetic, identifiedLocation, new MetadataStorage(), null);
+    public static Builder builder() {
+      return new Builder();
     }
 
     public Specified copy(Expression value) {

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/DefinitionArgument.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/DefinitionArgument.java
@@ -44,7 +44,7 @@ public interface DefinitionArgument extends IR {
     }
 
     public static Builder builder() {
-      return new Builder();
+      return new Builder().ascribedType(Option.empty()).defaultValue(Option.empty());
     }
 
     public static Builder builder(Specified original) {

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/DefinitionArgument.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/DefinitionArgument.java
@@ -43,34 +43,12 @@ public interface DefinitionArgument extends IR {
       super(name, ascribedType, defaultValue, suspended, identifiedLocation, passData, diagnostics);
     }
 
-    public Specified(
-        Name name,
-        Option<Expression> ascribedType,
-        Option<Expression> defaultValue,
-        boolean suspended,
-        IdentifiedLocation identifiedLocation) {
-      this(
-          name,
-          ascribedType,
-          defaultValue,
-          suspended,
-          identifiedLocation,
-          new MetadataStorage(),
-          null);
+    public static Builder builder() {
+      return new Builder();
     }
 
-    public Specified(
-        Name name,
-        Option<Expression> ascribedType,
-        Option<Expression> defaultValue,
-        boolean suspended,
-        IdentifiedLocation identifiedLocation,
-        MetadataStorage passData) {
-      this(name, ascribedType, defaultValue, suspended, identifiedLocation, passData, null);
-    }
-
-    public Specified(Name name) {
-      this(name, Option.empty(), Option.empty(), false, null, new MetadataStorage());
+    public static Builder builder(Specified original) {
+      return new Builder(original);
     }
 
     @Override

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/Application.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/Application.java
@@ -181,7 +181,6 @@ public interface Application extends Expression {
       return new Builder();
     }
 
-
     @Override
     public String showCode(int indent) {
       var itemsStr = items().map(it -> it.showCode(indent)).mkString(" ");

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/Application.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/Application.java
@@ -30,17 +30,8 @@ public interface Application extends Expression {
       super(function, arguments, hasDefaultsSuspended, identifiedLocation, passData, diagnostics);
     }
 
-    public Prefix(
-        Expression function,
-        List<CallArgument> arguments,
-        boolean hasDefaultsSuspended,
-        IdentifiedLocation identifiedLocation,
-        MetadataStorage passData) {
-      this(function, arguments, hasDefaultsSuspended, identifiedLocation, passData, null);
-    }
-
-    public Prefix(Expression function, List<CallArgument> arguments) {
-      this(function, arguments, false, null, new MetadataStorage(), null);
+    public static Builder builder() {
+      return new Builder();
     }
 
     public Prefix copy(Expression function, List<CallArgument> arguments) {
@@ -102,9 +93,8 @@ public interface Application extends Expression {
       super(target, identifiedLocation, passData, diagnostics);
     }
 
-    public Force(
-        Expression target, IdentifiedLocation identifiedLocation, MetadataStorage passData) {
-      this(target, identifiedLocation, passData, null);
+    public static Builder builder() {
+      return new Builder();
     }
 
     @Override
@@ -187,10 +177,10 @@ public interface Application extends Expression {
       super(items, identifiedLocation, passData, diagnostics);
     }
 
-    public Sequence(
-        List<Expression> items, IdentifiedLocation identifiedLocation, MetadataStorage passData) {
-      this(items, identifiedLocation, passData, null);
+    public static Builder builder() {
+      return new Builder();
     }
+
 
     @Override
     public String showCode(int indent) {

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -426,13 +426,12 @@ final class SuggestionBuilder[A: IndexedSource](
     argument: DefinitionArgument
   ): Suggestion = {
     val getterName = argument.name.name
-    val thisArg = new DefinitionArgument.Specified(
-      Name.Self(identifiedLocation = null),
-      None,
-      None,
-      false,
-      null
-    )
+    val thisArg = DefinitionArgument.Specified.builder()
+      .name(Name.Self(identifiedLocation = null))
+      .ascribedType(None)
+      .defaultValue(None)
+      .suspended(false)
+      .build()
     buildMethod(
       externalId         = None,
       module             = module,

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -427,11 +427,11 @@ final class SuggestionBuilder[A: IndexedSource](
   ): Suggestion = {
     val getterName = argument.name.name
     val thisArg = new DefinitionArgument.Specified(
-      name               = Name.Self(identifiedLocation = null),
-      ascribedType       = None,
-      defaultValue       = None,
-      suspended          = false,
-      identifiedLocation = null
+      Name.Self(identifiedLocation = null),
+      None,
+      None,
+      false,
+      null
     )
     buildMethod(
       externalId         = None,

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -429,8 +429,6 @@ final class SuggestionBuilder[A: IndexedSource](
     val thisArg = DefinitionArgument.Specified
       .builder()
       .name(Name.Self(identifiedLocation = null))
-      .ascribedType(None)
-      .defaultValue(None)
       .suspended(false)
       .build()
     buildMethod(

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -426,7 +426,8 @@ final class SuggestionBuilder[A: IndexedSource](
     argument: DefinitionArgument
   ): Suggestion = {
     val getterName = argument.name.name
-    val thisArg = DefinitionArgument.Specified.builder()
+    val thisArg = DefinitionArgument.Specified
+      .builder()
       .name(Name.Self(identifiedLocation = null))
       .ascribedType(None)
       .defaultValue(None)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1646,15 +1646,15 @@ class IrToTruffle(
               Option(asType(binding)) match {
                 case Some(tpe) =>
                   val argOfType = List(
-                    new DefinitionArgument.Specified(
-                      typePattern.name,
-                      None,
-                      None,
-                      suspended = false,
-                      typePattern.identifiedLocation,
-                      passData    = typePattern.name.passData,
-                      diagnostics = typePattern.name.diagnostics
-                    )
+                    DefinitionArgument.Specified.builder()
+                      .name(typePattern.name)
+                      .ascribedType(None)
+                      .defaultValue(None)
+                      .suspended(false)
+                      .location(typePattern.identifiedLocation)
+                      .passData(typePattern.name.passData)
+                      .diagnostics(typePattern.name.diagnostics)
+                      .build()
                   )
 
                   val branchCodeNode = childProcessor.processFunctionBody(
@@ -1683,15 +1683,15 @@ class IrToTruffle(
                   .get()
               if (polySymbol != null) {
                 val argOfType = List(
-                  new DefinitionArgument.Specified(
-                    typePattern.name,
-                    None,
-                    None,
-                    suspended = false,
-                    typePattern.identifiedLocation,
-                    passData    = typePattern.name.passData,
-                    diagnostics = typePattern.name.diagnostics
-                  )
+                  DefinitionArgument.Specified.builder()
+                    .name(typePattern.name)
+                    .ascribedType(None)
+                    .defaultValue(None)
+                    .suspended(false)
+                    .location(typePattern.identifiedLocation)
+                    .passData(typePattern.name.passData)
+                    .diagnostics(typePattern.name.diagnostics)
+                    .build()
                 )
 
                 val branchCodeNode = childProcessor.processFunctionBody(
@@ -1747,15 +1747,15 @@ class IrToTruffle(
       * @return `name` as a function definition argument.
       */
     private def genArgFromMatchField(name: Pattern.Name): DefinitionArgument = {
-      new DefinitionArgument.Specified(
-        name.name,
-        None,
-        None,
-        suspended = false,
-        name.identifiedLocation,
-        passData    = name.name.passData,
-        diagnostics = name.name.diagnostics
-      )
+      DefinitionArgument.Specified.builder()
+        .name(name.name)
+        .ascribedType(None)
+        .defaultValue(None)
+        .suspended(false)
+        .location(name.identifiedLocation)
+        .passData(name.name.passData)
+        .diagnostics(name.name.diagnostics)
+        .build()
     }
 
     /** Generates code for an Enso binding expression.

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1649,8 +1649,6 @@ class IrToTruffle(
                     DefinitionArgument.Specified
                       .builder()
                       .name(typePattern.name)
-                      .ascribedType(None)
-                      .defaultValue(None)
                       .suspended(false)
                       .location(typePattern.identifiedLocation)
                       .passData(typePattern.name.passData)
@@ -1752,8 +1750,6 @@ class IrToTruffle(
       DefinitionArgument.Specified
         .builder()
         .name(name.name)
-        .ascribedType(None)
-        .defaultValue(None)
         .suspended(false)
         .location(name.identifiedLocation)
         .passData(name.name.passData)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1646,7 +1646,8 @@ class IrToTruffle(
               Option(asType(binding)) match {
                 case Some(tpe) =>
                   val argOfType = List(
-                    DefinitionArgument.Specified.builder()
+                    DefinitionArgument.Specified
+                      .builder()
                       .name(typePattern.name)
                       .ascribedType(None)
                       .defaultValue(None)
@@ -1683,7 +1684,8 @@ class IrToTruffle(
                   .get()
               if (polySymbol != null) {
                 val argOfType = List(
-                  DefinitionArgument.Specified.builder()
+                  DefinitionArgument.Specified
+                    .builder()
                     .name(typePattern.name)
                     .ascribedType(None)
                     .defaultValue(None)
@@ -1747,7 +1749,8 @@ class IrToTruffle(
       * @return `name` as a function definition argument.
       */
     private def genArgFromMatchField(name: Pattern.Name): DefinitionArgument = {
-      DefinitionArgument.Specified.builder()
+      DefinitionArgument.Specified
+        .builder()
         .name(name.name)
         .ascribedType(None)
         .defaultValue(None)


### PR DESCRIPTION
Split from #13037

### Pull Request Description

- Remove parameter names when calling Java from Scala
  - For example in e26410b9ccc55583438aa8f22ea3a9520ad14aa6
  - Reason: Although it is possible (because `runtime-compiler/javacOpts` has `-parameters`), it sometimes breaks incremental compilation of `runtime-compiler`. Both locally and on CI.
- Prefer builder to direct constructors.
  - For example in 1395d2c159b85ba6d5dfb2d3900370edb896e1bb
  - Reason: Better readability, ensuring proper defaults, can have just a single constructor.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
- [X] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
