### PR TITLE
Remove poi references from enso code

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -38,10 +38,10 @@ from project.Internal.Excel_Reader import handle_invalid_location
 from project.Internal.Table_Helpers import duplicate_rows
 
 polyglot java import java.io.File as Java_File
-polyglot java import org.apache.poi.ss.usermodel.Workbook
 polyglot java import org.enso.table.excel.ExcelConnectionPool
 polyglot java import org.enso.table.excel.ExcelFileFormat
 polyglot java import org.enso.table.excel.ReadOnlyExcelConnection
+polyglot java import org.enso.table.excel.ExcelWorkbook as Workbook
 polyglot java import org.enso.table.read.ExcelReader
 
 type Excel_Workbook

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -40,8 +40,8 @@ from project.Internal.Table_Helpers import duplicate_rows
 polyglot java import java.io.File as Java_File
 polyglot java import org.enso.table.excel.ExcelConnectionPool
 polyglot java import org.enso.table.excel.ExcelFileFormat
+polyglot java import org.enso.table.excel.ExcelWorkbook
 polyglot java import org.enso.table.excel.ReadOnlyExcelConnection
-polyglot java import org.enso.table.excel.ExcelWorkbook as Workbook
 polyglot java import org.enso.table.read.ExcelReader
 
 type Excel_Workbook
@@ -397,7 +397,7 @@ type Excel_Workbook
     ## ---
        private: true
        ---
-    with_java_workbook : (Workbook -> Any) -> Any ! Illegal_State
+    with_java_workbook : (ExcelWorkbook -> Any) -> Any ! Illegal_State
     with_java_workbook self f = Illegal_State.handle_java_exception <| handle_invalid_location <| Empty_Sheet.handle_java_exception <|
         case self.excel_connection_resource_ref.get of
             Nothing ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
@@ -13,11 +13,11 @@ from project.Errors import Empty_Sheet, Invalid_Location
 from project.In_Memory_Table import from_java_table
 
 polyglot java import java.io.File as Java_File
-polyglot java import org.apache.poi.poifs.filesystem.NotOLE2FileException
-polyglot java import org.apache.poi.UnsupportedFileFormatException
+polyglot java import java.io.IOException
 polyglot java import org.enso.table.error.InvalidLocationException
 polyglot java import org.enso.table.excel.ExcelFileFormat
 polyglot java import org.enso.table.excel.ExcelHeaders
+polyglot java import org.enso.table.excel.ExcelConnectionPool.ExcelFileFormatMismatchException
 polyglot java import org.enso.table.read.ExcelReader
 
 ## ---
@@ -93,8 +93,8 @@ handle_bad_format file ~action =
    A helper that handles the Java exceptions reported when a malformed XLS file
    is opened.
 handle_bad_format_with_handler handler ~action =
-    Panic.catch UnsupportedFileFormatException handler=handler <|
-        Panic.catch NotOLE2FileException handler=handler <|
+    Panic.catch ExcelFileFormatMismatchException handler=handler <|
+        Panic.catch IOException handler=handler <|
             action
 
 ## ---

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Writer.enso
@@ -24,7 +24,7 @@ polyglot java import org.enso.table.excel.ExcelConnectionPool
 polyglot java import org.enso.table.excel.ExcelConnectionPool.ConnectionRecord
 polyglot java import org.enso.table.excel.ExcelConnectionPool.WriteHelper
 polyglot java import org.enso.table.excel.ExcelFileFormat
-polyglot java import org.enso.table.excel.ExcelWorkbook as Workbook
+polyglot java import org.enso.table.excel.ExcelWorkbook
 polyglot java import org.enso.table.read.ExcelReader
 polyglot java import org.enso.table.write.ExcelWriter
 polyglot java import org.enso.table.write.ExistingDataMode
@@ -132,7 +132,7 @@ find_bak_file base_file =
 ## ---
    private: true
    ---
-prepare_file_modification_strategy : Table -> Excel_Section -> Existing_File_Behavior -> Match_Columns -> (Workbook -> Nothing)
+prepare_file_modification_strategy : Table -> Excel_Section -> Existing_File_Behavior -> Match_Columns -> (ExcelWorkbook -> Nothing)
 prepare_file_modification_strategy table section on_existing_file match_columns =
     existing_data_mode = make_java_existing_data_mode on_existing_file match_columns
     case section of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Writer.enso
@@ -16,7 +16,6 @@ from project.Errors import Column_Count_Mismatch, Column_Name_Mismatch, Existing
 
 polyglot java import java.io.File as Java_File
 polyglot java import java.lang.IllegalStateException
-polyglot java import org.apache.poi.ss.usermodel.Workbook
 polyglot java import org.enso.base.DryRunFileManager
 polyglot java import org.enso.table.error.ExistingDataException
 polyglot java import org.enso.table.error.InvalidLocationException
