### PR TITLE
Fix output-port double-click causing UDC to be exited

### DIFF
--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
@@ -186,7 +186,11 @@ graph.value?.suggestEdgeFromOutput(outputHovered)
             @pointerenter="mouseOverOutput = port.portId"
             @pointerleave="mouseOverOutput = undefined"
           >
-            <g class="clickable" @pointerdown.stop.prevent="handlePortClick($event, port.portId)">
+            <g
+              class="clickable"
+              @pointerdown.stop="handlePortClick($event, port.portId)"
+              @click.stop
+            >
               <rect class="outputPortHoverArea" />
               <rect
                 v-if="!componentBrowserOpened && isPortDisconnected(port.portId)"


### PR DESCRIPTION
### Pull Request Description

Output port stops click propagation (Fixes #13793)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
