### PR TITLE
Improve Regex text performance by using UTF 16 Spans

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Text/Span.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Text/Span.md
@@ -11,6 +11,7 @@
 - type Utf_16_Span
     - Value range:Standard.Base.Data.Range.Range parent:Standard.Base.Data.Text.Text
     - end self -> Standard.Base.Any.Any
+    - extended_text self -> Standard.Base.Any.Any
     - length self -> Standard.Base.Any.Any
     - start self -> Standard.Base.Any.Any
     - text self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -157,6 +157,13 @@ type Regex
 
        ## Arguments
         - `input`: The text to match the pattern described by `self` against.
+
+       ## Remarks
+
+       ### UTF 16 Span
+       Note that this method uses the UTF 16 span of the match, and so may
+       split graphemes. If you want the text of a whole grapheme, use
+       `match input . span . text` to get the grapheme-based text.
     find : Text -> Text | Nothing | Type_Error
     find self (input : Text) =
        match_to_group_maybe <| self.match input
@@ -172,6 +179,13 @@ type Regex
 
        ## Arguments
         - `input`: The text to match the pattern described by `self` against.
+
+       ## Remarks
+
+       ### UTF 16 Span
+       Note that this method uses the UTF 16 span of the match, and so may
+       split graphemes. If you want the text of a whole grapheme, use
+       `match_all input . map m->m.span.text` to get the grapheme-based text.
     find_all : Text -> Vector Text ! Type_Error
     find_all self (input : Text) =
        self.match_all input . map match_to_group_maybe
@@ -258,9 +272,27 @@ type Regex
              Regex.compile '(\S+)(?:\s+|$)' . tokenize 'Hello Big\r\nWide\tWorld\nGoodbye!'
                  == ['Hello','Big','Wide','World','Goodbye!']
        ```
+
+       ## Remarks
+
+       ### UTF 16 Span
+       Note that this method uses the UTF 16 span of the match, and so may
+       split graphemes. If you want to tokenize based on grapheme-spans, then
+       you can use the `match_all` method and extract the text from each match
+       using the `span` method.
     tokenize : Text -> Vector Text
     tokenize self input:Text =
-        self.match_all input . map (build_tokenization_output_from_match self _)
+        pattern_is_empty = self.pattern == ''
+        if pattern_is_empty then Error.throw (Illegal_Argument.Error "Cannot run match_all with an empty pattern") else
+            Vector.build builder->
+                it = Match_Iterator.new self input
+                go it = case it.next of
+                    Match_Iterator_Value.Next _ match next_it ->
+                        builder.append (build_tokenization_output_from_match self match)
+                        @Tail_Call go next_it
+                    Match_Iterator_Value.Last _ ->
+                        Nothing
+                go it
 
     ## ---
        group: Text
@@ -524,15 +556,15 @@ build_tokenization_output_from_match pattern match =
     if pattern.group_count == 1 then match.text 0 else
         # Extract the ranges of the spans of all capturing groups
         group_numbers = 1.up_to pattern.group_count
-        spans = group_numbers.map (n-> match.span n) . filter i->i.is_nothing.not
-        ranges = spans.map span-> case span of Span.Value range _ -> range
+        spans = group_numbers.map (n-> match.utf_16_span n) . filter i->i.is_nothing.not
+        ranges = spans.map span-> case span of Utf_16_Span.Value range _ -> range
 
         # Eliminate nested capturing groups by sorting and merging the ranges.
         top_level_ranges = sort_and_merge_ranges ranges
 
         # Reconstruct `Spans` from the synthesized `Ranges`, and concatenate.
-        text_all = case spans.at 0 of Span.Value _ text -> text
-        top_level_spans = top_level_ranges.map range-> Span.Value range text_all
+        text_all = case spans.at 0 of Utf_16_Span.Value _ text -> text
+        top_level_spans = top_level_ranges.map range-> Utf_16_Span.Value range text_all
         top_level_spans.map (.text) . join
 
 ## An error that is emitted when there is no such group in the match for the

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -157,13 +157,6 @@ type Regex
 
        ## Arguments
         - `input`: The text to match the pattern described by `self` against.
-
-       ## Remarks
-
-       ### UTF 16 Span
-       Note that this method uses the UTF 16 span of the match, and so may
-       split graphemes. If you want the text of a whole grapheme, use
-       `match input . span . text` to get the grapheme-based text.
     find : Text -> Text | Nothing | Type_Error
     find self (input : Text) =
        match_to_group_maybe <| self.match input
@@ -179,13 +172,6 @@ type Regex
 
        ## Arguments
         - `input`: The text to match the pattern described by `self` against.
-
-       ## Remarks
-
-       ### UTF 16 Span
-       Note that this method uses the UTF 16 span of the match, and so may
-       split graphemes. If you want the text of a whole grapheme, use
-       `match_all input . map m->m.span.text` to get the grapheme-based text.
     find_all : Text -> Vector Text ! Type_Error
     find_all self (input : Text) =
        self.match_all input . map match_to_group_maybe
@@ -272,14 +258,6 @@ type Regex
              Regex.compile '(\S+)(?:\s+|$)' . tokenize 'Hello Big\r\nWide\tWorld\nGoodbye!'
                  == ['Hello','Big','Wide','World','Goodbye!']
        ```
