### PR TITLE
Unify Logging in libs to SLF4J

### DIFF
--- a/std-bits/aws/src/main/java/org/enso/aws/BucketLocator.java
+++ b/std-bits/aws/src/main/java/org/enso/aws/BucketLocator.java
@@ -2,8 +2,9 @@ package org.enso.aws;
 
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.logging.Logger;
 import org.enso.aws.regions.AWSRegion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.BucketLocationConstraint;
@@ -20,7 +21,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
  */
 public class BucketLocator {
   private static final HashMap<String, AWSRegion> cache = new HashMap<>();
-  private static final Logger logger = Logger.getLogger(BucketLocator.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(BucketLocator.class);
 
   public static void flushCache() {
     cache.clear();
@@ -60,15 +61,14 @@ public class BucketLocator {
     } catch (S3Exception error) {
       var details = error.awsErrorDetails();
       if (details == null) {
-        logger.fine(
-            "Failed to locate a bucket (missing details in error response): " + error.getMessage());
+        LOGGER.trace("Failed to locate a bucket (missing details in error response).", error);
         return null;
       }
 
       // We can extract the region from the error response as well.
       return findRegionInResponse(details.sdkHttpResponse());
     } catch (Exception e) {
-      logger.fine("Failed to locate a bucket using HeadBucket: " + e.getMessage());
+      LOGGER.trace("Failed to locate a bucket using HeadBucket.", e);
       return null;
     }
   }
@@ -94,7 +94,7 @@ public class BucketLocator {
       }
 
       if (locationConstraint == BucketLocationConstraint.UNKNOWN_TO_SDK_VERSION) {
-        logger.fine("AWS returned an unknown location constraint.");
+        LOGGER.trace("AWS returned an unknown location constraint.");
         return null;
       }
 
@@ -103,13 +103,13 @@ public class BucketLocator {
       if (isKnown) {
         return inferredRegion;
       } else {
-        logger.fine(
-            "AWS returned a location constraint that cannot be mapped to a known region: "
-                + locationConstraint);
+        LOGGER.trace(
+            "AWS returned a location constraint that cannot be mapped to a known region: {}",
+            locationConstraint);
         return null;
       }
     } catch (Exception e) {
-      logger.fine("Failed to locate a bucket (legacy GetBucketLocation): " + e.getMessage());
+      LOGGER.trace("Failed to locate a bucket (legacy GetBucketLocation).", e);
       return null;
     }
   }

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/audit/AuditLogApiAccess.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/audit/AuditLogApiAccess.java
@@ -15,17 +15,18 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import org.enso.base.cache.ReloadDetector;
 import org.enso.base.enso_cloud.AuthenticationProvider;
 import org.enso.base.enso_cloud.CloudAPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Gives access to the low-level log event API in the Cloud and manages asynchronously submitting
  * the logs.
  */
 public final class AuditLogApiAccess implements ReloadDetector.HasClearableCache {
-  private static final Logger logger = Logger.getLogger(AuditLogApiAccess.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogApiAccess.class);
 
   /**
    * We still want to limit the batch size to some reasonable number - sending too many logs in one
@@ -246,10 +247,10 @@ public final class AuditLogApiAccess implements ReloadDetector.HasClearableCache
       }
     } catch (RequestFailureException e) {
       if (retryCount < 0) {
-        logger.severe("Failed to send log messages after retrying: " + e.getMessage());
+        LOGGER.error("Failed to send log messages after retrying.", e);
         throw e;
       } else {
-        logger.warning("Exception when sending log messages: " + e.getMessage() + ". Retrying...");
+        LOGGER.warn("Exception when sending log messages: {}. Retrying...", e.getMessage());
         sendLogRequest(request, retryCount - 1);
       }
     }

--- a/std-bits/database/src/main/java/org/enso/database/audit/CloudAuditedConnection.java
+++ b/std-bits/database/src/main/java/org/enso/database/audit/CloudAuditedConnection.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.logging.Logger;
 import org.enso.base.enso_cloud.audit.AuditLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class CloudAuditedConnection extends AuditedConnection {
-  private static final Logger logger = Logger.getLogger(CloudAuditedConnection.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(CloudAuditedConnection.class);
   private final ObjectNode metadata;
 
   /**
@@ -28,7 +29,7 @@ public final class CloudAuditedConnection extends AuditedConnection {
       metadata.put("connectionUri", underlying.getMetaData().getURL());
     } catch (SQLException e) {
       // We ignore the exception, only logging it
-      logger.warning("Failed to get connection URI for " + underlying + ": " + e.getMessage());
+      LOGGER.warn("Failed to get connection URI for {} : {}", underlying, e.getMessage(), e);
     }
   }
 

--- a/std-bits/database/src/main/java/org/enso/database/audit/LocalAuditedConnection.java
+++ b/std-bits/database/src/main/java/org/enso/database/audit/LocalAuditedConnection.java
@@ -2,10 +2,11 @@ package org.enso.database.audit;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LocalAuditedConnection extends AuditedConnection {
-  private static final Logger logger = Logger.getLogger("Standard.Database.Connection");
+  private static final Logger LOGGER = LoggerFactory.getLogger("Standard.Database.Connection");
   private final String connectionIdentifier;
 
   public LocalAuditedConnection(Connection underlying) {
@@ -23,11 +24,13 @@ public class LocalAuditedConnection extends AuditedConnection {
 
   @Override
   protected void auditQuery(String operationType, String sql) {
-    logger.info(connectionIdentifier + " - " + operationType + ": " + sql);
+    LOGGER.info(connectionIdentifier + " - {}: {}", operationType, sql);
   }
+
+  private static final String operationType = "transaction";
 
   @Override
   protected void auditTransaction(String operation) {
-    logger.info(connectionIdentifier + " - transaction - " + operation);
+    auditQuery(operationType, operation);
   }
 }

--- a/std-bits/database/src/main/java/org/enso/database/dryrun/OperationSynchronizer.java
+++ b/std-bits/database/src/main/java/org/enso/database/dryrun/OperationSynchronizer.java
@@ -2,8 +2,9 @@ package org.enso.database.dryrun;
 
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
-import java.util.logging.Logger;
 import org.graalvm.polyglot.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A helper for ensuring that only one database operation is running at a time, and that maintenance
@@ -12,6 +13,8 @@ import org.graalvm.polyglot.Value;
  * <p>Additionally, it allows running maintenance actions when no regular actions are being run.
  */
 public class OperationSynchronizer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OperationSynchronizer.class);
+
   /** This lock guarantees that only one thread can access the connection at a time. */
   private final ReentrantLock lock = new ReentrantLock();
 
@@ -84,8 +87,7 @@ public class OperationSynchronizer {
           try {
             maintenanceAction.apply(null);
           } catch (Exception e) {
-            Logger.getLogger("enso-std-database")
-                .severe("A maintenance action failed with exception: " + e.getMessage());
+            LOGGER.error("Maintenance action failed", e);
           } finally {
             nestingLevel--;
           }

--- a/std-bits/microsoft/src/main/java/org/enso/microsoft/azure/AzureBlobStorage.java
+++ b/std-bits/microsoft/src/main/java/org/enso/microsoft/azure/AzureBlobStorage.java
@@ -8,9 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class AzureBlobStorage {
-  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AzureBlobStorage.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobStorage.class);
 
   private static BlobServiceClient makeClient(
       AzureCredential credential, String storageAccountName) {

--- a/std-bits/tableau/src/main/java/org/enso/tableau/HyperFormat.java
+++ b/std-bits/tableau/src/main/java/org/enso/tableau/HyperFormat.java
@@ -33,8 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.enso.table.data.column.builder.Builder;
@@ -56,13 +54,15 @@ import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
 import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Class responsible for reading/writing Tableau Hyper files. */
 public class HyperFormat {
   public static final Path HYPER_PATH = Path.of(getHyperPath());
   private static HyperProcess process;
 
-  private static final Logger LOGGER = Logger.getLogger("enso-hyper-reader");
+  private static final Logger LOGGER = LoggerFactory.getLogger(HyperFormat.class);
 
   private static String getHyperPath() {
     if (System.getenv("HYPER_PATH") != null) {
@@ -129,7 +129,7 @@ public class HyperFormat {
         var classLoader = new TableauClassLoader();
         var jnaPath = classLoader.getResource("jnidispatch");
         Thread.currentThread().setContextClassLoader(classLoader);
-        LOGGER.log(Level.INFO, "Starting Hyper process: {0}.", HYPER_PATH);
+        LOGGER.info("Starting Hyper process: {}.", HYPER_PATH);
         try {
           if (jnaPath != null) {
             // Use URI to correctly handle spaces and other encoded characters.
@@ -138,7 +138,7 @@ public class HyperFormat {
           }
           process = new HyperProcess(HYPER_PATH, Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU);
         } catch (Throwable ioe) {
-          LOGGER.log(Level.SEVERE, "Failed to start Hyper process.", ioe);
+          LOGGER.error("Failed to start Hyper process.", ioe);
           throw new IOException("Failed to start Hyper process.", ioe);
         }
       } finally {
@@ -168,8 +168,7 @@ public class HyperFormat {
         var found = bindings.invokeMember("find_native_library", libName);
         try {
           if (found == null || found.asString() == null) {
-            LOGGER.log(
-                Level.WARNING, "Failed to find library `{0}`. Retrying with a fallback", libName);
+            LOGGER.warn("Failed to find library `{}`. Retrying with a fallback", libName);
             return super.getResource(name);
           } else {
             return new File(found.asString()).toURI().toURL();
@@ -196,8 +195,7 @@ public class HyperFormat {
         var found = bindings.invokeMember("find_native_library", libName);
         try {
           if (found == null || found.asString() == null) {
-            LOGGER.log(
-                Level.WARNING, "Failed to find library `{0}`. Retrying with a fallback", libName);
+            LOGGER.warn("Failed to find library `{}`. Retrying with a fallback", libName);
             return super.getResourceAsStream(name);
           } else {
             return new FileInputStream(found.asString());
@@ -217,7 +215,7 @@ public class HyperFormat {
           InvalidPathException,
           UnsupportedOperationException,
           SecurityException {
-    LOGGER.log(Level.INFO, "Downloading Hyper from: {0}", uri);
+    LOGGER.info("Downloading Hyper from: {}", uri);
     var hyperdFile = HYPER_PATH.resolve(fileName).toFile();
     var url = new URI(uri);
     var readChannel = Channels.newChannel(url.toURL().openStream());


### PR DESCRIPTION
### Pull Request Description

- Move all logging to be via the SLF4J.
- Standardise so always called `LOGGER` and built in standard way.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
