### PR TITLE
Table expression: Autocomplete static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Autocompletion for Column methods in table expressions][13797]
 - [Autocompletion for Column names in table expressions][13848]
 - [Removal of --no-global-cache option][13909]
+- [Autocompletion for table expression builtin functions in table expressions][13914]
 
 [11868]: https://github.com/enso-org/enso/pull/11868
 [13225]: https://github.com/enso-org/enso/pull/13225
@@ -15,6 +16,7 @@
 [13797]: https://github.com/enso-org/enso/pull/13797
 [13848]: https://github.com/enso-org/enso/pull/13848
 [13909]: https://github.com/enso-org/enso/pull/13909
+[13914]: https://github.com/enso-org/enso/pull/13914
 
 # Next Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - [Autocompletion for Column names in table expressions][13848]
 - [Removal of --no-global-cache option][13909]
 - [Autocompletion for table expression builtin functions in table expressions][13914]
+- [Autocompletion for table expression builtin functions in table
+  expressions][13914]
 
 [11868]: https://github.com/enso-org/enso/pull/11868
 [13225]: https://github.com/enso-org/enso/pull/13225

--- a/app/gui/src/project-view/components/GraphEditor.vue
+++ b/app/gui/src/project-view/components/GraphEditor.vue
@@ -40,6 +40,7 @@ import { provideNodeCreation } from '@/providers/graphNodeCreation'
 import { provideGraphSelection } from '@/providers/graphSelection'
 import { provideStackNavigator } from '@/providers/graphStackNavigator'
 import { injectKeyboard } from '@/providers/keyboard'
+import { provideLanguageSupportExtensions } from '@/providers/languageSupportExtensions'
 import { providePopoverRoot } from '@/providers/popoverRoot'
 import type { Node, NodeId } from '@/stores/graph'
 import { isInputNode, nodeId } from '@/stores/graph/graphDatabase'
@@ -82,6 +83,11 @@ const graphStore = useGraphStore()
 const widgetRegistry = useWidgetRegistry()
 const suggestionDb = useSuggestionDbStore()
 provideVisualizationStore(projectStore)
