### PR TITLE
Revert "Remove `refetchType: 'all'` to avoid unnecessary 'list directory' requests (#13903)"

### DIFF
--- a/app/gui/src/dashboard/hooks/backendBatchedHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendBatchedHooks.ts
@@ -65,6 +65,7 @@ export function deleteAssetsMutationOptions(backend: Backend) {
         [backend.type, 'listAssetVersions'],
       ],
       awaitInvalidates: true,
+      refetchType: 'all',
     },
   })
 }
@@ -137,6 +138,7 @@ export function restoreAssetsMutationOptions(backend: Backend) {
         [backend.type, 'getAssetDetails'],
       ],
       awaitInvalidates: true,
+      refetchType: 'all',
     },
   })
 }
@@ -212,6 +214,7 @@ export function copyAssetsMutationOptions(backend: Backend) {
         [backend.type, 'getAssetDetails'],
       ],
       awaitInvalidates: true,
+      refetchType: 'all',
     },
   })
 }

--- a/app/gui/src/dashboard/hooks/backendHooks.ts
+++ b/app/gui/src/dashboard/hooks/backendHooks.ts
@@ -192,6 +192,9 @@ export function backendMutationOptions<Method extends BackendMutationMethod>(
       ...options?.meta,
       invalidates,
       awaitInvalidates: options?.meta?.awaitInvalidates ?? true,
+      refetchType:
+        options?.meta?.refetchType ??
+        (invalidates.some((key) => key[1] === 'listDirectory') ? 'all' : 'active'),
     },
   }
 }

--- a/app/gui/src/project-view/composables/backend.ts
+++ b/app/gui/src/project-view/composables/backend.ts
@@ -102,6 +102,7 @@ export function backendMutationOptions<Method extends BackendMutationMethod>(
       meta: {
         invalidates,
         awaitInvalidates: true,
+        refetchType: invalidates.some((key) => key[1] === 'listDirectory') ? 'all' : 'active',
         ...opts?.meta,
       },
     }


### PR DESCRIPTION
This reverts commit 9801d67f4bcce1f8bffd216716eab9ac76b2e16e.

This it to fix integration test problems after merging #13507 . Both PRs are making issues together, reverting this one, because it's shorter.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