@@ -25,6 +24,7 @@ polyglot java import org.enso.table.excel.ExcelConnectionPool
 polyglot java import org.enso.table.excel.ExcelConnectionPool.ConnectionRecord
 polyglot java import org.enso.table.excel.ExcelConnectionPool.WriteHelper
 polyglot java import org.enso.table.excel.ExcelFileFormat
+polyglot java import org.enso.table.excel.ExcelWorkbook as Workbook
 polyglot java import org.enso.table.read.ExcelReader
 polyglot java import org.enso.table.write.ExcelWriter
 polyglot java import org.enso.table.write.ExistingDataMode

--- a/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reflect-config.json
+++ b/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/reflect-config.json
@@ -1256,15 +1256,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"org.apache.poi.UnsupportedFileFormatException"
-},
-{
-  "name":"org.apache.poi.poifs.filesystem.NotOLE2FileException"
-},
-{
-  "name":"org.apache.poi.ss.usermodel.Workbook"
-},
-{
   "name":"org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -11,7 +11,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.function.Function;
-
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OLE2NotOfficeXmlFileException;
@@ -274,14 +273,14 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
 
         try {
           try {
-          workbook =
-              format == ExcelFileFormat.XLSX
-                  ? new XSSFReaderWorkbook(file.getAbsolutePath())
-                  : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
+            workbook =
+                format == ExcelFileFormat.XLSX
+                    ? new XSSFReaderWorkbook(file.getAbsolutePath())
+                    : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
           } catch (OLE2NotOfficeXmlFileException e) {
-          throw new IOException(
-              "Invalid format encountered when opening the file " + file + " as " + format + ".",
-              e);
+            throw new IOException(
+                "Invalid format encountered when opening the file " + file + " as " + format + ".",
+                e);
           }
         } catch (IOException e) {
           initializationException = e;
@@ -316,16 +315,16 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
     return switch (format) {
       case XLS -> {
         try {
-        boolean readOnly = !writeAccess;
-        POIFSFileSystem fs = new POIFSFileSystem(file, readOnly);
-        try {
-          // If the initialization succeeds, the POIFSFileSystem will be closed by the
-          // HSSFWorkbook::close.
-          yield new HSSFWorkbook(fs);
-        } catch (IOException e) {
-          fs.close();
-          throw e;
-        }
+          boolean readOnly = !writeAccess;
+          POIFSFileSystem fs = new POIFSFileSystem(file, readOnly);
+          try {
+            // If the initialization succeeds, the POIFSFileSystem will be closed by the
+            // HSSFWorkbook::close.
+            yield new HSSFWorkbook(fs);
+          } catch (IOException e) {
+            fs.close();
+            throw e;
+          }
         } catch (OfficeXmlFileException e) {
           throw new IOException(
               "Invalid format encountered when opening the file " + file + " as " + format + ".",

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -11,12 +11,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.function.Function;
-import org.apache.poi.UnsupportedFileFormatException;
+
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.OLE2NotOfficeXmlFileException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -271,10 +273,16 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
         }
 
         try {
+          try {
           workbook =
               format == ExcelFileFormat.XLSX
                   ? new XSSFReaderWorkbook(file.getAbsolutePath())
                   : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
+          } catch (OLE2NotOfficeXmlFileException e) {
+          throw new IOException(
+              "Invalid format encountered when opening the file " + file + " as " + format + ".",
+              e);
+          }
         } catch (IOException e) {
           initializationException = e;
           if (throwOnFailure) {
@@ -307,6 +315,7 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
       throws IOException {
     return switch (format) {
       case XLS -> {
+        try {
         boolean readOnly = !writeAccess;
         POIFSFileSystem fs = new POIFSFileSystem(file, readOnly);
         try {
@@ -316,6 +325,11 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
         } catch (IOException e) {
           fs.close();
           throw e;
+        }
+        } catch (OfficeXmlFileException e) {
+          throw new IOException(
+              "Invalid format encountered when opening the file " + file + " as " + format + ".",
+              e);
         }
       }
       case XLSX, XLSX_FALLBACK -> {
@@ -328,7 +342,7 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
             pkg.close();
             throw e;
           }
-        } catch (InvalidFormatException e) {
+        } catch (InvalidFormatException | OLE2NotOfficeXmlFileException e) {
           throw new IOException(
               "Invalid format encountered when opening the file " + file + " as " + format + ".",
               e);
@@ -344,7 +358,7 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
     };
   }
 
-  public static class ExcelFileFormatMismatchException extends UnsupportedFileFormatException {
+  public static class ExcelFileFormatMismatchException extends IllegalArgumentException {
     public ExcelFileFormatMismatchException(String message) {
       super(message);
     }


### PR DESCRIPTION
### Pull Request Description

poi is an implementation detail of our Excel read/write code and as such should not leak its internals into the enso code space.

This MR removes all references to poi from enso code and so also can remove them from reflect-config.json (I think)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
