### PR TITLE
Avoid loading `Source` when creating `EnsoRootNode` from caches

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -516,7 +516,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
           Api.RecomputeContextRequest(contextId, None, None, Seq())
         )
       )
-      context.receiveNIgnoreExpressionUpdates(3) should contain allOf (
+      context.receiveNIgnoreExpressionUpdates(2) should contain allOf (
         Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
         context.executionComplete(contextId)
       )
@@ -5673,7 +5673,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
       )
 
       // Includes a warning about unused variable
-      val editFileResponse = context.receiveNIgnoreExpressionUpdates(3)
+      val editFileResponse = context.receiveNIgnoreExpressionUpdates(2)
       editFileResponse should contain(
         context.executionComplete(contextId)
       )

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -304,7 +304,7 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
               new IrToTruffle(
                   context,
                   module.getPackage(),
-                  request.getSource(),
+                  request::getSource,
                   mod,
                   redirectConfigWithStrictErrors);
           exprNode = toTruffle.runInline(ir, sco, "<inline_source>");

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
@@ -4,8 +4,10 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.source.Source;
+import java.util.function.Supplier;
 import org.enso.compiler.context.LocalScope;
+import org.enso.compiler.core.ir.Location;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
@@ -28,11 +30,12 @@ public class ClosureRootNode extends EnsoRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       ExpressionNode body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location location,
       String name,
       Boolean subjectToInstrumentation,
       boolean usedInBinding) {
-    super(language, localScope, moduleScope, name, section);
+    super(language, localScope, moduleScope, name, source, location);
     this.body = body;
     this.subjectToInstrumentation = Boolean.TRUE.equals(subjectToInstrumentation);
     this.usedInBinding = usedInBinding;
@@ -45,7 +48,8 @@ public class ClosureRootNode extends EnsoRootNode {
    * @param localScope a description of the local scope
    * @param moduleScope a description of the module scope
    * @param body the program body to be executed
-   * @param section a mapping from {@code body} to the program source
+   * @param source lazy provider of the associated source
+   * @param location the position in the source or {@code null}
    * @param name a name for the node
    * @param subjectToInstrumentation shall this node be instrumented
    * @param usedInBinding is this node directly used in a variable binding
@@ -56,7 +60,8 @@ public class ClosureRootNode extends EnsoRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       ExpressionNode body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location location,
       String name,
       Boolean subjectToInstrumentation,
       boolean usedInBinding) {
@@ -65,7 +70,8 @@ public class ClosureRootNode extends EnsoRootNode {
         localScope,
         moduleScope,
         body,
-        section,
+        source,
+        location,
         name,
         subjectToInstrumentation,
         usedInBinding);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ConstantNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ConstantNode.java
@@ -16,7 +16,7 @@ public final class ConstantNode extends EnsoRootNode {
    * @param constant the value to return.
    */
   public ConstantNode(EnsoLanguage language, ModuleScope moduleScope, Object constant) {
-    super(language, LocalScope.empty(), moduleScope, constant.toString(), null);
+    super(language, LocalScope.empty(), moduleScope, constant.toString(), null, null);
     this.constant = constant;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -119,17 +119,16 @@ public abstract class EnsoRootNode extends RootNode {
   @TruffleBoundary
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
+      if (rootNode.sourceStartIndex == NO_SOURCE) {
+        return null;
+      }
       var src = rootNode.source == null ? null : rootNode.source.get();
-      if (src == null || !rootNode.moduleScope.getModule().isModuleSource(src)) {
-        if (rootNode.sourceStartIndex == NO_SOURCE) {
-          return null;
-        } else {
-          return rootNode
-              .getModuleScope()
-              .getModule()
-              .createSection(sourceStartIndex, sourceLength);
-        }
+      var module = rootNode.getModuleScope().getModule();
+      if (src == null || module.isModuleSource(src)) {
+        // ask the module for a (patched) section
+        return module.createSection(sourceStartIndex, sourceLength);
       } else {
+        // ask the source itself
         return src.createSection(sourceStartIndex, sourceLength);
       }
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -119,10 +119,14 @@ public abstract class EnsoRootNode extends RootNode {
   @TruffleBoundary
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
-      var src = rootNode.source == null ? null : rootNode.source.get();
+      if (rootNode.source == null) {
+        return null;
+      }
+      var src = rootNode.source.get();
+      assert src != null;
       var module = rootNode.getModuleScope().getModule();
       var ownedByModule = module.isModuleSource(src);
-      if (src == null || ownedByModule) {
+      if (ownedByModule) {
         // ask the module for a (patched) section
         return module.createSection(sourceStartIndex, sourceLength);
       } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -50,7 +50,7 @@ public abstract class EnsoRootNode extends RootNode {
     this.name = name;
     this.localScope = localScope;
     this.moduleScope = moduleScope;
-    this.source = CachingSupplier.wrap(sourceSupplier);
+    this.source = sourceSupplier == null ? null : CachingSupplier.wrap(sourceSupplier);
     this.sourceStartIndex = location == null ? NO_SOURCE : location.start();
     this.sourceLength = location == null ? NO_SOURCE : location.length();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -120,10 +120,7 @@ public abstract class EnsoRootNode extends RootNode {
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
       var src = rootNode.source == null ? null : rootNode.source.get();
-      if (rootNode.moduleScope.getModule().isModuleSource(src)) {
-        src = null;
-      }
-      if (src == null) {
+      if (src == null || !rootNode.moduleScope.getModule().isModuleSource(src)) {
         if (rootNode.sourceStartIndex == NO_SOURCE) {
           return null;
         } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -124,7 +124,8 @@ public abstract class EnsoRootNode extends RootNode {
       }
       var src = rootNode.source == null ? null : rootNode.source.get();
       var module = rootNode.getModuleScope().getModule();
-      if (src == null || module.isModuleSource(src)) {
+      var ownedByModule = module.isModuleSource(src);
+      if (src == null || ownedByModule) {
         // ask the module for a (patched) section
         return module.createSection(sourceStartIndex, sourceLength);
       } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -7,11 +7,14 @@ import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.enso.compiler.context.LocalScope;
+import org.enso.compiler.core.ir.Location;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /** A common base class for all kinds of root node in Enso. */
 @NodeInfo(shortName = "Root", description = "A root node for Enso computations")
@@ -21,7 +24,7 @@ public abstract class EnsoRootNode extends RootNode {
   private final int sourceLength;
   private final LocalScope localScope;
   private final ModuleScope moduleScope;
-  private final Source inlineSource;
+  private final CachingSupplier<Source> source;
 
   /**
    * Constructs the root node.
@@ -30,14 +33,16 @@ public abstract class EnsoRootNode extends RootNode {
    * @param localScope a reference to the construct local scope
    * @param moduleScope a reference to the construct module scope. May be {@code null}.
    * @param name the name of the construct
-   * @param sourceSection a reference to the source code being executed. May be {@code null}.
+   * @param sourceSupplier a reference to the source code being executed. May be {@code null}.
+   * @param location in the (to be supplied) source. May be {@code null}
    */
   protected EnsoRootNode(
       EnsoLanguage language,
       LocalScope localScope,
       ModuleScope moduleScope,
       String name,
-      SourceSection sourceSection) {
+      Supplier<Source> sourceSupplier,
+      Location location) {
     super(language, buildFrameDescriptor(name, localScope));
     Objects.requireNonNull(language);
     Objects.requireNonNull(localScope);
@@ -45,14 +50,9 @@ public abstract class EnsoRootNode extends RootNode {
     this.name = name;
     this.localScope = localScope;
     this.moduleScope = moduleScope;
-    if (sourceSection == null
-        || moduleScope.getModule().isModuleSource(sourceSection.getSource())) {
-      this.inlineSource = null;
-    } else {
-      this.inlineSource = sourceSection.getSource();
-    }
-    this.sourceStartIndex = sourceSection == null ? NO_SOURCE : sourceSection.getCharIndex();
-    this.sourceLength = sourceSection == null ? NO_SOURCE : sourceSection.getCharLength();
+    this.source = CachingSupplier.wrap(sourceSupplier);
+    this.sourceStartIndex = location == null ? NO_SOURCE : location.start();
+    this.sourceLength = location == null ? NO_SOURCE : location.length();
   }
 
   /**
@@ -117,7 +117,7 @@ public abstract class EnsoRootNode extends RootNode {
 
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
-      if (rootNode.inlineSource == null) {
+      if (rootNode.source == null) {
         if (rootNode.sourceStartIndex == NO_SOURCE) {
           return null;
         } else {
@@ -127,7 +127,7 @@ public abstract class EnsoRootNode extends RootNode {
               .createSection(sourceStartIndex, sourceLength);
         }
       } else {
-        return rootNode.inlineSource.createSection(sourceStartIndex, sourceLength);
+        return rootNode.source.get().createSection(sourceStartIndex, sourceLength);
       }
     }
     return null;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -119,9 +119,6 @@ public abstract class EnsoRootNode extends RootNode {
   @TruffleBoundary
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
-      if (rootNode.sourceStartIndex == NO_SOURCE) {
-        return null;
-      }
       var src = rootNode.source == null ? null : rootNode.source.get();
       var module = rootNode.getModuleScope().getModule();
       var ownedByModule = module.isModuleSource(src);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.NodeInfo;
@@ -115,6 +116,7 @@ public abstract class EnsoRootNode extends RootNode {
 
   static final int NO_SOURCE = -1;
 
+  @TruffleBoundary
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
       var src = rootNode.source == null ? null : rootNode.source.get();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -117,7 +117,11 @@ public abstract class EnsoRootNode extends RootNode {
 
   static SourceSection findSourceSection(final RootNode n, int sourceStartIndex, int sourceLength) {
     if (sourceStartIndex != NO_SOURCE && n instanceof EnsoRootNode rootNode) {
-      if (rootNode.source == null) {
+      var src = rootNode.source == null ? null : rootNode.source.get();
+      if (rootNode.moduleScope.getModule().isModuleSource(src)) {
+        src = null;
+      }
+      if (src == null) {
         if (rootNode.sourceStartIndex == NO_SOURCE) {
           return null;
         } else {
@@ -127,7 +131,7 @@ public abstract class EnsoRootNode extends RootNode {
               .createSection(sourceStartIndex, sourceLength);
         }
       } else {
-        return rootNode.source.get().createSection(sourceStartIndex, sourceLength);
+        return src.createSection(sourceStartIndex, sourceLength);
       }
     }
     return null;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/MethodRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/MethodRootNode.java
@@ -5,10 +5,11 @@ import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.source.Source;
 import java.util.function.Supplier;
 import org.enso.compiler.context.LocalScope;
 import org.enso.compiler.core.CompilerError;
+import org.enso.compiler.core.ir.Location;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -30,7 +31,8 @@ public class MethodRootNode extends ClosureRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       ExpressionNode body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       Type type,
       String methodName) {
     super(
@@ -38,6 +40,7 @@ public class MethodRootNode extends ClosureRootNode {
         localScope,
         moduleScope,
         body,
+        source,
         section,
         shortName(type.getName(), methodName),
         null,
@@ -68,11 +71,19 @@ public class MethodRootNode extends ClosureRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       Supplier<ExpressionNode> body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       Type type,
       String methodName) {
     return build(
-        language, localScope, moduleScope, new LazyBodyNode(body), section, type, methodName);
+        language,
+        localScope,
+        moduleScope,
+        new LazyBodyNode(body),
+        source,
+        section,
+        type,
+        methodName);
   }
 
   public static MethodRootNode build(
@@ -80,10 +91,12 @@ public class MethodRootNode extends ClosureRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       ExpressionNode body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       Type type,
       String methodName) {
-    return new MethodRootNode(language, localScope, moduleScope, body, section, type, methodName);
+    return new MethodRootNode(
+        language, localScope, moduleScope, body, source, section, type, methodName);
   }
 
   /**
@@ -104,9 +117,10 @@ public class MethodRootNode extends ClosureRootNode {
       LocalScope localScope,
       ModuleScope moduleScope,
       ExpressionNode body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       AtomConstructor constructor) {
-    return new Constructor(language, localScope, moduleScope, body, section, constructor);
+    return new Constructor(language, localScope, moduleScope, body, source, section, constructor);
   }
 
   /**
@@ -131,7 +145,8 @@ public class MethodRootNode extends ClosureRootNode {
       Supplier<ExpressionNode> readLeft,
       Supplier<ExpressionNode> readRight,
       Supplier<ExpressionNode> body,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       Type type,
       String methodName) {
     Supplier<ExpressionNode> supplyWholeBody =
@@ -142,7 +157,8 @@ public class MethodRootNode extends ClosureRootNode {
           var operatorNode = new BinaryOperatorNode(readLeftNode, readRightNode, exprNode);
           return operatorNode;
         };
-    return build(language, localScope, moduleScope, supplyWholeBody, section, type, methodName);
+    return build(
+        language, localScope, moduleScope, supplyWholeBody, source, section, type, methodName);
   }
 
   /**
@@ -234,13 +250,15 @@ public class MethodRootNode extends ClosureRootNode {
         LocalScope localScope,
         ModuleScope moduleScope,
         ExpressionNode body,
-        SourceSection section,
+        Supplier<Source> source,
+        Location section,
         AtomConstructor constructor) {
       super(
           language,
           localScope,
           moduleScope,
           body,
+          source,
           section,
           constructor.getType(),
           constructor.getName());

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -96,7 +96,15 @@ public abstract class EvalNode extends BaseNode {
     }
     ClosureRootNode framedNode =
         ClosureRootNode.build(
-            context.getLanguage(), localScope, moduleScope, expr, null, "<eval>", false, false);
+            context.getLanguage(),
+            localScope,
+            moduleScope,
+            expr,
+            null,
+            null,
+            "<eval>",
+            false,
+            false);
     return framedNode.getCallTarget();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -22,6 +22,7 @@ import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /** Node running Enso expressions passed to it as strings. */
 @NodeInfo(shortName = "Eval", description = "Evaluates code passed to it as string")
@@ -85,7 +86,9 @@ public abstract class EvalNode extends BaseNode {
 
     var sco = newInlineContext.localScope().getOrElse(LocalScope::empty);
     var mod = newInlineContext.getModule();
-    var toTruffle = new IrToTruffle(context, mod.getPackage(), src, mod, compiler.getConfig());
+    var toTruffle =
+        new IrToTruffle(
+            context, mod.getPackage(), CachingSupplier.forValue(src), mod, compiler.getConfig());
     var expr = toTruffle.runInline(ir, sco, "<inline_source>");
 
     if (shouldCaptureResultScope) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -460,6 +460,7 @@ public final class Module extends EnsoObject {
    * @param s source to check
    * @return {@code true} if the source has been created for this module
    */
+  @TruffleBoundary
   public final boolean isModuleSource(Source s) {
     return allSources.containsKey(s);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -38,6 +38,7 @@ import org.enso.interpreter.caches.Cache;
 import org.enso.interpreter.caches.ModuleCache;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.node.callable.dispatch.LoopingCallOptimiserNode;
+import org.enso.interpreter.node.expression.builtin.debug.DebugEvalNode;
 import org.enso.interpreter.runtime.builtin.BuiltinFunction;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.CallerInfo;
@@ -455,7 +456,9 @@ public final class Module extends EnsoObject {
   }
 
   /**
-   * Check whether given source has ever been associated with this module.
+   * Check whether given source has ever been associated with this module. For example {@link
+   * DebugEvalNode} likes to create sources in a context of some module, but those are not
+   * associated with the module itself.
    *
    * @param s source to check
    * @return {@code true} if the source has been created for this module

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -50,6 +50,7 @@ import org.enso.interpreter.caches.ImportExportCache.MapToBindings;
 import org.enso.interpreter.caches.ModuleCache;
 import org.enso.interpreter.caches.SuggestionsCache;
 import org.enso.interpreter.runtime.type.Types;
+import org.enso.interpreter.runtime.util.CachingSupplier;
 import org.enso.interpreter.runtime.util.DiagnosticFormatter;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
@@ -160,7 +161,8 @@ final class TruffleCompilerContext implements CompilerContext {
       throws IOException {
     var m = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
     var sb = TruffleCompilerModuleScopeBuilder.fromCompilerModuleScopeBuilder(scopeBuilder);
-    new IrToTruffle(context, m.getPackage(), m.getSource(), sb, config).run(module.getIr());
+    var ss = CachingSupplier.from(m::getSource);
+    new IrToTruffle(context, m.getPackage(), ss, sb, config).run(module.getIr());
   }
 
   // module related

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
@@ -12,11 +12,14 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.enso.compiler.context.LocalScope;
+import org.enso.compiler.core.ir.Location;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.node.EnsoRootNode;
@@ -212,9 +215,12 @@ public final class UnresolvedConstructor extends EnsoObject {
       var lang = EnsoLanguage.get(null);
       var body = BlockNode.buildSilent(new ExpressionNode[0], expr);
       body.adoptChildren();
+      var loc =
+          section == null ? null : new Location(section.getCharIndex(), section.getCharEndIndex());
+      Supplier<Source> src = section == null ? null : section::getSource;
       var root =
           ClosureRootNode.build(
-              lang, LocalScope.empty(), scope, body, section, prototype.getName(), true, true);
+              lang, LocalScope.empty(), scope, body, src, loc, prototype.getName(), true, true);
       root.adoptChildren();
       assert Objects.equals(expr.getSourceSection(), section)
           : "Expr: " + expr.getSourceSection() + " orig: " + section;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.source.Source;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +19,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import org.enso.compiler.context.LocalScope;
+import org.enso.compiler.core.ir.Location;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.MethodRootNode;
@@ -114,19 +115,22 @@ public final class AtomConstructor extends EnsoObject {
    * @param args the list of argument definitions
    */
   public static InitializationBuilder newInitializationBuilder(
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       LocalScope localScope,
       ExpressionNode[] assignments,
       ExpressionNode[] varReads,
       Annotation[] annotations,
       ArgumentDefinition[] args) {
-    return new InitializationBuilder(section, localScope, assignments, varReads, annotations, args);
+    return new InitializationBuilder(
+        source, section, localScope, assignments, varReads, annotations, args);
   }
 
   /** Builder required for initialization of the atom constructor. */
   public static final class InitializationBuilder {
 
-    private final SourceSection section;
+    private final Supplier<Source> source;
+    private final Location section;
     private final LocalScope localScope;
     private final ExpressionNode[] assignments;
     private final ExpressionNode[] varReads;
@@ -145,12 +149,14 @@ public final class AtomConstructor extends EnsoObject {
      * @param args the list of argument definitions
      */
     InitializationBuilder(
-        SourceSection section,
+        Supplier<Source> source,
+        Location section,
         LocalScope localScope,
         ExpressionNode[] assignments,
         ExpressionNode[] varReads,
         Annotation[] annotations,
         ArgumentDefinition[] args) {
+      this.source = source;
       this.section = section;
       this.localScope = localScope;
       this.assignments = assignments;
@@ -159,7 +165,7 @@ public final class AtomConstructor extends EnsoObject {
       this.args = args;
     }
 
-    private SourceSection getSection() {
+    private Location getSection() {
       return section;
     }
 
@@ -209,7 +215,7 @@ public final class AtomConstructor extends EnsoObject {
 
     var builder =
         newInitializationBuilder(
-            null, LocalScope.empty(), new ExpressionNode[0], reads, new Annotation[0], args);
+            null, null, LocalScope.empty(), new ExpressionNode[0], reads, new Annotation[0], args);
     return initializeFields(language, scopeBuilder, CachingSupplier.forValue(builder), fieldNames);
   }
 
@@ -243,6 +249,7 @@ public final class AtomConstructor extends EnsoObject {
               var constructorFunction =
                   buildConstructorFunction(
                       language,
+                      builder.source,
                       builder.getSection(),
                       builder.getLocalScope(),
                       scopeBuilder,
@@ -277,7 +284,8 @@ public final class AtomConstructor extends EnsoObject {
    */
   private Function buildConstructorFunction(
       EnsoLanguage language,
-      SourceSection section,
+      Supplier<Source> source,
+      Location section,
       LocalScope localScope,
       ModuleScopeBuilder scopeBuilder,
       ExpressionNode[] assignments,
@@ -286,12 +294,18 @@ public final class AtomConstructor extends EnsoObject {
       ArgumentDefinition[] args) {
     ExpressionNode instantiateNode = InstantiateNode.build(this, varReads);
     if (section != null) {
-      instantiateNode.setSourceLocation(section.getCharIndex(), section.getCharLength());
+      instantiateNode.setSourceLocation(section.start(), section.length());
     }
     BlockNode instantiateBlock = BlockNode.buildRoot(assignments, instantiateNode);
     RootNode rootNode =
         MethodRootNode.buildConstructor(
-            language, localScope, scopeBuilder.asModuleScope(), instantiateBlock, section, this);
+            language,
+            localScope,
+            scopeBuilder.asModuleScope(),
+            instantiateBlock,
+            source,
+            section,
+            this);
     RootCallTarget callTarget = rootNode.getCallTarget();
     var schemaBldr = FunctionSchema.newBuilder().annotations(annotations).argumentDefinitions(args);
     if (type.hasAllConstructorsPrivate()) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/GetFieldBaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/GetFieldBaseNode.java
@@ -16,7 +16,7 @@ abstract class GetFieldBaseNode extends EnsoRootNode {
   protected final ModuleScope moduleScope;
 
   GetFieldBaseNode(EnsoLanguage language, Type type, String fieldName, ModuleScope moduleScope) {
-    super(language, LocalScope.empty(), moduleScope, fieldName, null);
+    super(language, LocalScope.empty(), moduleScope, fieldName, null, null);
     this.type = type;
     this.fieldName = fieldName;
     this.moduleScope = moduleScope;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/QualifiedAccessorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/QualifiedAccessorNode.java
@@ -27,6 +27,7 @@ final class QualifiedAccessorNode extends EnsoRootNode {
         LocalScope.empty(),
         moduleScope,
         atomConstructor.getQualifiedName().toString(),
+        null,
         null);
     this.atomConstructor = atomConstructor;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/util/CachingSupplier.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/util/CachingSupplier.java
@@ -30,6 +30,18 @@ public final class CachingSupplier<T> implements Supplier<T> {
     }
   }
 
+  public static <V> CachingSupplier<V> from(java.util.concurrent.Callable<V> c) {
+    Supplier<V> supply =
+        () -> {
+          try {
+            return c.call();
+          } catch (Exception ex) {
+            throw raise(RuntimeException.class, ex);
+          }
+        };
+    return wrap(supply);
+  }
+
   public static <V> CachingSupplier<V> forValue(V value) {
     return new CachingSupplier<>(value);
   }
@@ -77,5 +89,10 @@ public final class CachingSupplier<T> implements Supplier<T> {
   @SuppressWarnings("unchecked")
   public static <V> Supplier<V> nullSupplier() {
     return EMPTY;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Exception> T raise(Class<T> type, Exception ex) throws T {
+    throw (T) ex;
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1,6 +1,6 @@
 package org.enso.interpreter.runtime
 
-import com.oracle.truffle.api.source.{Source, SourceSection}
+import com.oracle.truffle.api.source.Source
 import com.oracle.truffle.api.interop.InteropLibrary
 import org.enso.compiler.common.{
   BuildScopeFromModuleAlgorithm,
@@ -22,6 +22,7 @@ import org.enso.compiler.core.ir.{
   Function,
   IdentifiedLocation,
   Literal,
+  Location,
   Module,
   Name,
   Pattern,
@@ -298,7 +299,8 @@ private[runtime] class IrToTruffle(
                 expressionProcessor.scope,
                 scopeBuilder.asModuleScope(),
                 () => bodyBuilder.bodyNode(),
-                makeSection(scopeBuilder.getModule, conversion.location),
+                makeSource(scopeBuilder.getModule),
+                makeLocation(conversion.location),
                 toType,
                 conversion.methodName.name
               )
@@ -516,7 +518,8 @@ private[runtime] class IrToTruffle(
             expressionProcessor.scope,
             scopeBuilder.asModuleScope(),
             expressionNode,
-            makeSection(scopeBuilder.getModule, annotation.location),
+            makeSource(scopeBuilder.getModule),
+            makeLocation(annotation.location),
             closureName,
             true,
             false
@@ -525,7 +528,8 @@ private[runtime] class IrToTruffle(
         }
 
         AtomConstructor.newInitializationBuilder(
-          makeSection(scopeBuilder.getModule, atomDefn.location),
+          makeSource(scopeBuilder.getModule),
+          makeLocation(atomDefn.location),
           localScope,
           assignments.toArray,
           reads.toArray,
@@ -627,7 +631,8 @@ private[runtime] class IrToTruffle(
           () => bodyBuilder.argsExpr._1(0),
           () => bodyBuilder.argsExpr._1(1),
           () => bodyBuilder.argsExpr._2,
-          makeSection(scopeBuilder.getModule, methodDef.location),
+          makeSource(scopeBuilder.getModule),
+          makeLocation(methodDef.location),
           cons,
           methodDef.methodName.name
         )
@@ -637,7 +642,8 @@ private[runtime] class IrToTruffle(
           expressionProcessor.scope,
           scopeBuilder.asModuleScope(),
           () => bodyBuilder.bodyNode(),
-          makeSection(scopeBuilder.getModule, methodDef.location),
+          makeSource(scopeBuilder.getModule),
+          makeLocation(methodDef.location),
           cons,
           methodDef.methodName.name
         )
@@ -689,10 +695,8 @@ private[runtime] class IrToTruffle(
               expressionProcessor.scope,
               scopeBuilder.asModuleScope(),
               expressionNode,
-              makeSection(
-                scopeBuilder.getModule,
-                annotation.location
-              ),
+              makeSource(scopeBuilder.getModule),
+              makeLocation(annotation.location),
               closureName,
               true,
               false
@@ -859,20 +863,27 @@ private[runtime] class IrToTruffle(
     * @param location the location to turn into a section
     * @return the source section corresponding to `location`
     */
-  private def makeSection(
-    module: org.enso.interpreter.runtime.Module,
+  private def makeSource(
+    module: org.enso.interpreter.runtime.Module
+  ): Supplier[Source] = { () =>
+    {
+      val m = module
+      if (m.isModuleSource(source)) {
+        module.getSource()
+      } else {
+        source
+      }
+    }
+  }
+
+  private def makeLocation(
     location: Option[IdentifiedLocation]
-  ): SourceSection = {
-    location
-      .map(loc => {
-        val m = module
-        if (m.isModuleSource(source)) {
-          module.createSection(loc.start, loc.length)
-        } else {
-          source.createSection(loc.start, loc.length)
-        }
-      })
-      .getOrElse(source.createUnavailableSection())
+  ): Location = {
+    if (location.isDefined) {
+      location.get.location
+    } else {
+      null
+    }
   }
 
   private def getTailStatus(
@@ -1296,7 +1307,8 @@ private[runtime] class IrToTruffle(
           childScope,
           scopeBuilder.asModuleScope(),
           blockNode,
-          makeSection(scopeBuilder.getModule, block.location),
+          makeSource(scopeBuilder.getModule),
+          makeLocation(block.location),
           currentVarName,
           false,
           false
@@ -2244,7 +2256,8 @@ private[runtime] class IrToTruffle(
         scope,
         scopeBuilder.asModuleScope(),
         bodyBuilder.bodyNode(),
-        makeSection(scopeBuilder.getModule, location),
+        makeSource(scopeBuilder.getModule),
+        makeLocation(location),
         scopeName,
         false,
         binding
@@ -2437,7 +2450,7 @@ private[runtime] class IrToTruffle(
               s"${scopeName}<arg-${name.map(_.name).getOrElse(String.valueOf(position))}>"
 
             val section = value.location
-              .map(loc => source.createSection(loc.start, loc.length))
+              .map(loc => loc.location)
               .orNull
 
             val closureRootNode = ClosureRootNode.build(
@@ -2445,6 +2458,7 @@ private[runtime] class IrToTruffle(
               childScope,
               scopeBuilder.asModuleScope(),
               argumentExpression,
+              () => source,
               section,
               displayName,
               subjectToInstrumentation,
@@ -2531,10 +2545,8 @@ private[runtime] class IrToTruffle(
               scope,
               scopeBuilder.asModuleScope(),
               defaultExpression,
-              makeSection(
-                scopeBuilder.getModule,
-                arg.defaultValue.get.location()
-              ),
+              makeSource(scopeBuilder.getModule),
+              makeLocation(arg.defaultValue.get.location()),
               s"<default::$scopeName::${arg.name.showCode()}>",
               false,
               false

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -127,7 +127,7 @@ import scala.jdk.OptionConverters._
 private[runtime] class IrToTruffle(
   val context: EnsoContext,
   val pkg: org.enso.pkg.Package[_],
-  val source: Source,
+  private val sourceSupplier: Supplier[Source],
   val scopeBuilder: TruffleCompilerModuleScopeBuilder,
   val compilerConfig: CompilerConfig
 ) {
@@ -135,18 +135,20 @@ private[runtime] class IrToTruffle(
     Builtins.get(context)
   }
 
+  lazy val source = sourceSupplier.get
+
   val language: EnsoLanguage = context.getLanguage
 
   def this(
     context: EnsoContext,
     pkg: org.enso.pkg.Package[_],
-    source: Source,
+    sourceSupplier: Supplier[Source],
     mod: CompilerContext.Module,
     compilerConfig: CompilerConfig
   ) = this(
     context,
     pkg,
-    source,
+    sourceSupplier,
     TruffleCompilerModuleScopeBuilder.fromCompilerModule(mod),
     compilerConfig
   )


### PR DESCRIPTION
### Pull Request Description

- Another attempt to reduce I/O activity when initializing the system
- Inspired by #13756

### Objective

When running `Import_World.enso` there should be **no standard library** `.enso` file loaded into memory. Verify with:
```
enso$ ENSO_LAUNCHER=native sbt buildEngineDistribution
enso$ strace -f ./enso --run test/Benchmarks/src/Startup/Import_World.enso 2>&1 | grep "open.*enso\""
```
Which should yield almost no output. If they do, it is important to investigate who's loading the files into the process. 

The [startup benchmarks](https://github.com/enso-org/enso/pull/13915#issuecomment-3247920747) is also improved.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] Benchmarks show some improvements - [stdlibs run](https://github.com/enso-org/enso/actions/runs/17424750292)