### PR TITLE
Type of cache decides where it should be stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 - [Open type check `Type&Any` lets all visible types thru][13225]
 - [The documentation panel opens to the scroll position at last close][13647]
 - [Autocompletion for Column methods in table expressions][13797]
+- [Removal of --no-global-cache option][13909]
 
 [11868]: https://github.com/enso-org/enso/pull/11868
 [13225]: https://github.com/enso-org/enso/pull/13225
 [13647]: https://github.com/enso-org/enso/pull/13647
 [13797]: https://github.com/enso-org/enso/pull/13797
+[13909]: https://github.com/enso-org/enso/pull/13909
 
 # Next Release
 

--- a/docs/runtime/compiler-ir.md
+++ b/docs/runtime/compiler-ir.md
@@ -24,7 +24,7 @@ Automatic removal of unused imports can be enabled with
 from the whole `Standard.Base`, run:
 
 ```
-enso --no-compile-dependencies --no-global-cache --no-ir-caches --vm.D enso.compiler.RemoveUnusedImports --compile distribution/lib/Standard/Base/0.0.0-dev/
+enso --no-compile-dependencies --no-ir-caches --vm.D enso.compiler.RemoveUnusedImports --compile distribution/lib/Standard/Base/0.0.0-dev/
 ```
 
 ## Dumping IR

--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -10,15 +10,17 @@ order: 10
 
 One of the largest pain points for users of Enso at the moment is the fact that
 it has to precompile the entire standard library on every project load. This is,
-in essence, due to the fact that the current parser is abysmally slow, and
-incredibly demanding. The obvious solution to improve this is to take the parser
-out of the equation in its entirety, by serializing the parser's output.
+in essence, due to the fact that while the current parser (rewritten to Rust) is
+fast, the compiler passes that follow continue to be abysmally slow, and
+incredibly demanding. The obvious solution to improve this is to take the
+compiler passes out of the equation in its entirety, by serializing their IR
+output.
 
 To that end, we want to serialize the Enso IR to a format that can later be read
-back in, bypassing the parser entirely. Furthermore, we can move the boundary at
-which this serialization takes place to the end of the compiler pipeline,
-thereby bypassing doing most of the compilation work, and further improving
-startup performance.
+back in, bypassing parser and many compiler passes entirely. Furthermore, by
+moving the boundary at which this serialization takes place to the end of the
+compiler pipeline, thereby bypassing doing most of the compilation work, and
+further improving startup performance.
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 
@@ -40,7 +42,7 @@ startup performance.
 
 Using classical Java Serialization turned out to be unsuitably slow. Rather than
 switching to other serialization framework that does the same, but faster we
