### PR TITLE
Exchanging direct `ByteBuffer`s between the dual JVMs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4174,7 +4174,7 @@ lazy val `jvm-channel` =
     .in(file("lib/java/jvm-channel"))
     .enablePlugins(JPMSPlugin)
     .settings(
-      customFrgaalJavaCompilerSettings("24"),
+      customFrgaalJavaCompilerSettings(targetJdk = "24"),
       autoScalaLibrary := false,
       (Test / fork) := true,
       commands += WithDebugCommand.withDebug,
@@ -4202,7 +4202,7 @@ lazy val `jvm-interop` =
     .in(file("lib/java/jvm-interop"))
     .enablePlugins(JPMSPlugin)
     .settings(
-      frgaalJavaCompilerSetting,
+      customFrgaalJavaCompilerSettings("24"),
       // jvm-interop/test has to run with -ea disabled form Truffle.
       // Otherwise Truffle library performs a lot of additional
       // checks and they skew the message counts. Thus enabling -ea

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherInteropType.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherInteropType.java
@@ -42,6 +42,7 @@ final class OtherInteropType {
 
   private static final int MASK_ARRAY = 0x0400;
   private static final int MASK_HASH = 0x0800;
+  private static final int MASK_BUFFER = 0x1000;
 
   private OtherInteropType() {}
 
@@ -53,6 +54,9 @@ final class OtherInteropType {
     }
     if (iop.hasHashEntries(obj)) {
       one |= MASK_HASH;
+    }
+    if (iop.hasBufferElements(obj)) {
+      one |= MASK_BUFFER;
     }
     return one;
   }
@@ -183,6 +187,10 @@ final class OtherInteropType {
 
   static boolean hasHashEntries(int v) {
     return (v & MASK_HASH) == MASK_HASH;
+  }
+
+  static boolean hasBufferElements(int v) {
+    return (v & MASK_BUFFER) == MASK_BUFFER;
   }
 
   @Persistable(id = 1)

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmMessage.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmMessage.java
@@ -10,6 +10,8 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.Message;
 import com.oracle.truffle.api.library.ReflectionLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +19,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.enso.jvm.channel.Channel;
 import org.enso.persist.Persistable;
+import org.graalvm.polyglot.Value;
 
 /** Sends a message to the other side with ReflectionLibrary-like arguments. */
 @Persistable(id = 81901)
@@ -24,26 +27,38 @@ public record OtherJvmMessage(long id, Message message, List<Object> args)
     implements Function<
         Channel<OtherJvmPool>, OtherJvmResult<? extends Object, ? extends Exception>> {
   private static final Message IS_IDENTICAL = Message.resolve(InteropLibrary.class, "isIdentical");
+  private static final Message IS_POINTER = Message.resolve(InteropLibrary.class, "isPointer");
+  private static final Message AS_POINTER = Message.resolve(InteropLibrary.class, "asPointer");
 
   @Override
   public OtherJvmResult<? extends Object, ? extends Exception> apply(Channel<OtherJvmPool> t) {
-    var node = ReflectionLibrary.getUncached();
-    var prev = t.getConfig().enter(t.isMaster(), node);
+    var lib = ReflectionLibrary.getUncached();
+    var prev = t.getConfig().enter(t.isMaster(), lib);
     try {
       var receiver = t.getConfig().findObject(id());
       if (receiver == null) {
         throw new NullPointerException(
             "No object for " + id() + " message: " + message() + " args: " + args());
       }
+      var iop = InteropLibrary.getUncached();
       if (message == IS_IDENTICAL) {
-        args.set(1, InteropLibrary.getUncached());
+        args.set(1, iop);
       }
-      var res = node.send(receiver, message, args.toArray());
+      if (message == IS_POINTER && iop.hasBufferElements(receiver)) {
+        var buf = Value.asValue(receiver).as(ByteBuffer.class);
+        return new ReturnValue<>(buf.isDirect());
+      }
+      if (message == AS_POINTER && iop.hasBufferElements(receiver)) {
+        var buf = Value.asValue(receiver).as(ByteBuffer.class);
+        var seg = MemorySegment.ofBuffer(buf);
+        return new ReturnValue<>(seg.address());
+      }
+      var res = lib.send(receiver, message, args.toArray());
       return new ReturnValue<>(res);
     } catch (Exception ex) {
       return ThrowException.create(ex);
     } finally {
-      t.getConfig().leave(t.isMaster(), node, prev);
+      t.getConfig().leave(t.isMaster(), lib, prev);
     }
   }
 

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
@@ -161,9 +161,6 @@ final class OtherJvmObject implements TruffleObject {
       if (message == HAS_HASH_ENTRIES) {
         return OtherInteropType.hasHashEntries(mask);
       }
-      if (message == HAS_ARRAY_ELEMENTS) {
-        return OtherInteropType.hasArrayElements(mask);
-      }
       if (message == HAS_BUFFER_ELEMENTS) {
         return OtherInteropType.hasBufferElements(mask);
       }

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmObject.java
@@ -55,6 +55,8 @@ final class OtherJvmObject implements TruffleObject {
       Message.resolve(InteropLibrary.class, "hasArrayElements");
   private static final Message HAS_HASH_ENTRIES =
       Message.resolve(InteropLibrary.class, "hasHashEntries");
+  private static final Message HAS_BUFFER_ELEMENTS =
+      Message.resolve(InteropLibrary.class, "hasBufferElements");
 
   private static final Message IS_DATE = Message.resolve(InteropLibrary.class, "isDate");
   private static final Message IS_TIME = Message.resolve(InteropLibrary.class, "isTime");
@@ -161,6 +163,9 @@ final class OtherJvmObject implements TruffleObject {
       }
       if (message == HAS_ARRAY_ELEMENTS) {
         return OtherInteropType.hasArrayElements(mask);
+      }
+      if (message == HAS_BUFFER_ELEMENTS) {
+        return OtherInteropType.hasBufferElements(mask);
       }
       if (message == IS_TIME) {
         return OtherInteropType.isTime(mask);

--- a/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
+++ b/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
@@ -14,6 +14,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import java.lang.foreign.MemorySegment;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -506,7 +507,7 @@ public class OtherJvmObjectTest {
     assertEquals('l', seq.byteAt(3));
     assertEquals('o', seq.byteAt(4));
 
-    var buf = bufValue.as(ByteBuffer.class);
+    var buf = asByteBuffer(bufValue);
     assertEquals('H', buf.get(0));
     assertEquals('e', buf.get(1));
     assertEquals('l', buf.get(2));
@@ -515,6 +516,27 @@ public class OtherJvmObjectTest {
     buf.put(0, "Ahoj!".getBytes());
 
     assertEquals("Ahoj!", withBuffer.invokeMember("toText").asString());
+  }
+
+  /**
+   * Converting a buffer-like value to {@link ByteBuffer} is tricky. Simple {@link
+   * Value#as(java.lang.Class)} works only for {@code HostObject}. To convert "guest value" we need
+   * to do something special. Let's rely on special <em>native pointer</em> support provided by the
+   * other JVM for direct {@link ByteBuffer}.
+   *
+   * @param value the value to convert to {@link ByteBuffer}
+   * @return instance of {@link ByteBuffer} to use in this JVM
+   */
+  private static ByteBuffer asByteBuffer(Value value) throws Exception {
+    assertTrue("The value is buffer-like", value.hasBufferElements());
+    try {
+      return value.as(ByteBuffer.class);
+    } catch (ClassCastException ex) {
+      assertTrue("Direct buffer should support native address", value.isNativePointer());
+      var address = value.asNativePointer();
+      var seg = MemorySegment.ofAddress(address).reinterpret(value.getBufferSize());
+      return seg.asByteBuffer();
+    }
   }
 
   private static Value loadOtherJvmClass(String name) throws Exception {

--- a/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
+++ b/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
@@ -23,6 +24,7 @@ import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.io.ByteSequence;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -454,6 +456,65 @@ public class OtherJvmObjectTest {
               var rawClass2 = (OtherJvmObject) ctx.unwrapValue(clazz2);
               assertSame("Represented by the same truffle object", rawClass1, rawClass2);
             });
+  }
+
+  public static final class WithABuffer {
+    public final ByteBuffer buf;
+
+    WithABuffer(ByteBuffer buf) {
+      this.buf = buf;
+    }
+
+    public String toText() {
+      var arr = new byte[buf.limit()];
+      buf.get(arr);
+      return new String(arr);
+    }
+  }
+
+  public static WithABuffer withBuffer(int type, int size) {
+    var buf =
+        switch (type) {
+          case 0 -> ByteBuffer.allocateDirect(size);
+          default -> throw new IllegalArgumentException();
+        };
+    buf.put("Hello".getBytes());
+    buf.flip();
+    return new WithABuffer(buf);
+  }
+
+  @Test
+  public void directByteBufferHostInterop() throws Exception {
+    var otherClass = ctx.asValue(OtherJvmObjectTest.class).getMember("static");
+    checkDirectByteBuffer(otherClass);
+  }
+
+  @Test
+  public void directByteBufferGuestInterop() throws Exception {
+    var otherClass = loadOtherJvmClass(OtherJvmObjectTest.class.getName());
+    checkDirectByteBuffer(otherClass);
+  }
+
+  private void checkDirectByteBuffer(Value otherClass) throws Exception {
+    var withBuffer = otherClass.invokeMember("withBuffer", 0, 10);
+    var bufValue = withBuffer.getMember("buf");
+    assertTrue("It is a byte buffer", bufValue.hasBufferElements());
+    var seq = bufValue.as(ByteSequence.class);
+    assertEquals('H', seq.byteAt(0));
+    assertEquals('e', seq.byteAt(1));
+    assertEquals('l', seq.byteAt(2));
+    assertEquals('l', seq.byteAt(3));
+    assertEquals('o', seq.byteAt(4));
+
+    var buf = bufValue.as(ByteBuffer.class);
+    assertEquals('H', buf.get(0));
+    assertEquals('e', buf.get(1));
+    assertEquals('l', buf.get(2));
+    assertEquals('l', buf.get(3));
+    assertEquals('o', buf.get(4));
+    buf.put(0, "Ahoj!".getBytes());
+
+    assertEquals("Ahoj!", withBuffer.invokeMember("toText").asString());
   }
 
   private static Value loadOtherJvmClass(String name) throws Exception {


### PR DESCRIPTION
### Pull Request Description

- To effectively exchange huge chunks of memory among the _"dual JVMs"_  ...
  - introduced by #13570
- ... as needed by _In-Memory table_ implementations, let's rely on _direct byte buffers_
- with this PR we have a way for the two _"dual JVMs"_ to exchange and share the same chunk of memory 

### Important Notes

- care must be taken to work properly with GC & free
- holding just the [ByteBuffer instance](https://github.com/enso-org/enso/pull/13904#discussion_r2315138775) doesn't prevent other JVM to GC and release its memory region
- holding a pointer to the original `Value` object while working with the `ByteBuffer` should be enough to prevent GC

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
