### PR TITLE
Prevent `Cmd+ArrowLeft` and `Cmd+ArrowRight` from triggering shortcuts when an input is focused

### DIFF
--- a/app/gui/src/dashboard/components/Dialog/Dialog.tsx
+++ b/app/gui/src/dashboard/components/Dialog/Dialog.tsx
@@ -61,6 +61,15 @@ export function Dialog(props: DialogProps) {
       className={({ isEntering, isExiting }) =>
         DIALOG_OVERLAY_STYLES({ isEntering, isExiting, blockInteractions: !isDismissable })
       }
+      ref={(element) => {
+        if (element) {
+          element.addEventListener('keydown', (event) => {
+            if (event.key !== 'Escape') {
+              event.stopPropagation()
+            }
+          })
+        }
+      }}
       isDismissable={isDismissable}
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}
       UNSTABLE_portalContainer={root}

--- a/app/gui/src/dashboard/utilities/event.ts
+++ b/app/gui/src/dashboard/utilities/event.ts
@@ -54,14 +54,19 @@ export function isTextInputKey(event: KeyboardEvent | React.KeyboardEvent) {
   return (
     !SPECIAL_CHARACTER_KEYCODE_REGEX.test(event.key) ||
     event.key === 'Backspace' ||
-    event.key === 'Delete'
+    event.key === 'Delete' ||
+    event.key === 'ArrowLeft' ||
+    event.key === 'ArrowRight'
   )
 }
 
 /** Whether `event` will produce text. This excludes shortcutManager, as they do not produce text. */
 export function isTextInputEvent(event: KeyboardEvent | React.KeyboardEvent) {
   // Allow `alt` key to be pressed in case it is being used to enter special characters.
-  return !event.ctrlKey && !event.shiftKey && !event.metaKey && isTextInputKey(event)
+  return (
+    (!event.ctrlKey && !event.shiftKey && !event.metaKey && isTextInputKey(event)) ||
+    (!event.shiftKey && !event.metaKey && (event.key === 'ArrowLeft' || event.key === 'ArrowRight'))
+  )
 }
 
 /** Whether the element accepts text input. */


### PR DESCRIPTION
### Pull Request Description
- Prevent `Cmd+ArrowLeft` and `Cmd+ArrowRight` from triggering shortcuts when an input is focused
- Stop *all* keyboard events other than `Escape` from escaping out of `Dialog`s (mostly modals)

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
