### PR TITLE
Add new Secret_Not_Found error

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
@@ -21,17 +21,20 @@
     - name self -> Standard.Base.Any.Any
     - path self -> Standard.Base.Any.Any
     - pretty self -> Standard.Base.Any.Any
-    - resolve_path path:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret!Standard.Base.Errors.Common.Not_Found
+    - resolve_path path:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret!Standard.Base.Enso_Cloud.Enso_Secret.Secret_Not_Found
     - to_display_text self -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
     - update_value self new_value:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
+- type Enso_Secret_Error
+    - Access_Denied
+    - to_display_text self -> Standard.Base.Any.Any
+- type Secret_Not_Found
+    - Error resolved_path:Standard.Base.Any.Any
+    - to_display_text self -> Standard.Base.Any.Any
 - as_credential_reference secret:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret -> Standard.Base.Enso_Cloud.Enso_Secret.CredentialReference
 - as_hideable_value value:(Standard.Base.Data.Text.Text|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value) -> Standard.Base.Any.Any
 - secret_asset_uri secret:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - secret_resource_uri secret:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
-- type Enso_Secret_Error
-    - Access_Denied
-    - to_display_text self -> Standard.Base.Any.Any
 - Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
+- Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
@@ -21,20 +21,18 @@
     - name self -> Standard.Base.Any.Any
     - path self -> Standard.Base.Any.Any
     - pretty self -> Standard.Base.Any.Any
-    - resolve_path path:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret!Standard.Base.Enso_Cloud.Enso_Secret.Secret_Not_Found
+    - resolve_path path:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret!Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret_Error
     - to_display_text self -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
     - update_value self new_value:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
-- type Enso_Secret_Error
-    - Access_Denied
-    - to_display_text self -> Standard.Base.Any.Any
-- type Secret_Not_Found
-    - Error resolved_path:Standard.Base.Any.Any
-    - to_display_text self -> Standard.Base.Any.Any
 - as_credential_reference secret:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret -> Standard.Base.Enso_Cloud.Enso_Secret.CredentialReference
 - as_hideable_value value:(Standard.Base.Data.Text.Text|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value) -> Standard.Base.Any.Any
 - secret_asset_uri secret:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - secret_resource_uri secret:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 - Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
+- type Enso_Secret_Error
+    - Access_Denied
+    - Not_Found resolved_path:Standard.Base.Any.Any
+    - to_display_text self -> Standard.Base.Any.Any
+- Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value.from that:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
@@ -82,6 +82,7 @@
     - method_name self -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
 - type Not_Found
+    - to_display_text self -> Standard.Base.Any.Any
 - type Not_Invokable
     - Error target:Standard.Base.Any.Any cause:Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
@@ -16,6 +16,7 @@ import project.Error.Error
 import project.Errors.Deprecated.Deprecated
 import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Meta
+import project.Meta.Type
 import project.Nothing.Nothing
 import project.Runtime.Source_Location.Source_Location
 import project.Warning.Warning
@@ -174,6 +175,8 @@ Any.to_js_object self =
         _ : Meta.Constructor ->
             type_name = self.to Meta.Type . qualified_name . split '.' . at -2
             JS_Object.from_pairs [["type", type_name], ["constructor", m.name]]
+        _ : Type ->
+            JS_Object.from_pairs [["type", Meta.type_of self . to_text]]
         _ -> Error.throw ("Cannot convert " + self.to_text + " to JSON")
 
 ## ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -121,7 +121,7 @@ type Enso_Secret
           `Nothing` then will search in the current working directory. If an
           `enso://` path is provided, the parent argument is not considered and
           must be `Nothing`.
-    get : Text -> Enso_File | Nothing -> Enso_Secret ! Secret_Not_Found
+    get : Text -> Enso_File | Nothing -> Enso_Secret ! Enso_Secret_Error
     get name:Text parent:(Enso_File | Nothing)=Nothing =
         is_path = name.starts_with Enso_Path.protocol_prefix
         case is_path of
@@ -137,10 +137,10 @@ type Enso_Secret
     ## ---
        private: true
        ---
-    resolve_path (path:Text) -> Enso_Secret ! Secret_Not_Found =
+    resolve_path (path:Text) -> Enso_Secret ! Enso_Secret_Error =
         resolved_path = Enso_Path.parse path
         resolved_path.if_not_error <|
-            asset = Existing_Enso_Asset.resolve_path resolved_path.to_text if_not_found=(Error.throw (Secret_Not_Found.Error resolved_path.to_text))
+            asset = Existing_Enso_Asset.resolve_path resolved_path.to_text if_not_found=(Error.throw (Enso_Secret_Error.Not_Found resolved_path.to_text))
             if asset.asset_type != Enso_Asset_Type.Secret then Error.throw (Illegal_Argument.Error "The provided path points to "+asset.asset_type.to_text+", not a Secret.") else
                 _from_asset asset resolved_path
 
