### PR TITLE
Remove `refetchType: 'all'` to avoid unnecessary 'list directory' requests

### DIFF
--- a/app/gui/src/dashboard/hooks/backendBatchedHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendBatchedHooks.ts
@@ -65,7 +65,6 @@ export function deleteAssetsMutationOptions(backend: Backend) {
         [backend.type, 'listAssetVersions'],
       ],
       awaitInvalidates: true,
-      refetchType: 'all',
     },
   })
 }
@@ -138,7 +137,6 @@ export function restoreAssetsMutationOptions(backend: Backend) {
         [backend.type, 'getAssetDetails'],
       ],
       awaitInvalidates: true,
-      refetchType: 'all',
     },
   })
 }
@@ -214,7 +212,6 @@ export function copyAssetsMutationOptions(backend: Backend) {
         [backend.type, 'getAssetDetails'],
       ],
       awaitInvalidates: true,
-      refetchType: 'all',
     },
   })
 }

--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -194,9 +194,6 @@ export function backendMutationOptions<Method extends BackendMutationMethod>(
       ...options?.meta,
       invalidates,
       awaitInvalidates: options?.meta?.awaitInvalidates ?? true,
-      refetchType:
-        options?.meta?.refetchType ??
-        (invalidates.some((key) => key[1] === 'listDirectory') ? 'all' : 'active'),
     },
   }
 }

--- a/app/gui/src/project-view/composables/backend.ts
+++ b/app/gui/src/project-view/composables/backend.ts
@@ -102,7 +102,6 @@ export function backendMutationOptions<Method extends BackendMutationMethod>(
       meta: {
         invalidates,
         awaitInvalidates: true,
-        refetchType: invalidates.some((key) => key[1] === 'listDirectory') ? 'all' : 'active',
         ...opts?.meta,
       },
     }


### PR DESCRIPTION
### Pull Request Description
- Avoid refetching all `listDirectory` calls by avoiding `refetchType: 'all'`

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