-
-       ## Remarks
-
-       ### UTF 16 Span
-       Note that this method uses the UTF 16 span of the match, and so may
-       split graphemes. If you want to tokenize based on grapheme-spans, then
-       you can use the `match_all` method and extract the text from each match
-       using the `span` method.
     tokenize : Text -> Vector Text
     tokenize self input:Text =
         pattern_is_empty = self.pattern == ''
@@ -565,7 +543,7 @@ build_tokenization_output_from_match pattern match =
         # Reconstruct `Spans` from the synthesized `Ranges`, and concatenate.
         text_all = case spans.at 0 of Utf_16_Span.Value _ text -> text
         top_level_spans = top_level_ranges.map range-> Utf_16_Span.Value range text_all
-        top_level_spans.map (.text) . join
+        top_level_spans.map (.extended_text) . join
 
 ## An error that is emitted when there is no such group in the match for the
    provided `id`.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Internal/Match_Iterator.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Internal/Match_Iterator.enso
@@ -86,4 +86,3 @@ type Match_Iterator_Value
        private: true
        ---
     Last (filler : Utf_16_Span)
-

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Internal/Match_Iterator.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Internal/Match_Iterator.enso
@@ -46,7 +46,8 @@ type Match_Iterator
        Also returns the next iterator, if there was a match.
     next : Match_Iterator_Value
     next self =
-        regex_result = if self.cursor > self.input.char_vector.length then Nothing else self.pattern.internal_regex_object.exec self.input self.cursor
+        regex_result = if self.cursor > self.input.char_vector.length then Nothing else
+            self.pattern.internal_regex_object.exec self.input self.cursor
         case regex_result.is_nothing.not && regex_result.isMatch of
             False ->
                 filler_range = Range.new self.cursor (Text_Utils.char_length self.input)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
@@ -231,9 +231,14 @@ type Match
        "ab((c)|(d))".find "abc" In this case, the group id for "(d)", which is 3,
        is a valid group id and (Regex.lookup_group 3) will return 3. If the
        caller tries to get group 3, Match.text will return the default value.
+
+       ### UTF 16 Span
+       Note that this method uses the UTF 16 span of the match, and so may
+       split graphemes. If you want the text of a whole grapheme, use
+       `Match.span` to get the grapheme span, and then get the text from that
     text : Integer | Text -> Any -> Text ! No_Such_Group
     text self group=0 ~default=Nothing =
-        result = self.span group Nothing
+        result = self.utf_16_span group Nothing
         if result.is_nothing then default else result.text
 
     ## ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
@@ -231,15 +231,10 @@ type Match
        "ab((c)|(d))".find "abc" In this case, the group id for "(d)", which is 3,
        is a valid group id and (Regex.lookup_group 3) will return 3. If the
        caller tries to get group 3, Match.text will return the default value.