@@ -243,33 +243,18 @@ type Enso_Secret_Error
        private: true
        ---
     Access_Denied
+    ## ---
+       private: true
+       ---
+    Not_Found resolved_path
 
     ## ---
        private: true
        ---
     to_display_text : Text
-    to_display_text self = "Cannot read secret value into Enso."
-
-## ---
-   private: true
-   ---
-type Secret_Not_Found
-    ## ---
-       private: true
-       ---
-       The runtime representation of a syntax error.
-
-       ## Arguments
-        - `message`: A description of the erroneous syntax.
-    Error resolved_path
-
-    ## ---
-       private: true
-       ---
-       Convert the Syntax_Error error to a human-readable format.
-    to_display_text : Text
-    to_display_text self = "Cannot find secret: "+self.resolved_path
-
+    to_display_text self = case self of 
+        Enso_Secret_Error.Access_Denied -> "Cannot read secret value into Enso."
+        Enso_Secret_Error.Not_Found resolved_path -> "Cannot find secret: "+resolved_path
 
 ## A derived value that may be derived from secrets.
 type Derived_Secret_Value

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -9,7 +9,6 @@ import project.Enso_Cloud.Internal.Existing_Enso_Asset.Credential_Secret_Metadat
 import project.Enso_Cloud.Internal.Existing_Enso_Asset.Existing_Enso_Asset
 import project.Enso_Cloud.Internal.Utils
 import project.Error.Error
-import project.Errors.Common.Not_Found
 import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Network.HTTP.HTTP_Method.HTTP_Method
 import project.Network.URI.URI
@@ -122,7 +121,7 @@ type Enso_Secret
           `Nothing` then will search in the current working directory. If an
           `enso://` path is provided, the parent argument is not considered and
           must be `Nothing`.
-    get : Text -> Enso_File | Nothing -> Enso_Secret ! Not_Found
+    get : Text -> Enso_File | Nothing -> Enso_Secret ! Secret_Not_Found
     get name:Text parent:(Enso_File | Nothing)=Nothing =
         is_path = name.starts_with Enso_Path.protocol_prefix
         case is_path of
@@ -138,10 +137,10 @@ type Enso_Secret
     ## ---
        private: true
        ---
-    resolve_path (path:Text) -> Enso_Secret ! Not_Found =
+    resolve_path (path:Text) -> Enso_Secret ! Secret_Not_Found =
         resolved_path = Enso_Path.parse path
         resolved_path.if_not_error <|
-            asset = Existing_Enso_Asset.resolve_path resolved_path.to_text if_not_found=(Error.throw Not_Found)
+            asset = Existing_Enso_Asset.resolve_path resolved_path.to_text if_not_found=(Error.throw (Secret_Not_Found.Error resolved_path.to_text))
             if asset.asset_type != Enso_Asset_Type.Secret then Error.throw (Illegal_Argument.Error "The provided path points to "+asset.asset_type.to_text+", not a Secret.") else
                 _from_asset asset resolved_path
 
@@ -250,6 +249,27 @@ type Enso_Secret_Error
        ---
     to_display_text : Text
     to_display_text self = "Cannot read secret value into Enso."
+
+## ---
+   private: true
+   ---
+type Secret_Not_Found
+    ## ---
+       private: true
+       ---
+       The runtime representation of a syntax error.
+
+       ## Arguments
+        - `message`: A description of the erroneous syntax.
+    Error resolved_path
+
+    ## ---
+       private: true
+       ---
+       Convert the Syntax_Error error to a human-readable format.
+    to_display_text : Text
+    to_display_text self = "Cannot find secret: "+self.resolved_path
+
 
 ## A derived value that may be derived from secrets.
 type Derived_Secret_Value

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -22,6 +22,13 @@ polyglot java import org.enso.base.CompareException
 
 ## An error indicating that no value was found.
 type Not_Found
+    ## ---
+       private: true
+       ---
+       Convert the Not_Found error to a human-readable format.
+    to_display_text : Text
+    to_display_text self =
+        "The target was not found."
 
 @Builtin_Type
 type Index_Out_Of_Bounds

--- a/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
+++ b/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
@@ -2,7 +2,6 @@ from Standard.Base import all
 import Standard.Base.Data.Base_64.Base_64
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret_Error
-import Standard.Base.Enso_Cloud.Enso_Secret.Secret_Not_Found
 import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Network.HTTP.Request.Request
@@ -118,7 +117,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 v1.simplify . should_equal "XY"
                 # Cannot simplify if it contains secrets
                 v2.simplify . should_equal v2
