### PR TITLE
Show confirmation dialog when dragging from Team category to User category

### DIFF
--- a/app/gui/src/dashboard/hooks/cutAndPasteHooks.tsx
+++ b/app/gui/src/dashboard/hooks/cutAndPasteHooks.tsx
@@ -1,4 +1,5 @@
 /** @file Events related to changes in the asset list. */
+import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import {
   dropOperationBetweenCategories,
   useTransferBetweenCategories,
@@ -24,7 +25,7 @@ export interface PasteActionOptions {
 export function usePaste(category: Category) {
   const transferBetweenCategories = useTransferBetweenCategories(category)
 
-  return (options: PasteActionOptions) => {
+  return useEventCallback((options: PasteActionOptions) => {
     const { newParentId, pasteData, fromCategory, toCategory, method } = options
     const dropOperation = dropOperationBetweenCategories(fromCategory, toCategory, newParentId)
     if (dropOperation === 'cancel') return
@@ -35,5 +36,5 @@ export function usePaste(category: Category) {
       newParentId,
       method,
     )
-  }
+  })
 }

--- a/app/gui/src/dashboard/layouts/AssetContextMenu.tsx
+++ b/app/gui/src/dashboard/layouts/AssetContextMenu.tsx
@@ -77,14 +77,14 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
   const openProjectNatively = projectHooks.useOpenProjectNatively()
   const openProjectLocally = projectHooks.useOpenProjectLocally()
   const closeProject = projectHooks.useCloseProject()
-  const deleteAssetsMutation = useMutationCallback(deleteAssetsMutationOptions(backend))
-  const restoreAssetsMutation = useMutationCallback(restoreAssetsMutationOptions(backend))
-  const copyAssetsMutation = useMutationCallback(copyAssetsMutationOptions(backend))
-  const downloadAssetsMutation = useMutationCallback(downloadAssetsMutationOptions(backend))
+  const deleteAssets = useMutationCallback(deleteAssetsMutationOptions(backend))
+  const restoreAssets = useMutationCallback(restoreAssetsMutationOptions(backend))
+  const copyAssets = useMutationCallback(copyAssetsMutationOptions(backend))
+  const downloadAssets = useMutationCallback(downloadAssetsMutationOptions(backend))
   const self = permissions.tryFindSelfPermission(user, asset.permissions)
   const encodedEnsoPath = asset.ensoPath ? encodeURI(asset.ensoPath) : undefined
   const copyMutation = useCopy()
-  const uploadFileToCloudMutation = useUploadFileToCloudMutation()
+  const uploadFileToCloud = useUploadFileToCloudMutation()
   const uploadFileToLocal = useUploadFileToLocal(category)
   const exportArchive = useExportArchive({ backend })
   const disabledTooltip =
@@ -195,7 +195,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
             label: getText('restoreFromTrashShortcut'),
             doAction: () => {
               void goToDrive()
-              void restoreAssetsMutation({
+              void restoreAssets({
                 ids: [asset.id],
                 parentId: null,
               })
@@ -212,7 +212,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
                   cannotUndo
                   actionText={getText('deleteTheAssetTypeTitleForever', asset.type, asset.title)}
                   onConfirm={async () => {
-                    await deleteAssetsMutation([[asset.id], true])
+                    await deleteAssets([[asset.id], true])
                   }}
                 />,
               )
@@ -283,7 +283,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
             feature: 'uploadToCloud',
             doAction: () => {
               void goToDrive()
-              void uploadFileToCloudMutation(localBackend, {
+              void uploadFileToCloud(localBackend, {
                 assets: [asset],
                 targetDirectoryId: user.rootDirectoryId,
               })
@@ -321,7 +321,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
           action: 'download',
           doAction: () => {
             void goToDrive()
-            void downloadAssetsMutation({
+            void downloadAssets({
               ids: [{ id: asset.id, title: asset.title }],
               targetDirectoryId:
                 !isCloud ? (localCategories.localCategory?.homeDirectoryId ?? null) : null,
@@ -362,7 +362,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
           action: 'duplicate',
           doAction: () => {
             void goToDrive()
-            void copyAssetsMutation([[asset.id], asset.parentId])
+            void copyAssets([[asset.id], asset.parentId])
           },
         },
         {
@@ -390,7 +390,7 @@ export const AssetContextMenu = React.forwardRef(function AssetContextMenu(
                     asset.title,
                   )}
                   onConfirm={async () => {
-                    await deleteAssetsMutation([[asset.id], false])
+                    await deleteAssets([[asset.id], false])
                   }}
                 />,
               )

--- a/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
+++ b/app/gui/src/dashboard/layouts/CategorySwitcher.tsx
@@ -12,7 +12,6 @@ import {
   areCategoriesEqual,
   ASSETS_DATA_TRANSFER_PAYLOAD,
   canTransferBetweenCategories,
-  dropOperationBetweenCategories,
   useTransferBetweenCategories,
   type Category,
 } from '#/layouts/Drive/Categories'
@@ -150,10 +149,7 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
     <aria.DropZone
       aria-label={dropZoneLabel}
       getDropOperation={(types) => {
-        if (acceptedDragTypes.some((type) => types.has(type))) {
-          return dropOperationBetweenCategories(currentCategory, category)
-        }
-
+        if (acceptedDragTypes.some((type) => types.has(type))) return 'move'
         return 'cancel'
       }}
       className="group relative flex w-full min-w-0 flex-auto items-start rounded-full drop-target-after"

--- a/app/gui/src/dashboard/layouts/Drive/Categories/Category.ts
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/Category.ts
@@ -15,7 +15,9 @@ import { isIconName } from '@/util/iconMetadata/iconName'
 import type { DropOperation } from '@react-types/shared'
 import * as z from 'zod'
 
+// oxlint-disable-next-line no-unused-vars
 const PATH_SCHEMA = z.string().refine((s): s is Path => true)
+// oxlint-disable-next-line no-unused-vars
 const DIRECTORY_ID_SCHEMA = z.string().refine((s): s is DirectoryId => true)
 
 const EACH_CATEGORY_SCHEMA = z.object({

--- a/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
+++ b/app/gui/src/dashboard/layouts/Drive/Categories/transferBetweenCategoriesHooks.tsx
@@ -62,19 +62,17 @@ export function useTransferBetweenCategories(currentCategory: Category) {
   const { getCategoryByDirectoryId } = useCategories()
   const { getText } = useText()
 
-  const uploadFileToCloudMutation = useUploadFileToCloudMutation()
-  const downloadAssetsMutation = useMutationCallback(downloadAssetsMutationOptions(remoteBackend))
-  const deleteAssetsMutation = useMutationCallback(deleteAssetsMutationOptions(backend))
-  const copyAssetsMutation = useMutationCallback(copyAssetsMutationOptions(backend))
-  const restoreAssetsMutation = useMutationCallback(restoreAssetsMutationOptions(backend))
-  const moveAssetsMutation = useMutationCallback(moveAssetsMutationOptions(backend))
+  const uploadFileToCloud = useUploadFileToCloudMutation()
+  const downloadAssets = useMutationCallback(downloadAssetsMutationOptions(remoteBackend))
+  const deleteAssets = useMutationCallback(deleteAssetsMutationOptions(backend))
+  const copyAssets = useMutationCallback(copyAssetsMutationOptions(backend))
+  const restoreAssets = useMutationCallback(restoreAssetsMutationOptions(backend))
+  const moveAssets = useMutationCallback(moveAssetsMutationOptions(backend))
 
   const mutationByOperation = {
     cancel: () => Promise.resolve(),
-    move: (keys: Array<AssetId>, newParentId: DirectoryId) =>
-      moveAssetsMutation([keys, newParentId]),
-    copy: (keys: Array<AssetId>, newParentId: DirectoryId) =>
-      copyAssetsMutation([keys, newParentId]),
+    move: (keys: Array<AssetId>, newParentId: DirectoryId) => moveAssets([keys, newParentId]),
+    copy: (keys: Array<AssetId>, newParentId: DirectoryId) => copyAssets([keys, newParentId]),
     link: () => Promise.resolve(),
   } as const
 
@@ -98,7 +96,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
         case 'cloud':
         case 'user': {
           if (to.type === 'trash') {
-            await deleteAssetsMutation([keysArray, false])
+            await deleteAssets([keysArray, false])
             return
           }
 
@@ -109,7 +107,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
             }
 
             await toast.promise(
-              downloadAssetsMutation({
+              downloadAssets({
                 ids: assetsArray,
                 targetDirectoryId,
               }),
@@ -133,7 +131,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
             }
 
             if (resolution === 'confirm') {
-              await copyAssetsMutation([keysArray, targetDirectoryId])
+              await copyAssets([keysArray, targetDirectoryId])
               return
             }
           }
@@ -162,17 +160,17 @@ export function useTransferBetweenCategories(currentCategory: Category) {
               .map(([_, assetsByCategory]) => {
                 const assetsIds = assetsByCategory.map((asset) => asset.id)
 
-                return restoreAssetsMutation({
+                return restoreAssets({
                   ids: assetsIds,
                   parentId: targetDirectoryId,
                 })
               }),
             ...entries
               .filter(([category]) => category.type === 'team')
-              .map(([category, assetsByCategory]) => {
+              .map(async ([category, assetsByCategory]) => {
                 const assetsIds = assetsByCategory.map((asset) => asset.id)
 
-                return ask(AlertDialog, {
+                const resolution = await ask(AlertDialog, {
                   title: getText('actionUnavailable'),
                   confirm: getText('copyInstead'),
                   children: (
@@ -186,11 +184,11 @@ export function useTransferBetweenCategories(currentCategory: Category) {
                       </Alert>
                     </>
                   ),
-                }).then((resolution) => {
-                  if (resolution === 'confirm') {
-                    return copyAssetsMutation([assetsIds, targetDirectoryId])
-                  }
                 })
+
+                if (resolution === 'confirm') {
+                  return copyAssets([assetsIds, targetDirectoryId])
+                }
               }),
           ])
         }
@@ -201,7 +199,7 @@ export function useTransferBetweenCategories(currentCategory: Category) {
             'The Local backend must be present to transfer assets from or to the local category.',
           )
           if (isCloudCategory(to)) {
-            return uploadFileToCloudMutation(localBackend, {
+            return uploadFileToCloud(localBackend, {
               assets: assetsArray,
               targetDirectoryId,
             })


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/2124
  - Show confirmation dialog when dragging from Team category to User category

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
