### PR TITLE
Cleanup project directory before unpacking hybrid project

### DIFF
--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -56,6 +56,8 @@ import { tarFsPack, unzipEntries, zipWriteStream } from './archive'
 // === Constants ===
 // =================
 
+const FS_MAX_RETRIES = 3
+
 const HTTP_STATUS_OK = 200
 const HTTP_STATUS_BAD_REQUEST = 400
 const HTTP_STATUS_NOT_FOUND = 404
@@ -141,7 +143,8 @@ export default function projectManagerShimMiddleware(
           const parentDirectory = path.join(projectsDirectory, `cloud-${projectId}`)
           const projectRootDirectory = path.join(parentDirectory, 'project_root')
 
-          fs.mkdir(projectRootDirectory, { recursive: true })
+          fs.rm(parentDirectory, { recursive: true, force: true, maxRetries: FS_MAX_RETRIES })
+            .then(() => fs.mkdir(projectRootDirectory, { recursive: true }))
             .then(() => projectManagement.unpackBundle(actualResponse, projectRootDirectory))
             .then(() => {
               response
@@ -152,7 +155,7 @@ export default function projectManagerShimMiddleware(
               console.error(e)
               try {
                 if (fsSync.existsSync(parentDirectory)) {
-                  fsSync.rmdirSync(parentDirectory, { maxRetries: 3, recursive: true })
+                  fsSync.rmdirSync(parentDirectory, { maxRetries: FS_MAX_RETRIES, recursive: true })
                 }
               } catch (e) {
                 console.error(`Failed to cleanup directory ${parentDirectory}.`, e)

--- a/app/ide-desktop/client/src/server.ts
+++ b/app/ide-desktop/client/src/server.ts
@@ -60,17 +60,7 @@ import {
   isFolderPath,
 } from 'enso-common/src/utilities/file'
 import { createReadStream, createWriteStream, statSync } from 'node:fs'
-import {
-  access,
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  rmdir,
-  stat,
-  writeFile,
-} from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { finished } from 'node:stream/promises'
 import { pathToFileURL } from 'node:url'
@@ -495,6 +485,7 @@ export class Server {
     const parentDirectory = path.join(projectsDirectory, `cloud-${projectId}`)
     const projectRootDirectory = path.join(parentDirectory, 'project_root')
 
+    await rm(parentDirectory, { recursive: true, force: true, maxRetries: 3 })
     await mkdir(projectRootDirectory, { recursive: true })
     await projectManagement.unpackBundle(response, projectRootDirectory)
     return { projectRootDirectory, parentDirectory }
@@ -523,7 +514,7 @@ export class Server {
       const parentDirectory = path.join(projectsDirectory, `cloud-${projectId}`)
       await access(parentDirectory)
         .then(() => {
-          rmdir(parentDirectory, { maxRetries: 3, recursive: true })
+          rm(parentDirectory, { maxRetries: 3, recursive: true, force: true })
         })
         .catch((e) => {
           logger.error(`Failed to cleanup directory ${parentDirectory}.`, e)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Cleanup the target direcory before unpacking the hybrid project. Should help to prevent the creation of corrupted archives when uploading back to the Cloud.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
