### PR TITLE
Only allow images as profile pictures

### DIFF
--- a/app/gui/src/dashboard/layouts/Settings/OrganizationProfilePictureInput.tsx
+++ b/app/gui/src/dashboard/layouts/Settings/OrganizationProfilePictureInput.tsx
@@ -29,7 +29,9 @@ export default function OrganizationProfilePictureInput(
 
   return (
     <Form
-      schema={(z) => z.object({ picture: z.instanceof(File) })}
+      schema={(z) =>
+        z.object({ picture: z.instanceof(File).refine((file) => file.type.startsWith('image/')) })
+      }
       onSubmit={({ picture }) =>
         uploadOrganizationPicture.mutateAsync([{ fileName: picture.name }, picture])
       }
@@ -54,7 +56,7 @@ export default function OrganizationProfilePictureInput(
             className="pointer-events-none h-full w-full"
           />
 
-          <HiddenFile autoSubmit name="picture" />
+          <HiddenFile autoSubmit name="picture" accept="image/*" />
         </aria.Label>
       </FocusRing>
       <aria.Text className="w-profile-picture-caption py-profile-picture-caption-y">

--- a/app/gui/src/dashboard/layouts/Settings/ProfilePictureInput.tsx
+++ b/app/gui/src/dashboard/layouts/Settings/ProfilePictureInput.tsx
@@ -26,7 +26,9 @@ export default function ProfilePictureInput(props: ProfilePictureInputProps) {
 
   return (
     <Form
-      schema={(z) => z.object({ picture: z.instanceof(File) })}
+      schema={(z) =>
+        z.object({ picture: z.instanceof(File).refine((file) => file.type.startsWith('image/')) })
+      }
       onSubmit={async ({ picture }) => {
         await uploadUserPicture.mutateAsync([{ fileName: picture.name }, picture])
       }}
@@ -50,7 +52,7 @@ export default function ProfilePictureInput(props: ProfilePictureInputProps) {
             size="large"
             className="pointer-events-none h-full w-full"
           />
-          <HiddenFile autoSubmit name="picture" />
+          <HiddenFile autoSubmit name="picture" accept="image/*" />
         </aria.Label>
       </FocusRing>
 


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/2135
  - Prevent non-images from being selected in the file picker for profile pictures
  - Linux (through `xdg-desktop-portal-gtk`) seems to ignore file type filters when filtering by name in the file picker GUI. To prevent this, the validation for the form has been 

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
