### PR TITLE
Two types aren't the same just because they have the same name

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/example/TestClass.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/example/TestClass.java
@@ -116,4 +116,16 @@ public class TestClass {
       return "subclass";
     }
   }
+
+  public static Function<Object, Object> alien() {
+    return (x) -> x;
+  }
+
+  public static TestClass.FnIntrfc real() {
+    return (x) -> x;
+  }
+
+  public static TestClass.FnIntrfc subclass() {
+    return new FnIntrfcSubclass();
+  }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/JavaInteropTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-import java.util.function.Function;
 import org.enso.example.TestClass;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
@@ -134,12 +133,14 @@ public abstract class JavaInteropTest {
   public void testCaseOnFunctionalInterface() {
     var code =
         """
-        from Standard.Base import IO
         polyglot java import org.enso.example.TestClass
         polyglot java import org.enso.example.TestClass.FnIntrfc
 
         check x y=42 = case x of
           call:FnIntrfc -> call.perform y
+          "alien" -> TestClass.alien
+          "real" -> TestClass.real
+          "subclass" -> TestClass.subclass
           _ -> "no"
 
         main = check
@@ -148,11 +149,12 @@ public abstract class JavaInteropTest {
 
     assertEquals("'no'", check.execute("Not FnIntrfc").toString());
 
-    Function<Object, Object> alien = (x) -> x;
+    var alien = check.execute("alien"); // Function<Object, Object> alien = (x) -> x;
+
     assertEquals(
         "Function isn't the right Java interface", "'no'", check.execute(alien).toString());
 
-    TestClass.FnIntrfc real = (x) -> x;
+    var real = check.execute("real"); // TestClass.FnIntrfc real = (x) -> x;
     assertEquals(
         "FnIntrfc is the right interface", "'good'", check.execute(real, "good").toString());
 
@@ -169,7 +171,7 @@ public abstract class JavaInteropTest {
         "'no'",
         check.execute(atom).toString());
 
-    TestClass.FnIntrfc subclass = new TestClass.FnIntrfcSubclass();
+    var subclass = check.execute("subclass"); // new TestClass.FnIntrfcSubclass();
     assertEquals(
         "FnIntrfcSubclass implements the right interface",
         "'subclass'",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -10,7 +10,6 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.Type;
 
 @BuiltinMethod(
@@ -50,24 +49,12 @@ public abstract class IsSameObjectNode extends Node {
    *
    * @return True if the qualified names of the meta objects are same.
    */
-  @Specialization(
-      guards = {
-        "!interop.isNull(metaLeft)",
-        "interop.isMetaObject(metaLeft)",
-        "!interop.isNull(metaRight)",
-        "interop.isMetaObject(metaRight)"
-      })
+  @Specialization(guards = {"interop.isMetaObject(metaLeft)", "interop.isMetaObject(metaRight)"})
   boolean isSameMetaObjects(
       Object metaLeft,
       Object metaRight,
       @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
-    try {
-      Object metaLeftName = interop.getMetaQualifiedName(metaLeft);
-      Object metaRightName = interop.getMetaQualifiedName(metaRight);
-      return isIdenticalObjects(metaLeftName, metaRightName, interop);
-    } catch (UnsupportedMessageException e) {
-      throw EnsoContext.get(this).raiseAssertionPanic(this, null, e);
-    }
+    return isIdenticalObjects(metaLeft, metaRight, interop);
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -10,6 +10,7 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.Type;
 
 @BuiltinMethod(
@@ -71,6 +72,12 @@ public abstract class IsSameObjectNode extends Node {
       } catch (UnsupportedMessageException ex) {
         // go on
       }
+    }
+    var ctx = EnsoContext.get(this);
+    if (ctx.isJavaPolyglotObject(left) && ctx.isJavaPolyglotObject(right)) {
+      var hostLeft = ctx.asJavaPolyglotObject(left);
+      var hostRight = ctx.asJavaPolyglotObject(right);
+      return hostLeft == hostRight;
     }
     return interop.isIdentical(left, right, interop);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -36,26 +36,43 @@ public abstract class IsSameObjectNode extends Node {
     }
   }
 
+  @Specialization(
+      guards = {
+        "interop.isString(left)",
+        "interop.isString(right)",
+      })
+  boolean isSameString(
+      Object left,
+      Object right,
+      @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
+    try {
+      return interop.asString(left).equals(interop.asString(right));
+    } catch (UnsupportedMessageException ex) {
+      return false;
+    }
+  }
+
   @Specialization
   boolean isSameType(Type typeLeft, Type typeRight) {
     return typeLeft == typeRight;
   }
 
-  /**
-   * Shortcut specialization for meta objects.
-   *
-   * <p>Note: Do not remove, as this is a workaround for an unexpected behavior of HostObject
-   * interop in GraalVM 22.3.0, where isIdentical(ArrayList.class, arrayListObject.getClass()) would
-   * return false.
-   *
-   * @return True if the qualified names of the meta objects are same.
-   */
-  @Specialization(guards = {"interop.isMetaObject(metaLeft)", "interop.isMetaObject(metaRight)"})
-  boolean isSameMetaObjects(
-      Object metaLeft,
-      Object metaRight,
+  @Specialization(
+      guards = {
+        "interop.isMetaObject(left)",
+        "interop.isMetaObject(right)",
+      })
+  boolean isSameMeta(
+      Object left,
+      Object right,
       @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
-    return isIdenticalObjects(metaLeft, metaRight, interop);
+    var ctx = EnsoContext.get(this);
+    if (ctx.isJavaPolyglotObject(left) && ctx.isJavaPolyglotObject(right)) {
+      var hostLeft = ctx.asJavaPolyglotObject(left);
+      var hostRight = ctx.asJavaPolyglotObject(right);
+      return hostLeft == hostRight;
+    }
+    return interop.isIdentical(left, right, interop);
   }
 
   @Fallback
@@ -65,19 +82,6 @@ public abstract class IsSameObjectNode extends Node {
       @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
     if (left == right) {
       return true;
-    }
-    if (interop.isString(left) && interop.isString(right)) {
-      try {
-        return interop.asString(left).equals(interop.asString(right));
-      } catch (UnsupportedMessageException ex) {
-        // go on
-      }
-    }
-    var ctx = EnsoContext.get(this);
-    if (ctx.isJavaPolyglotObject(left) && ctx.isJavaPolyglotObject(right)) {
-      var hostLeft = ctx.asJavaPolyglotObject(left);
-      var hostRight = ctx.asJavaPolyglotObject(right);
-      return hostLeft == hostRight;
     }
     return interop.isIdentical(left, right, interop);
   }

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.library.ReflectionLibrary;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.enso.jvm.channel.Channel;
@@ -87,6 +88,18 @@ final class OtherJvmObject implements TruffleObject {
         if (id() == other.id()) {
           return true;
         } else {
+          if (OtherInteropType.isMetaObject(mask)) {
+            if (OtherInteropType.isMetaObject(other.mask)) {
+              // two meta objects currently must have the same name
+              return Objects.equals(metaQualifiedName, other.metaQualifiedName);
+            } else {
+              return false;
+            }
+          } else {
+            if (OtherInteropType.isMetaObject(other.mask)) {
+              return false;
+            }
+          }
           // fall thru but without the library
           args[1] = null;
         }


### PR DESCRIPTION
### Pull Request Description

- don't compare _meta objects_ by name only!
   - originally needed because there are two kinds of `HostObject` for a class
   - One is [forStaticClass](https://github.com/oracle/graal/blob/24a1a36b0094596d223c7bd3880df6411e59f802/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostObject.java#L141)
   - One is [forClass](https://github.com/oracle/graal/blob/24a1a36b0094596d223c7bd3880df6411e59f802/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostObject.java#L136)
   - alas these two types aren't `InteropLibrary.isIdentical` - and that lead us to use `getMetaObjectName` when comparing
- however now, when there are `HostObject` and `OtherJvmObject` instances along each other
   - comparing by name yields _false positives_
   - two classes of the same name can be loaded by different JVMs
   - and they are not equal then
- fixed by differentiating between `HostObject` and `OtherJvmObject`
- and letting each of them to compare by their own means
  

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
