### PR TITLE
Add button to cancel checking for payment

### DIFF
--- a/app/gui/src/dashboard/components/Loader.tsx
+++ b/app/gui/src/dashboard/components/Loader.tsx
@@ -1,10 +1,9 @@
 /** @file A full-screen loading spinner. */
 import { StatelessSpinner, type SpinnerState } from '#/components/StatelessSpinner'
-
-import * as twv from '#/utilities/tailwindVariants'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 import { memo } from 'react'
 
-const STYLES = twv.tv({
+const STYLES = tv({
   base: 'animate-appear-delayed flex h-full w-full items-center justify-center duration-200',
   variants: {
     minHeight: {
@@ -48,7 +47,8 @@ const SIZE_MAP: Record<Size, number> = {
 export type Size = 'large' | 'medium' | 'small'
 
 /** Props for a {@link Loader}. */
-export interface LoaderProps extends twv.VariantProps<typeof STYLES> {
+export interface LoaderProps extends VariantProps<typeof STYLES> {
+  readonly children?: React.ReactNode
   readonly className?: string
   readonly size?: Size | number
   readonly state?: SpinnerState
@@ -58,6 +58,7 @@ export interface LoaderProps extends twv.VariantProps<typeof STYLES> {
 
 export const Loader = memo(function Loader(props: LoaderProps) {
   const {
+    children,
     className,
     size: sizeRaw = 'medium',
     state = 'loading-fast',
@@ -70,7 +71,10 @@ export const Loader = memo(function Loader(props: LoaderProps) {
 
   return (
     <div className={STYLES({ minHeight, className, color, height })}>
-      <StatelessSpinner size={size} phase={state} className="text-current" />
+      <div>
+        <StatelessSpinner size={size} phase={state} className="text-current" />
+        {children}
+      </div>
     </div>
   )
 })

--- a/app/gui/src/dashboard/components/Loader.tsx
+++ b/app/gui/src/dashboard/components/Loader.tsx
@@ -71,7 +71,7 @@ export const Loader = memo(function Loader(props: LoaderProps) {
 
   return (
     <div className={STYLES({ minHeight, className, color, height })}>
-      <div>
+      <div className="flex flex-col items-center gap-2">
         <StatelessSpinner size={size} phase={state} className="text-current" />
         {children}
       </div>

--- a/app/gui/src/dashboard/pages/PaymentsSuccess.tsx
+++ b/app/gui/src/dashboard/pages/PaymentsSuccess.tsx
@@ -1,4 +1,5 @@
 /** @file A page for when a subscription payment succeeds. */
+import { Button } from '#/components/Button'
 import { Loader } from '#/components/Loader'
 import Page from '#/components/Page'
 import { useMount } from '#/hooks/mountHooks'
@@ -8,6 +9,7 @@ import { useAuth } from '$/providers/auth'
 import { useRouter, useText, useUserSession } from '$/providers/react'
 import * as analytics from '$/utils/analytics'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
 import { toast } from 'react-toastify'
 
 const USER_REFETCH_DELAY_MS = 3_000
@@ -20,13 +22,30 @@ export function PaymentsSuccess() {
   const { getText } = useText()
   const { refetchSession } = useAuth()
   const oldSession = useUserSession()
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+
+    return () => {
+      isMounted.current = false
+    }
+  })
 
   useMount(() => {
     const promise = (async () => {
       const startEpochMs = Number(new Date())
+      // Extracted into a function to disable flow typing, because `isMounted.current` may be mutated.
+      const getIsMounted = () => isMounted.current
 
       while (true) {
+        if (!getIsMounted()) {
+          throw new Error('Operation cancelled.')
+        }
         const { data: session } = await refetchSession()
+        if (!getIsMounted()) {
+          throw new Error('Operation cancelled.')
+        }
         if (
           session &&
           'user' in session &&
@@ -67,7 +86,16 @@ export function PaymentsSuccess() {
 
   return (
     <Page>
-      <Loader className="h-full w-full" />
+      <Loader className="h-full w-full">
+        <Button
+          variant="delete"
+          onPress={async () => {
+            await router.push(DASHBOARD_PATH)
+          }}
+        >
+          {getText('cancel')}
+        </Button>
+      </Loader>
     </Page>
   )
 }


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/2129
  - Add a button to cancel checking for a payment. This is needed in case a user exits out of the Stripe browser tab, since there is no way to detect the Stripe tab being cancelled

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
