### PR TITLE
Run visualizations only when out of sync

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/UpdatesSynchronizationState.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/UpdatesSynchronizationState.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import org.slf4j.Logger;
 
 /**
  * The synchronization state of runtime updates.
@@ -137,10 +138,11 @@ public class UpdatesSynchronizationState {
    *
    * @param key the visualization id.
    */
-  public void runAndSetVisualizationSync(UUID key, Runnable runnable) {
+  public void runAndSetVisualizationSync(UUID key, Runnable runnable, Logger logger) {
     synchronized (visualizationsState) {
-      runnable.run();
       if (!visualizationsState.contains(key)) {
+        logger.trace("Visualization {} is out-of-sync. Running.", key);
+        runnable.run();
         visualizationsState.add(key);
       }
     }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -310,8 +310,9 @@ public final class ExecutionService {
    * @param expression the expression to evaluate
    * @return a computation representing the evaluation of an expression
    */
-  public CompletionStage<Object> evaluateExpression(Module module, String expression) {
-    LOGGER.trace("evaluateExpression in {} code: {}", module.getName(), expression);
+  public CompletionStage<Object> evaluateExpression(
+      Module module, String expression, String context) {
+    LOGGER.trace("evaluateExpression in {} code ({}): {}", module.getName(), context, expression);
     return submitExecution(() -> invoke.getCallTarget().call(module, expression));
   }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/WarningPreview.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/WarningPreview.scala
@@ -22,7 +22,8 @@ object WarningPreview {
     val visualizationExpressionFuture: CompletionStage[AnyRef] =
       ctx.executionService.evaluateExpression(
         ctx.executionService.getContext.getBuiltins.getModule,
-        METHOD
+        METHOD,
+        "warning preview"
       )
     val visualizationResultFuture =
       visualizationExpressionFuture.thenCompose(visualizationExpression =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -154,7 +154,7 @@ final class JobExecutionEngine(
     synchronized {
       if (isBackgroundJobsStarted) {
         cancelDuplicateJobs(job, backgroundJobsRef)
-        runInternal(job, backgroundJobExecutor, backgroundJobsRef)
+        runInternal(job, backgroundJobExecutor, backgroundJobsRef, "background")
       } else {
         job match {
           case job: UniqueJob[_] =>
@@ -173,7 +173,7 @@ final class JobExecutionEngine(
     cancelDuplicateJobs(job, runningJobsRef)
     val executor =
       if (job.highPriority) highPriorityJobExecutor else jobExecutor
-    runInternal(job, executor, runningJobsRef)
+    runInternal(job, executor, runningJobsRef, "regular")
   }
 
   private def cancelDuplicateJobs[A](
@@ -220,7 +220,8 @@ final class JobExecutionEngine(
   private def runInternal[A](
     job: Job[A],
     executorService: ExecutorService,
-    runningJobsRef: AtomicReference[Vector[RunningJob]]
+    runningJobsRef: AtomicReference[Vector[RunningJob]],
+    queueName: String
   ): Future[A] = {
     val jobId   = UUID.randomUUID()
     val promise = Promise[A]()
@@ -254,7 +255,8 @@ final class JobExecutionEngine(
       } finally {
         val remaining = runningJobsRef.updateAndGet(_.filterNot(_.id == jobId))
         logger.trace(
-          "Number of remaining pending jobs: {}",
+          "Number of remaining pending {} jobs: {}",
+          queueName,
           remaining.size
         )
       }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -799,7 +799,8 @@ object ProgramExecutionSupport {
                 )
               )
             )
-          }
+          },
+          logger
         )
 
       case Right(data) =>
@@ -822,7 +823,8 @@ object ProgramExecutionSupport {
                 )
               )
             )
-          }
+          },
+          logger
         )
     }
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -388,7 +388,11 @@ object UpsertVisualizationJob {
   ): Either[EvaluationFailure, AnyRef] = {
     Try {
       val pending =
-        ctx.executionService.evaluateExpression(module, argumentExpression)
+        ctx.executionService.evaluateExpression(
+          module,
+          argumentExpression,
+          "evaluate args"
+        )
       pending.toCompletableFuture.get()
     }.toEither.left.flatMap {
       case _: ThreadInterruptedException
@@ -453,7 +457,8 @@ object UpsertVisualizationJob {
         case Api.VisualizationExpression.Text(_, expression, _) =>
           ctx.executionService.evaluateExpression(
             expressionModule,
-            expression
+            expression,
+            "evaluate visualization function"
           )
         case Api.VisualizationExpression.ModuleMethod(
               Api.MethodPointer(_, definedOnType, name),

--- a/lib/java/logging-service-common/src/main/java/org/enso/logging/service/LogJobsProcessor.java
+++ b/lib/java/logging-service-common/src/main/java/org/enso/logging/service/LogJobsProcessor.java
@@ -138,7 +138,7 @@ public abstract class LogJobsProcessor {
   }
 
   private void notifyJobsAboutSuccess(List<LogJob> logJobs) {
-    logger.trace("Successfully sent {} log messages", logJobs.size());
+    // logger.trace("Successfully sent {} log messages", logJobs.size());
     for (var logJob : logJobs) {
       if (logJob.completionNofitication() != null) {
         logJob.completionNofitication().complete(null);
@@ -211,11 +211,13 @@ public abstract class LogJobsProcessor {
     var inEarlyFuture = now.plus(TOKEN_EARLY_REFRESH_PERIOD);
     var expiration = authenticationData.expireAt();
     var res = inEarlyFuture.compareTo(expiration) > 0;
-    logger.trace(
-        "Token needs refresh: {}. Current time (plus early refresh period): {}, expiration: {}",
-        res,
-        inEarlyFuture,
-        expiration);
+    if (res) {
+      logger.trace(
+          "Token needs refresh: {}. Current time (plus early refresh period): {}, expiration: {}",
+          res,
+          inEarlyFuture,
+          expiration);
+    }
     return res;
   }
 


### PR DESCRIPTION
### Pull Request Description

Typo: visualization runnable should be run only when the condition dictates that it is out of sync.
Added more context to logging to help with debugging.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
