### PR TITLE
Cache all arguments

### DIFF
--- a/engine/common/src/main/java/org/enso/common/CachePreferences.java
+++ b/engine/common/src/main/java/org/enso/common/CachePreferences.java
@@ -23,7 +23,7 @@ public record CachePreferences(Map<UUID, Kind> preferences) {
   /** A kind of cached value. */
   public enum Kind {
     BINDING_EXPRESSION,
-    SELF_ARGUMENT
+    ARGUMENT
   }
 
   /**

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -108,7 +108,7 @@ public final class PassPersistance {
         var id = in.readInline(UUID.class);
         var kind =
             switch (in.readByte()) {
-              case 1 -> CachePreferences.Kind.SELF_ARGUMENT;
+              case 1 -> CachePreferences.Kind.ARGUMENT;
               case 2 -> CachePreferences.Kind.BINDING_EXPRESSION;
               default -> throw new IOException();
             };
@@ -126,7 +126,7 @@ public final class PassPersistance {
         out.writeInline(UUID.class, entry.getKey());
         out.writeByte(
             switch (entry.getValue()) {
-              case SELF_ARGUMENT -> 1;
+              case ARGUMENT -> 1;
               case BINDING_EXPRESSION -> 2;
               default -> throw new IOException();
             });

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
@@ -150,8 +150,15 @@ case object CachePreferenceAnalysis extends IRPass {
       case app: Application.Prefix =>
         app.arguments match {
           case self :: rest =>
-            val newSelf = analyseSelfCallArgument(self, weights)
-            app.copyWithArguments(newSelf :: rest)
+            val newSelf = analyseCallArgument(
+              self,
+              weights,
+              CachePreferences.Kind.ARGUMENT
+            )
+            val newRest = rest.map(
+              analyseCallArgument(_, weights, CachePreferences.Kind.ARGUMENT)
+            )
+            app.copyWithArguments(newSelf :: newRest)
           case _ =>
             app
         }
@@ -162,12 +169,13 @@ case object CachePreferenceAnalysis extends IRPass {
     }
   }
 
-  private def analyseSelfCallArgument(
+  private def analyseCallArgument(
     callArgument: CallArgument,
-    weights: WeightInfo
+    weights: WeightInfo,
+    kind: CachePreferences.Kind
   ): CallArgument = {
     callArgument.value.getExternalId
-      .foreach(weights.update(_, CachePreferences.Kind.SELF_ARGUMENT))
+      .foreach(weights.update(_, kind))
     callArgument match {
       case arg: Specified =>
         arg.copy(

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/pass/PassPersistanceTest.java
@@ -28,7 +28,7 @@ public class PassPersistanceTest {
     var idSelf = UUID.randomUUID();
     var idBind = UUID.randomUUID();
     var pref = new CachePreferences(new HashMap<>());
-    pref.set(idSelf, CachePreferences.Kind.SELF_ARGUMENT);
+    pref.set(idSelf, CachePreferences.Kind.ARGUMENT);
     pref.set(idBind, CachePreferences.Kind.BINDING_EXPRESSION);
 
     var out = serde(CachePreferences.class, pref, -1);

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -396,7 +396,7 @@ class EnsureCompiledJob(
       CacheInvalidation(
         CacheInvalidation.StackSelector.Tail,
         CacheInvalidation.Command.InvalidateByKind(
-          Seq(CachePreferences.Kind.SELF_ARGUMENT)
+          Seq(CachePreferences.Kind.ARGUMENT)
         )
       )
     )

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -7134,6 +7134,7 @@ class RuntimeServerTest
         contextId,
         `y_x`,
         ConstantsGen.INTEGER,
+        fromCache   = true,
         typeChanged = false
       ),
       TestMessages.update(


### PR DESCRIPTION
### Pull Request Description

In real-life, larger workflows we see re-executions taking place due to visualizations being attached to more and more arguments.

The situation is expected as non-self arguments were not cached and are being recomputed all the time. But impact on performance, especially during startup, is very much visible.
This change caches all arguments. While small, the change has significant impact on performance during startup as we appear to avoid most of the numerous re-executions.

### Important Notes

This is a change very much in the _risky_ category. It really depends how much we are willing to wait for #10525.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