-
-       ### UTF 16 Span
-       Note that this method uses the UTF 16 span of the match, and so may
-       split graphemes. If you want the text of a whole grapheme, use
-       `Match.span` to get the grapheme span, and then get the text from that
     text : Integer | Text -> Any -> Text ! No_Such_Group
     text self group=0 ~default=Nothing =
         result = self.utf_16_span group Nothing
-        if result.is_nothing then default else result.text
+        if result.is_nothing then default else result.extended_text
 
     ## ---
        group: Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Span.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Span.enso
@@ -174,6 +174,16 @@ type Utf_16_Span
     text self = Text_Utils.substring self.parent self.start self.end
 
     ## ---
+       group: Metadata
+       icon: metadata
+       ---
+       Returns the part of the text that this span covers but expanded to the
+       nearest grapheme cluster boundaries.
+    extended_text : Text
+    extended_text self =
+        Text_Utils.substring_clustered self.parent self.start self.end
+
+    ## ---
        group: Conversions
        icon: convert
        ---

--- a/std-bits/base/src/main/java/org/enso/base/FileLineReader.java
+++ b/std-bits/base/src/main/java/org/enso/base/FileLineReader.java
@@ -13,10 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.enso.base.arrays.LongArrayList;
 import org.graalvm.polyglot.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A reader for reading lines from a file one at a time. */
 public class FileLineReader {
@@ -97,7 +97,7 @@ public class FileLineReader {
     }
   }
 
-  private static final Logger LOGGER = Logger.getLogger("enso-file-line-reader");
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileLineReader.class);
 
   /** Amount of data to read at a time for a single line (4KB). */
   private static final int LINE_BUFFER = 4 * 1024;
@@ -262,6 +262,8 @@ public class FileLineReader {
     }
     int index = action == null ? rowMap.getSize() - 1 : startAt;
 
