### PR TITLE
Fix Reading DateTime in Snowflake.

### DIFF
--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeColumnFetcherFactory.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeColumnFetcherFactory.java
@@ -5,10 +5,12 @@ import java.sql.SQLException;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import org.enso.database.fetchers.BaseColumnFetcher;
 import org.enso.database.fetchers.ColumnFetcher;
 import org.enso.database.fetchers.ColumnFetcherFactory;
 import org.enso.database.fetchers.GenericColumnFetcher;
+import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.DateTimeType;
 import org.enso.table.data.column.storage.type.StorageType;
@@ -19,9 +21,21 @@ public class SnowflakeColumnFetcherFactory
     extends ColumnFetcherFactory.DefaultColumnFetcherFactory {
   public static final ColumnFetcherFactory INSTANCE = new SnowflakeColumnFetcherFactory();
 
-  private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.S[ XX][ XXXXX]";
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .append(DateTimeFormatter.ISO_LOCAL_DATE)
+          .appendLiteral(' ')
+          .append(DateTimeFormatter.ISO_LOCAL_TIME)
+          .optionalStart()
+          .appendLiteral(' ')
+          .appendOffset("+HHMM", "+0000")
+          .optionalEnd()
+          .optionalStart()
+          .appendLiteral(' ')
+          .appendOffset("+HH:MM:ss", "Z")
+          .optionalEnd()
+          .toFormatter();
 
   private static final class SnowflakeIntegerFetcher extends BaseColumnFetcher {
     SnowflakeIntegerFetcher(int index, String name) {
@@ -67,7 +81,7 @@ public class SnowflakeColumnFetcherFactory
               timestampString.length() > 10 && timestampString.charAt(10) == 'T'
                   ? timestampString.substring(0, 10) + ' ' + timestampString.substring(11)
                   : timestampString;
-          return ZonedDateTime.parse(normalised, DATE_TIME_FORMATTER);
+          return Core_Date_Utils.parseZonedDateTime(normalised, DATE_TIME_FORMATTER);
         }
       };
       case BigIntegerType bit -> new SnowflakeIntegerFetcher(colIndex, columnName);

--- a/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeColumnFetcherFactory.java
+++ b/std-bits/snowflake/src/main/java/org/enso/snowflake/SnowflakeColumnFetcherFactory.java
@@ -3,7 +3,6 @@ package org.enso.snowflake;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import org.enso.database.fetchers.BaseColumnFetcher;


### PR DESCRIPTION
### Pull Request Description

- The `DateTimeFormatter` was wrong - didn't convert from old code correctly.
- Need to use `Core_Date_Utils` to cope when no offset given.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