+provideLanguageSupportExtensions({
+  project: projectStore,
+  projectNames,
+  suggestionDb: suggestionDb.entries,
+})
 
 const nodeExecution = provideNodeExecution(projectStore)
 ;(window as any)._mockSuggestion = suggestionDb.mockSuggestion

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
@@ -75,11 +75,7 @@ const placeholder = computed(() =>
 const textInputConfig = computed(() =>
   props.input.dynamicConfig?.kind === 'Text_Input' ? props.input.dynamicConfig : undefined,
 )
-const extensions = useLanguageSupport(() => textInputConfig.value?.syntax, {
-  project: () => currentProject.value?.store,
-  projectNames: () => currentProject.value?.names,
-  suggestionDb: () => currentProject.value?.suggestionDb.entries,
-})
+const extensions = useLanguageSupport(() => textInputConfig.value?.syntax)
 
 function isTextMultiline(text: string) {
   return !!text.match(/[\r\n]/)

--- a/app/gui/src/project-view/providers/languageSupportExtensions.ts
+++ b/app/gui/src/project-view/providers/languageSupportExtensions.ts
@@ -1,0 +1,50 @@
+import { createContextStore } from '@/providers'
+import type { ProjectStore } from '@/stores/project'
+import type { ProjectNameStore } from '@/stores/projectNames'
+import type { SuggestionDb } from '@/stores/suggestionDatabase'
+import { useTableExpressionExtension } from '@/util/codemirror/language/tableExpression'
+import type { ToValue } from '@/util/reactivity'
+import type { Extension } from '@codemirror/state'
+import type { Ref } from 'vue'
+import type { Opt } from 'ydoc-shared/util/data/opt'
+
+export interface LanguageSupportOptions {
+  project: ToValue<Opt<ProjectStore>>
+  projectNames: ToValue<Opt<ProjectNameStore>>
+  suggestionDb: ToValue<Opt<SuggestionDb>>
+}
+
+/**
+ * A context store for language-support CodeMirror extensions.
+ *
+ * Some extensions have reactive dependencies on project data; this store allows such extensions to
+ * share computation between instances in any number of editors.
+ */
+export const [provideLanguageSupportExtensions, useLanguageSupportExtensions] =
+  createContextStore(
+    'Table expression extension',
+    ({
+      project,
+      projectNames,
+      suggestionDb,
+    }: LanguageSupportOptions): ((languageName: string) => Extension | undefined) => {
+      // For each extension, a function is run to perform any necessary setup; the function returns
+      // a ref that allows the extension itself to be initialized lazily.
+      const extensions: Record<string, Readonly<Ref<Extension>>> = Object.assign(
+        Object.create(null),
+        {
+          'enso-table-expression': useTableExpressionExtension({
+            project,
+            projectNames,
+            suggestionDb,
+          }),
+        },
+      )
+      function getLanguageExtension(languageName: string): Extension | undefined {
+        const extension = extensions[languageName]
+        DEV: if (!extension) console.warn(`Unknown WidgetText syntax: ${languageName}`)
+        return extension?.value
+      }
+      return getLanguageExtension
+    },
+  )

--- a/app/gui/src/project-view/providers/languageSupportExtensions.ts
+++ b/app/gui/src/project-view/providers/languageSupportExtensions.ts
@@ -20,31 +20,30 @@ export interface LanguageSupportOptions {
  * Some extensions have reactive dependencies on project data; this store allows such extensions to
  * share computation between instances in any number of editors.
  */
-export const [provideLanguageSupportExtensions, useLanguageSupportExtensions] =
-  createContextStore(
-    'Table expression extension',
-    ({
-      project,
-      projectNames,
-      suggestionDb,
-    }: LanguageSupportOptions): ((languageName: string) => Extension | undefined) => {
-      // For each extension, a function is run to perform any necessary setup; the function returns
-      // a ref that allows the extension itself to be initialized lazily.
-      const extensions: Record<string, Readonly<Ref<Extension>>> = Object.assign(
-        Object.create(null),
-        {
-          'enso-table-expression': useTableExpressionExtension({
-            project,
-            projectNames,
-            suggestionDb,
-          }),
-        },
-      )
-      function getLanguageExtension(languageName: string): Extension | undefined {
-        const extension = extensions[languageName]
-        DEV: if (!extension) console.warn(`Unknown WidgetText syntax: ${languageName}`)
-        return extension?.value
-      }
-      return getLanguageExtension
-    },
-  )
+export const [provideLanguageSupportExtensions, useLanguageSupportExtensions] = createContextStore(
+  'Table expression extension',
+  ({
+    project,
+    projectNames,
+    suggestionDb,
+  }: LanguageSupportOptions): ((languageName: string) => Extension | undefined) => {
+    // For each extension, a function is run to perform any necessary setup; the function returns
+    // a ref that allows the extension itself to be initialized lazily.
+    const extensions: Record<string, Readonly<Ref<Extension>>> = Object.assign(
+      Object.create(null),
+      {
+        'enso-table-expression': useTableExpressionExtension({
+          project,
+          projectNames,
+          suggestionDb,
+        }),
+      },
+    )
+    function getLanguageExtension(languageName: string): Extension | undefined {
+      const extension = extensions[languageName]
+      DEV: if (!extension) console.warn(`Unknown WidgetText syntax: ${languageName}`)
+      return extension?.value
+    }
+    return getLanguageExtension
+  },
+)

--- a/app/gui/src/project-view/stores/suggestionDatabase/index.ts
+++ b/app/gui/src/project-view/stores/suggestionDatabase/index.ts
@@ -80,6 +80,13 @@ export class SuggestionDb extends ReactiveDb<SuggestionId, SuggestionEntry> {
     )
   }
 
+  /** Returns methods defined on the specified type, including private methods. */
+  typeMethods(memberOf: ProjectPath): IterableIterator<MethodSuggestionEntry> {
+    return iter.filter(this.getAllEntriesOfKind(SuggestionKind.Method), (method) =>
+      memberOf.equals(method.memberOf),
+    )
+  }
+
   dropdownTypeExpressionTags = computed((): ExpressionTag[] => {
     return Array.from(this.selectableTypes.value, (ty) => ExpressionTag.FromEntry(this, ty))
   })

--- a/app/gui/src/project-view/util/codemirror/language/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/index.ts
@@ -3,7 +3,7 @@ import type { ToValue } from '@/util/reactivity'
 import { acceptCompletion, autocompletion, startCompletion } from '@codemirror/autocomplete'
 import { Prec, type Extension } from '@codemirror/state'
 import { keymap, ViewPlugin, type PluginValue, type ViewUpdate } from '@codemirror/view'
-import { computed, toValue, type Ref } from 'vue'
+import { computed, toValue, type Ref, shallowRef } from 'vue'
 import { mapOr, type Opt } from 'ydoc-shared/util/data/opt'
 
 const NULL_EXTENSION: Extension = []
@@ -53,7 +53,7 @@ const completionBindings = keymap.of([
 /** @returns a reactive syntax support extension for the specified language. */
 export function useLanguageSupport(syntax: ToValue<Opt<string>>): Readonly<Ref<Extension>> {
   const languageExtension = useLanguageSupportExtensions(true)
-  if (!languageExtension) return computed(() => NULL_EXTENSION)
+  if (!languageExtension) return shallowRef(NULL_EXTENSION)
   /** Language support for a known syntax. */
   const languageExt = computed((): Extension | undefined =>
     mapOr(toValue(syntax), undefined, languageExtension),

--- a/app/gui/src/project-view/util/codemirror/language/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/index.ts
@@ -1,19 +1,10 @@
-import type { ProjectStore } from '@/stores/project'
-import type { ProjectNameStore } from '@/stores/projectNames'
-import type { SuggestionDb } from '@/stores/suggestionDatabase'
-import { useTableExpressionExtension } from '@/util/codemirror/language/tableExpression'
+import { useLanguageSupportExtensions } from '@/providers/languageSupportExtensions'
 import type { ToValue } from '@/util/reactivity'
 import { acceptCompletion, autocompletion, startCompletion } from '@codemirror/autocomplete'
 import { Prec, type Extension } from '@codemirror/state'
 import { keymap, ViewPlugin, type PluginValue, type ViewUpdate } from '@codemirror/view'
 import { computed, toValue, type Ref } from 'vue'
 import { mapOr, type Opt } from 'ydoc-shared/util/data/opt'
-
-export interface LanguageSupportOptions {
-  project: ToValue<Opt<ProjectStore>>
-  projectNames: ToValue<Opt<ProjectNameStore>>
-  suggestionDb: ToValue<Opt<SuggestionDb>>
-}
 
 const NULL_EXTENSION: Extension = []
 
@@ -60,23 +51,9 @@ const completionBindings = keymap.of([
 ])
 
 /** @returns a reactive syntax support extension for the specified language. */
-export function useLanguageSupport(
-  syntax: ToValue<Opt<string>>,
-  { project, projectNames, suggestionDb }: LanguageSupportOptions,
-) {
-  const extensions: Record<string, Readonly<Ref<Extension>>> = Object.assign(Object.create(null), {
-    'enso-table-expression': useTableExpressionExtension({
-      project,
-      projectNames,
-      suggestionDb,
-    }),
-  })
-  function languageExtension(languageName: string): Extension | undefined {
-    const extension = extensions[languageName]
-    DEV: if (!extension) console.warn(`Unknown WidgetText syntax: ${languageName}`)
-    return extension?.value
-  }
-
+export function useLanguageSupport(syntax: ToValue<Opt<string>>): Readonly<Ref<Extension>> {
+  const languageExtension = useLanguageSupportExtensions(true)
+  if (!languageExtension) return computed(() => NULL_EXTENSION)
   /** Language support for a known syntax. */
   const languageExt = computed((): Extension | undefined =>
     mapOr(toValue(syntax), undefined, languageExtension),

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression.ts
@@ -9,7 +9,7 @@ import type { QualifiedName } from '@/util/qualifiedName'
 import type { ToValue } from '@/util/reactivity'
 import type { Extension } from '@codemirror/state'
 import { tableExpression, type MethodCompletionInfo } from 'lezer-enso-table-expr'
-import { computed, toValue, type Ref } from 'vue'
+import { computed, toRef, toValue, watch, type Ref } from 'vue'
 import type { Opt } from 'ydoc-shared/util/data/opt'
 
 export interface TableExpressionExtensionOptions {
@@ -22,13 +22,20 @@ export interface TableExpressionExtensionOptions {
 export function useTableExpressionExtension(
   options: TableExpressionExtensionOptions,
 ): Readonly<Ref<Extension>> {
-  const { projectNames, suggestionDb } = options
+  const { projectNames } = options
   const project = toValue(options.project)
+  const suggestionDb = toRef(options.suggestionDb)
 
+  const columnMethodEntries = computed(() =>
+    [...(suggestionDb.value?.selectableMethods(COLUMN_TYPE) ?? [])].filter(
+      (method) => !EXCLUDED_COLUMN_METHODS.has(method.name),
+    ),
+  )
+  const staticMethodEntries = computed(() => [
+    ...(suggestionDb.value?.typeMethods(EXPRESSION_STATICS_TYPE) ?? []),
+  ])
   const methodInfos = computed(() =>
-    [...(toValue(suggestionDb)?.selectableMethods(COLUMN_TYPE) ?? [])]
-      .filter((method) => !EXCLUDED_METHODS.has(method.name))
-      .map(methodInfoFromEntry),
+    [...columnMethodEntries.value, ...staticMethodEntries.value].map(methodInfoFromEntry),
   )
 
   const columns =
@@ -45,14 +52,20 @@ const COLUMN_TYPE = ProjectPath.create(
   'Column.Column' as QualifiedName,
 )
 
+const EXPRESSION_STATICS_TYPE = ProjectPath.create(
+  'Standard.Table' as QualifiedName,
+  'Internal.Expression_Statics.Expression_Statics' as QualifiedName,
+)
+
 function methodInfoFromEntry(entry: MethodSuggestionEntry): MethodCompletionInfo {
   return {
     name: entry.name,
     description: entry.documentationSummary,
+    args: entry.arguments.length > 0,
   }
 }
 
-const EXCLUDED_METHODS = new Set([
+const EXCLUDED_COLUMN_METHODS = new Set([
   ///// Syntactic methods /////
   // These methods are used to implement special syntaxes in the expression language. Some cannot
   // syntactically be used as methods; others could legally be used, but the dedicated syntax is

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression.ts
@@ -9,7 +9,7 @@ import type { QualifiedName } from '@/util/qualifiedName'
 import type { ToValue } from '@/util/reactivity'
 import type { Extension } from '@codemirror/state'
 import { tableExpression, type MethodCompletionInfo } from 'lezer-enso-table-expr'
-import { computed, toRef, toValue, watch, type Ref } from 'vue'
+import { computed, toRef, toValue, type Ref } from 'vue'
 import type { Opt } from 'ydoc-shared/util/data/opt'
 
 export interface TableExpressionExtensionOptions {

--- a/app/table-expression/src/autocomplete/index.ts
+++ b/app/table-expression/src/autocomplete/index.ts
@@ -6,6 +6,7 @@ import { completionTypeAt, type NameCompletion } from './completionType'
 export interface MethodCompletionInfo {
   name: string
   description?: string | undefined
+  args: boolean
 }
 
 interface StringCompletion extends Completion {
@@ -14,21 +15,25 @@ interface StringCompletion extends Completion {
 
 function getMethodOptions(infos: MethodCompletionInfo[]) {
   const methods: StringCompletion[] = []
+  const methodsWithParen: StringCompletion[] = []
   const binaryOperators: Completion[] = []
-  for (const { name, description } of infos) {
+  for (const { name, description, args } of infos) {
     if (/^[a-z]/.test(name)) {
-      methods.push({
+      const baseCompletion = {
         label: name,
         type: 'method',
         ...(description ? { detail: description } : {}),
         apply: name,
-      })
+      }
+      methods.push(baseCompletion)
+      methodsWithParen.push({ ...baseCompletion, apply: name + (args ? '(' : '()') })
     } else {
       binaryOperators.push({ label: name, type: 'operator' })
     }
   }
   return {
     methods,
+    methodsWithParen,
     binaryOperators,
   }
 }
@@ -36,7 +41,6 @@ function getMethodOptions(infos: MethodCompletionInfo[]) {
 function applyMapper(f: (s: string) => string): (completion: StringCompletion) => StringCompletion {
   return (completion) => ({ ...completion, apply: f(completion.apply) })
 }
-const openParenAfter = applyMapper((s) => `${s}(`)
 const closeBracketAfter = applyMapper((s) => `${s}]`)
 const encloseBrackets = applyMapper((s) => `[${s}]`)
 
@@ -46,7 +50,6 @@ export function useCompletions(
   columns: (() => string[]) | undefined,
 ) {
   const methodOptions = computed(() => getMethodOptions(methods?.() ?? []))
-  const methodsWithParen = computed(() => methodOptions.value.methods.map(openParenAfter))
   const columnOptions = computed(() =>
     Array.from(columns?.() ?? [], (column) => ({
       label: column,
@@ -57,7 +60,7 @@ export function useCompletions(
   )
   const columnsWithBracket = computed(() => columnOptions.value.map(closeBracketAfter))
   const valueOptions = computed(() => [
-    ...methodsWithParen.value,
+    ...methodOptions.value.methodsWithParen,
     ...columnOptions.value.map(encloseBrackets),
   ])
 
@@ -69,7 +72,10 @@ export function useCompletions(
       : completion.type === 'functionName' ?
         nameCompletions(
           completion,
-          () => (completion.insertDelim ? methodsWithParen.value : methodOptions.value.methods),
+          () =>
+            completion.insertDelim ?
+              methodOptions.value.methodsWithParen
+            : methodOptions.value.methods,
           context,
         )
       : completion.type === 'columnName' ?

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -50,7 +50,7 @@ type Expression
         ## Helper for the expression to tell it which functions needs a Vector
         var_args_functions = ['is_in', 'coalesce', 'min', 'max']
         ## Define which enso types we will look in to resolve methods in the expression
-        mr1 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Expression_Statics" "Expression_Statics" isStaticMethod=True makeTypedColumn=Nothing
+        mr1 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Internal.Expression_Statics" "Expression_Statics" isStaticMethod=True makeTypedColumn=Nothing
         mr2 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Column" "Column" isStaticMethod=False makeTypedColumn=c->c
         mr3 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Refined_Types.Numeric_Column" "Numeric_Column" isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         method_resolvers = [mr1, mr2, mr3]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Expression_Statics.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Expression_Statics.enso
@@ -1,5 +1,3 @@
-private
-
 from Standard.Base import all
 
 ## Set of static functions for expression support allowing callback to Enso code.


### PR DESCRIPTION
### Pull Request Description

The table expression editor now includes the special methods defined in `Expression_Statics`.

https://github.com/user-attachments/assets/420bb995-6bfd-4a92-8c6e-cc1b50810e19

### Important Notes

- Changed `Expression_Statics` from a `private` module to a non-private, `Internal` module--so that the GUI will receive SDB entries for the methods, but will not suggest them in the CB.
- Reactive CM extension data is now shared between all CM instances
- Autocompleting a zero-argument function now includes the closing parenthesis.

Part of #12305.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