+    String path = file.getAbsolutePath();
+
     long position = rowMap.get(index);
     if (position >= length) {
       return null;
@@ -306,7 +308,7 @@ public class FileLineReader {
             }
 
             if (index % 100000 == 0) {
-              LOGGER.log(Level.INFO, "Scanned Lines: {0}", index);
+              LOGGER.info("Scanned Lines: {} of {}", index, path);
             }
             index++;
 

--- a/std-bits/base/src/main/java/org/enso/base/Text_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Text_Utils.java
@@ -38,6 +38,24 @@ public class Text_Utils {
   }
 
   /**
+   * Creates a substring of the given string, indexing using the Java standard (UTF-16) indexing
+   * mechanism but using a BreakIterator to ensure that the indices correspond to grapheme
+   * boundaries.
+   *
+   * @param string the string to substring
+   * @param from starting index
+   * @param to index one past the end of the desired substring
+   * @return a suitable substring
+   */
+  public static String substring_clustered(String string, int from, int to) {
+    BreakIterator iter = BreakIterator.getCharacterInstance();
+    iter.setText(string);
+    int start = from == 0 ? 0 : (iter.isBoundary(from) ? from : iter.preceding(from));
+    int end = to >= string.length() ? string.length() : (iter.isBoundary(to) ? to : iter.following(to));
+    return string.substring(start, end);
+  }
+
+  /**
    * Checks if the string has leading or trailing whitespace.
    *
    * @param s the string to check

--- a/std-bits/base/src/main/java/org/enso/base/Text_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Text_Utils.java
@@ -51,7 +51,8 @@ public class Text_Utils {
     BreakIterator iter = BreakIterator.getCharacterInstance();
     iter.setText(string);
     int start = from == 0 ? 0 : (iter.isBoundary(from) ? from : iter.preceding(from));
-    int end = to >= string.length() ? string.length() : (iter.isBoundary(to) ? to : iter.following(to));
+    int end =
+        to >= string.length() ? string.length() : (iter.isBoundary(to) ? to : iter.following(to));
     return string.substring(start, end);
   }
 

--- a/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/LRUCache.java
@@ -16,10 +16,10 @@ import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.enso.base.Stream_Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * LRUCache is a cache for data presented via InputStreams. Files are deleted on JVM exit.
@@ -51,7 +51,7 @@ import org.enso.base.Stream_Utils;
  * @param <M> Additional metadata to associate with the data.
  */
 public class LRUCache<M> implements ReloadDetector.HasClearableCache {
-  private static final Logger logger = Logger.getLogger(LRUCache.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(LRUCache.class);
 
   /**
    * An upper limit on the total cache size. If the cache size limit specified by the other
@@ -105,10 +105,8 @@ public class LRUCache<M> implements ReloadDetector.HasClearableCache {
       // We don't re-attempt to store the cache file and entry. In some cases
       // (such as a cache file deleted from the outside), we could, but this is
       // a rare case so it seems unnecessary.
-      logger.log(
-          Level.WARNING,
-          "Error in cache file handling; will re-execute without caching: {0}",
-          e.getMessage());
+      LOGGER.warn(
+          "Error in cache file handling; will re-execute without caching: {}", e.getMessage());
       Item<M> rerequested = itemBuilder.buildItem();
       return new CacheResult<>(rerequested.stream(), rerequested.metadata());
     }
@@ -202,7 +200,7 @@ public class LRUCache<M> implements ReloadDetector.HasClearableCache {
       outputStream.close();
       if (!successful) {
         if (!temp.delete()) {
-          logger.log(Level.WARNING, "Unable to delete cache file (key {})", cacheKey);
+          LOGGER.warn("Unable to delete cache file (key {})", cacheKey);
         }
       }
     }
@@ -256,7 +254,7 @@ public class LRUCache<M> implements ReloadDetector.HasClearableCache {
   private void removeCacheFile(String key, CacheEntry<M> cacheEntry) {
     boolean removed = cacheEntry.responseData.delete();
     if (!removed) {
-      logger.log(Level.WARNING, "Unable to delete cache file for key {0}", key);
+      LOGGER.warn("Unable to delete cache file for key {}", key);
     }
   }
 

--- a/std-bits/base/src/main/java/org/enso/base/cache/LRUCacheSettings.java
+++ b/std-bits/base/src/main/java/org/enso/base/cache/LRUCacheSettings.java
@@ -1,11 +1,11 @@
 package org.enso.base.cache;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.enso.base.Environment_Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LRUCacheSettings {
-  private static final Logger logger = Logger.getLogger(LRUCacheSettings.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(LRUCacheSettings.class);
 
   private static final String MAX_FILE_SIZE_ENV_VAR = "ENSO_LIB_HTTP_CACHE_MAX_FILE_SIZE_MB";
   private static final String TOTAL_CACHE_SIZE_ENV_VAR =
@@ -70,8 +70,7 @@ public class LRUCacheSettings {
       double maxFileSizeMegs = Double.parseDouble(maxFileSizeSpec);
       return (long) (maxFileSizeMegs * 1024 * 1024);
     } catch (NumberFormatException e) {
-      logger.log(
-          Level.WARNING,
+      LOGGER.warn(
           "Unable to parse environment variable "
               + MAX_FILE_SIZE_ENV_VAR
               + ": {}, falling back to default",
@@ -91,8 +90,7 @@ public class LRUCacheSettings {
     try {
       return TotalCacheLimit.parse(totalCacheLimitSpec);
     } catch (IllegalArgumentException e) {
-      logger.log(
-          Level.WARNING,
+      LOGGER.warn(
           "Unable to parse environment variable "
               + TOTAL_CACHE_SIZE_ENV_VAR
               + ": {}, falling back to default",


### PR DESCRIPTION
### Pull Request Description

- Separate the iterator for `tokenize` from `match_all` to avoid making two `Vector`s.
- Add a `extended_text` to `Utf_16_Span` which then uses `proceeding` and `following` to avoid doing a full scan in the `BreakIterator`.
- Use `utf_16_span` and `extended_text` to read from parts of input in a `Regex.Match`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
