### PR TITLE
Give ProgramRootNode name and source section

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/ProgramRootNodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/ProgramRootNodeTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -36,6 +37,21 @@ public class ProgramRootNodeTest {
       }
     } else {
       fail("" + vector.getMetaQualifiedName());
+    }
+  }
+
+  @Test
+  public void sourceSectionAndName() throws Exception {
+    var code = """
+        main = "Error!
+        """;
+    var src = Source.newBuilder("enso", code, "error_test.enso").build();
+    try {
+      var m = ctx.eval(src);
+      fail("Expecting an error exception: " + m);
+    } catch (PolyglotException ex) {
+      var f = ex.getPolyglotStackTrace().iterator().next();
+      assertEquals("error_test", f.getRootName());
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
@@ -36,6 +36,7 @@ public class ProgramRootNode extends RootNode {
   }
 
   @Override
+  @CompilerDirectives.TruffleBoundary
   public String getName() {
     var segs = sourceCode.getName().split("\\.");
     if (segs.length == 0) {
@@ -46,6 +47,7 @@ public class ProgramRootNode extends RootNode {
   }
 
   @Override
+  @CompilerDirectives.TruffleBoundary
   public SourceSection getSourceSection() {
     return sourceCode.createSection(0, sourceCode.getLength());
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
 import java.io.File;
 import java.util.LinkedList;
 import org.enso.interpreter.EnsoLanguage;
@@ -34,6 +35,21 @@ public class ProgramRootNode extends RootNode {
     this.sourceCode = sourceCode;
   }
 
+  @Override
+  public String getName() {
+    var segs = sourceCode.getName().split("\\.");
+    if (segs.length == 0) {
+      return "Unnamed";
+    } else {
+      return segs[0];
+    }
+  }
+
+  @Override
+  public SourceSection getSourceSection() {
+    return sourceCode.createSection(0, sourceCode.getLength());
+  }
+
   /**
    * Constructs the root node.
    *
@@ -56,14 +72,13 @@ public class ProgramRootNode extends RootNode {
     if (module == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       var ctx = EnsoContext.get(this);
-      var srcName = canonicalizeName(sourceCode.getName());
       if (sourceCode.getPath() != null) {
         var src = ctx.getTruffleFile(new File(sourceCode.getPath()));
         var pkg = ctx.getPackageOf(src).orElse(null);
-        var qualifiedName = findQualifiedNameInPackage(pkg, src, srcName);
+        var qualifiedName = findQualifiedNameInPackage(pkg, src, getName());
         module = new Module(qualifiedName, pkg, src);
       } else {
-        var simpleName = QualifiedName.simpleName(srcName);
+        var simpleName = QualifiedName.simpleName(getName());
         module = new Module(simpleName, null, sourceCode.getCharacters().toString());
       }
       ctx.getPackageRepository().registerModuleCreatedInRuntime(module.asCompilerModule());
@@ -96,15 +111,6 @@ public class ProgramRootNode extends RootNode {
       }
     }
     return QualifiedName.simpleName(srcName);
-  }
-
-  private String canonicalizeName(String name) {
-    String[] segs = name.split("\\.");
-    if (segs.length == 0) {
-      return "Unnamed";
-    } else {
-      return segs[0];
-    }
   }
 
   /* Note [Static Passes]


### PR DESCRIPTION
### Pull Request Description

Improves polyglot stack trace when in Enso Compiler or parser. Putting breakpoint into `TreeToIr` and running:
```
sbt:enso> runEngineDistribution --run test/Base_Tests/src/Data/Vector_Spec.enso --debug --no-ir-caches
```
now shows:
<img width="1527" height="428" alt="in polyglot debugger" src="https://github.com/user-attachments/assets/62c0a8b5-2d0d-452a-a5f4-aa6c42a37b58" />
e.g. there is `Vector_Spec (Vector_Spec.enso:1)` top most stack frame. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
