### PR TITLE
Handle pending dynamic configs

### DIFF
--- a/app/gui/integration-test/project-view/visualizationUpdates.ts
+++ b/app/gui/integration-test/project-view/visualizationUpdates.ts
@@ -7,3 +7,8 @@ export async function mockVisualizationDataUpdate(page: Page, preprocessor: stri
     { preprocessor, data },
   )
 }
+
+/** Clear standard widget configurations. Use `updateMockWidgetConfiguration` to set a specific configuration needed for test. */
+export async function resetMockWidgetConfigurations(page: Page) {
+  await page.evaluate(() => (window as any)._resetMockWidgetConfigurations())
+}

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -3,7 +3,7 @@ import * as actions from './actions'
 import { expect } from './customExpect'
 import { mockMethodCallInfo } from './expressionUpdates'
 import * as locate from './locate'
-import { mockVisualizationDataUpdate } from './visualizationUpdates'
+import { mockVisualizationDataUpdate, resetMockWidgetConfigurations } from './visualizationUpdates'
 
 class DropDownLocator {
   readonly rootWidget: Locator
@@ -299,12 +299,11 @@ async function dataReadNodeWithMethodCallInfo(page: Page): Promise<Locator> {
 
 test('Dynamic configuration overrides static drop-down', async ({ page }) => {
   await actions.goToGraph(page)
+  await resetMockWidgetConfigurations(page)
   const node = await dataReadNodeWithMethodCallInfo(page)
   const topLevelArgs = node.locator('.WidgetTopLevelArgument')
   await node.click()
   await expect(topLevelArgs).toHaveCount(3)
-  // Reset dynamic configuration for `read` method.
-  await mockVisualizationDataUpdate(page, '.read', null)
   await expect(
     topLevelArgs.filter({ has: page.getByText('format') }).locator('.WidgetSelection'),
   ).not.toBeVisible()

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -303,12 +303,14 @@ test('Dynamic configuration overrides static drop-down', async ({ page }) => {
   const topLevelArgs = node.locator('.WidgetTopLevelArgument')
   await node.click()
   await expect(topLevelArgs).toHaveCount(3)
+  // Reset dynamic configuration for `read` method.
+  await mockVisualizationDataUpdate(page, '.read', null)
   await expect(
     topLevelArgs.filter({ has: page.getByText('format') }).locator('.WidgetSelection'),
   ).not.toBeVisible()
 
   // Provide dynamic configuration for `format` arg
-  await mockVisualizationDataUpdate(page, 'Standard.Visualization.Widgets.get_widget_json', [
+  await mockVisualizationDataUpdate(page, '.read', [
     [
       'format',
       {

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -2,6 +2,7 @@ import test, { type Locator, type Page } from 'playwright/test'
 import * as actions from './actions'
 import { expect } from './customExpect'
 import { mockMethodCallInfo } from './expressionUpdates'
+import { CONTROL_KEY } from './keyboard'
 import * as locate from './locate'
 import { mockVisualizationDataUpdate, resetMockWidgetConfigurations } from './visualizationUpdates'
 
@@ -299,50 +300,263 @@ async function dataReadNodeWithMethodCallInfo(page: Page): Promise<Locator> {
   return locate.graphNodeByBinding(page, 'data')
 }
 
-test('Dynamic configuration overrides static drop-down', async ({ page }) => {
-  await actions.goToGraph(page)
-  await resetMockWidgetConfigurations(page)
-  const node = await dataReadNodeWithMethodCallInfo(page)
-  const topLevelArgs = node.locator('.WidgetTopLevelArgument')
-  await node.click()
-  await expect(topLevelArgs).toHaveCount(3)
-  await expect(
-    topLevelArgs.filter({ has: page.getByText('format') }).locator('.WidgetSelection'),
-  ).not.toBeVisible()
+test.describe('Dynamic configuration updates', () => {
+  test.beforeEach(async ({ page }) => {
+    await actions.goToGraph(page)
+    await resetMockWidgetConfigurations(page)
+  })
 
-  // Provide dynamic configuration for `format` arg
-  await mockVisualizationDataUpdate(page, '.read', [
-    [
-      'format',
-      {
-        type: 'Widget',
-        constructor: 'Single_Choice',
-        label: null,
-        values: [
-          {
-            type: 'Choice',
-            constructor: 'Option',
-            value: '..Csv',
-            label: 'Csv',
-            parameters: [],
-          },
-          {
-            type: 'Choice',
-            constructor: 'Option',
-            value: '..Excel',
-            label: 'Excel',
-            parameters: [],
-          },
-        ],
-        display: { type: 'Display', constructor: 'Always' },
+  /**
+   * Check that dynamic dropdowns (with items provided by widget configuration) are not shown
+   * until dynamic configuration arrives from the engine.
+   * This test uses `format` argument of the `Data.read`, which has both static tags and a
+   * dynamic configuration.
+   * We check that no dropdown is shown until dynamic configuration arrives.
+   */
+  test('Dynamic dropdown', async ({ page }) => {
+    const node = await dataReadNodeWithMethodCallInfo(page)
+    const topLevelArgs = node.locator('.WidgetTopLevelArgument')
+    await node.click()
+    await expect(topLevelArgs).toHaveCount(3)
+
+    // No dropdown is shown until dynamic configuration arrives.
+    await expect(
+      topLevelArgs.filter({ has: page.getByText('format') }).locator('.WidgetSelection'),
+    ).not.toBeVisible()
+
+    // Provide dynamic configuration for `format` arg.
+    await mockVisualizationDataUpdate(page, '.read', [
+      [
+        'format',
+        {
+          type: 'Widget',
+          constructor: 'Single_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '..Csv',
+              label: 'Csv',
+              parameters: [],
+            },
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '..Excel',
+              label: 'Excel',
+              parameters: [],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+
+    const formatArg = topLevelArgs.filter({ has: page.getByText('format') })
+    const formatDropdown = new DropDownLocator(formatArg)
+    await formatArg.click()
+    await formatDropdown.expectVisibleWithOptions(['Csv', 'Excel'])
+  })
+
+  /**
+   * Check that numeric widget is displayed even if dynamic configuration is not provided.
+   * Unlike dynamic dropdowns, numeric widget can work normally without dynamic configuration.
+   */
+  test('Number widget', async ({ page }) => {
+    const node = locate.graphNodeByBinding(page, 'selected')
+    await locate.graphNodeIcon(node).click({ modifiers: [CONTROL_KEY] })
+    await expect(locate.componentBrowser(page)).toBeVisible()
+    const content = locate.componentBrowserInput(page)
+    await page.keyboard.press('End')
+    await page.keyboard.type(` 1`)
+    await expect(content).toHaveText(`select_columns 1`)
+    await page.keyboard.press('Enter')
+    await expect(locate.componentBrowser(page)).toBeHidden()
+    await mockMethodCallInfo(page, 'selected', {
+      methodPointer: {
+        module: 'Standard.Table.Table',
+        definedOnType: 'Standard.Table.Table.Table',
+        name: 'select_columns',
       },
-    ],
-  ])
+      notAppliedArguments: [2, 3, 4, 5],
+    })
+    const topLevelArgs = node.locator('.WidgetTopLevelArgument')
+    await expect(topLevelArgs).toHaveCount(5)
+    await expect(node.locator('.WidgetNumber')).toBeVisible()
+    await expect(node.locator('.WidgetNumber')).toHaveValue('1')
+    // Input has no slider, because there is no limits information.
+    await expect(node.locator('.AutoSizedInput')).not.toHaveClass(/slider/)
 
-  const formatArg = topLevelArgs.filter({ has: page.getByText('format') })
-  const formatDropdown = new DropDownLocator(formatArg)
-  await formatArg.click()
-  await formatDropdown.expectVisibleWithOptions(['Csv', 'Excel'])
+    // Provide limits from dynamic configuration.
+    await mockVisualizationDataUpdate(page, '.select_columns', [
+      [
+        'columns',
+        {
+          type: 'Widget',
+          constructor: 'Numeric_Input',
+          maximum: 10,
+          minimum: 0,
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+    // Slider is now displayed.
+    await expect(node.locator('.AutoSizedInput')).toHaveClass(/slider/)
+  })
+
+  /**
+   * File browser widget is weird. We want to match it even when dynamic configuration is not yet provided,
+   * but it also uses a dropdown widget internally. This is why we have a special test case for it.
+   */
+  test('File browser widget', async ({ page }) => {
+    const node = await dataReadNodeWithMethodCallInfo(page)
+    await node.click()
+    await expect(node.locator('.WidgetTopLevelArgument')).toHaveCount(3)
+    const pathArg = node.locator('.WidgetTopLevelArgument').filter({ has: page.getByText('path') })
+    await pathArg.click()
+    const pathDropdown = new DropDownLocator(pathArg)
+    await pathDropdown.expectVisibleWithOptions([...CHOOSE_FILE_OPTIONS])
+    // Provide dynamic configuration for `path` argument.
+    // (we use Folder_Browser here, and check how dropdown items have changed)
+    await mockVisualizationDataUpdate(page, '.read', [
+      [
+        'path',
+        {
+          type: 'Widget',
+          constructor: 'Folder_Browse',
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+    await pathDropdown.expectVisibleWithOptions(['Choose directory…', 'Choose directory in cloud…'])
+  })
+
+  /**
+   * Some widgets inherit their configuration from a parent widget. When new configuration arrives,
+   * it should override the inherited configuration. We using `aggregated` node to test this.
+   */
+  test('Inherited configuration', async ({ page }) => {
+    const node = locate.graphNodeByBinding(page, 'aggregated')
+    await mockMethodCallInfo(page, 'aggregated', {
+      methodPointer: {
+        module: 'Standard.Table.Table',
+        definedOnType: 'Standard.Table.Table.Table',
+        name: 'aggregate',
+      },
+      notAppliedArguments: [1, 2, 3, 4],
+    })
+    await node.click()
+    await expect(node.locator('.WidgetTopLevelArgument')).toHaveCount(4)
+    // Initial configuration.
+    await mockVisualizationDataUpdate(page, '.aggregate', [
+      [
+        'columns',
+        {
+          type: 'Widget',
+          constructor: 'Single_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Group_By',
+              label: 'Group By',
+              parameters: [
+                [
+                  'column',
+                  {
+                    type: 'Widget',
+                    constructor: 'Single_Choice',
+                    label: null,
+                    values: [
+                      {
+                        type: 'Choice',
+                        constructor: 'Option',
+                        value: '"column 1"',
+                        label: 'column 1',
+                        parameters: [],
+                      },
+                      {
+                        type: 'Choice',
+                        constructor: 'Option',
+                        value: '"column 2"',
+                        label: 'column 2',
+                        parameters: [],
+                      },
+                    ],
+                    display: { type: 'Display', constructor: 'Always' },
+                  },
+                ],
+              ],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+    const columnsArg = node
+      .locator('.WidgetTopLevelArgument')
+      .filter({ has: page.getByText('columns', { exact: true }) })
+    await columnsArg.click()
+    const columnsDropdown = new DropDownLocator(columnsArg)
+    await columnsDropdown.expectVisibleWithOptions(['Group By'])
+    await columnsDropdown.clickOption('Group By')
+    await expect(columnsArg.locator('.WidgetToken')).toContainText([
+      'Aggregate_Column',
+      '.',
+      'Group_By',
+    ])
+    await mockMethodCallInfo(
+      page,
+      {
+        binding: 'aggregated',
+        expr: 'Aggregate_Column.Group_By',
+      },
+      {
+        methodPointer: {
+          module: 'Standard.Table.Aggregate_Column',
+          definedOnType: 'Standard.Table.Aggregate_Column.Aggregate_Column',
+          name: 'Group_By',
+        },
+        notAppliedArguments: [0, 1],
+      },
+    )
+    const firstItem = columnsArg.locator('.WidgetPort > .WidgetSelection').nth(0)
+    const firstItemDropdown = new DropDownLocator(firstItem)
+    await firstItemDropdown.clickWidget()
+    await firstItemDropdown.expectVisibleWithOptions(['column 1', 'column 2'])
+
+    // Provide dynamic configuration for `column` argument of `Aggregate_Column.Group_By`.
+    await mockVisualizationDataUpdate(page, '.Group_By', [
+      [
+        'column',
+        {
+          type: 'Widget',
+          constructor: 'Single_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '"column 3"',
+              label: 'column 3',
+              parameters: [],
+            },
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '"column 4"',
+              label: 'column 4',
+              parameters: [],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+    await firstItemDropdown.expectVisibleWithOptions(['column 3', 'column 4'])
+  })
 })
 
 test('Selection widgets in Data.read node', async ({ page }) => {

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -3,6 +3,7 @@ import * as actions from './actions'
 import { expect } from './customExpect'
 import { mockMethodCallInfo } from './expressionUpdates'
 import * as locate from './locate'
+import { mockVisualizationDataUpdate } from './visualizationUpdates'
 
 class DropDownLocator {
   readonly rootWidget: Locator
@@ -295,6 +296,51 @@ async function dataReadNodeWithMethodCallInfo(page: Page): Promise<Locator> {
   })
   return locate.graphNodeByBinding(page, 'data')
 }
+
+test('Dynamic configuration overrides static drop-down', async ({ page }) => {
+  await actions.goToGraph(page)
+  const node = await dataReadNodeWithMethodCallInfo(page)
+  const topLevelArgs = node.locator('.WidgetTopLevelArgument')
+  await node.click()
+  await expect(topLevelArgs).toHaveCount(3)
+  await expect(
+    topLevelArgs.filter({ has: page.getByText('format') }).locator('.WidgetSelection'),
+  ).not.toBeVisible()
+
+  // Provide dynamic configuration for `format` arg
+  await mockVisualizationDataUpdate(page, 'Standard.Visualization.Widgets.get_widget_json', [
+    [
+      'format',
+      {
+        type: 'Widget',
+        constructor: 'Single_Choice',
+        label: null,
+        values: [
+          {
+            type: 'Choice',
+            constructor: 'Option',
+            value: '..Csv',
+            label: 'Csv',
+            parameters: [],
+          },
+          {
+            type: 'Choice',
+            constructor: 'Option',
+            value: '..Excel',
+            label: 'Excel',
+            parameters: [],
+          },
+        ],
+        display: { type: 'Display', constructor: 'Always' },
+      },
+    ],
+  ])
+
+  const formatArg = topLevelArgs.filter({ has: page.getByText('format') })
+  const formatDropdown = new DropDownLocator(formatArg)
+  await formatArg.click()
+  await formatDropdown.expectVisibleWithOptions(['Csv', 'Excel'])
+})
 
 test('Selection widgets in Data.read node', async ({ page }) => {
   await actions.goToGraph(page)

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -433,8 +433,9 @@ test.describe('Dynamic configuration updates', () => {
   })
 
   /**
-   * Some widgets inherit their configuration from a parent widget. When new configuration arrives,
-   * it should override the inherited configuration. We using `aggregated` node to test this.
+   * Some widgets inherit their configuration from a parent widget.
+   * Inherited config has a priority even if newer configuration for the child expression arrives.
+   * We are using `aggregated` node to test this.
    */
   test('Inherited configuration', async ({ page }) => {
     const node = locate.graphNodeByBinding(page, 'aggregated')
@@ -448,7 +449,7 @@ test.describe('Dynamic configuration updates', () => {
     })
     await node.click()
     await expect(node.locator('.WidgetTopLevelArgument')).toHaveCount(4)
-    // Initial configuration.
+    // Top-level configuration, including configuration for child widgets.
     await mockVisualizationDataUpdate(page, '.aggregate', [
       [
         'columns',
@@ -528,6 +529,8 @@ test.describe('Dynamic configuration updates', () => {
     await firstItemDropdown.expectVisibleWithOptions(['column 1', 'column 2'])
 
     // Provide dynamic configuration for `column` argument of `Aggregate_Column.Group_By`.
+    // It shouldn’t affect the selectable variants of the dropdown, because parent
+    // config has a priority.
     await mockVisualizationDataUpdate(page, '.Group_By', [
       [
         'column',
@@ -555,7 +558,56 @@ test.describe('Dynamic configuration updates', () => {
         },
       ],
     ])
-    await firstItemDropdown.expectVisibleWithOptions(['column 3', 'column 4'])
+    await firstItemDropdown.expectVisibleWithOptions(['column 1', 'column 2'])
+
+    // Update parent configuration
+    await mockVisualizationDataUpdate(page, '.aggregate', [
+      [
+        'columns',
+        {
+          type: 'Widget',
+          constructor: 'Single_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Group_By',
+              label: 'Group By',
+              parameters: [
+                [
+                  'column',
+                  {
+                    type: 'Widget',
+                    constructor: 'Single_Choice',
+                    label: null,
+                    values: [
+                      {
+                        type: 'Choice',
+                        constructor: 'Option',
+                        value: '"column 5"',
+                        label: 'column 5',
+                        parameters: [],
+                      },
+                      {
+                        type: 'Choice',
+                        constructor: 'Option',
+                        value: '"column 6"',
+                        label: 'column 6',
+                        parameters: [],
+                      },
+                    ],
+                    display: { type: 'Display', constructor: 'Always' },
+                  },
+                ],
+              ],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ])
+    await firstItemDropdown.expectVisibleWithOptions(['column 5', 'column 6'])
   })
 })
 

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -8,6 +8,7 @@ import { mockVisualizationDataUpdate, resetMockWidgetConfigurations } from './vi
 class DropDownLocator {
   readonly rootWidget: Locator
   readonly dropDown: Locator
+  readonly dropDownAnyState: Locator
   readonly items: Locator
   readonly selectedItems: Locator
 
@@ -17,6 +18,7 @@ class DropDownLocator {
     // There can be only one open dropdown at a time on a page. We have to filter out the ones that
     // still have leaving animation running.
     this.dropDown = page.locator('.DropdownWidget:not([data-transitioning])')
+    this.dropDownAnyState = page.locator('.DropdownWidget')
     this.items = this.dropDown.locator('.item')
     this.selectedItems = this.dropDown.locator('.item.selected')
   }
@@ -39,7 +41,7 @@ class DropDownLocator {
   }
 
   async expectNotVisible(): Promise<void> {
-    await expect(this.dropDown).toBeHidden()
+    await expect(this.dropDownAnyState).toBeHidden()
   }
 
   async clickOption(option: string): Promise<void> {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -1,7 +1,9 @@
 import type { WidgetInput } from '@/providers/widgetRegistry'
 import {
   argsWidgetConfigurationSchema,
+  FunctionCall,
   functionCallConfiguration,
+  pending,
 } from '@/providers/widgetRegistry/configuration'
 import type { GraphDb } from '@/stores/graph/graphDatabase'
 import { type NodeVisualizationConfiguration } from '@/stores/project/executionContext'
@@ -91,6 +93,13 @@ export function useWidgetFunctionCallInfo(
     return null
   })
 
+  const annotatedArguments = computed(() => {
+    const info = methodCallInfo.value
+    if (!info) return null
+    if (!entryIsAnnotatable(info.suggestion)) return null
+    return info.suggestion.annotations
+  })
+
   const visualizationConfig = computed<Opt<NodeVisualizationConfiguration>>(() => {
     const args = ArgumentApplication.collectArgumentNamesAndUuids(
       interpreted.value,
@@ -100,8 +109,8 @@ export function useWidgetFunctionCallInfo(
     const info = methodCallInfo.value
     if (!info) return null
     if (!entryIsAnnotatable(info.suggestion)) return null
-    const annotatedArgs = info.suggestion.annotations
-    if (!annotatedArgs.length) return null
+    const annotatedArgs = annotatedArguments.value
+    if (!annotatedArgs?.length) return null
     const name = info.suggestion.name
     const positionalArgumentsExpressions = [
       `.${name}`,
@@ -177,7 +186,12 @@ export function useWidgetFunctionCallInfo(
     } else if (data != null && !data.ok) {
       data.error.log('Cannot load dynamic configuration')
     }
-    return inheritedConfig.value
+    const parameters: FunctionCall['parameters'] = inheritedConfig.value?.parameters ?? new Map()
+    annotatedArguments.value?.forEach((name) => parameters.set(name, pending()))
+    return {
+      kind: 'FunctionCall',
+      parameters,
+    } satisfies FunctionCall
   })
 
   const application = computed(() => {

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -186,7 +186,7 @@ export function useWidgetFunctionCallInfo(
     } else if (data != null && !data.ok) {
       data.error.log('Cannot load dynamic configuration')
     }
-    const parameters: FunctionCall['parameters'] = inheritedConfig.value?.parameters ?? new Map()
+    const parameters: FunctionCall['parameters'] = new Map(inheritedConfig.value?.parameters ?? [])
     annotatedArguments.value?.forEach((name) => {
       if (parameters.get(name) == null) parameters.set(name, pending())
     })

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo.ts
@@ -187,7 +187,9 @@ export function useWidgetFunctionCallInfo(
       data.error.log('Cannot load dynamic configuration')
     }
     const parameters: FunctionCall['parameters'] = inheritedConfig.value?.parameters ?? new Map()
-    annotatedArguments.value?.forEach((name) => parameters.set(name, pending()))
+    annotatedArguments.value?.forEach((name) => {
+      if (parameters.get(name) == null) parameters.set(name, pending())
+    })
     return {
       kind: 'FunctionCall',
       parameters,

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetNumber.vue
@@ -57,6 +57,7 @@ export const widgetDefinition = defineWidget(
     priority: 1001,
     score: (props) => {
       if (
+        props.input.dynamicConfig?.kind === 'Numeric_Input' ||
         props.input.value instanceof Ast.NumericLiteral ||
         (props.input.value instanceof Ast.NegationApp &&
           props.input.value.argument instanceof Ast.NumericLiteral)

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -247,9 +247,8 @@ export const widgetDefinition = defineWidget(
     score: (props) =>
       // We don’t want to show the dropdown until the dynamic config is received
       // to avoid showing stale dropdown items. Custom dropdown items should be displayed without delay, though.
-      props.input.dynamicConfig?.kind === 'Pending' && props.input[CustomDropdownItemsKey] == null ?
-        Score.Mismatch
-      : props.input[CustomDropdownItemsKey] != null ? Score.Perfect
+      props.input[CustomDropdownItemsKey] != null ? Score.Perfect
+      : props.input.dynamicConfig?.kind === 'Pending' ? Score.Mismatch
       : props.input.dynamicConfig?.kind === 'Single_Choice' ? Score.Perfect
       : isHandledByCheckboxWidget(props.input[ArgumentInfoKey]?.info) ? Score.Mismatch
         // TODO[ao] here, instead of checking for existing dynamic config, we should rather return

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -246,8 +246,9 @@ export const widgetDefinition = defineWidget(
     priority: 50,
     score: (props) =>
       // We don’t want to show the dropdown until the dynamic config is received
-      // to avoid showing stale dropdown items.
-      props.input.dynamicConfig?.kind === 'Pending' ? Score.Mismatch
+      // to avoid showing stale dropdown items. Custom dropdown items should be displayed without delay, though.
+      props.input.dynamicConfig?.kind === 'Pending' && props.input[CustomDropdownItemsKey] == null ?
+        Score.Mismatch
       : props.input[CustomDropdownItemsKey] != null ? Score.Perfect
       : props.input.dynamicConfig?.kind === 'Single_Choice' ? Score.Perfect
       : isHandledByCheckboxWidget(props.input[ArgumentInfoKey]?.info) ? Score.Mismatch

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection.vue
@@ -245,7 +245,10 @@ export const widgetDefinition = defineWidget(
   {
     priority: 50,
     score: (props) =>
-      props.input[CustomDropdownItemsKey] != null ? Score.Perfect
+      // We don’t want to show the dropdown until the dynamic config is received
+      // to avoid showing stale dropdown items.
+      props.input.dynamicConfig?.kind === 'Pending' ? Score.Mismatch
+      : props.input[CustomDropdownItemsKey] != null ? Score.Perfect
       : props.input.dynamicConfig?.kind === 'Single_Choice' ? Score.Perfect
       : isHandledByCheckboxWidget(props.input[ArgumentInfoKey]?.info) ? Score.Mismatch
         // TODO[ao] here, instead of checking for existing dynamic config, we should rather return

--- a/app/gui/src/project-view/mock/engine.ts
+++ b/app/gui/src/project-view/mock/engine.ts
@@ -624,6 +624,7 @@ function updateVisualization(preprocessor: string, data: unknown) {
       const exprId = visualizationExprIds.get(id)
       const vizData = encodeJSON(data)
       sendVizUpdate(id, config.executionContextId, exprId, vizData)
+      mockWidgetConfigurations.set(preprocessor, vizData)
     }
   }
 }

--- a/app/gui/src/project-view/mock/engine.ts
+++ b/app/gui/src/project-view/mock/engine.ts
@@ -221,13 +221,78 @@ NmZmYiIGQ9Ik0wIDBoNDB2NDBIMHoiLz48L2NsaXBQYXRoPjwvZGVmcz48L3N2Zz4=`,
     ]),
   }
 
-function mockWidgetConfiguration(method: string | undefined) {
-  switch (method) {
-    case '.read':
-      return encodeJSON([
-        [
-          'path',
-          {
+const mockWidgetConfigurations: Map<string, Uint8Array> = new Map([
+  [
+    '.read',
+    encodeJSON([
+      [
+        'path',
+        {
+          type: 'Widget',
+          constructor: 'Single_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '"File 1"',
+              label: 'File 1',
+              parameters: [],
+            },
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: '"File 2"',
+              label: 'File 2',
+              parameters: [],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ]),
+  ],
+  [
+    '.select_columns',
+    encodeJSON([
+      [
+        'columns',
+        {
+          type: 'Widget',
+          constructor: 'Multiple_Choice',
+          label: null,
+          values: [
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: "'Column A'",
+              label: 'Column A',
+              parameters: [],
+            },
+            {
+              type: 'Choice',
+              constructor: 'Option',
+              value: "'Column B'",
+              label: 'Column B',
+              parameters: [],
+            },
+          ],
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ]),
+  ],
+  [
+    '.aggregate',
+    encodeJSON([
+      [
+        'columns',
+        {
+          type: 'Widget',
+          constructor: 'Vector_Editor',
+          /* eslint-disable camelcase */
+          item_default: 'Aggregate_Column.Group_By',
+          item_editor: {
             type: 'Widget',
             constructor: 'Single_Choice',
             label: null,
@@ -235,148 +300,95 @@ function mockWidgetConfiguration(method: string | undefined) {
               {
                 type: 'Choice',
                 constructor: 'Option',
-                value: '"File 1"',
-                label: 'File 1',
+                value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Group_By',
+                label: null,
+                parameters: [
+                  [
+                    'column',
+                    {
+                      type: 'Widget',
+                      constructor: 'Single_Choice',
+                      label: null,
+                      values: [
+                        {
+                          type: 'Choice',
+                          constructor: 'Option',
+                          value: '"column 1"',
+                          label: 'column 1',
+                          parameters: [],
+                        },
+                        {
+                          type: 'Choice',
+                          constructor: 'Option',
+                          value: '"column 2"',
+                          label: 'column 2',
+                          parameters: [],
+                        },
+                      ],
+                      display: { type: 'Display', constructor: 'Always' },
+                    },
+                  ],
+                ],
+              },
+              {
+                type: 'Choice',
+                constructor: 'Option',
+                value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Count',
+                label: null,
                 parameters: [],
               },
               {
                 type: 'Choice',
                 constructor: 'Option',
-                value: '"File 2"',
-                label: 'File 2',
-                parameters: [],
+                value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Count_Distinct',
+                label: null,
+                parameters: [
+                  [
+                    'columns',
+                    {
+                      type: 'Widget',
+                      constructor: 'Single_Choice',
+                      label: null,
+                      values: [
+                        {
+                          type: 'Choice',
+                          constructor: 'Option',
+                          value: '"column 1"',
+                          label: 'column 1',
+                          parameters: [],
+                        },
+                        {
+                          type: 'Choice',
+                          constructor: 'Option',
+                          value: '"column 2"',
+                          label: 'column 2',
+                          parameters: [],
+                        },
+                      ],
+                      display: { type: 'Display', constructor: 'Always' },
+                    },
+                  ],
+                ],
               },
             ],
             display: { type: 'Display', constructor: 'Always' },
           },
-        ],
-      ])
-    case '.select_columns':
-      return encodeJSON([
-        [
-          'columns',
-          {
-            type: 'Widget',
-            constructor: 'Multiple_Choice',
-            label: null,
-            values: [
-              {
-                type: 'Choice',
-                constructor: 'Option',
-                value: "'Column A'",
-                label: 'Column A',
-                parameters: [],
-              },
-              {
-                type: 'Choice',
-                constructor: 'Option',
-                value: "'Column B'",
-                label: 'Column B',
-                parameters: [],
-              },
-            ],
-            display: { type: 'Display', constructor: 'Always' },
-          },
-        ],
-      ])
-    case '.aggregate':
-      return encodeJSON([
-        [
-          'columns',
-          {
-            type: 'Widget',
-            constructor: 'Vector_Editor',
-            /* eslint-disable camelcase */
-            item_default: 'Aggregate_Column.Group_By',
-            item_editor: {
-              type: 'Widget',
-              constructor: 'Single_Choice',
-              label: null,
-              values: [
-                {
-                  type: 'Choice',
-                  constructor: 'Option',
-                  value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Group_By',
-                  label: null,
-                  parameters: [
-                    [
-                      'column',
-                      {
-                        type: 'Widget',
-                        constructor: 'Single_Choice',
-                        label: null,
-                        values: [
-                          {
-                            type: 'Choice',
-                            constructor: 'Option',
-                            value: '"column 1"',
-                            label: 'column 1',
-                            parameters: [],
-                          },
-                          {
-                            type: 'Choice',
-                            constructor: 'Option',
-                            value: '"column 2"',
-                            label: 'column 2',
-                            parameters: [],
-                          },
-                        ],
-                        display: { type: 'Display', constructor: 'Always' },
-                      },
-                    ],
-                  ],
-                },
-                {
-                  type: 'Choice',
-                  constructor: 'Option',
-                  value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Count',
-                  label: null,
-                  parameters: [],
-                },
-                {
-                  type: 'Choice',
-                  constructor: 'Option',
-                  value: 'Standard.Table.Aggregate_Column.Aggregate_Column.Count_Distinct',
-                  label: null,
-                  parameters: [
-                    [
-                      'columns',
-                      {
-                        type: 'Widget',
-                        constructor: 'Single_Choice',
-                        label: null,
-                        values: [
-                          {
-                            type: 'Choice',
-                            constructor: 'Option',
-                            value: '"column 1"',
-                            label: 'column 1',
-                            parameters: [],
-                          },
-                          {
-                            type: 'Choice',
-                            constructor: 'Option',
-                            value: '"column 2"',
-                            label: 'column 2',
-                            parameters: [],
-                          },
-                        ],
-                        display: { type: 'Display', constructor: 'Always' },
-                      },
-                    ],
-                  ],
-                },
-              ],
-              display: { type: 'Display', constructor: 'Always' },
-            },
-            /* eslint-enable camelcase */
-            display: { type: 'Display', constructor: 'Always' },
-          },
-        ],
-      ])
-    default:
-      return null
-  }
+          /* eslint-enable camelcase */
+          display: { type: 'Display', constructor: 'Always' },
+        },
+      ],
+    ]),
+  ],
+])
+
+function resetMockWidgetConfigurations() {
+  mockWidgetConfigurations.clear()
+}
+;(window as any)._resetMockWidgetConfigurations = resetMockWidgetConfigurations
+
+function mockWidgetConfiguration(method: string | undefined) {
+  if (!method) return null
+  return mockWidgetConfigurations.get(method) ?? null
 }
 
 function createMessageId(builder: Builder) {

--- a/app/gui/src/project-view/mock/engine.ts
+++ b/app/gui/src/project-view/mock/engine.ts
@@ -1,3 +1,7 @@
+import {
+  GET_WIDGETS_METHOD,
+  WIDGETS_ENSO_MODULE,
+} from '@/components/GraphEditor/widgets/WidgetFunction/widgetFunctionCallInfo'
 import { Ast } from '@/util/ast'
 import { Pattern } from '@/util/ast/match'
 import type { MockYdocProviderImpl } from '@/util/crdt'
@@ -135,71 +139,73 @@ const scatterplotJson = (params: string[]) =>
     ],
   })
 
-const mockVizPreprocessors: Record<string, Uint8Array | ((params: string[]) => Uint8Array)> = {
-  // JSON
-  'Standard.Visualization.Preprocessor.default_preprocessor': scatterplotJson,
-  'Standard.Visualization.Scatter_Plot.process_to_json_text': scatterplotJson,
-  'Standard.Visualization.SQL.Visualization.prepare_visualization': encodeJSON({
-    dialect: 'sql',
-    code: `SELECT * FROM \`foo\` WHERE \`a\` = ? AND b LIKE ?;`,
-    interpolations: [
-      // eslint-disable-next-line camelcase
-      { enso_type: 'Data.Numbers.Number', value: '123' },
-      // eslint-disable-next-line camelcase
-      { enso_type: 'Builtins.Main.Text', value: "a'bcd" },
-    ],
-  }),
-  'Standard.Visualization.Geo_Map.process_to_json_text': encodeJSON({
-    latitude: 37.8,
-    longitude: -122.45,
-    zoom: 15,
-    controller: true,
-    showingLabels: true, // Enables presenting labels when hovering over a point.
-    layers: [
-      {
-        type: 'Scatterplot_Layer',
-        data: [
-          {
-            latitude: 37.8,
-            longitude: -122.45,
-            color: [255, 0, 0],
-            radius: 100,
-            label: 'an example label',
-          },
-        ],
+const mockVizPreprocessors: Record<string, Uint8Array | ((params: string[]) => Uint8Array | null)> =
+  {
+    // JSON
+    'Standard.Visualization.Preprocessor.default_preprocessor': scatterplotJson,
+    'Standard.Visualization.Scatter_Plot.process_to_json_text': scatterplotJson,
+    'Standard.Visualization.SQL.Visualization.prepare_visualization': encodeJSON({
+      dialect: 'sql',
+      code: `SELECT * FROM \`foo\` WHERE \`a\` = ? AND b LIKE ?;`,
+      interpolations: [
+        // eslint-disable-next-line camelcase
+        { enso_type: 'Data.Numbers.Number', value: '123' },
+        // eslint-disable-next-line camelcase
+        { enso_type: 'Builtins.Main.Text', value: "a'bcd" },
+      ],
+    }),
+    'Standard.Visualization.Geo_Map.process_to_json_text': encodeJSON({
+      latitude: 37.8,
+      longitude: -122.45,
+      zoom: 15,
+      controller: true,
+      showingLabels: true, // Enables presenting labels when hovering over a point.
+      layers: [
+        {
+          type: 'Scatterplot_Layer',
+          data: [
+            {
+              latitude: 37.8,
+              longitude: -122.45,
+              color: [255, 0, 0],
+              radius: 100,
+              label: 'an example label',
+            },
+          ],
+        },
+      ],
+    }),
+    'Standard.Visualization.Histogram.process_to_json_text': encodeJSON({
+      axis: {
+        x: { label: 'x-axis label', scale: 'linear' },
+        y: { label: 'y-axis label', scale: 'logarithmic' },
       },
-    ],
-  }),
-  'Standard.Visualization.Histogram.process_to_json_text': encodeJSON({
-    axis: {
-      x: { label: 'x-axis label', scale: 'linear' },
-      y: { label: 'y-axis label', scale: 'logarithmic' },
-    },
-    color: 'rgb(1.0,0.0,0.0)',
-    bins: 10,
-    data: {
-      values: [0.1, 0.2, 0.1, 0.15, 0.7],
-    },
-  }),
-  'Standard.Visualization.Table.Visualization.prepare_visualization': encodeJSON({
-    type: 'Matrix',
-    // eslint-disable-next-line camelcase
-    column_count: 5,
-    // eslint-disable-next-line camelcase
-    all_rows_count: 10,
-    json: Array.from({ length: 10 }, (_, i) => Array.from({ length: 5 }, (_, j) => `${i},${j}`)),
-  }),
-  'Standard.Visualization.Warnings.process_to_json_text': encodeJSON([
-    'warning 1',
-    "warning 2!!&<>;'\x22",
-  ]),
-  'Standard.Visualization.Widgets.get_widget_json': (params) => mockWidgetConfiguration(params[0]),
+      color: 'rgb(1.0,0.0,0.0)',
+      bins: 10,
+      data: {
+        values: [0.1, 0.2, 0.1, 0.15, 0.7],
+      },
+    }),
+    'Standard.Visualization.Table.Visualization.prepare_visualization': encodeJSON({
+      type: 'Matrix',
+      // eslint-disable-next-line camelcase
+      column_count: 5,
+      // eslint-disable-next-line camelcase
+      all_rows_count: 10,
+      json: Array.from({ length: 10 }, (_, i) => Array.from({ length: 5 }, (_, j) => `${i},${j}`)),
+    }),
+    'Standard.Visualization.Warnings.process_to_json_text': encodeJSON([
+      'warning 1',
+      "warning 2!!&<>;'\x22",
+    ]),
+    'Standard.Visualization.Widgets.get_widget_json': (params) =>
+      mockWidgetConfiguration(params[0]),
 
-  // The following visualizations do not have unique transformation methods, and as such are only kept
-  // for posterity.
-  Image: encodeJSON({
-    mediaType: 'image/svg+xml',
-    base64: `PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0\
+    // The following visualizations do not have unique transformation methods, and as such are only kept
+    // for posterity.
+    Image: encodeJSON({
+      mediaType: 'image/svg+xml',
+      base64: `PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0\
 MCI+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj48cGF0aCBkPSJNMjAuMDUgMEEyMCAyMCAwIDAgMCAwIDIwLjA1IDIwLjA2IDIwLjA\
 2IDAgMSAwIDIwLjA1IDBabTAgMzYuMDVjLTguOTMgMC0xNi4xLTcuMTctMTYuMS0xNi4xIDAtOC45NCA3LjE3LTE2LjEgMTYuMS\
 0xNi4xIDguOTQgMCAxNi4xIDcuMTYgMTYuMSAxNi4xYTE2LjE4IDE2LjE4IDAgMCAxLTE2LjEgMTYuMVoiLz48cGF0aCBkPSJNM\
@@ -207,13 +213,13 @@ jcuMTIgMTcuNzdhNC42OCA0LjY4IDAgMCAxIDIuMzkgNS45MiAxMC4yMiAxMC4yMiAwIDAgMS05LjU2I
 IDAgMCAxIDkuNzcgMjAuMzZzMS41NSAyLjA4IDQuNTcgMi4wOGMzLjAxIDAgNC4zNi0xLjE0IDUuNi0yLjA4IDEuMjUtLjkzIDI\
 uMDktMyA1LjItMyAuNzMgMCAxLjQ2LjIgMS45OC40WiIvPjwvZz48ZGVmcz48Y2xpcFBhdGggaWQ9ImEiPjxwYXRoIGZpbGw9Ii\
 NmZmYiIGQ9Ik0wIDBoNDB2NDBIMHoiLz48L2NsaXBQYXRoPjwvZGVmcz48L3N2Zz4=`,
-  }),
-  Heatmap: encodeJSON([
-    ['A', 'B', 'C', 'D', 'A'],
-    ['D', 'E', 'D', 'X', 'Z'],
-    [50, 25, 40, 20, 10],
-  ]),
-}
+    }),
+    Heatmap: encodeJSON([
+      ['A', 'B', 'C', 'D', 'A'],
+      ['D', 'E', 'D', 'X', 'Z'],
+      [50, 25, 40, 20, 10],
+    ]),
+  }
 
 function mockWidgetConfiguration(method: string | undefined) {
   switch (method) {
@@ -369,7 +375,7 @@ function mockWidgetConfiguration(method: string | undefined) {
         ],
       ])
     default:
-      return encodeJSON([])
+      return null
   }
 }
 
@@ -386,21 +392,28 @@ function createId(id: Uuid) {
 
 type VizRequest = { type: 'widget'; id: string | undefined } | { type: 'visualization'; id: string }
 function recognizeVizRequest(config: VisualizationConfiguration): VizRequest {
-  return (
-    typeof config.expression === 'string' ?
-      // Getting widget configuration is a special case, where we sometimes pass lambda as
-      // expression to discard the input value
-      /^[a-z_]+ *->.*get_widget_json/.test(config.expression) ?
-        ({ type: 'widget', id: config.positionalArgumentsExpressions?.at(0) } satisfies VizRequest)
-      : ({
-          type: 'visualization',
-          id: `${config.visualizationModule}.${config.expression}`,
-        } satisfies VizRequest)
-    : ({
+  if (typeof config.expression === 'string') {
+    // Getting widget configuration is a special case, where we sometimes pass lambda as
+    // expression to discard the input value
+    if (/^[a-z_]+ *->.*get_widget_json/.test(config.expression)) {
+      return { type: 'widget', id: config.positionalArgumentsExpressions?.at(0) } as VizRequest
+    } else {
+      return {
         type: 'visualization',
-        id: `${config.expression.definedOnType}.${config.expression.name}`,
-      } satisfies VizRequest)
-  )
+        id: `${config.visualizationModule}.${config.expression}`,
+      } as VizRequest
+    }
+  } else if (
+    config.expression.module === WIDGETS_ENSO_MODULE &&
+    config.expression.name === GET_WIDGETS_METHOD
+  ) {
+    return { type: 'widget', id: config.positionalArgumentsExpressions?.at(0) } as VizRequest
+  } else {
+    return {
+      type: 'visualization',
+      id: `${config.expression.definedOnType}.${config.expression.name}`,
+    } as VizRequest
+  }
 }
 
 function sendVizData(id: Uuid, config: VisualizationConfiguration, expressionId?: Uuid) {
@@ -412,6 +425,7 @@ function sendVizData(id: Uuid, config: VisualizationConfiguration, expressionId?
     vizDataHandler instanceof Uint8Array ? vizDataHandler : (
       vizDataHandler(config.positionalArgumentsExpressions ?? [])
     )
+  if (!vizData) return
   const exprId = expressionId ?? visualizationExprIds.get(id)
   sendVizUpdate(id, config.executionContextId, exprId, vizData)
 }

--- a/app/gui/src/project-view/mock/mockSuggestions.json
+++ b/app/gui/src/project-view/mock/mockSuggestions.json
@@ -1267,7 +1267,7 @@
     ],
     "returnType": "Standard.Table.Aggregate_Column.Aggregate_Column",
     "documentation": " ---\nprivate: true\n---\nSpecifies a column to group the rows by. Deprecated but used internally.\n\n## Arguments\n- `column`: the column (either name, expression or index) to group by.\n- `as`: name of new column.",
-    "annotations": [],
+    "annotations": ["column"],
     "reexports": []
   },
   {

--- a/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
+++ b/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
@@ -280,7 +280,7 @@ export function functionCallConfiguration(
 ): FunctionCall {
   const parametersMap = new Map(inherited?.parameters)
   for (const [name, param] of parameters) {
-    parametersMap.set(name, parametersMap.get(name) ?? param)
+    if (param) parametersMap.set(name, param)
   }
   return {
     kind: 'FunctionCall',

--- a/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
+++ b/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
@@ -113,6 +113,23 @@ export type WidgetConfiguration =
   | FunctionCall
   | OneOfFunctionCalls
   | SomeOfFunctionCalls
+  | PendingConfiguration
+
+/**
+ * Sometimes it takes time to receive the configuration, but we still want to know that it is expected.
+ * This configuration is not provided by the engine directly, but is derived from existing argument annotations.
+ */
+export interface PendingConfiguration {
+  kind: 'Pending'
+}
+
+/** Helper for creating a pending configuration record. */
+export function pending(): WidgetConfiguration & WithDisplay {
+  return {
+    kind: 'Pending',
+    display: DisplayMode.Always,
+  }
+}
 
 export interface VectorEditor {
   kind: 'Vector_Editor'

--- a/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
+++ b/app/gui/src/project-view/providers/widgetRegistry/configuration.ts
@@ -273,6 +273,9 @@ export type ArgsWidgetConfiguration = z.infer<typeof argsWidgetConfigurationSche
 /**
  * Create {@link WidgetConfiguration} object from parameters received from the engine, possibly
  * applying those to an inherited config received from parent widget.
+ *
+ * Inherited config has a priority, as we expect parent widget has more information available
+ * and can provide better configuration for its children.
  */
 export function functionCallConfiguration(
   parameters: ArgumentWidgetConfiguration[],
@@ -280,7 +283,8 @@ export function functionCallConfiguration(
 ): FunctionCall {
   const parametersMap = new Map(inherited?.parameters)
   for (const [name, param] of parameters) {
-    if (param) parametersMap.set(name, param)
+    // Merge with inherited parameters, inherited ones have priority.
+    if (param && !parametersMap.has(name)) parametersMap.set(name, param)
   }
   return {
     kind: 'FunctionCall',


### PR DESCRIPTION
### Pull Request Description

Fixes #13792

The case from the issue, with an artificial 10-second delay for receiving dynamic config:

https://github.com/user-attachments/assets/d1a0e291-dfe3-4c97-8017-3fbafed0dd86

I considered all widget types that currently use dynamic configuration and found that they can be split into two groups:
1. We don’t want to match the widget when we know that dynamic config is expected and has not yet arrived. This is Selection (the case from the issue), MultiSelection, and AnyToTarget.
2. We still want to match the widget, because it is generally applicable even without dynamic config. This is FileBrowser, Number, Text, and Vector. All these can still be used without correct dynamic configuration, although some functionality can be limited.

Because no general solution is possible, I added a new widget config kind called `Pending` that can be checked manually when matching a widget.

Changes covered with integration tests. It is now possible to override widget configuration on a per-argument basis in integration tests (some restrictions apply ©). I also fixed a weird issue with inherited config that wasn’t actually inherited but was overriding more accurate ‘child’ configurations.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