-desided in [PR-8207](https://github.com/enso-org/enso/pull/8207) to create _own
+decided in [PR-8207](https://github.com/enso-org/enso/pull/8207) to create _own
 persistance framework_ that radically changes the way we can read the caches.
 Rather than loading all the megabytes of stored data, it reads them _lazily on
 demand_.
@@ -49,7 +51,7 @@ Use following command to generate the Javadoc for the `org.enso.persist`
 package:
 
 ```bash
-enso$ find lib/java/persistance/src/main/java/ | grep java$ | xargs ~/bin/graalvm-21/bin/javadoc -d target/javadoc/ --snippet-path lib/java/persistance/src/test/java/
+enso$ find lib/java/persistance/src/main/java/ | grep java$ | xargs /graalvm-24/bin/javadoc -d target/javadoc/ --snippet-path lib/java/persistance/src/test/java/
 enso$ links target/javadoc/index.html
 ```
 
@@ -70,8 +72,9 @@ the `ModuleScope`. The `ModuleScope` may then reference other `runtime.Module`s
 which all contain `IR.Module`s. Therefore, done in a silly fashion, we end up
 serializing the entire reachable module graph. This is not what we want.
 
-The `Persistance.write` method contains additional `writeReplace` function which
-our cache system uses to perform following modification just before
+The `Persistance.Pool` with its `write` method allows an additional
+`writeReplace` function to be associated with it. The IR caches system uses such
+a function to perform following modification just before
 `ProcessingPass.Metadata` are stored down:
 
 - modify `BindingsMap` and its child types to be able to contain an unlinked
@@ -96,32 +99,33 @@ that it serializes. Despite this, we _also_ want to be able to ship cached IR
 with libraries. This leads to a two pronged solution where we check two
 locations for the cache.
 
-1. **With the Library:** As libraries can have a hidden `.enso` directory, we
-   can use a path within that for caching. This should be
+1. **With the Library** distribution: As libraries can have a hidden `.enso`
+   directory, we can use a path within that for caching. This should be
    `$package/.enso/cache/ir/enso-$version/`, and can be accessed by extending
-   the `pkg` library to be aware of the cache directories.
-2. **Globally:** As some library locations may not be writeable, we need to have
-   a global out-of-line cache that is used if the first one is not writeable.
-   This is located under `$ENSO_DATA` (whose location can be obtained from the
-   `RuntimeDistributionManager`), and is located under the path
-   `$ENSO_DATA/cache/ir/$hash/enso-$version/`, where `$hash` is the `SHA3-224`
+   the `pkg` library to be aware of the cache directories. This location is used
+   for `.bindings` and suggestion caches
+2. **Per user:** System shared library locations may not be writeable, we need
+   to have a fallback out-of-line cache that is used if the first one is not
+   writeable. This is located under `$ENSO_DATA` (whose location can be obtained
+   from the `RuntimeDistributionManager`), and is located under the path
+   `$ENSO_DATA/cache/ir/$namespace/$libraryName/$version/enso-$version/`
+
+   <!-- we don't use hash...
+   where `$hash` is the `SHA3-224`
    hash of the tuple `(namespace, library_name, version)`, where
    `version = SemVer | "local"`. This hash is computed by concatenating the
    string representations of these fields.
+   -->
 
-In each location, the IR is stored with the following assumptions:
+   This _per user_ location is used for storing `.ir` cache files for individual
+   Enso modules. The IR file is located in a directory modelled after its module
+   path, followed by a file named after the module itself with the extension
+   `.ir` (e.g. the IR for `Standard.Base.Data.Vector` is stored in
+   `Standard/Base/Data/Vector.ir`).
 
-- The IR file is located in a directory modelled after its module path, followed
-  by a file named after the module itself with the extension `.ir` (e.g. the IR
-  for `Standard.Base.Data.Vector` is stored in `Standard/Base/Data/Vector.ir`).
-- The [metadata](#metadata-format) file is located in a directory modelled after
-  its module path, followed by a file named after the module itself with the
-  extension `.meta` (e.g. the metadata for `Standard.Base.Data.Vector.enso` is
-  stored in `Standard/Base/Data/Vector.meta`). This is right next to the
-  corresponding `.ir` file.
-
-Storage of the IR only takes place iff the intended location for that IR is
-_empty_.
+There is an associated [metadata](#metadata-format) file is located right next
+to the corresponding cache file. Storage of the IR only takes place iff the
+intended location for that IR is _empty_.
 
 ### Metadata Format
 
@@ -180,19 +184,19 @@ stamp calculated from all `Persistance` classes. Increasing the
 Loading the IR is a multi-stage process that involves performing integrity
 checking on the loaded cache. It works as follows.
 
-1. **Find the Cache:** Look in the global cache directory under `$ENSO_DATA`. If
-   there is no cached IR here that is valid for the current configuration, check
-   the ibrary's `.enso/cache` folder. This should be hooked into in
-   `Compiler::parseModule`.
+1. **Find the Cache:** Check library's `.enso/cache` folder. If there is a
+   `.bindings` file, assume it is up to date and use it. If there is no such
+   file in the _library distribution_ look in the _per user directory_ under
+   `$ENSO_DATA` for module appropriate `.ir` file.
 2. **Check Integrity:** Check the module's [metadata](#metadata-format) for
    validity according to the [integrity rules](#integrity-checking).
 3. **Load:** If the cache passes the integrity check, load the `.ir` file. If
    deserialization fails in any way, immediately fall back to parsing the source
    file.
-4. **Re-Link:** Relinking is part of **Load**. When using `Persistance.read`
-   provide own `readResolve` function. Such a function gets a chance to change
-   and replace each object read-in with appropriate variant respecting the whole
-   compiler environment.
+4. **Re-Link:** Relinking is part of **Load**. When using
+   `Persistance.Pool.read` provide own `readResolve` function. Such a function
+   gets a chance to change and replace each object read-in with appropriate
+   variant respecting the whole compiler environment.
 
 The main subtlety here is handling the dependencies between modules. We need to
 ensure that, when loading multiple cached libraries, we properly handle them
@@ -201,7 +205,7 @@ setting `AFTER_STATIC_PASSES` as the compilation state after loading the module.
 This will tie into the current `ImportsResolver` and `ExportsResolver` which are
 run in an un-gated fashion in `Compiler::run`.
 
-Unlike classical Java deserialization nly registered `Persistance` subclasses
+Unlike classical Java deserialization only registered `Persistance` subclasses
 may participate in deserialization making it much safer and less vulnerable.
 
 ### Integrity Checking
@@ -283,8 +287,8 @@ them more:
 - have a single _blob_ with all `IR`s per a library and read only the parts that
   are needed
 
-- experiement with GC - being able to release parts of unused `IR` once they
-  were used (for code generation or co.)
+- experiment with GC - being able to release parts of unused `IR` once they were
+  used (for code generation or co.)
 
 - make the `.ir` files smaller where possible
 

--- a/engine/common/src/main/java/org/enso/common/ContextFactory.java
+++ b/engine/common/src/main/java/org/enso/common/ContextFactory.java
@@ -48,7 +48,6 @@ public final class ContextFactory {
   private boolean treatWarningsAsErrors = false;
   private boolean strictErrors;
   private boolean disableLinting;
-  private boolean useGlobalIrCacheLocation = true;
   private boolean enableAutoParallelism;
   private String executionEnvironment;
   private String checkForWarnings;
@@ -135,11 +134,6 @@ public final class ContextFactory {
     return this;
   }
 
-  public ContextFactory useGlobalIrCacheLocation(boolean useGlobalIrCacheLocation) {
-    this.useGlobalIrCacheLocation = useGlobalIrCacheLocation;
-    return this;
-  }
-
   public ContextFactory enableAutoParallelism(boolean enableAutoParallelism) {
     this.enableAutoParallelism = enableAutoParallelism;
     return this;
@@ -211,9 +205,6 @@ public final class ContextFactory {
             .option(RuntimeOptions.STRICT_ERRORS, Boolean.toString(strictErrors))
             .option(RuntimeOptions.DISABLE_LINTING, Boolean.toString(disableLinting))
             .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
-            .option(
-                RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION,
-                Boolean.toString(useGlobalIrCacheLocation))
             .option(RuntimeOptions.DISABLE_IR_CACHES, Boolean.toString(!enableIrCaches))
             .option(RuntimeOptions.DISABLE_PRIVATE_CHECK, Boolean.toString(disablePrivateCheck))
             .option(RuntimeOptions.ENABLE_STATIC_ANALYSIS, Boolean.toString(enableStaticAnalysis))

--- a/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
+++ b/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
@@ -149,12 +149,6 @@ public final class RuntimeOptions {
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY, WAIT_FOR_PENDING_SERIALIZATION_JOBS)
           .build();
 
-  public static final String USE_GLOBAL_IR_CACHE_LOCATION = optionName("useGlobalIrCacheLocation");
-  public static final OptionKey<Boolean> USE_GLOBAL_IR_CACHE_LOCATION_KEY = new OptionKey<>(true);
-  public static final OptionDescriptor USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR =
-      OptionDescriptor.newBuilder(USE_GLOBAL_IR_CACHE_LOCATION_KEY, USE_GLOBAL_IR_CACHE_LOCATION)
-          .build();
-
   public static final String ENABLE_EXECUTION_TIMER = optionName("enableExecutionTimer");
 
   /* Enables timer that counts down the execution time of expressions. */
@@ -201,7 +195,6 @@ public final class RuntimeOptions {
               DISABLE_IR_CACHES_DESCRIPTOR,
               PREINITIALIZE_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
-              USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR,
               ENABLE_EXECUTION_TIMER_DESCRIPTOR,
               WARNINGS_LIMIT_DESCRIPTOR));
 

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -98,7 +98,6 @@ public class Main {
   private static final String TREAT_WARNINGS_AS_ERRORS_OPTION = "Werror";
   private static final String COMPILE_OPTION = "compile";
   private static final String NO_COMPILE_DEPENDENCIES_OPTION = "no-compile-dependencies";
-  private static final String NO_GLOBAL_CACHE_OPTION = "no-global-cache";
   private static final String LOG_LEVEL = "log-level";
   private static final String LOGGER_CONNECT = "logger-connect";
   private static final String NO_LOG_MASKING = "no-log-masking";
@@ -431,11 +430,6 @@ public class Main {
                 "Tells the compiler to not compile dependencies when performing static"
                     + " compilation.")
             .build();
-    var noGlobalCacheOption =
-        cliOptionBuilder()
-            .longOpt(NO_GLOBAL_CACHE_OPTION)
-            .desc("Tells the compiler not to write compiled data to the global cache locations.")
-            .build();
 
     var irCachesOption =
         cliOptionBuilder()
@@ -560,7 +554,6 @@ public class Main {
         .addOption(noReadIrCachesOption)
         .addOption(compileOption)
         .addOption(noCompileDependenciesOption)
-        .addOption(noGlobalCacheOption)
         .addOptionGroup(cacheOptionsGroup)
         .addOption(autoParallelism)
         .addOption(skipGraalVMUpdater)
@@ -673,8 +666,6 @@ public class Main {
    * @param path the path to the package or file being compiled
    * @param shouldCompileDependencies whether the dependencies of that package should also be
    *     compiled
-   * @param shouldUseGlobalCache whether or not the compilation result should be written to the
-   *     global cache
    * @param shouldUseIrCaches whether or not IR caches should be used.
    * @param disablePrivateCheck whether or not the private check should be disabled
    * @param enableStaticAnalysis whether or not static type checking, and other static analysis,
@@ -687,7 +678,6 @@ public class Main {
       String cwd,
       String path,
       boolean shouldCompileDependencies,
-      boolean shouldUseGlobalCache,
       boolean shouldUseIrCaches,
       boolean disablePrivateCheck,
       boolean enableStaticAnalysis,
@@ -713,7 +703,6 @@ public class Main {
                 .enableStaticAnalysis(enableStaticAnalysis)
                 .treatWarningsAsErrors(treatWarningsAsErrors)
                 .strictErrors(true)
-                .useGlobalIrCacheLocation(shouldUseGlobalCache)
                 .build());
 
     try {
@@ -1204,13 +1193,11 @@ public class Main {
     if (line.hasOption(COMPILE_OPTION)) {
       var packagePath = line.getOptionValue(COMPILE_OPTION);
       var shouldCompileDependencies = !line.hasOption(NO_COMPILE_DEPENDENCIES_OPTION);
-      var shouldUseGlobalCache = !line.hasOption(NO_GLOBAL_CACHE_OPTION);
 
       compile(
           cwd,
           packagePath,
           shouldCompileDependencies,
-          shouldUseGlobalCache,
           shouldEnableIrCaches(line),
           line.hasOption(DISABLE_PRIVATE_CHECK_OPTION),
           line.hasOption(ENABLE_STATIC_ANALYSIS_OPTION),

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -34,8 +34,6 @@ public interface CompilerContext extends CompilerStub {
 
   boolean isPrivateCheckDisabled();
 
-  boolean isUseGlobalCacheLocations();
-
   boolean isInteractiveMode();
 
   PackageRepository getPackageRepository();
@@ -95,13 +93,11 @@ public interface CompilerContext extends CompilerStub {
 
   boolean wasLoadedFromCache(Module module);
 
-  Future<Boolean> serializeLibrary(
-      Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations);
+  Future<Boolean> serializeLibrary(Compiler compiler, LibraryName libraryName);
 
   scala.Option<Object> deserializeSuggestions(LibraryName libraryName) throws InterruptedException;
 
-  Future<Boolean> serializeModule(
-      Compiler compiler, Module module, boolean useGlobalCacheLocations, boolean usePool);
+  Future<Boolean> serializeModule(Compiler compiler, Module module, boolean usePool);
 
   boolean deserializeModule(Compiler compiler, Module module);
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -68,7 +68,6 @@ class Compiler(
   private val passManager: PassManager         = passes.passManager
   private val importResolver: ImportResolver   = new ImportResolver(this)
   private val irCachingEnabled                 = !context.isIrCachingDisabled
-  private val useGlobalCacheLocations          = context.isUseGlobalCacheLocations
   private val isInteractiveMode                = context.isInteractiveMode
   private val output: PrintStream =
     if (config.outputRedirect.isDefined)
@@ -136,15 +135,12 @@ class Compiler(
     *                         to the cache; if set to False, a 'lint' compilation
     *                         will be performed, reporting any problems,
     *                         but no results will be written
-    * @param useGlobalCacheLocations whether or not the compilation result should
-    *                                  be written to the global cache
     * @param generateDocs should a documenation be generied
     * @return future to track subsequent serialization of the library
     */
   def compile(
     shouldCompileDependencies: Boolean,
     shouldWriteCache: Boolean,
-    useGlobalCacheLocations: Boolean,
     generateDocs: Option[String]
   ): Future[java.lang.Boolean] = {
     getPackageRepository.getMainProjectPackage match {
@@ -209,8 +205,7 @@ class Compiler(
             if (shouldWriteCache) {
               context.serializeLibrary(
                 this,
-                pkg.libraryName,
-                useGlobalCacheLocations
+                pkg.libraryName
               )
             } else {
               CompletableFuture.completedFuture(true)
@@ -536,7 +531,6 @@ class Compiler(
                 context.serializeModule(
                   this,
                   module,
-                  useGlobalCacheLocations,
                   true
                 )
               }

--- a/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockCompilerContext.java
+++ b/engine/runtime-compiler/src/test/java/org/enso/compiler/test/mock/MockCompilerContext.java
@@ -41,11 +41,6 @@ final class MockCompilerContext implements CompilerContext {
   }
 
   @Override
-  public boolean isUseGlobalCacheLocations() {
-    return false;
-  }
-
-  @Override
   public boolean isInteractiveMode() {
     return false;
   }
@@ -190,8 +185,7 @@ final class MockCompilerContext implements CompilerContext {
   }
 
   @Override
-  public Future<Boolean> serializeLibrary(
-      Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
+  public Future<Boolean> serializeLibrary(Compiler compiler, LibraryName libraryName) {
     throw new UnsupportedOperationException();
   }
 
@@ -202,8 +196,7 @@ final class MockCompilerContext implements CompilerContext {
   }
 
   @Override
-  public Future<Boolean> serializeModule(
-      Compiler compiler, Module module, boolean useGlobalCacheLocations, boolean usePool) {
+  public Future<Boolean> serializeModule(Compiler compiler, Module module, boolean usePool) {
     throw new UnsupportedOperationException();
   }
 

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -19,7 +19,6 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
   public Void runImpl(RuntimeContext ctx) {
     var ensoContext = ctx.executionService().getContext();
     var compiler = ensoContext.getCompiler();
-    boolean useGlobalCacheLocations = ensoContext.isUseGlobalCache();
     ctx.locking()
         .withWriteCompilationLock(
             this.getClass(),
@@ -33,11 +32,7 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
                             : "Attempt to serialize the module that needs compilation: " + module;
                         compiler
                             .context()
-                            .serializeModule(
-                                compiler,
-                                module.asCompilerModule(),
-                                useGlobalCacheLocations,
-                                false);
+                            .serializeModule(compiler, module.asCompilerModule(), false);
                       });
               return null;
             });

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerdeCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerdeCompilerTest.java
@@ -65,11 +65,11 @@ public class SerdeCompilerTest {
           .filter((m) -> !m.isSynthetic())
           .foreach(
               (m) -> {
-                var future = compiler.context().serializeModule(compiler, m, true, true);
+                var future = compiler.context().serializeModule(compiler, m, true);
                 futures.add(future);
                 return null;
               });
-      futures.add(compiler.compile(false, true, true, scala.Option.empty()));
+      futures.add(compiler.compile(false, true, scala.Option.empty()));
       for (var f : futures) {
         var persisted = f.get(10, TimeUnit.SECONDS);
         assertEquals("Fib_Test library has been fully persisted", true, persisted);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerializationManagerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerializationManagerTest.java
@@ -89,7 +89,7 @@ public class SerializationManagerTest {
     Object result =
         ensoContext
             .getCompiler()
-            .compile(false, true, false, scala.Option.empty())
+            .compile(false, true, scala.Option.empty())
             .get(COMPILE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     Assert.assertEquals(Boolean.TRUE, result);
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerializerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/SerializerTest.java
@@ -58,7 +58,7 @@ public class SerializerTest {
       var result = compiler.run(module);
       assertEquals(result.compiledModules().exists(m -> m == module), true);
       var useThreadPool = compiler.context().isCreateThreadAllowed();
-      var future = compiler.context().serializeModule(compiler, module, true, useThreadPool);
+      var future = compiler.context().serializeModule(compiler, module, useThreadPool);
       var serialized = future.get(5, TimeUnit.SECONDS);
       assertEquals(serialized, true);
       var deserialized = compiler.context().deserializeModule(compiler, module);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
@@ -131,7 +131,6 @@ public class HelloWorldCacheTest {
                         disablePrivateCheck ? "true" : "false")
                     .option(
                         RuntimeOptions.DISABLE_IR_CACHES, disablePrivateCheck ? "true" : "false")
-                    .option(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION, "false")
                     .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true"))
         .withProjectRoot(projRoot);
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/IRCacheLocationTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/IRCacheLocationTest.java
@@ -43,7 +43,6 @@ public class IRCacheLocationTest {
                 bldr ->
                     bldr.option(RuntimeOptions.LOG_LEVEL, Level.FINE.getName())
                         .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
-                        .option(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION, "false")
                         .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true"))
             .withProjectRoot(projDir.toPath())
             .build()) {
@@ -56,7 +55,7 @@ public class IRCacheLocationTest {
     }
 
     var cacheDir = projDir.toPath().resolve(".enso");
-    assertThat("Cache dir was created", cacheDir.toFile().exists(), is(true));
+    assertThat("Cache dir was not created in project", cacheDir.toFile().exists(), is(false));
   }
 
   @Test
@@ -86,7 +85,6 @@ public class IRCacheLocationTest {
                 bldr ->
                     bldr.option(RuntimeOptions.LOG_LEVEL, Level.FINE.getName())
                         .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
-                        .option(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION, "false")
                         .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true"))
             .withProjectRoot(projDir.toPath())
             .build()) {
@@ -110,6 +108,6 @@ public class IRCacheLocationTest {
     }
 
     var libCacheDir = libDir.toPath().resolve(".enso");
-    assertThat("Cache dir for Lib was created", libCacheDir.toFile().exists(), is(true));
+    assertThat("Cache dir for Lib was not created", libCacheDir.toFile().exists(), is(false));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
@@ -12,6 +12,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.logging.Level;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -99,26 +100,14 @@ public final class Cache<T, M> {
    *
    * @param entry data to save
    * @param context the language context in which loading is taking place
-   * @param useGlobalCacheLocations if true, will use global cache location, local one otherwise
    * @return the location of the successfully saved location of the cached data
    * @throws IOException if something goes wrong
    */
-  public final TruffleFile save(T entry, EnsoContext context, boolean useGlobalCacheLocations)
-      throws IOException {
+  public final TruffleFile save(T entry, EnsoContext context) throws IOException {
     TruffleLogger logger = context.getLogger(this.getClass());
-    var rootsOption = spi.getCacheRoots(context);
-    if (rootsOption.isPresent()) {
-      var roots = rootsOption.get();
-      if (useGlobalCacheLocations) {
-        if (saveCacheTo(context, roots.globalCacheRoot, entry, logger)) {
-          return roots.globalCacheRoot;
-        }
-      } else {
-        logger.log(logLevel, "Skipping use of global cache locations for " + logName + ".");
-      }
-
-      if (saveCacheTo(context, roots.localCacheRoot, entry, logger)) {
-        return roots.localCacheRoot;
+    for (var root : spi.getCacheRoots(context)) {
+      if (saveCacheTo(context, root, entry, logger)) {
+        return root;
       }
     }
     throw new IOException("Unable to write cache data for " + logName + ".");
@@ -187,43 +176,29 @@ public final class Cache<T, M> {
    * @return the cached data if possible, and [[None]] if it could not load a valid cache
    */
   public final Optional<T> load(EnsoContext context) {
+    var logger = context.getLogger(this.getClass());
+    var collected = new ArrayList<IOException>();
     synchronized (LOCK) {
-      TruffleLogger logger = context.getLogger(this.getClass());
-      return spi.getCacheRoots(context)
-          .flatMap(
-              roots -> {
-                // Load from the global root as a priority.
-                try {
-                  var globalCache = loadCacheFrom(roots.globalCacheRoot(), context, logger);
-                  logger.log(
-                      logLevel,
-                      "Using cache for ["
-                          + logName
-                          + " at location ["
-                          + toMaskedPath(roots.globalCacheRoot()).applyMasking()
-                          + "].");
-                  return Optional.of(globalCache);
-                } catch (IOException globalEx) {
-                  try {
-                    var localCache = loadCacheFrom(roots.localCacheRoot(), context, logger);
-                    logger.log(
-                        logLevel,
-                        "Using cache for ["
-                            + logName
-                            + " at location ["
-                            + toMaskedPath(roots.localCacheRoot()).applyMasking()
-                            + "].");
-                    return Optional.of(localCache);
-                  } catch (IOException localEx) {
-                    logCacheLoadFailure(
-                        logger, "Unable to load a global cache [" + logName + "]: ", globalEx);
-                    logCacheLoadFailure(
-                        logger, "Unable to load a local cache [" + logName + "]: ", localEx);
-                  }
-                  return Optional.empty();
-                }
-              });
+      for (var root : spi.getCacheRoots(context)) {
+        try {
+          var cache = loadCacheFrom(root, context, logger);
+          logger.log(
+              logLevel,
+              "Using cache for ["
+                  + logName
+                  + " at location ["
+                  + toMaskedPath(root).applyMasking()
+                  + "].");
+          return Optional.of(cache);
+        } catch (IOException ex) {
+          collected.add(ex);
+        }
+      }
     }
+    for (var ex : collected) {
+      logCacheLoadFailure(logger, "Unable to load a cache [" + logName + "]: ", ex);
+    }
+    return Optional.empty();
   }
 
   private void logCacheLoadFailure(TruffleLogger logger, String prefix, IOException ex) {
@@ -388,26 +363,15 @@ public final class Cache<T, M> {
   public final void invalidate(EnsoContext context) {
     synchronized (LOCK) {
       TruffleLogger logger = context.getLogger(this.getClass());
-      spi.getCacheRoots(context)
-          .ifPresent(
-              roots -> {
-                invalidateCache(roots.globalCacheRoot, logger);
-                invalidateCache(roots.localCacheRoot, logger);
-              });
+      for (var root : spi.getCacheRoots(context)) {
+        invalidateCache(root, logger);
+      }
     }
   }
 
   final <T> T asSpi(Class<T> type) {
     return type.cast(spi);
   }
-
-  /**
-   * Roots encapsulates two possible locations where caches can be stored.
-   *
-   * @param localCacheRoot project's local location of the cache
-   * @param globalCacheRoot system's global location of the cache
-   */
-  record Roots(TruffleFile localCacheRoot, TruffleFile globalCacheRoot) {}
 
   private static boolean writeBytesTo(TruffleFile file, byte[] bytes) {
     try (OutputStream stream =
@@ -507,7 +471,7 @@ public final class Cache<T, M> {
      * @param context the language context in which loading is taking place
      * @return non-empty if the locations have been inferred successfully, empty otherwise
      */
-    public abstract Optional<Roots> getCacheRoots(EnsoContext context);
+    public abstract Iterable<TruffleFile> getCacheRoots(EnsoContext context);
 
     public abstract String entryName();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -8,10 +8,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
-import org.apache.commons.lang3.StringUtils;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.data.BindingsMap.DefinedEntity;
 import org.enso.compiler.data.BindingsMap.ModuleReference;
@@ -97,31 +97,16 @@ public final class ImportExportCache
 
   @Override
   @SuppressWarnings("unchecked")
-  public Optional<Cache.Roots> getCacheRoots(EnsoContext context) {
-    return context
-        .getPackageRepository()
-        .getPackageForLibraryJava(libraryName)
-        .map(
-            pkg -> {
-              TruffleFile bindingsCacheRoot =
-                  pkg.getBindingsCacheRootForPackage(BuildVersion.ensoVersion());
-              var localCacheRoot = bindingsCacheRoot.resolve(libraryName.namespace());
-              var distribution = context.getDistributionManager();
-              var pathSegments =
-                  new String[] {
-                    pkg.namespace(),
-                    pkg.normalizedName(),
-                    pkg.getConfig().version(),
-                    BuildVersion.ensoVersion(),
-                    libraryName.namespace()
-                  };
-              var path =
-                  distribution.LocallyInstalledDirectories()
-                      .irCacheDirectory()
-                      .resolve(StringUtils.join(pathSegments, "/"));
-              var globalCacheRoot = context.getTruffleFile(path.toFile());
-              return new Cache.Roots(localCacheRoot, globalCacheRoot);
-            });
+  public Iterable<TruffleFile> getCacheRoots(EnsoContext context) {
+    var pkg = context.getPackageRepository().getPackageForLibraryJava(libraryName);
+
+    if (pkg.isPresent()) {
+      TruffleFile bindingsCacheRoot =
+          pkg.get().getBindingsCacheRootForPackage(BuildVersion.ensoVersion());
+      var perUserRoot = bindingsCacheRoot.resolve(libraryName.namespace());
+      return Collections.singletonList(perUserRoot);
+    }
+    return Collections.emptyList();
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.caches;
 
+import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.source.Source;
 import java.io.ByteArrayInputStream;
@@ -11,11 +12,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.logging.Level;
 import org.apache.commons.lang3.StringUtils;
 import org.enso.common.CompilationStage;
-import org.enso.common.MethodNames;
 import org.enso.compiler.core.ir.Module;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.version.BuildVersion;
@@ -108,51 +109,29 @@ public final class ModuleCache
   }
 
   @Override
-  public Optional<Cache.Roots> getCacheRoots(EnsoContext context) {
+  public Iterable<TruffleFile> getCacheRoots(EnsoContext context) {
     if (module != context.getBuiltins().getModule()) {
-      return context
-          .getPackageOf(module.getSourceFile())
-          .map(
-              pkg -> {
-                var irCacheRoot = pkg.getIrCacheRootForPackage(BuildVersion.ensoVersion());
-                var qualName = module.getName();
-                var localCacheRoot = irCacheRoot.resolve(qualName.path().mkString("/"));
-
-                var distribution = context.getDistributionManager();
-                var pathSegmentsJava = new ArrayList<String>();
-                pathSegmentsJava.addAll(
-                    Arrays.asList(
-                        pkg.namespace(),
-                        pkg.normalizedName(),
-                        pkg.getConfig().version(),
-                        BuildVersion.ensoVersion()));
-                pathSegmentsJava.addAll(qualName.pathAsJava());
-                var path =
-                    distribution.LocallyInstalledDirectories()
-                        .irCacheDirectory()
-                        .resolve(StringUtils.join(pathSegmentsJava, "/"));
-                var globalCacheRoot = context.getTruffleFile(path.toFile());
-
-                return new Cache.Roots(localCacheRoot, globalCacheRoot);
-              });
-    } else {
-      var distribution = context.getDistributionManager();
-      var pathSegmentsJava = new ArrayList<String>();
-      pathSegmentsJava.addAll(
-          Arrays.asList(
-              MethodNames.Builtins.NAMESPACE,
-              MethodNames.Builtins.PACKAGE_NAME,
-              BuildVersion.ensoVersion(),
-              BuildVersion.ensoVersion()));
-      pathSegmentsJava.addAll(module.getName().pathAsJava());
-      var path =
-          distribution.LocallyInstalledDirectories()
-              .irCacheDirectory()
-              .resolve(StringUtils.join(pathSegmentsJava, "/"));
-      var globalCacheRoot = context.getTruffleFile(path.toFile());
-
-      return Optional.of(new Cache.Roots(globalCacheRoot, globalCacheRoot));
+      var pkg = context.getPackageOf(module.getSourceFile());
+      if (pkg.isPresent()) {
+        var qualName = module.getName();
+        var distribution = context.getDistributionManager();
+        var pathSegmentsJava = new ArrayList<String>();
+        pathSegmentsJava.addAll(
+            Arrays.asList(
+                pkg.get().namespace(),
+                pkg.get().normalizedName(),
+                pkg.get().getConfig().version(),
+                BuildVersion.ensoVersion()));
+        pathSegmentsJava.addAll(qualName.pathAsJava());
+        var path =
+            distribution.LocallyInstalledDirectories()
+                .irCacheDirectory()
+                .resolve(StringUtils.join(pathSegmentsJava, "/"));
+        var perUser = context.getTruffleFile(path.toFile());
+        return Collections.singletonList(perUser);
+      }
     }
+    return Collections.emptyList();
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
@@ -108,8 +108,8 @@ public final class SuggestionsCache
     } else {
       var bindingsCacheRoot =
           pkg.get().getSuggestionsCacheRootForPackage(BuildVersion.ensoVersion());
-      var localCacheRoot = bindingsCacheRoot.resolve(libraryName.namespace());
-      return Collections.singletonList(localCacheRoot);
+      var distributionRoot = bindingsCacheRoot.resolve(libraryName.namespace());
+      return Collections.singletonList(distributionRoot);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/SuggestionsCache.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.caches;
 
+import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -7,10 +8,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
-import org.apache.commons.lang3.StringUtils;
 import org.enso.editions.LibraryName;
 import org.enso.interpreter.caches.SuggestionsCache.CachedSuggestions;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -100,31 +101,16 @@ public final class SuggestionsCache
   }
 
   @Override
-  public Optional<Cache.Roots> getCacheRoots(EnsoContext context) {
-    return context
-        .getPackageRepository()
-        .getPackageForLibraryJava(libraryName)
-        .map(
-            pkg -> {
-              var bindingsCacheRoot =
-                  pkg.getSuggestionsCacheRootForPackage(BuildVersion.ensoVersion());
-              var localCacheRoot = bindingsCacheRoot.resolve(libraryName.namespace());
-              var distribution = context.getDistributionManager();
-              var pathSegments =
-                  new String[] {
-                    pkg.namespace(),
-                    pkg.normalizedName(),
-                    pkg.getConfig().version(),
-                    BuildVersion.ensoVersion(),
-                    libraryName.namespace()
-                  };
-              var path =
-                  distribution.LocallyInstalledDirectories()
-                      .irCacheDirectory()
-                      .resolve(StringUtils.join(pathSegments, "/"));
-              var globalCacheRoot = context.getTruffleFile(path.toFile());
-              return new Cache.Roots(localCacheRoot, globalCacheRoot);
-            });
+  public Iterable<TruffleFile> getCacheRoots(EnsoContext context) {
+    var pkg = context.getPackageRepository().getPackageForLibraryJava(libraryName);
+    if (pkg.isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      var bindingsCacheRoot =
+          pkg.get().getSuggestionsCacheRootForPackage(BuildVersion.ensoVersion());
+      var localCacheRoot = bindingsCacheRoot.resolve(libraryName.namespace());
+      return Collections.singletonList(localCacheRoot);
+    }
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -700,15 +700,6 @@ public final class EnsoContext {
     return getOption(RuntimeOptions.ENABLE_PROGRESS_REPORT_KEY);
   }
 
-  /**
-   * Checks whether global caches are to be used.
-   *
-   * @return true if so
-   */
-  public boolean isUseGlobalCache() {
-    return getOption(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
-  }
-
   public boolean isAssertionsEnabled() {
     return assertionsEnabled;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -86,11 +86,6 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
-  public boolean isUseGlobalCacheLocations() {
-    return context.isUseGlobalCache();
-  }
-
-  @Override
   public boolean isInteractiveMode() {
     return context.isInteractiveMode();
   }
@@ -202,9 +197,8 @@ final class TruffleCompilerContext implements CompilerContext {
     return cache.load(context);
   }
 
-  final <T> TruffleFile saveCache(Cache<T, ?> cache, T entry, boolean useGlobalCacheLocations)
-      throws IOException {
-    return cache.save(entry, context, useGlobalCacheLocations);
+  final <T> TruffleFile saveCache(Cache<T, ?> cache, T entry) throws IOException {
+    return cache.save(entry, context);
   }
 
   @Override
@@ -236,7 +230,7 @@ final class TruffleCompilerContext implements CompilerContext {
       }
 
       if (irCachingEnabled && !wasLoadedFromCache(builtinsModule)) {
-        serializeModule(compiler, builtinsModule, true, true);
+        serializeModule(compiler, builtinsModule, true);
       }
     }
   }
@@ -302,11 +296,10 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Future<Boolean> serializeLibrary(
-      Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
+  public Future<Boolean> serializeLibrary(Compiler compiler, LibraryName libraryName) {
     logSerializationManager(Level.INFO, "Requesting serialization for library [{0}].", libraryName);
 
-    var task = doSerializeLibrary(compiler, libraryName, useGlobalCacheLocations);
+    var task = doSerializeLibrary(compiler, libraryName);
 
     return serializationPool.submitTask(
         task, isCreateThreadAllowed(), toQualifiedName(libraryName));
@@ -327,7 +320,6 @@ final class TruffleCompilerContext implements CompilerContext {
    * thread and the module may be mutated beneath it.
    *
    * @param module the module to serialize
-   * @param useGlobalCacheLocations if true, will use global caches location, local one otherwise
    * @param useThreadPool if true, will perform serialization asynchronously
    * @return Future referencing the serialization task. On completion Future will return `true` if
    *     `module` has been successfully serialized, `false` otherwise
@@ -335,10 +327,7 @@ final class TruffleCompilerContext implements CompilerContext {
   @SuppressWarnings("unchecked")
   @Override
   public Future<Boolean> serializeModule(
-      Compiler compiler,
-      CompilerContext.Module module,
-      boolean useGlobalCacheLocations,
-      boolean useThreadPool) {
+      Compiler compiler, CompilerContext.Module module, boolean useThreadPool) {
     if (module.isSynthetic()) {
       throw new IllegalStateException(
           "Cannot serialize synthetic module [" + module.getName() + "]");
@@ -364,8 +353,7 @@ final class TruffleCompilerContext implements CompilerContext {
             duplicatedIr,
             module.getCompilationStage(),
             module.getName(),
-            src,
-            useGlobalCacheLocations);
+            src);
     return serializationPool.submitTask(task, useThreadPool, module.getName());
   }
 
@@ -377,7 +365,6 @@ final class TruffleCompilerContext implements CompilerContext {
    * @param stage the compilation stage of the module
    * @param name the name of the module being serialized
    * @param source the source of the module being serialized
-   * @param useGlobalCacheLocations if true, will use global caches location, local one otherwise
    * @return the task that serialies the provided `ir`
    */
   private Callable<Boolean> doSerializeModule(
@@ -385,8 +372,7 @@ final class TruffleCompilerContext implements CompilerContext {
       org.enso.compiler.core.ir.Module ir,
       CompilationStage stage,
       QualifiedName name,
-      Source source,
-      boolean useGlobalCacheLocations) {
+      Source source) {
     return () -> {
       var pool = serializationPool;
       pool.waitWhileSerializing(name);
@@ -398,11 +384,7 @@ final class TruffleCompilerContext implements CompilerContext {
             stage.isAtLeast(CompilationStage.AFTER_STATIC_PASSES)
                 ? CompilationStage.AFTER_STATIC_PASSES
                 : stage;
-        var saved =
-            saveCache(
-                cache,
-                new ModuleCache.CachedModule(ir, fixedStage, source),
-                useGlobalCacheLocations);
+        var saved = saveCache(cache, new ModuleCache.CachedModule(ir, fixedStage, source));
         return saved != null;
       } catch (Throwable e) {
         logSerializationManager(
@@ -514,8 +496,7 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @SuppressWarnings("unchecked")
-  Callable<Boolean> doSerializeLibrary(
-      Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations) {
+  Callable<Boolean> doSerializeLibrary(Compiler compiler, LibraryName libraryName) {
     return () -> {
       var pool = serializationPool;
       pool.waitWhileSerializing(toQualifiedName(libraryName));
@@ -541,11 +522,10 @@ final class TruffleCompilerContext implements CompilerContext {
           new ImportExportCache.CachedBindings(
               libraryName, new ImportExportCache.MapToBindings(map), snd);
       try {
-        boolean result =
-            doSerializeLibrarySuggestions(compiler, libraryName, useGlobalCacheLocations);
+        boolean result = doSerializeLibrarySuggestions(compiler, libraryName);
         try {
           var cache = ImportExportCache.create(libraryName);
-          var file = saveCache(cache, bindingsCache, useGlobalCacheLocations);
+          var file = saveCache(cache, bindingsCache);
           result &= file != null;
         } catch (Throwable e) {
           logSerializationManager(
@@ -561,8 +541,7 @@ final class TruffleCompilerContext implements CompilerContext {
     };
   }
 
-  private boolean doSerializeLibrarySuggestions(
-      Compiler compiler, LibraryName libraryName, boolean useGlobalCacheLocations)
+  private boolean doSerializeLibrarySuggestions(Compiler compiler, LibraryName libraryName)
       throws IOException {
     var exportsBuilder = new ExportsBuilder();
     var exportsMap = new ExportsMap();
@@ -595,7 +574,7 @@ final class TruffleCompilerContext implements CompilerContext {
 
       var cachedSuggestions = new SuggestionsCache.CachedSuggestions(libraryName, suggestions);
       var cache = SuggestionsCache.create(libraryName);
-      var file = saveCache(cache, cachedSuggestions, useGlobalCacheLocations);
+      var file = saveCache(cache, cachedSuggestions);
       return file != null;
     } catch (Throwable e) {
       logSerializationManager(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -203,7 +203,6 @@ public final class TopLevelScope extends EnsoObject {
     @CompilerDirectives.TruffleBoundary
     private static Object compile(Object[] arguments, EnsoContext context)
         throws UnsupportedTypeException, ArityException {
-      boolean useGlobalCache = context.isUseGlobalCache();
       boolean shouldCompileDependencies;
       scala.Option<String> generateDocs;
       switch (arguments.length) {
@@ -224,7 +223,7 @@ public final class TopLevelScope extends EnsoObject {
       try {
         return context
             .getCompiler()
-            .compile(shouldCompileDependencies, shouldWriteCache, useGlobalCache, generateDocs)
+            .compile(shouldCompileDependencies, shouldWriteCache, generateDocs)
             .get();
       } catch (InterruptedException e) {
         throw new RuntimeException(e);

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -286,7 +286,6 @@ object DistributionPackage {
         val command = Seq(
           fileToExecute.getAbsolutePath,
           "--no-compile-dependencies",
-          "--no-global-cache",
           "--compile",
           path.getAbsolutePath
         )

--- a/test/Benchmarks/src/Compiler/Compile.enso
+++ b/test/Benchmarks/src/Compiler/Compile.enso
@@ -11,7 +11,7 @@ type Data
     Value ~enso_bin:File ~std_base:File
 
     bench_compile_base self extra_params=[] =
-        self.startup ["--no-compile-dependencies", "--log-level", "debug", "--no-global-cache", "--compile", self.std_base.to_text]+extra_params
+        self.startup ["--no-compile-dependencies", "--log-level", "debug", "--compile", self.std_base.to_text]+extra_params
 
     startup self  args =
         cache_dir = self.std_base / ".enso" / "cache"


### PR DESCRIPTION
### Pull Request Description

- fixes #12027 
- `.ir` goes into **per user** cache only - never into the `built-distribution`
- `.bindings` belongs to into **distribution** cache - never anywhere else
- dtto for `.suggestions` - also belongs only into **distribution** cache

### Important Notes

I am trying to avoid terminology global/local, as it doesn't make sense should Enso ever be installed by an admin and shared among multiple users. For example by having a Snap version of Enso. Then distribution would be global and per-user local. E.g. exactly up-side down.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
