### PR TITLE
Fix Local folder resetting after renaming an asset

### DIFF
--- a/app/gui/src/components/AppContainer.vue
+++ b/app/gui/src/components/AppContainer.vue
@@ -38,7 +38,7 @@ export const dataLoader: DataLoader<DashboardProps> = {
     const resolvedPath = await backend.resolveEnsoPath(path).catch(() => null)
     const typedAsset = resolvedPath && extractTypeFromId(resolvedPath.id)
     if (typedAsset?.type !== AssetType.project) return Ok({})
-    const options = backendQueryOptions('getAssetDetails', [typedAsset.id, undefined], backend)
+    const options = backendQueryOptions('getAssetDetails', [typedAsset.id], backend)
     const assetResponse: AssetDetailsResponse<ProjectId> = await queryClient.fetchQuery(options)
     if (!assetResponse) return Ok({})
     const asset: ProjectAsset = { ...assetResponse, ensoPath: path }

--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -276,9 +276,7 @@ export function listDirectoryQueryOptions(options: ListDirectoryQueryOptions) {
   })
 }
 
-/**
- * Options for {@link unsafe_assetFromCacheQueryOptions}.
- */
+/** Options for {@link unsafe_assetFromCacheQueryOptions}. */
 export interface AssetFromCacheQueryOptions {
   readonly backend: Backend
   readonly assetId: AssetId

--- a/app/gui/src/dashboard/layouts/AssetsTable.tsx
+++ b/app/gui/src/dashboard/layouts/AssetsTable.tsx
@@ -20,6 +20,7 @@ import { usePaste } from '#/hooks/cutAndPasteHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useCloseProject, useOpenProjectLocally } from '#/hooks/projectHooks'
 import { useStore } from '#/hooks/storeHooks'
+import { useSyncRef } from '#/hooks/syncRefHooks'
 import { useToastAndLog } from '#/hooks/toastAndLogHooks'
 import type * as assetSearchBar from '#/layouts/AssetSearchBar'
 import { useSetSuggestions } from '#/layouts/AssetSearchBar'
@@ -241,6 +242,7 @@ function AssetsTable(props: AssetsTableProps) {
   const { queryDirectoryId, currentDirectoryId } = useDirectoryIds({
     category,
   })
+  const currentDirectoryIdRef = useSyncRef(currentDirectoryId)
   const listDirectoryRefetchInterval = useListDirectoryRefetchInterval()
   const { data: assets = [] } = useSuspenseQuery({
     ...listDirectoryQueryOptions({
@@ -250,6 +252,7 @@ function AssetsTable(props: AssetsTableProps) {
       refetchInterval: listDirectoryRefetchInterval,
     }),
     retry: () => {
+      if (currentDirectoryId !== currentDirectoryIdRef.current) return true
       setDriveLocation(null, category.id)
       return false
     },

--- a/app/gui/src/dashboard/layouts/Drive/Categories/CategoriesProvider.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/CategoriesProvider.tsx
@@ -19,8 +19,7 @@ export function CategoriesProvider(props: CategoriesProviderProps) {
   const categoryId = useCategoryId() ?? (localBackend != null ? 'local' : 'cloud')
   const category = findCategoryById(categoryId)
 
-  // This usually doesn't happen but if so,
-  // We reset the category to the default.
+  // This usually doesn't happen but if so, we reset the category to the default.
   if (category == null) {
     setDriveLocation(null, null)
     return null

--- a/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarNavigation.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/Drive/DriveBar/DriveBarNavigation.tsx
@@ -10,6 +10,7 @@ import { Menu } from '#/components/Menu'
 import { Scroller } from '#/components/Scroller/Scroller'
 import { moveAssetsMutationOptions } from '#/hooks/backendBatchedHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
+import { useSyncRef } from '#/hooks/syncRefHooks'
 import CategorySwitcher from '#/layouts/CategorySwitcher'
 import { useCategories, useCategoriesAPI } from '#/layouts/Drive/Categories/categoriesHooks'
 import { useDirectoryIds } from '#/layouts/Drive/directoryIdsHooks'
@@ -34,6 +35,7 @@ export function DriveBarNavigation() {
   const { associatedBackend, category } = useCategoriesAPI()
 
   const { rootDirectoryId, currentDirectoryId } = useDirectoryIds({ category })
+  const currentDirectoryIdRef = useSyncRef(currentDirectoryId)
 
   const rightPanel = useRightPanelData()
 
@@ -59,7 +61,10 @@ export function DriveBarNavigation() {
     queryFn: () => associatedBackend.getAssetDetails(currentDirectoryId),
     meta: { persist: false },
     retry: (count, error) => {
-      if (error instanceof AssetDoesNotExistError || error instanceof NetworkError) {
+      if (
+        (error instanceof AssetDoesNotExistError || error instanceof NetworkError) &&
+        currentDirectoryId === currentDirectoryIdRef.current
+      ) {
         setDriveLocation(null, null)
         return false
       }

--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -278,7 +278,9 @@ export default class LocalBackend extends Backend {
           }
         })
         .sort(backend.compareAssets)
-    } catch {
+    } catch (error) {
+      // eslint-disable-next-line no-restricted-properties
+      console.error(`Could not find directory '${parentIdRaw}':`, error)
       // Failed so check if exists
       if (!(await this.projectManager.exists(parentIdRaw))) {
         if (parentIdRaw === this.projectManager.rootDirectory) {


### PR DESCRIPTION
### Pull Request Description
- Fix Local folder resetting after renaming an asset

### Important Notes
None

### Reproduction Steps
- Enter a deeply nested folder
- Exit out of the folder
- Rename the folder
- Observe the path to the current directory being *fully* reset

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
