### PR TITLE
Merging `ModuleScopeBuilder` and `TruffleCompilerModuleScopeBuilder`

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -480,6 +480,7 @@ class Compiler(
       runErrorHandling(requiredModules)
 
       val requiredModulesWithScope = requiredModules.map { module =>
+        val moduleScopeBuilder = module.getScopeBuilder()
         if (
           !module
             .getCompilationStage()
@@ -487,18 +488,9 @@ class Compiler(
               CompilationStage.AFTER_RUNTIME_STUBS
             )
         ) {
-          val moduleScopeBuilder = module.getScopeBuilder()
           context.runStubsGenerator(module, moduleScopeBuilder)
-          context.updateModule(
-            module,
-            { u =>
-              u.compilationStage(CompilationStage.AFTER_RUNTIME_STUBS)
-            }
-          )
-          (module, moduleScopeBuilder)
-        } else {
-          (module, module.getScopeBuilder)
         }
+        (module, moduleScopeBuilder)
       }
 
       requiredModulesWithScope.foreach { case (module, moduleScopeBuilder) =>

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Builtin.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Builtin.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.enso.interpreter.EnsoLanguage;
+import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.atom.AtomConstructor;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 
 /** A base class for all classes annotated with @BuiltinType */
 public abstract class Builtin {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -47,7 +47,6 @@ import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.type.Types;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
@@ -174,7 +173,7 @@ public final class Module extends EnsoObject {
       this.compilationStage = CompilationStage.INITIAL;
     } else {
       if (fillWith != null) {
-        fillWith.accept(scopeBuilder.unsafeScopeBuilder());
+        fillWith.accept(scopeBuilder);
       }
       this.compilationStage = CompilationStage.AFTER_CODEGEN;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -556,7 +556,7 @@ public final class Module extends EnsoObject {
    */
   final ModuleScopeBuilder getScopeBuilder(boolean reset) {
     var sb = TruffleCompilerContext.findCompilerModule(this).getScopeBuilder(reset);
-    return sb.unsafeScopeBuilder();
+    return sb;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeAccessor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeAccessor.java
@@ -1,8 +1,13 @@
 package org.enso.interpreter.runtime;
 
-import java.util.function.Consumer;
+import com.oracle.truffle.api.interop.TruffleObject;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.scope.ImportExportScope;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 
 /**
  * Accessor between this package and package that defines {@link ModuleScopeBuilder}. Controls who
@@ -17,7 +22,7 @@ public abstract class ModuleScopeAccessor {
   private static ModuleScopeAccessor INSTANCE;
 
   static {
-    var forceInitialization = ModuleScopeBuilder.class;
+    var forceInitialization = ModuleScope.class;
     try {
       Class.forName(forceInitialization.getName(), true, forceInitialization.getClassLoader());
     } catch (ClassNotFoundException ex) {
@@ -36,5 +41,20 @@ public abstract class ModuleScopeAccessor {
     INSTANCE = this;
   }
 
-  protected abstract ModuleScopeBuilder newScopeBuilder(Module m, Consumer<ModuleScope> update);
+  // protected abstract ModuleScopeBuilder newScopeBuilder(Module m, Consumer<ModuleScope> update);
+  protected abstract Function findMethodForType(
+      Type tpe, final Map<Type, Map<String, Supplier<Function>>> m, String name);
+
+  protected abstract Supplier<TruffleObject> findPolyglotSymbolSupplier(
+      Map<String, Supplier<TruffleObject>> ps, String symbolName);
+
+  protected abstract ModuleScope newModuleScope(
+      Module module,
+      Type associatedType,
+      Map<String, Supplier<TruffleObject>> unmodifiableMap,
+      Map<String, Type> unmodifiableMap0,
+      Map<Type, Map<String, Supplier<Function>>> unmodifiableMap1,
+      Map<Type, Map<Type, Supplier<Function>>> unmodifiableMap2,
+      Set<ImportExportScope> unmodifiableSet,
+      Set<ImportExportScope> unmodifiableSet0);
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeBuilder.java
@@ -1,268 +1,64 @@
 package org.enso.interpreter.runtime;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.interop.TruffleObject;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.enso.compiler.context.CompilerContext;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.error.RedefinedConversionException;
-import org.enso.interpreter.runtime.error.RedefinedMethodException;
-import org.enso.interpreter.runtime.scope.ImportExportScope;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.interpreter.runtime.util.CachingSupplier;
 
-/** Builder to create an instance of {@link ModuleScope}. */
-public abstract class ModuleScopeBuilder extends CompilerContext.ModuleScopeBuilder {
-  private final Consumer<ModuleScope> onFinish;
-  private ModuleScope moduleScope;
-  private final Module module;
-  private final Type associatedType;
-  private final Map<String, Supplier<TruffleObject>> polyglotSymbols;
-  private final Map<String, Type> types;
-  private final Map<Type, Map<String, Supplier<Function>>> methods;
-  private final Map<Type, Map<Type, Supplier<Function>>> conversions;
-  private final Set<ImportExportScope> imports;
-  private final Set<ImportExportScope> exports;
-
-  /** Only for TruffleCompilerModuleScopeBuilder */
-  ModuleScopeBuilder(Module module, Consumer<ModuleScope> onFinish) {
-    this.module = module;
-    this.onFinish = onFinish;
-    this.polyglotSymbols = new LinkedHashMap<>();
-    this.types = new LinkedHashMap<>();
-    this.methods = new LinkedHashMap<>();
-    this.conversions = new LinkedHashMap<>();
-    this.imports = new LinkedHashSet<>();
-    this.exports = new LinkedHashSet<>();
-    this.associatedType = Type.createSingleton(module.getName().item(), this, null, false, false);
-  }
-
-  public Type registerType(Type type) {
-    assert moduleScope == null;
-    Type current = types.putIfAbsent(type.getName(), type);
-    return current == null ? type : current;
-  }
-
-  public TruffleCompilerModuleScopeBuilder toCompilerBuilder() {
-    return (TruffleCompilerModuleScopeBuilder) this;
-  }
+/**
+ * Module scope builder to allow runtime infrastructure to populate {@link ModuleScope} during
+ * {@link Compiler} execution. This interface is needed by {@link Type} and {@link AtomConstructor}
+ * and {@link Builtins} that modify the scope outside of this package. The {@code IrToTruffle} code
+ * itself is using directly the package private implementation of {@link
+ * TruffleCompilerModuleScopeBuilder}.
+ */
+public sealed interface ModuleScopeBuilder permits TruffleCompilerModuleScopeBuilder {
+  /**
+   * This scope builder has 1:1 association with {@link CompilerContext}'s module scope builder.
+   *
+   * @return the associated module scope builder
+   */
+  public CompilerContext.ModuleScopeBuilder toCompilerBuilder();
 
   /**
-   * Returns a map of methods defined in this module for a given type.
+   * This scope builder is creating {@link ModuleScope} for a particular odule.
    *
-   * @param type the type for which method map is requested
-   * @return a map containing all the defined methods by name
+   * @return the module this scope will become scope of
    */
-  private Map<String, Supplier<Function>> ensureMethodMapFor(Type type) {
-    Type tpeKey = type == null ? Type.noType() : type;
-    return methods.computeIfAbsent(tpeKey, k -> new LinkedHashMap<>());
-  }
+  public Module getModule();
 
   /**
-   * Registers a method defined for a given type.
+   * Each {@link #getModule} has one associated type. This method provides access to it bypassing
+   * access to {@link ModuleScope#getAssociatedType()}.
    *
-   * @param type the type the method was defined for
-   * @param method method name
-   * @param function the {@link Function} associated with this definition
+   * @return the associated type
    */
-  public void registerMethod(Type type, String method, Function function) {
-    assert moduleScope == null;
-    Map<String, Supplier<Function>> methodMap = ensureMethodMapFor(type);
-    // Builtin types will have double definition because of
-    // BuiltinMethod and that's OK
-    if (methodMap.containsKey(method) && !type.isBuiltin()) {
-      throw new RedefinedMethodException(type.getName(), method);
-    } else {
-      methodMap.put(method, CachingSupplier.forValue(function));
-    }
-  }
+  public Type getAssociatedType();
 
   /**
-   * Registers a lazily constructed method defined for a given type.
+   * Queries list of already registered types.
    *
-   * @param type the type the method was defined for
-   * @param method method name
-   * @param supply provider of the {@link Function} associated with this definition
+   * @param name name to search for
+   * @param ignoreAssociatedType ignore {@link #getAssociatedType()}
+   * @return a type or {@code null}
    */
-  public void registerMethod(Type type, String method, Supplier<Function> supply) {
-    assert moduleScope == null;
-    Map<String, Supplier<Function>> methodMap = ensureMethodMapFor(type);
-    // Builtin types will have double definition because of
-    // BuiltinMethod and that's OK
-    if (methodMap.containsKey(method) && !type.isBuiltin()) {
-      throw new RedefinedMethodException(type.getName(), method);
-    } else {
-      methodMap.put(method, CachingSupplier.wrap(supply));
-    }
-  }
+  public Type getType(String name, boolean ignoreAssociatedType);
+
+  public Type registerType(Type type);
+
+  public void registerMethod(Type tpeKey, String name, Supplier<Function> fun);
+
+  public void registerAllMethodsOfTypeToScope(Type tpe, ModuleScopeBuilder scope);
+
+  /** Finishes building of the scope */
+  public void finish();
 
   /**
-   * Registers a conversion method for a given type
+   * Access to scope this builder has built by {@link #finish}.
    *
-   * @param toType type the conversion was defined to
-   * @param fromType type the conversion was defined from
-   * @param function the {@link Function} associated with this definition
+   * @return ModuleScope, if the builder has already been `built`
+   * @throws Error nasty error when this method is called sooner than {@link #finish}
    */
-  public void registerConversionMethod(Type toType, Type fromType, Function function) {
-    registerConversionMethod(toType, fromType, () -> function);
-  }
-
-  public void registerConversionMethod(Type toType, Type fromType, Supplier<Function> supply) {
-    assert moduleScope == null;
-    java.util.Map<
-            org.enso.interpreter.runtime.data.Type,
-            java.util.function.Supplier<org.enso.interpreter.runtime.callable.function.Function>>
-        sourceMap = conversions.computeIfAbsent(toType, k -> new LinkedHashMap<>());
-    if (sourceMap.containsKey(fromType)) {
-      throw new RedefinedConversionException(toType.getName(), fromType.getName());
-    } else {
-      sourceMap.put(fromType, CachingSupplier.wrap(supply));
-    }
-  }
-
-  /**
-   * Registers a new symbol in the polyglot namespace.
-   *
-   * @param name the name of the symbol
-   * @param symbolFactory the value being exposed
-   */
-  public void registerPolyglotSymbol(String name, Supplier<TruffleObject> symbolFactory) {
-    assert moduleScope == null;
-    polyglotSymbols.put(name, CachingSupplier.wrap(symbolFactory));
-  }
-
-  /**
-   * Registers all methods of a type in the provided scope.
-   *
-   * @param tpe the methods of which type should be registered
-   * @param scope target scope where methods should be registered to
-   */
-  public void registerAllMethodsOfTypeToScope(Type tpe, ModuleScopeBuilder scope) {
-    // FIXME: because of Builtins can't enable 'assert moduleScope == null;'
-    Type tpeKey = tpe == null ? Type.noType() : tpe;
-    java.util.Map<
-            java.lang.String,
-            java.util.function.Supplier<org.enso.interpreter.runtime.callable.function.Function>>
-        allTypeMethods = methods.get(tpeKey);
-    if (allTypeMethods != null) {
-      allTypeMethods.forEach((name, fun) -> scope.registerMethod(tpeKey, name, fun));
-    }
-  }
-
-  /**
-   * Adds a dependency for this module.
-   *
-   * @param scope the scope of the newly added dependency
-   */
-  public void addImport(ImportExportScope scope) {
-    assert moduleScope == null;
-    imports.add(scope);
-  }
-
-  /**
-   * Adds an information about the module exporting another module.
-   *
-   * @param scope the exported scope
-   */
-  public void addExport(ImportExportScope scope) {
-    assert moduleScope == null;
-    exports.add(scope);
-  }
-
-  public Module getModule() {
-    return module;
-  }
-
-  /** Complete building this scope */
-  public void finish() {
-    build();
-  }
-
-  /**
-   * Materializes the builder and ensures that no further modifications to ModuleScope are possible.
-   * Action is idempotent.
-   *
-   * @return an immutable ModuleScope
-   */
-  private ModuleScope build() {
-    if (moduleScope == null) {
-      moduleScope = createModuleScope();
-      onFinish.accept(moduleScope);
-    }
-    return moduleScope;
-  }
-
-  public Type getAssociatedType() {
-    return associatedType;
-  }
-
-  public Type getType(String name, boolean ignoreAssociatedType) {
-    if (!ignoreAssociatedType && associatedType.getName().equals(name)) {
-      return associatedType;
-    }
-    return types.get(name);
-  }
-
-  public Supplier<TruffleObject> getPolyglotSymbolSupplier(String symbolName) {
-    return ModuleScopeAccessor.getInstance()
-        .findPolyglotSymbolSupplier(polyglotSymbols, symbolName);
-  }
-
-  public Function getMethodForType(Type tpe, String name) {
-    return ModuleScopeAccessor.getInstance().findMethodForType(tpe, methods, name);
-  }
-
-  /**
-   * Return a view on `this` as a ModuleScope, rather than its builder.
-   *
-   * @return ModuleScope, if the builder has already been `built`, a proxy instance with the
-   *     currently registered entities
-   */
-  public ModuleScope asModuleScope() {
-    if (moduleScope != null) {
-      return moduleScope;
-    } else {
-      throw CompilerDirectives.shouldNotReachHere("build() first!");
-    }
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  private ModuleScope createModuleScope() {
-    return ModuleScopeAccessor.getInstance()
-        .newModuleScope(
-            module,
-            associatedType,
-            Collections.unmodifiableMap(polyglotSymbols),
-            Collections.unmodifiableMap(types),
-            Collections.unmodifiableMap(methods),
-            Collections.unmodifiableMap(conversions),
-            Collections.unmodifiableSet(imports),
-            Collections.unmodifiableSet(exports));
-  }
-
-  @Override
-  public java.lang.String toString() {
-    StringBuilder builder = new StringBuilder();
-    builder.append("ModuleScope builder for " + module.getName());
-    builder.append(",\n");
-    builder.append("Polyglot Symbols: " + polyglotSymbols);
-    builder.append(",\n");
-    builder.append("Methods: " + methods);
-    builder.append(",\n");
-    builder.append("Conversions: " + conversions);
-    builder.append(",\n");
-    builder.append("Imports: " + imports);
-    builder.append(",\n");
-    builder.append("Exports: " + exports);
-    builder.append(",\n");
-    builder.append("Types: " + types);
-    return builder.toString();
-  }
+  public ModuleScope asModuleScope();
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ModuleScopeBuilder.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.runtime.scope;
+package org.enso.interpreter.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.TruffleObject;
@@ -9,25 +9,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.enso.interpreter.runtime.Module;
-import org.enso.interpreter.runtime.ModuleScopeAccessor;
+import org.enso.compiler.context.CompilerContext;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.RedefinedConversionException;
 import org.enso.interpreter.runtime.error.RedefinedMethodException;
+import org.enso.interpreter.runtime.scope.ImportExportScope;
+import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /** Builder to create an instance of {@link ModuleScope}. */
-public final class ModuleScopeBuilder {
-  private static final ModuleScopeAccessor IMPL =
-      new ModuleScopeAccessor() {
-        @Override
-        protected final ModuleScopeBuilder newScopeBuilder(
-            Module m, Consumer<ModuleScope> onFinish) {
-          return new ModuleScopeBuilder(m, onFinish);
-        }
-      };
-
+public abstract class ModuleScopeBuilder extends CompilerContext.ModuleScopeBuilder {
   private final Consumer<ModuleScope> onFinish;
   private ModuleScope moduleScope;
   private final Module module;
@@ -39,7 +31,8 @@ public final class ModuleScopeBuilder {
   private final Set<ImportExportScope> imports;
   private final Set<ImportExportScope> exports;
 
-  private ModuleScopeBuilder(Module module, Consumer<ModuleScope> onFinish) {
+  /** Only for TruffleCompilerModuleScopeBuilder */
+  ModuleScopeBuilder(Module module, Consumer<ModuleScope> onFinish) {
     this.module = module;
     this.onFinish = onFinish;
     this.polyglotSymbols = new LinkedHashMap<>();
@@ -57,6 +50,10 @@ public final class ModuleScopeBuilder {
     return current == null ? type : current;
   }
 
+  public TruffleCompilerModuleScopeBuilder toCompilerBuilder() {
+    return (TruffleCompilerModuleScopeBuilder) this;
+  }
+
   /**
    * Returns a map of methods defined in this module for a given type.
    *
@@ -64,7 +61,7 @@ public final class ModuleScopeBuilder {
    * @return a map containing all the defined methods by name
    */
   private Map<String, Supplier<Function>> ensureMethodMapFor(Type type) {
-    Type tpeKey = type == null ? ModuleScopeUtils.noTypeKey : type;
+    Type tpeKey = type == null ? Type.noType() : type;
     return methods.computeIfAbsent(tpeKey, k -> new LinkedHashMap<>());
   }
 
@@ -149,7 +146,7 @@ public final class ModuleScopeBuilder {
    */
   public void registerAllMethodsOfTypeToScope(Type tpe, ModuleScopeBuilder scope) {
     // FIXME: because of Builtins can't enable 'assert moduleScope == null;'
-    Type tpeKey = tpe == null ? ModuleScopeUtils.noTypeKey : tpe;
+    Type tpeKey = tpe == null ? Type.noType() : tpe;
     java.util.Map<
             java.lang.String,
             java.util.function.Supplier<org.enso.interpreter.runtime.callable.function.Function>>
@@ -196,16 +193,7 @@ public final class ModuleScopeBuilder {
    */
   private ModuleScope build() {
     if (moduleScope == null) {
-      moduleScope =
-          new ModuleScope(
-              module,
-              associatedType,
-              Collections.unmodifiableMap(polyglotSymbols),
-              Collections.unmodifiableMap(types),
-              Collections.unmodifiableMap(methods),
-              Collections.unmodifiableMap(conversions),
-              Collections.unmodifiableSet(imports),
-              Collections.unmodifiableSet(exports));
+      moduleScope = createModuleScope();
       onFinish.accept(moduleScope);
     }
     return moduleScope;
@@ -223,11 +211,12 @@ public final class ModuleScopeBuilder {
   }
 
   public Supplier<TruffleObject> getPolyglotSymbolSupplier(String symbolName) {
-    return ModuleScopeUtils.findPolyglotSymbolSupplier(polyglotSymbols, symbolName);
+    return ModuleScopeAccessor.getInstance()
+        .findPolyglotSymbolSupplier(polyglotSymbols, symbolName);
   }
 
   public Function getMethodForType(Type tpe, String name) {
-    return ModuleScopeUtils.findMethodForType(tpe, methods, name);
+    return ModuleScopeAccessor.getInstance().findMethodForType(tpe, methods, name);
   }
 
   /**
@@ -246,15 +235,16 @@ public final class ModuleScopeBuilder {
 
   @CompilerDirectives.TruffleBoundary
   private ModuleScope createModuleScope() {
-    return new ModuleScope(
-        module,
-        associatedType,
-        Collections.unmodifiableMap(polyglotSymbols),
-        Collections.unmodifiableMap(types),
-        Collections.unmodifiableMap(methods),
-        Collections.unmodifiableMap(conversions),
-        Collections.unmodifiableSet(imports),
-        Collections.unmodifiableSet(exports));
+    return ModuleScopeAccessor.getInstance()
+        .newModuleScope(
+            module,
+            associatedType,
+            Collections.unmodifiableMap(polyglotSymbols),
+            Collections.unmodifiableMap(types),
+            Collections.unmodifiableMap(methods),
+            Collections.unmodifiableMap(conversions),
+            Collections.unmodifiableSet(imports),
+            Collections.unmodifiableSet(exports));
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -870,9 +870,7 @@ final class TruffleCompilerContext implements CompilerContext {
      */
     final TruffleCompilerModuleScopeBuilder getScopeBuilder(boolean reset) {
       if (reset || sb == null) {
-        var scopeBuilder =
-            ModuleScopeAccessor.getInstance().newScopeBuilder(module, module::updateModuleScope);
-        sb = new TruffleCompilerModuleScopeBuilder(scopeBuilder);
+        sb = new TruffleCompilerModuleScopeBuilder(module, module::updateModuleScope);
       }
       return sb;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -245,8 +245,7 @@ final class TruffleCompilerContext implements CompilerContext {
   public void runStubsGenerator(
       CompilerContext.Module module, CompilerContext.ModuleScopeBuilder scopeBuilder) {
     var m = ((Module) module).unsafeModule();
-    var s = ((TruffleCompilerModuleScopeBuilder) scopeBuilder).unsafeScopeBuilder();
-    stubsGenerator.run(m.getIr(), s);
+    stubsGenerator.run(m.getIr(), (TruffleCompilerModuleScopeBuilder) scopeBuilder);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -246,6 +246,7 @@ final class TruffleCompilerContext implements CompilerContext {
       CompilerContext.Module module, CompilerContext.ModuleScopeBuilder scopeBuilder) {
     var m = ((Module) module).unsafeModule();
     stubsGenerator.run(m.getIr(), (TruffleCompilerModuleScopeBuilder) scopeBuilder);
+    m.unsafeSetCompilationStage(CompilationStage.AFTER_RUNTIME_STUBS);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
@@ -11,14 +11,10 @@ final class TruffleCompilerModuleScopeBuilder extends ModuleScopeBuilder {
 
   static ModuleScopeBuilder fromCompilerModuleScopeBuilder(
       CompilerContext.ModuleScopeBuilder scopeBuilder) {
-    return ((TruffleCompilerModuleScopeBuilder) scopeBuilder).unsafeScopeBuilder();
+    return (TruffleCompilerModuleScopeBuilder) scopeBuilder;
   }
 
   static ModuleScopeBuilder fromCompilerModule(CompilerContext.Module module) {
     return fromCompilerModuleScopeBuilder(module.getScopeBuilder());
-  }
-
-  org.enso.interpreter.runtime.ModuleScopeBuilder unsafeScopeBuilder() {
-    return this;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
@@ -1,14 +1,12 @@
 package org.enso.interpreter.runtime;
 
+import java.util.function.Consumer;
 import org.enso.compiler.context.CompilerContext;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
+import org.enso.interpreter.runtime.scope.ModuleScope;
 
-final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScopeBuilder {
-  private final org.enso.interpreter.runtime.scope.ModuleScopeBuilder scopeBuilder;
-
-  TruffleCompilerModuleScopeBuilder(
-      org.enso.interpreter.runtime.scope.ModuleScopeBuilder scopeBuilder) {
-    this.scopeBuilder = scopeBuilder;
+final class TruffleCompilerModuleScopeBuilder extends ModuleScopeBuilder {
+  TruffleCompilerModuleScopeBuilder(Module module, Consumer<ModuleScope> onFinish) {
+    super(module, onFinish);
   }
 
   static ModuleScopeBuilder fromCompilerModuleScopeBuilder(
@@ -20,11 +18,7 @@ final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScop
     return fromCompilerModuleScopeBuilder(module.getScopeBuilder());
   }
 
-  org.enso.interpreter.runtime.scope.ModuleScopeBuilder unsafeScopeBuilder() {
-    return scopeBuilder;
-  }
-
-  final void finish() {
-    this.scopeBuilder.finish();
+  org.enso.interpreter.runtime.ModuleScopeBuilder unsafeScopeBuilder() {
+    return this;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerModuleScopeBuilder.java
@@ -1,20 +1,273 @@
 package org.enso.interpreter.runtime;
 
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.interop.TruffleObject;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.enso.compiler.context.CompilerContext;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.error.RedefinedConversionException;
+import org.enso.interpreter.runtime.error.RedefinedMethodException;
+import org.enso.interpreter.runtime.scope.ImportExportScope;
 import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.interpreter.runtime.util.CachingSupplier;
 
-final class TruffleCompilerModuleScopeBuilder extends ModuleScopeBuilder {
+/**
+ * Builder to create an instance of {@link ModuleScope}. Implements the {@link CompilerContext}'s
+ * module scope builder interface, but adds Truffle related functionality to {@code IrToTruffle} &
+ * co. to build up necessary runtime structures.
+ */
+final class TruffleCompilerModuleScopeBuilder extends CompilerContext.ModuleScopeBuilder
+    implements ModuleScopeBuilder {
+  private final Consumer<ModuleScope> onFinish;
+  private ModuleScope moduleScope;
+  private final Module module;
+  private final Type associatedType;
+  private final Map<String, Supplier<TruffleObject>> polyglotSymbols;
+  private final Map<String, Type> types;
+  private final Map<Type, Map<String, Supplier<Function>>> methods;
+  private final Map<Type, Map<Type, Supplier<Function>>> conversions;
+  private final Set<ImportExportScope> imports;
+  private final Set<ImportExportScope> exports;
+
   TruffleCompilerModuleScopeBuilder(Module module, Consumer<ModuleScope> onFinish) {
-    super(module, onFinish);
+    this.module = module;
+    this.onFinish = onFinish;
+    this.polyglotSymbols = new LinkedHashMap<>();
+    this.types = new LinkedHashMap<>();
+    this.methods = new LinkedHashMap<>();
+    this.conversions = new LinkedHashMap<>();
+    this.imports = new LinkedHashSet<>();
+    this.exports = new LinkedHashSet<>();
+    this.associatedType = Type.createSingleton(module.getName().item(), this, null, false, false);
   }
 
-  static ModuleScopeBuilder fromCompilerModuleScopeBuilder(
+  static TruffleCompilerModuleScopeBuilder fromCompilerModuleScopeBuilder(
       CompilerContext.ModuleScopeBuilder scopeBuilder) {
     return (TruffleCompilerModuleScopeBuilder) scopeBuilder;
   }
 
-  static ModuleScopeBuilder fromCompilerModule(CompilerContext.Module module) {
+  static TruffleCompilerModuleScopeBuilder fromCompilerModule(CompilerContext.Module module) {
     return fromCompilerModuleScopeBuilder(module.getScopeBuilder());
+  }
+
+  @Override
+  public Type registerType(Type type) {
+    assert moduleScope == null;
+    Type current = types.putIfAbsent(type.getName(), type);
+    return current == null ? type : current;
+  }
+
+  @Override
+  public TruffleCompilerModuleScopeBuilder toCompilerBuilder() {
+    return this;
+  }
+
+  /**
+   * Returns a map of methods defined in this module for a given type.
+   *
+   * @param type the type for which method map is requested
+   * @return a map containing all the defined methods by name
+   */
+  private Map<String, Supplier<Function>> ensureMethodMapFor(Type type) {
+    Type tpeKey = type == null ? Type.noType() : type;
+    return methods.computeIfAbsent(tpeKey, k -> new LinkedHashMap<>());
+  }
+
+  /**
+   * Registers a method defined for a given type.
+   *
+   * @param type the type the method was defined for
+   * @param method method name
+   * @param function the {@link Function} associated with this definition
+   */
+  public void registerMethod(Type type, String method, Function function) {
+    assert moduleScope == null;
+    Map<String, Supplier<Function>> methodMap = ensureMethodMapFor(type);
+    // Builtin types will have double definition because of
+    // BuiltinMethod and that's OK
+    if (methodMap.containsKey(method) && !type.isBuiltin()) {
+      throw new RedefinedMethodException(type.getName(), method);
+    } else {
+      methodMap.put(method, CachingSupplier.forValue(function));
+    }
+  }
+
+  /**
+   * Registers a lazily constructed method defined for a given type.
+   *
+   * @param type the type the method was defined for
+   * @param method method name
+   * @param supply provider of the {@link Function} associated with this definition
+   */
+  @Override
+  public void registerMethod(Type type, String method, Supplier<Function> supply) {
+    assert moduleScope == null;
+    Map<String, Supplier<Function>> methodMap = ensureMethodMapFor(type);
+    // Builtin types will have double definition because of
+    // BuiltinMethod and that's OK
+    if (methodMap.containsKey(method) && !type.isBuiltin()) {
+      throw new RedefinedMethodException(type.getName(), method);
+    } else {
+      methodMap.put(method, CachingSupplier.wrap(supply));
+    }
+  }
+
+  /**
+   * Registers a conversion method for a given type
+   *
+   * @param toType type the conversion was defined to
+   * @param fromType type the conversion was defined from
+   * @param function the {@link Function} associated with this definition
+   */
+  void registerConversionMethod(Type toType, Type fromType, Function function) {
+    registerConversionMethod(toType, fromType, () -> function);
+  }
+
+  void registerConversionMethod(Type toType, Type fromType, Supplier<Function> supply) {
+    assert moduleScope == null;
+    java.util.Map<
+            org.enso.interpreter.runtime.data.Type,
+            java.util.function.Supplier<org.enso.interpreter.runtime.callable.function.Function>>
+        sourceMap = conversions.computeIfAbsent(toType, k -> new LinkedHashMap<>());
+    if (sourceMap.containsKey(fromType)) {
+      throw new RedefinedConversionException(toType.getName(), fromType.getName());
+    } else {
+      sourceMap.put(fromType, CachingSupplier.wrap(supply));
+    }
+  }
+
+  /**
+   * Registers a new symbol in the polyglot namespace.
+   *
+   * @param name the name of the symbol
+   * @param symbolFactory the value being exposed
+   */
+  void registerPolyglotSymbol(String name, Supplier<TruffleObject> symbolFactory) {
+    assert moduleScope == null;
+    polyglotSymbols.put(name, CachingSupplier.wrap(symbolFactory));
+  }
+
+  /**
+   * Registers all methods of a type in the provided scope.
+   *
+   * @param tpe the methods of which type should be registered
+   * @param scope target scope where methods should be registered to
+   */
+  @Override
+  public void registerAllMethodsOfTypeToScope(Type tpe, ModuleScopeBuilder scope) {
+    // FIXME: because of Builtins can't enable 'assert moduleScope == null;'
+    Type tpeKey = tpe == null ? Type.noType() : tpe;
+    java.util.Map<
+            java.lang.String,
+            java.util.function.Supplier<org.enso.interpreter.runtime.callable.function.Function>>
+        allTypeMethods = methods.get(tpeKey);
+    if (allTypeMethods != null) {
+      allTypeMethods.forEach((name, fun) -> scope.registerMethod(tpeKey, name, fun));
+    }
+  }
+
+  /**
+   * Adds a dependency for this module.
+   *
+   * @param scope the scope of the newly added dependency
+   */
+  void addImport(ImportExportScope scope) {
+    assert moduleScope == null;
+    imports.add(scope);
+  }
+
+  /**
+   * Adds an information about the module exporting another module.
+   *
+   * @param scope the exported scope
+   */
+  void addExport(ImportExportScope scope) {
+    assert moduleScope == null;
+    exports.add(scope);
+  }
+
+  @Override
+  public Module getModule() {
+    return module;
+  }
+
+  /** Complete building this scope */
+  @Override
+  public void finish() {
+    if (moduleScope == null) {
+      moduleScope = createModuleScope();
+      onFinish.accept(moduleScope);
+    }
+  }
+
+  @Override
+  public Type getAssociatedType() {
+    return associatedType;
+  }
+
+  @Override
+  public Type getType(String name, boolean ignoreAssociatedType) {
+    if (!ignoreAssociatedType && associatedType.getName().equals(name)) {
+      return associatedType;
+    }
+    return types.get(name);
+  }
+
+  public Supplier<TruffleObject> getPolyglotSymbolSupplier(String symbolName) {
+    return ModuleScopeAccessor.getInstance()
+        .findPolyglotSymbolSupplier(polyglotSymbols, symbolName);
+  }
+
+  public Function getMethodForType(Type tpe, String name) {
+    return ModuleScopeAccessor.getInstance().findMethodForType(tpe, methods, name);
+  }
+
+  @Override
+  public ModuleScope asModuleScope() {
+    if (moduleScope != null) {
+      return moduleScope;
+    } else {
+      throw CompilerDirectives.shouldNotReachHere("build() first!");
+    }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private ModuleScope createModuleScope() {
+    return ModuleScopeAccessor.getInstance()
+        .newModuleScope(
+            module,
+            associatedType,
+            Collections.unmodifiableMap(polyglotSymbols),
+            Collections.unmodifiableMap(types),
+            Collections.unmodifiableMap(methods),
+            Collections.unmodifiableMap(conversions),
+            Collections.unmodifiableSet(imports),
+            Collections.unmodifiableSet(exports));
+  }
+
+  @Override
+  public java.lang.String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("ModuleScope builder for " + module.getName());
+    builder.append(",\n");
+    builder.append("Polyglot Symbols: " + polyglotSymbols);
+    builder.append(",\n");
+    builder.append("Methods: " + methods);
+    builder.append(",\n");
+    builder.append("Conversions: " + conversions);
+    builder.append(",\n");
+    builder.append("Imports: " + imports);
+    builder.append(",\n");
+    builder.append("Exports: " + exports);
+    builder.append(",\n");
+    builder.append("Types: " + types);
+    return builder.toString();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -34,8 +34,8 @@ import org.enso.interpreter.node.expression.builtin.runtime.Context;
 import org.enso.interpreter.node.expression.builtin.text.Text;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.pkg.QualifiedName;
 
 /** Container class for static predefined atoms, methods, and their containing scope. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
@@ -20,9 +20,9 @@ import org.enso.compiler.core.CompilerError;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.expression.builtin.Builtin;
 import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
@@ -141,7 +141,8 @@ final class BuiltinsRegistry {
                   meth.isAutoRegister ? (!meth.isStatic() ? type : type.getEigentype()) : null;
               if (tpe != null) {
                 Optional<BuiltinFunction> fun = meth.toFunction(language, false);
-                fun.ifPresent(f -> scope.registerMethod(tpe, key, f.getFunction()));
+                fun.ifPresent(
+                    f -> scope.registerMethod(tpe, key, CachingSupplier.forValue(f.getFunction())));
               }
             });
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -30,6 +30,7 @@ import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMo
 import org.enso.interpreter.node.callable.InvokeMethodNode;
 import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
@@ -39,7 +40,6 @@ import org.enso.interpreter.runtime.data.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 import org.enso.pkg.QualifiedName;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
@@ -26,6 +26,7 @@ import org.enso.interpreter.node.callable.argument.ReadArgumentNode;
 import org.enso.interpreter.node.callable.function.BlockNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.callable.Annotation;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -34,7 +35,6 @@ import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 import org.enso.pkg.QualifiedName;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.enso.compiler.common.MethodResolutionAlgorithm;
 import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.ModuleScopeAccessor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
@@ -18,6 +19,33 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 /** A representation of Enso's per-file top-level scope. */
 @ExportLibrary(TypesLibrary.class)
 public final class ModuleScope extends EnsoObject {
+  private static final ModuleScopeAccessor IMPL =
+      new ModuleScopeAccessor() {
+        @Override
+        protected Function findMethodForType(
+            Type tpe, Map<Type, Map<String, Supplier<Function>>> m, String name) {
+          return ModuleScopeUtils.findMethodForType(tpe, m, name);
+        }
+
+        @Override
+        protected Supplier<TruffleObject> findPolyglotSymbolSupplier(
+            Map<String, Supplier<TruffleObject>> ps, String symbolName) {
+          return ModuleScopeUtils.findPolyglotSymbolSupplier(ps, symbolName);
+        }
+
+        @Override
+        protected ModuleScope newModuleScope(
+            Module module,
+            Type associatedType,
+            Map<String, Supplier<TruffleObject>> m1,
+            Map<String, Type> m2,
+            Map<Type, Map<String, Supplier<Function>>> m3,
+            Map<Type, Map<Type, Supplier<Function>>> m4,
+            Set<ImportExportScope> s1,
+            Set<ImportExportScope> s2) {
+          return new ModuleScope(module, associatedType, m1, m2, m3, m4, s1, s2);
+        }
+      };
   private final Type associatedType;
   private final Module module;
   private final Map<String, Supplier<TruffleObject>> polyglotSymbols;

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -98,7 +98,6 @@ import org.enso.interpreter.runtime.callable.{
 }
 import org.enso.interpreter.runtime.data.Type
 import org.enso.interpreter.runtime.scope.ImportExportScope
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder
 import org.enso.interpreter.{Constants, EnsoLanguage}
 import org.enso.interpreter.runtime.builtin.Builtins
 
@@ -532,7 +531,7 @@ class IrToTruffle(
       val fieldNames = atomDefn.arguments.map(_.name.name).toArray
       atomCons.initializeFields(
         language,
-        scopeBuilder,
+        scopeBuilder.toCompilerBuilder(),
         initializationBuilderSupplier,
         fieldNames
       )

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -126,7 +126,7 @@ import scala.jdk.OptionConverters._
 class IrToTruffle(
   val context: EnsoContext,
   val source: Source,
-  val scopeBuilder: ModuleScopeBuilder,
+  val scopeBuilder: TruffleCompilerModuleScopeBuilder,
   val compilerConfig: CompilerConfig
 ) {
   private def getBuiltins: Builtins = {
@@ -2558,7 +2558,9 @@ class IrToTruffle(
       }
   }
 
-  private def asScope(module: CompilerContext.Module): ModuleScopeBuilder = {
+  private def asScope(
+    module: CompilerContext.Module
+  ): TruffleCompilerModuleScopeBuilder = {
     TruffleCompilerModuleScopeBuilder.fromCompilerModule(module)
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
@@ -7,19 +7,21 @@ import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.data.atom.AtomConstructor
 import org.enso.interpreter.runtime.data.Type
-import org.enso.interpreter.runtime.ModuleScopeBuilder
 
 /** Generates stubs of runtime representations of atom constructors, to allow
   * [[IrToTruffle the code generator]] to refer to constructors that are not
   * fully generated yet.
   */
-class RuntimeStubsGenerator(builtins: Builtins) {
+private[runtime] class RuntimeStubsGenerator(builtins: Builtins) {
 
   /** Runs the stage on the given module.
     *
     * @param module the module to generate stubs in.
     */
-  private[runtime] def run(ir: IR, scope: ModuleScopeBuilder): Unit = {
+  private[runtime] def run(
+    ir: IR,
+    scope: TruffleCompilerModuleScopeBuilder
+  ): Unit = {
     val localBindings = ir.unsafeGetMetadata(
       BindingAnalysis,
       "Non-parsed module used in stubs generator"

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
@@ -7,7 +7,7 @@ import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.data.atom.AtomConstructor
 import org.enso.interpreter.runtime.data.Type
-import org.enso.interpreter.runtime.scope.ModuleScopeBuilder
+import org.enso.interpreter.runtime.ModuleScopeBuilder
 
 /** Generates stubs of runtime representations of atom constructors, to allow
   * [[IrToTruffle the code generator]] to refer to constructors that are not
@@ -19,7 +19,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
     *
     * @param module the module to generate stubs in.
     */
-  def run(ir: IR, scope: ModuleScopeBuilder): Unit = {
+  private[runtime] def run(ir: IR, scope: ModuleScopeBuilder): Unit = {
     val localBindings = ir.unsafeGetMetadata(
       BindingAnalysis,
       "Non-parsed module used in stubs generator"
@@ -27,6 +27,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
     val types = localBindings.definedEntities.collect {
       case t: BindingsMap.Type => t
     }
+    val compilerScope = scope.toCompilerBuilder()
     types.foreach { tp =>
       if (tp.builtinType) {
         val builtinType = builtins.getBuiltinType(tp.name)
@@ -46,7 +47,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
         scope.registerType(builtinType.getType)
         builtinType.getType.setShadowDefinitions(
           builtins.getLanguage(),
-          scope,
+          compilerScope,
           true
         )
       } else {
@@ -57,7 +58,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
             Type.create(
               builtins.getLanguage(),
               tp.name,
-              scope,
+              compilerScope,
               builtins.any(),
               builtins.any(),
               false,
@@ -66,7 +67,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
           } else {
             Type.createSingleton(
               tp.name,
-              scope,
+              compilerScope,
               builtins.any(),
               false,
               hasAllConstructorsPrivate


### PR DESCRIPTION
### Pull Request Description

- continuation of #13768 
- which followed #13716
- and also #13709
- the goal is to unify `ModuleScopeBuilder` and `TruffleCompilerModuleScopeBuilder`
- the unified class inherits `CompilerContext.ModuleScopeBuilder` - as such it can be used from `Compiler`
- the _package private_ `TruffleCompilerModuleScopeBuilder` class is used during `IrToTruffle` & co. _node generation_
- some functionality is needed outside of the package
- such a functionality is exposed via `seal interface ModuleScopeBuilder`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
