### PR TITLE
Find file in editor in the Enso project view

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,7 @@ tsconfig.json
 /distribution/ @4e6 @jdunkerley @hubertp @GregoryTravis @AdRiley
 /engine/ @4e6 @jaroslavtulach @hubertp @Akirathan
 /project/ @4e6 @jaroslavtulach @hubertp @Akirathan
-/tools/ @4e6 @jaroslavtulach @hubertp
+/tools/ @4e6 @jaroslavtulach @hubertp @Akirathan
 
 # Enso Libraries
 # This section should be amended once the engine moves to /app/engine

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoLogicalView.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoLogicalView.java
@@ -11,10 +11,7 @@ import org.netbeans.api.project.SourceGroup;
 import org.netbeans.spi.java.project.support.ui.PackageView;
 import org.netbeans.spi.project.ui.LogicalViewProvider;
 import org.netbeans.spi.project.ui.support.CommonProjectActions;
-import org.openide.awt.ActionID;
-import org.openide.awt.ActionReference;
-import org.openide.awt.ActionReferences;
-import org.openide.filesystems.*;
+import org.openide.filesystems.FileObject;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.ChildFactory;
 import org.openide.nodes.Children;
@@ -43,7 +40,7 @@ final class EnsoLogicalView implements LogicalViewProvider  {
         if (target instanceof FileObject) {
             FileObject fo = (FileObject) target;
             for (Node n : root.getChildren().getNodes(true)) {
-                Node result = PackageView.findPath(n, target);
+                Node result = PackageView.findPath(n, fo);
                 if (result != null) {
                     return result;
                 }

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
@@ -25,6 +25,8 @@ import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.FilterNode;
 import org.openide.nodes.Node;
+import org.openide.nodes.NodeNotFoundException;
+import org.openide.nodes.NodeOp;
 import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -54,7 +56,7 @@ public final class EnsoYamlProject implements Project {
       new EnsoActionProvider(this)
     );
   }
-  
+
   final FileObject getRoot() {
     return root;
   }
@@ -177,11 +179,44 @@ public final class EnsoYamlProject implements Project {
 
     @Override
     public Node findPath(Node node, Object o) {
-      if (o instanceof String path) {
-        return org.openide.nodes.NodeOp.findChild(node, path);
-      } else {
-        return null;
-      }
+        return switch (o) {
+            case String path -> NodeOp.findChild(node, path);
+            case FileObject fileToFind -> {
+                if (FileUtil.isArchiveArtifact(fileToFind)) {
+                    var jar = FileUtil.getArchiveFile(fileToFind);
+                    if (jar != null) {
+                        fileToFind = jar;
+                    }
+                }
+
+                for (var rootNode : node.getChildren().getNodes(true)) {
+                    var rootFile = rootNode.getLookup().lookup(FileObject.class);
+                    if (rootFile == null) {
+                        continue;
+                    }
+                    if (rootFile.equals(fileToFind)) {
+                        yield rootNode;
+                    }
+                    if (FileUtil.isParentOf(rootFile, fileToFind)) {
+                        var path = FileUtil.getRelativePath(rootFile, fileToFind).split("/");
+                        Node subNode;
+                        try {
+                            subNode = NodeOp.findPath(rootNode, path);
+                        } catch (NodeNotFoundException ex) {
+                            subNode = ex.getClosestNode();
+                            for (var ssn :ex.getClosestNode().getChildren().getNodes(true)) {
+                                if (fileToFind.equals(ssn.getLookup().lookup(FileObject.class))) {
+                                    subNode = ssn;
+                                }
+                            }
+                        }
+                        yield subNode;
+                    }
+                }
+                yield null;
+            }
+            default -> null;
+        };
     }
   }
 

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
@@ -50,6 +50,12 @@ public class EnsoYamlProjectTest extends NbTestCase {
     assertEquals("One source", 1, srcNodes.length);
     assertEquals("Main", srcNodes[0].getName());
     assertEquals("represents the Main.enso file", main, srcNodes[0].getLookup().lookup(FileObject.class));
+
+    var mainNode = lvp.findPath(node, main);
+    assertEquals("Finds Main.enso node", srcNodes[0], mainNode);
+
+    var yamlNode = lvp.findPath(node, yaml);
+    assertEquals("Finds package.yaml node", prjNodes[1], yamlNode);
   }
 
   public void testRecognizeStandardDistributionWith000dev() throws Exception {


### PR DESCRIPTION
### Pull Request Description

Selecting an Enso file in the VSCode editor finds it in the projects view:

<img width="912" height="702" alt="find a file in editor" src="https://github.com/user-attachments/assets/eb16693d-a9b0-42c7-8d4d-9777ca72f41a" />

Works the same in NetBeans or IGV. Just press Ctrl+Shift+1.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