-                v2.to_plain_text . should_fail_with Enso_Secret_Error
+                v2.to_plain_text . should_fail_with Enso_Secret_Error.Access_Denied
 
                 v1.to_text . should_equal "XY"
                 v2.to_text . should_equal "X__SECRET__"
@@ -163,7 +162,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 # The secret from a subdirectory should not appear in the root list:
                 Enso_Secret.list . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" . should_be_false
-                Enso_Secret.get "my-nested-secret-1" . should_fail_with Secret_Not_Found
+                Enso_Secret.get "my-nested-secret-1" . should_fail_with Enso_Secret_Error.Not_Found
 
             nested_secret.delete . should_succeed
 
@@ -171,7 +170,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
             Test.with_retries <|
                 Enso_Secret.list parent=subdirectory . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" parent=subdirectory . should_be_false
-                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Secret_Not_Found
+                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Enso_Secret_Error.Not_Found
 
         group_builder.specify "should allow to use secrets from a sub-directory" pending=(setup.real_cloud_pending.if_nothing setup.httpbin_pending) <| setup.with_prepared_environment <|
             nested_secret = Enso_Secret.create "my-nested-secret-2" "NESTED_secret_value" parent=subdirectory_for_tests.get

--- a/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
+++ b/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
@@ -117,7 +117,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 v1.simplify . should_equal "XY"
                 # Cannot simplify if it contains secrets
                 v2.simplify . should_equal v2
-                v2.to_plain_text . should_fail_with Enso_Secret_Error.Access_Denied
+                v2.to_plain_text . should_fail_with Enso_Secret_Error
 
                 v1.to_text . should_equal "XY"
                 v2.to_text . should_equal "X__SECRET__"
@@ -162,7 +162,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 # The secret from a subdirectory should not appear in the root list:
                 Enso_Secret.list . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" . should_be_false
-                Enso_Secret.get "my-nested-secret-1" . should_fail_with Enso_Secret_Error.Not_Found
+                Enso_Secret.get "my-nested-secret-1" . should_fail_with Enso_Secret_Error
 
             nested_secret.delete . should_succeed
 
@@ -170,7 +170,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
             Test.with_retries <|
                 Enso_Secret.list parent=subdirectory . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" parent=subdirectory . should_be_false
-                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Enso_Secret_Error.Not_Found
+                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Enso_Secret_Error
 
         group_builder.specify "should allow to use secrets from a sub-directory" pending=(setup.real_cloud_pending.if_nothing setup.httpbin_pending) <| setup.with_prepared_environment <|
             nested_secret = Enso_Secret.create "my-nested-secret-2" "NESTED_secret_value" parent=subdirectory_for_tests.get

--- a/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
+++ b/test/Cloud_Tests/src/Network/Enso_Cloud/Secrets_Spec.enso
@@ -2,8 +2,8 @@ from Standard.Base import all
 import Standard.Base.Data.Base_64.Base_64
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret_Error
+import Standard.Base.Enso_Cloud.Enso_Secret.Secret_Not_Found
 import Standard.Base.Errors.Common.Forbidden_Operation
-import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Network.HTTP.Request.Request
 import Standard.Base.Runtime.Context
@@ -163,7 +163,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
                 # The secret from a subdirectory should not appear in the root list:
                 Enso_Secret.list . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" . should_be_false
-                Enso_Secret.get "my-nested-secret-1" . should_fail_with Not_Found
+                Enso_Secret.get "my-nested-secret-1" . should_fail_with Secret_Not_Found
 
             nested_secret.delete . should_succeed
 
@@ -171,7 +171,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup =
             Test.with_retries <|
                 Enso_Secret.list parent=subdirectory . should_not_contain nested_secret
                 Enso_Secret.exists "my-nested-secret-1" parent=subdirectory . should_be_false
-                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Not_Found
+                Enso_Secret.get "my-nested-secret-1" parent=subdirectory . should_fail_with Secret_Not_Found
 
         group_builder.specify "should allow to use secrets from a sub-directory" pending=(setup.real_cloud_pending.if_nothing setup.httpbin_pending) <| setup.with_prepared_environment <|
             nested_secret = Enso_Secret.create "my-nested-secret-2" "NESTED_secret_value" parent=subdirectory_for_tests.get


### PR DESCRIPTION
### Pull Request Description

Fixes #13877 

The Not_Found error message really feels like it is more low level and not designed to be exposed to users.

This MR introduces a new Secret_Not_Found error with a better user facing display text

Not_Found display text will be fixed with this defect https://github.com/enso-org/enso/issues/13892

Before:

<img width="1084" height="366" alt="image" src="https://github.com/user-attachments/assets/5306b573-867d-42d3-acc2-b47264b34119" />


After:

<img width="795" height="250" alt="image" src="https://github.com/user-attachments/assets/4cc4baa4-6e99-4f7e-ae2e-1b223768e7b3" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
