### PR TITLE
Fix regression in startup benchmarks

### DIFF
--- a/test/Benchmarks/src/Compiler/Compile.enso
+++ b/test/Benchmarks/src/Compiler/Compile.enso
@@ -2,10 +2,11 @@ from Standard.Base import all
 
 from Standard.Test import Bench
 
+from project.Utils import find_enso_bin
+
 polyglot java import java.lang.System as Java_System
 polyglot java import java.io.File as Java_File
 
-from enso_dev.Base_Tests.Enso_Bin_Utils import enso_bin
 
 type Data
     Value ~enso_bin:File ~std_base:File
@@ -33,7 +34,7 @@ collect_benches = Bench.build builder->
 
 
     data =
-        Data.Value (File.new enso_bin) (find_lib enso_bin "Base")
+        Data.Value find_enso_bin (find_lib find_enso_bin "Base")
 
     builder.group "Compile" options group_builder->
         group_builder.specify "Compile_Standard_Base" <|

--- a/test/Benchmarks/src/Startup/Startup.enso
+++ b/test/Benchmarks/src/Startup/Startup.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 
 from Standard.Test import Bench
 
-from enso_dev.Base_Tests.Enso_Bin_Utils import enso_bin
+from project.Utils import find_enso_bin
 
 polyglot java import java.lang.System as Java_System
 polyglot java import java.io.File as Java_File
@@ -41,7 +41,7 @@ collect_benches = Bench.build builder->
     options = Bench.options . set_warmup (Bench.phase_conf 2 5) . set_measure (Bench.phase_conf 3 5)
 
     data =
-        Data.Value (File.new enso_bin) (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
+        Data.Value find_enso_bin (find_sibling "Empty_World.enso") (find_sibling "Hello_World.enso") (find_sibling "Import_World.enso")
 
     [["Native_Image_Startup", False], ["Startup", True]].each \entry->
         group_name = entry.first

--- a/test/Benchmarks/src/Utils.enso
+++ b/test/Benchmarks/src/Utils.enso
@@ -1,0 +1,26 @@
+private
+
+from Standard.Base import all
+
+## Find enso binary inside `built-distribution` directory.
+find_enso_bin =
+    find_prefix dir prefix =
+        vec = dir.list name_filter=prefix+"*"
+        if vec.length == 1 then vec.at 0 else
+            msg = "Cannot find " + prefix + "* in " + dir.to_text + '\n'
+            err = dir.list.fold msg t-> f->
+                t + f.to_text + '\n'
+            Panic.throw err
+
+    project_root = File.new enso_project.root.to_text
+    repository_root = project_root . parent . parent
+    built_distribution = find_prefix repository_root "built-distribution"
+    enso_engine = find_prefix built_distribution "enso-engine-"
+    enso = find_prefix enso_engine "enso-"
+    bin = find_prefix enso "bin"
+
+    exe = File.new bin / if Platform.os == Platform.OS.Windows then "enso.bat" else "enso"
+
+    if exe.is_regular_file.not then Panic.throw "Cannot find "+exe.to_text
+
+    exe


### PR DESCRIPTION
Reverts #13847 in benchmarks - removes usage of [ExecutableLocation](https://github.com/enso-org/enso/pull/13847/files#diff-07874c0b228d48d78c279dd4e39492606da6d11554fc2375d4d16c8672e6976fR5) polyglot symbol from the stdlib startup benchmarks.

### Pull Request Description

While investigating a [cryptic Startup bench regression](https://github.com/enso-org/enso/pull/13840#issuecomment-3241910328), I found out that the regression was caused by #13847. Moreover, #13847 also causes Startup benchmarks to fail (see #13883).

Locally, when running `sbt std-benchmarks/benchOnly org.enso.benchmarks.generated.Native_Image_Startup.empty_startup`:
- On develop before #13847 (be18e0752e61dc5e380349b4dccdac426cb565db): **28.249 ± 11.082**
- On develop after #13847 (87710e49914591e54dd73f794169ad9f06e7a39d): **81.300 ± 31.714**

The culprit is most likely usage of [ExecutableLocation](https://github.com/enso-org/enso/pull/13847/files#diff-07874c0b228d48d78c279dd4e39492606da6d11554fc2375d4d16c8672e6976fR5) polyglot symbol that is behind truffle boundary.

Finding Enso executable should not offset the real benchmark - which in this case is executing a subprocess. This PR reverts usage of `ExecutableLocation` from benchmarks.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
