### PR TITLE
Fix responsive cutoffs for trial counter

### DIFF
--- a/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query'
 import type { TextId } from 'enso-common/src/text'
 import { toReadableIsoString } from 'enso-common/src/utilities/data/dateTime'
 import { AnimatePresence, motion } from 'framer-motion'
+import { twJoin } from 'tailwind-merge'
 import { z } from 'zod'
 import { NotificationTray } from './NotificationTray'
 import { UserMenu } from './UserMenu'
@@ -109,14 +110,6 @@ export function UserBar(props: UserBarProps) {
             </motion.div>
           )}
         </AnimatePresence>
-        <div className="flex sm:hidden">
-          <Popover.Trigger>
-            <Button variant="icon" icon="help" aria-label={getText('help')} />
-            <Popover size="auto">
-              <UserBarHelpSection items={topbarLinks.items} className="flex-col" />
-            </Popover>
-          </Popover.Trigger>
-        </div>
         {trialProgress && subscription?.trialEnd != null && (
           <VisualTooltip
             className="relative px-2"
@@ -135,7 +128,26 @@ export function UserBar(props: UserBarProps) {
             <Text className="absolute inset-0 mx-2 cursor-help text-center">{trialText}</Text>
           </VisualTooltip>
         )}
-        <UserBarHelpSection items={topbarLinks.items} className="hidden sm:flex" />
+        <div
+          className={twJoin(
+            'flex',
+            trialProgress && subscription?.trialEnd != null ? 'md:hidden' : 'sm:hidden',
+          )}
+        >
+          <Popover.Trigger>
+            <Button variant="icon" icon="help" aria-label={getText('help')} />
+            <Popover size="auto">
+              <UserBarHelpSection items={topbarLinks.items} className="flex-col" />
+            </Popover>
+          </Popover.Trigger>
+        </div>
+        <UserBarHelpSection
+          items={topbarLinks.items}
+          className={twJoin(
+            'hidden',
+            trialProgress && subscription?.trialEnd != null ? 'md:flex' : 'sm:flex',
+          )}
+        />
         {shouldShowInviteButton && (
           <Dialog.Trigger>
             <Button size="medium" variant="outline">

--- a/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
@@ -84,6 +84,7 @@ export function UserBar(props: UserBarProps) {
     : trialProgress.daysLeft > 0 ? getText('xDaysLeftInTrial', trialProgress.daysLeft)
     : trialProgress.hoursLeft > 0 ? getText('xHoursLeftInTrial', trialProgress.hoursLeft)
     : getText('lessThanOneHourLeftInTrial')
+  const isCurrentlyTrialing = trialProgress != null && subscription?.trialEnd != null
 
   const shouldShowInviteButton = !isFeatureUnderPaywall('inviteUser')
   const shouldShowUpgradeButton = user.isOrganizationAdmin && user.plan === Plan.free
@@ -110,7 +111,7 @@ export function UserBar(props: UserBarProps) {
             </motion.div>
           )}
         </AnimatePresence>
-        {trialProgress && subscription?.trialEnd != null && (
+        {isCurrentlyTrialing && (
           <VisualTooltip
             className="relative px-2"
             tooltip={getText(
@@ -128,12 +129,7 @@ export function UserBar(props: UserBarProps) {
             <Text className="absolute inset-0 mx-2 cursor-help text-center">{trialText}</Text>
           </VisualTooltip>
         )}
-        <div
-          className={twJoin(
-            'flex',
-            trialProgress && subscription?.trialEnd != null ? 'md:hidden' : 'sm:hidden',
-          )}
-        >
+        <div className={twJoin('flex', isCurrentlyTrialing ? 'md:hidden' : 'sm:hidden')}>
           <Popover.Trigger>
             <Button variant="icon" icon="help" aria-label={getText('help')} />
             <Popover size="auto">
@@ -143,10 +139,7 @@ export function UserBar(props: UserBarProps) {
         </div>
         <UserBarHelpSection
           items={topbarLinks.items}
-          className={twJoin(
-            'hidden',
-            trialProgress && subscription?.trialEnd != null ? 'md:flex' : 'sm:flex',
-          )}
+          className={twJoin('hidden', isCurrentlyTrialing ? 'md:flex' : 'sm:flex')}
         />
         {shouldShowInviteButton && (
           <Dialog.Trigger>


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/2125
  - Fix responsive cutoffs for trial counter so that it does not split across multiple lines

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
