### PR TITLE
Properly compute FQN for a module inside of a project

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/ProgramRootNodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/ProgramRootNodeTest.java
@@ -1,0 +1,41 @@
+package org.enso.interpreter.node;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Source;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ProgramRootNodeTest {
+  @ClassRule public static final ContextUtils ctx = ContextUtils.createDefault();
+
+  @Test
+  public void checkRelativeInPackage() throws Exception {
+    var vector =
+        ctx.evalModule(
+            """
+            import Standard.Base.Data.Vector.Vector
+            main = Vector
+            """);
+
+    var rawVector = ctx.unwrapValue(vector);
+    if (rawVector instanceof Type vectorType) {
+      var vectorModule = vectorType.getDefinitionScope().getModule();
+      var vectorSource = vectorModule.getSource();
+
+      var newModule = ctx.eval(Source.newBuilder("enso", new File(vectorSource.getPath())).build());
+      if (ctx.unwrapValue(newModule) instanceof Module secondModule) {
+        assertEquals("Name is properly resolved", vectorModule.getName(), secondModule.getName());
+      } else {
+        fail("Other result should be a module: " + newModule);
+      }
+    } else {
+      fail("" + vector.getMetaQualifiedName());
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -15,7 +15,6 @@ import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.ExecutableNode;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.nodes.RootNode;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.ZoneId;
@@ -226,7 +225,7 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
    */
   @Override
   protected CallTarget parse(ParsingRequest request) {
-    RootNode root = ProgramRootNode.build(this, request.getSource());
+    var root = ProgramRootNode.build(this, request.getSource());
     return root.getCallTarget();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
@@ -7,11 +7,14 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import java.io.File;
+import java.util.LinkedList;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
+import org.enso.scala.wrapper.ScalaConversions;
+import org.slf4j.LoggerFactory;
 
 /**
  * This node handles static transformation of the input AST before execution and represents the root
@@ -52,20 +55,15 @@ public class ProgramRootNode extends RootNode {
   public Object execute(VirtualFrame frame) {
     if (module == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      QualifiedName simpleName = QualifiedName.simpleName(canonicalizeName(sourceCode.getName()));
-      EnsoContext ctx = EnsoContext.get(this);
+      var ctx = EnsoContext.get(this);
+      var srcName = canonicalizeName(sourceCode.getName());
       if (sourceCode.getPath() != null) {
-        TruffleFile src = ctx.getTruffleFile(new File(sourceCode.getPath()));
-        Package<TruffleFile> pkg = ctx.getPackageOf(src).orElse(null);
-        QualifiedName qualifiedName;
-        if (pkg != null) {
-          qualifiedName =
-              QualifiedName.fromString(pkg.libraryName().toString() + "." + simpleName.item());
-        } else {
-          qualifiedName = simpleName;
-        }
+        var src = ctx.getTruffleFile(new File(sourceCode.getPath()));
+        var pkg = ctx.getPackageOf(src).orElse(null);
+        var qualifiedName = findQualifiedNameInPackage(pkg, src, srcName);
         module = new Module(qualifiedName, pkg, src);
       } else {
+        var simpleName = QualifiedName.simpleName(srcName);
         module = new Module(simpleName, null, sourceCode.getCharacters().toString());
       }
       ctx.getPackageRepository().registerModuleCreatedInRuntime(module.asCompilerModule());
@@ -75,6 +73,27 @@ public class ProgramRootNode extends RootNode {
     }
     // Note [Static Passes]
     return module;
+  }
+
+  private static QualifiedName findQualifiedNameInPackage(
+      Package<TruffleFile> pkg, TruffleFile src, String srcName) {
+    if (pkg != null) {
+      try {
+        var rel = pkg.sourceDir().relativize(src.getParent());
+        var names = new LinkedList<String>();
+        while (rel != null) {
+          names.add(0, rel.getName());
+          rel = rel.getParent();
+        }
+        names.add(0, pkg.name());
+        names.add(0, pkg.namespace());
+        return QualifiedName.apply(ScalaConversions.asScala(names), srcName);
+      } catch (IllegalStateException ex) {
+        LoggerFactory.getLogger(ProgramRootNode.class)
+            .warn("Cannot find package name for " + src, ex);
+      }
+    }
+    return QualifiedName.simpleName(srcName);
   }
 
   private String canonicalizeName(String name) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
@@ -82,7 +82,9 @@ public class ProgramRootNode extends RootNode {
         var rel = pkg.sourceDir().relativize(src.getParent());
         var names = new LinkedList<String>();
         while (rel != null) {
-          names.add(0, rel.getName());
+          if (!rel.getName().isEmpty()) {
+            names.add(0, rel.getName());
+          }
           rel = rel.getParent();
         }
         names.add(0, pkg.name());


### PR DESCRIPTION
### Pull Request Description

Fixes #12240 by properly computing FQN of a deeply nested modules inside of a project. With this change we can:
```
sbt:enso> runEngineDistribution --run ./test/Base_Tests/src/Semantic/Default_Args_Spec.enso

9 tests succeeded.
0 tests failed.
0 tests skipped.
0 groups skipped.
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
