### PR TITLE
Upload heap dump on OutOfMemoryError

### DIFF
--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -877,7 +877,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -962,7 +962,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, aarch64)
+          name: Heap dumps (Standard Library Native Tests, macos, aarch64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1045,7 +1045,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library Native Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1129,7 +1129,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library Native Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1213,7 +1213,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1298,7 +1298,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, aarch64)
+          name: Heap dumps (Standard Library JVM Tests, macos, aarch64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1381,7 +1381,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library JVM Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1465,7 +1465,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library JVM Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1549,7 +1549,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1634,7 +1634,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, aarch64)
+          name: Heap dumps (Standard Library Microsoft Tests, macos, aarch64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1717,7 +1717,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1801,7 +1801,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1885,7 +1885,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -1969,7 +1969,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -2053,7 +2053,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -872,12 +872,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -956,12 +957,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, aarch64)
-          path: target/dump.hprof
+          name: Heap dump (macos, aarch64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1038,12 +1040,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1121,12 +1124,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1204,12 +1208,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1288,12 +1293,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, aarch64)
-          path: target/dump.hprof
+          name: Heap dump (macos, aarch64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1370,12 +1376,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1453,12 +1460,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1536,12 +1544,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1620,12 +1629,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, aarch64)
-          path: target/dump.hprof
+          name: Heap dump (macos, aarch64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1702,12 +1712,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1785,12 +1796,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1868,12 +1880,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1951,12 +1964,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -2034,12 +2048,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -879,6 +879,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -964,6 +965,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, macos, aarch64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1047,6 +1049,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1131,6 +1134,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1215,6 +1219,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1300,6 +1305,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, macos, aarch64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1383,6 +1389,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1467,6 +1474,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1551,6 +1559,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1636,6 +1645,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, macos, aarch64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1719,6 +1729,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1803,6 +1814,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1887,6 +1899,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1971,6 +1984,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -2055,6 +2069,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -872,6 +872,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -950,6 +956,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, aarch64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1026,6 +1038,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1103,6 +1121,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1180,6 +1204,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1258,6 +1288,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, aarch64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1334,6 +1370,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1411,6 +1453,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1488,6 +1536,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1566,6 +1620,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, aarch64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1642,6 +1702,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1719,6 +1785,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1796,6 +1868,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1873,6 +1951,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1950,6 +2034,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -873,12 +873,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -958,12 +958,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, aarch64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, aarch64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1041,12 +1041,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1125,12 +1125,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1209,12 +1209,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1294,12 +1294,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, aarch64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, aarch64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1377,12 +1377,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1461,12 +1461,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1545,12 +1545,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1630,12 +1630,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, aarch64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, aarch64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1713,12 +1713,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1797,12 +1797,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1881,12 +1881,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -1965,12 +1965,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -2049,12 +2049,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -213,6 +213,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -289,6 +295,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -365,6 +377,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (macos, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -218,7 +218,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library Native Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -301,7 +301,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library JVM Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -384,7 +384,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (macos, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, macos, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -214,12 +214,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -297,12 +297,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -380,12 +380,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (macos, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (macos, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -213,12 +213,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -295,12 +296,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -377,12 +379,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (macos, amd64)
-          path: target/dump.hprof
+          name: Heap dump (macos, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks-optional.yml
+++ b/.github/workflows/engine-checks-optional.yml
@@ -220,6 +220,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -303,6 +304,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -386,6 +388,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, macos, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -476,12 +476,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -560,12 +560,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -644,12 +644,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -728,12 +728,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -812,12 +812,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -896,12 +896,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (windows, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (windows, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -480,7 +480,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -564,7 +564,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library Native Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -648,7 +648,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -732,7 +732,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library JVM Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -816,7 +816,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
@@ -900,7 +900,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (windows, amd64)
+          name: Heap dumps (Standard Library Microsoft Tests, windows, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -475,6 +475,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -552,6 +558,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -629,6 +641,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -706,6 +724,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -783,6 +807,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -860,6 +890,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (windows, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -482,6 +482,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -566,6 +567,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Native Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -650,6 +652,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -734,6 +737,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library JVM Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -818,6 +822,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -902,6 +907,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Microsoft Tests, windows, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -475,12 +475,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -558,12 +559,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -641,12 +643,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -724,12 +727,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -807,12 +811,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean
@@ -890,12 +895,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (windows, amd64)
-          path: target/dump.hprof
+          name: Heap dump (windows, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -319,7 +319,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dumps (linux, amd64)
+          name: Heap dumps (Standard Library Cloud Tests, linux, amd64)
           path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -314,6 +314,12 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
+      - name: Upload HeapDump hprof file
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: HeapDump (linux, amd64)
+          path: target/dump.hprof
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -315,12 +315,12 @@ jobs:
           path-replace-backslashes: true
           reporter: java-junit
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        name: Upload Heap Dump
+        name: Upload Heap Dumps
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: Heap dump (linux, amd64)
-          path: "*/*.hprof"
+          name: Heap dumps (linux, amd64)
+          path: "**/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -314,12 +314,13 @@ jobs:
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
-      - name: Upload HeapDump hprof file
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dump
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: HeapDump (linux, amd64)
-          path: target/dump.hprof
+          name: Heap dump (linux, amd64)
+          path: "*/*.hprof"
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/.github/workflows/extra-nightly-tests.yml
+++ b/.github/workflows/extra-nightly-tests.yml
@@ -321,6 +321,7 @@ jobs:
           if-no-files-found: ignore
           name: Heap dumps (Standard Library Cloud Tests, linux, amd64)
           path: "**/*.hprof"
+          retention-days: 3
       - if: "${{ (always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || (github.ref == 'refs/heads/develop') || inputs.clean_build_required) }}"
         name: Clean after
         run: ./run git-clean

--- a/build.sbt
+++ b/build.sbt
@@ -3851,8 +3851,9 @@ lazy val `engine-runner` = project
           "org.enso.interpreter.runtime.nativeimage.NativeLibraryFeature"
         ) ++ (if (areStdlibsIncluded) Seq(databaseFeature, azureFeature)
               else Seq())
+        // heapdump monitoring is not supported on Windows
         val enableHeapDumpOpts =
-          if (!GraalVM.EnsoLauncher.release)
+          if (!GraalVM.EnsoLauncher.release && !Platform.isWindows)
             Seq(
               "--enable-monitoring=heapdump"
             )

--- a/build.sbt
+++ b/build.sbt
@@ -3851,6 +3851,26 @@ lazy val `engine-runner` = project
           "org.enso.interpreter.runtime.nativeimage.NativeLibraryFeature"
         ) ++ (if (areStdlibsIncluded) Seq(databaseFeature, azureFeature)
               else Seq())
+        val enableHeapDumpOpts =
+          if (!GraalVM.EnsoLauncher.release)
+            Seq(
+              "--enable-monitoring=heapdump"
+            )
+          else Seq()
+        val debugOpts =
+          if (GraalVM.EnsoLauncher.debug)
+            Seq(
+              "-g",
+              "-O0",
+              "-H:+SourceLevelDebug",
+              "-H:-DeleteLocalSymbols",
+              // you may need to set smallJdk := None to use following flags:
+              // "--trace-class-initialization=org.enso.syntax2.Parser",
+              // "--diagnostics-mode",
+              // "--verbose",
+              "-Dnic=nic"
+            )
+          else Seq()
         val mp = (Runtime / modulePath).value.map(_.getAbsolutePath)
         NativeImage
           .buildNativeImage(
@@ -3881,22 +3901,7 @@ lazy val `engine-runner` = project
               "--add-opens=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
               // Snowflake uses Apache Arrow (equivalent of #9664 in native-image setup)
               "--add-opens=java.base/java.nio=ALL-UNNAMED"
-            ) ++ (if (GraalVM.EnsoLauncher.debug) {
-                    // useful perf & debug switches:
-                    Seq(
-                      "-g",
-                      "-O0",
-                      "-H:+SourceLevelDebug",
-                      "-H:-DeleteLocalSymbols",
-                      // you may need to set smallJdk := None to use following flags:
-                      // "--trace-class-initialization=org.enso.syntax2.Parser",
-                      // "--diagnostics-mode",
-                      // "--verbose",
-                      "-Dnic=nic"
-                    )
-                  } else {
-                    Seq()
-                  }),
+            ) ++ enableHeapDumpOpts ++ debugOpts,
             mainModule = Some("org.enso.runner"),
             mainClass  = Some("org.enso.runner.Main"),
             initializeAtRuntime = Seq(

--- a/build_tools/build/paths.yaml
+++ b/build_tools/build/paths.yaml
@@ -105,9 +105,6 @@
     rust/:
     test-results/:
     small-jdk/:
-    # A heap dump from the last run of the engine tests.
-    # Is created only if the engine test failed with OutOfMemoryError.
-    dump.hprof: 
   test/:
     Benchmarks/:
   tools/:

--- a/build_tools/build/paths.yaml
+++ b/build_tools/build/paths.yaml
@@ -105,6 +105,9 @@
     rust/:
     test-results/:
     small-jdk/:
+    # A heap dump from the last run of the engine tests.
+    # Is created only if the engine test failed with OutOfMemoryError.
+    dump.hprof: 
   test/:
     Benchmarks/:
   tools/:

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -370,6 +370,11 @@ impl JobArchetype for StandardLibraryTests {
             } else {
                 main_step
             };
+            let hprof_path = "target/dump.hprof";
+            let upload_hprof = step::upload_artifact("Upload HeapDump hprof file")
+                .with_custom_argument("name", format!("HeapDump ({}, {})", target.0, target.1))
+                .with_custom_argument("path", hprof_path)
+                .with_custom_argument("if-no-files-found", "ignore");
 
             vec![
                 cleanup_engine_distribution,
@@ -378,6 +383,7 @@ impl JobArchetype for StandardLibraryTests {
                 step::unpack_engine_distribution(),
                 updated_main_step,
                 step::stdlib_test_reporter(target, graal_edition),
+                upload_hprof,
             ]
         });
         let mut job = build_job_ensuring_cloud_tests_run_on_github(

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -344,6 +344,8 @@ impl JobArchetype for StandardLibraryTests {
         let scope = self.scope;
         let job_name = format!("{job_title} ({graal_edition})", job_title = self.title());
         let run_command = format!("backend test {scope}");
+        let heapdump_artifact_name =
+            format!("Heap dumps ({}, {}, {})", &self.title(), target.0, target.1);
 
         let run_steps_builder = RunStepsBuilder::new(run_command).customize(move |step| {
             let cleanup_engine_distribution = step::cleanup_engine_distribution(engine_launcher);
@@ -370,7 +372,7 @@ impl JobArchetype for StandardLibraryTests {
             } else {
                 main_step
             };
-            let upload_hprof = step::heapdump_upload(target);
+            let upload_hprof = step::heapdump_upload(heapdump_artifact_name);
 
             vec![
                 cleanup_engine_distribution,

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -370,11 +370,7 @@ impl JobArchetype for StandardLibraryTests {
             } else {
                 main_step
             };
-            let hprof_path = "target/dump.hprof";
-            let upload_hprof = step::upload_artifact("Upload HeapDump hprof file")
-                .with_custom_argument("name", format!("HeapDump ({}, {})", target.0, target.1))
-                .with_custom_argument("path", hprof_path)
-                .with_custom_argument("if-no-files-found", "ignore");
+            let upload_hprof = step::heapdump_upload(target);
 
             vec![
                 cleanup_engine_distribution,

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -60,6 +60,7 @@ pub fn heapdump_upload(artifact_name: impl Into<String>) -> Step {
     let mut step = upload_artifact("Upload Heap Dumps")
         .with_custom_argument("name", artifact_name.into())
         .with_custom_argument("path", path)
+        .with_custom_argument("retention-days", 3)
         .with_custom_argument("if-no-files-found", "ignore");
     // This step should be run every time, but not on forks.
     step.r#if = Some(format!("(success() || failure()) && {}", not_a_fork()));

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -52,6 +52,19 @@ pub fn extra_stdlib_test_reporter((os, arch): Target, graal_edition: graalvm::Ed
     test_reporter(step_name, report_name, path)
 }
 
+/// Upload heap dump of a crashed JVM on OutOfMemoryError.
+pub fn heapdump_upload((os, arch): Target) -> Step {
+    let artifact_name = format!("Heap dump ({os}, {arch})");
+    let path = "*/*.hprof";
+    let mut step = upload_artifact("Upload Heap Dump")
+        .with_custom_argument("name", artifact_name)
+        .with_custom_argument("path", path)
+        .with_custom_argument("if-no-files-found", "ignore");
+    // This step should be run every time, but not on forks.
+    step.r#if = Some(format!("(success() || failure()) && {}", not_a_fork()));
+    step
+}
+
 pub fn upload_engine_distribution(
     target: Target,
     engine_launcher: engine::EngineLauncher,

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -53,10 +53,11 @@ pub fn extra_stdlib_test_reporter((os, arch): Target, graal_edition: graalvm::Ed
 }
 
 /// Upload heap dump of a crashed JVM on OutOfMemoryError.
+/// Note that there may be multiple `*.hprof` files if multiple processes crashed.
 pub fn heapdump_upload((os, arch): Target) -> Step {
-    let artifact_name = format!("Heap dump ({os}, {arch})");
-    let path = "*/*.hprof";
-    let mut step = upload_artifact("Upload Heap Dump")
+    let artifact_name = format!("Heap dumps ({os}, {arch})");
+    let path = "**/*.hprof";
+    let mut step = upload_artifact("Upload Heap Dumps")
         .with_custom_argument("name", artifact_name)
         .with_custom_argument("path", path)
         .with_custom_argument("if-no-files-found", "ignore");

--- a/build_tools/build/src/ci_gen/step.rs
+++ b/build_tools/build/src/ci_gen/step.rs
@@ -54,11 +54,11 @@ pub fn extra_stdlib_test_reporter((os, arch): Target, graal_edition: graalvm::Ed
 
 /// Upload heap dump of a crashed JVM on OutOfMemoryError.
 /// Note that there may be multiple `*.hprof` files if multiple processes crashed.
-pub fn heapdump_upload((os, arch): Target) -> Step {
-    let artifact_name = format!("Heap dumps ({os}, {arch})");
+/// `artifact_name` should be unique for each job in the whole workflow.
+pub fn heapdump_upload(artifact_name: impl Into<String>) -> Step {
     let path = "**/*.hprof";
     let mut step = upload_artifact("Upload Heap Dumps")
-        .with_custom_argument("name", artifact_name)
+        .with_custom_argument("name", artifact_name.into())
         .with_custom_argument("path", path)
         .with_custom_argument("if-no-files-found", "ignore");
     // This step should be run every time, but not on forks.

--- a/build_tools/build/src/engine.rs
+++ b/build_tools/build/src/engine.rs
@@ -159,6 +159,8 @@ pub struct BuildConfigurationFlags {
     /// Whether the Enso standard library should be tested.
     pub test_standard_library: Option<StandardLibraryTestsSelection>,
     pub extra_engine_runner_args: Option<Vec<String>>,
+    /// Extra options passed via `JAVA_TOOL_OPTIONS` env var for the engine runner process.
+    pub extra_java_tool_opts: Option<Vec<String>>,
     /// Whether benchmarks are compiled.
     ///
     /// Note that this does not run the benchmarks, only ensures that they are buildable.
@@ -317,6 +319,14 @@ impl BuildConfigurationFlags {
             self.extra_engine_runner_args = Some(vec![flag.into()]);
         }
     }
+
+    pub fn add_java_tool_opt(&mut self, flag: &str) {
+        if let Some(java_tool_opts) = &mut self.extra_java_tool_opts {
+            java_tool_opts.push(flag.into());
+        } else {
+            self.extra_java_tool_opts = Some(vec![flag.into()]);
+        }
+    }
 }
 
 impl Default for BuildConfigurationFlags {
@@ -325,6 +335,7 @@ impl Default for BuildConfigurationFlags {
             test_jvm: false,
             test_standard_library: None,
             extra_engine_runner_args: None,
+            extra_java_tool_opts: None,
             build_small_jdk: false,
             small_jdk_dir: None,
             build_benchmarks: false,

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -386,6 +386,7 @@ impl RunContext {
                     PARALLEL_ENSO_TESTS,
                     selection.clone(),
                     self.config.extra_engine_runner_args.clone(),
+                    self.config.extra_java_tool_opts.clone(),
                     self.config.has_native_runner(),
                 )
                 .await?;

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -156,6 +156,7 @@ impl BuiltEnso {
         Ok(command)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_tests(
         &self,
         ir_caches: IrCaches,

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -114,6 +114,7 @@ impl BuiltEnso {
         ir_caches: IrCaches,
         environment_overrides: Vec<(String, String)>,
         extra_args: Option<Vec<String>>,
+        extra_java_tool_opts: Option<Vec<String>>,
         native_image: bool,
     ) -> Result<Command> {
         let mut command = if native_image {
@@ -125,16 +126,20 @@ impl BuiltEnso {
         if let Some(args) = extra_args {
             command.args(args);
         }
+        let mut java_tool_opts: Vec<String> = vec![];
+        // This flag enables assertions in the JVM. Some of our stdlib tests had in the past
+        // failed on Graal/Truffle assertions, so we want to have them triggered.
+        java_tool_opts.push(
+            <&str>::from(ide_ci::programs::java::Option::EnableAssertions.as_ref()).to_string(),
+        );
+        if let Some(opts) = extra_java_tool_opts {
+            java_tool_opts.extend(opts);
+        }
         command
             .arg(ir_caches)
             .arg("--run")
             .arg(test_path.as_ref())
-            // This flag enables assertions in the JVM. Some of our stdlib tests had in the past
-            // failed on Graal/Truffle assertions, so we want to have them triggered.
-            .set_env(
-                JAVA_TOOL_OPTIONS,
-                &ide_ci::programs::java::Option::EnableAssertions.as_ref(),
-            )?;
+            .set_env(JAVA_TOOL_OPTIONS, &java_tool_opts.join(" "))?;
 
         for (k, v) in environment_overrides {
             command.env(k, &v);
@@ -159,6 +164,7 @@ impl BuiltEnso {
         async_policy: AsyncPolicy,
         test_selection: StandardLibraryTestsSelection,
         extra_runner_args: Option<Vec<String>>,
+        extra_java_tool_opts: Option<Vec<String>>,
         native_image: bool,
     ) -> Result {
         let paths = &self.paths;
@@ -289,6 +295,7 @@ impl BuiltEnso {
                 ir_caches,
                 environment_overrides.clone(),
                 extra_runner_args.clone(),
+                extra_java_tool_opts.clone(),
                 native_image,
             );
             async move { command?.run_ok().await }

--- a/build_tools/build/src/enso.rs
+++ b/build_tools/build/src/enso.rs
@@ -127,11 +127,10 @@ impl BuiltEnso {
             command.args(args);
         }
         let mut java_tool_opts: Vec<String> = vec![];
+        let enable_asserts_opt: &str = ide_ci::programs::java::Option::EnableAssertions.as_ref();
         // This flag enables assertions in the JVM. Some of our stdlib tests had in the past
         // failed on Graal/Truffle assertions, so we want to have them triggered.
-        java_tool_opts.push(
-            <&str>::from(ide_ci::programs::java::Option::EnableAssertions.as_ref()).to_string(),
-        );
+        java_tool_opts.push(enable_asserts_opt.to_string());
         if let Some(opts) = extra_java_tool_opts {
             java_tool_opts.extend(opts);
         }

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -557,7 +557,10 @@ impl Processor {
     fn add_heapdump_opts(&self, config: &mut enso_build::engine::BuildConfigurationFlags) {
         let dump_arg = "-XX:+HeapDumpOnOutOfMemoryError";
         config.add_java_tool_opt(dump_arg);
-        config.add_engine_runner_arg(dump_arg);
+        if TARGET_OS != OS::Windows {
+            // This flag is not supported on Windows NI.
+            config.add_engine_runner_arg(dump_arg);
+        }
     }
 
     /// Get a handle to the release by its identifier.

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -434,6 +434,9 @@ impl Processor {
                                     "Microsoft_Tests".to_string(),
                                 ]));
                             config.use_native_runner = true;
+                            // TODO: Remove
+                            let one_hundred_mb = "-XX:MaxHeapSize=104857600";
+                            config.add_java_tool_opt(one_hundred_mb);
                         }
                         Tests::StdSnowflake => {
                             config.test_standard_library =

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -385,6 +385,7 @@ impl Processor {
             }
             arg::backend::Command::Test { which } => {
                 let mut config = enso_build::engine::BuildConfigurationFlags::default();
+                self.add_heapdump_opts(&mut config);
                 for arg in which {
                     match arg {
                         Tests::Jvm => {
@@ -543,6 +544,14 @@ impl Processor {
             Ok(enso_build::engine::RunContext { inner, config, paths, external_runtime: None })
         }
         .boxed()
+    }
+
+    fn add_heapdump_opts(&self, config: &mut enso_build::engine::BuildConfigurationFlags) {
+        let hprof_path = self.repo_root.target.dump_hprof.path.clone();
+        config.add_java_tool_opt("-XX:+HeapDumpOnOutOfMemoryError");
+        config.add_java_tool_opt(
+            format!("-XX:HeapDumpPath={}", hprof_path.to_string_lossy()).as_str(),
+        );
     }
 
     /// Get a handle to the release by its identifier.

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -550,8 +550,14 @@ impl Processor {
         .boxed()
     }
 
+    /// Add options to produce heap dumps on OOM errors.
+    /// It is essential to pass the `-XX:+HeapDumpOnOutOfMemoryError` option both via
+    /// `JAVA_TOOL_OPTIONS` env var and as a command line argument to the runner.
+    /// For explanation, see https://github.com/enso-org/enso/pull/13984
     fn add_heapdump_opts(&self, config: &mut enso_build::engine::BuildConfigurationFlags) {
-        config.add_java_tool_opt("-XX:+HeapDumpOnOutOfMemoryError");
+        let dump_arg = "-XX:+HeapDumpOnOutOfMemoryError";
+        config.add_java_tool_opt(dump_arg);
+        config.add_engine_runner_arg(dump_arg);
     }
 
     /// Get a handle to the release by its identifier.

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -434,10 +434,6 @@ impl Processor {
                                     "Microsoft_Tests".to_string(),
                                 ]));
                             config.use_native_runner = true;
-                            // TODO: Remove
-                            let thirty_mb = "-XX:MaxHeapSize=369377280";
-                            config.add_java_tool_opt(thirty_mb);
-                            config.add_engine_runner_arg(thirty_mb);
                         }
                         Tests::StdSnowflake => {
                             config.test_standard_library =

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -437,6 +437,7 @@ impl Processor {
                             // TODO: Remove
                             let thirty_mb = "-XX:MaxHeapSize=369377280";
                             config.add_java_tool_opt(thirty_mb);
+                            config.add_engine_runner_arg(thirty_mb);
                         }
                         Tests::StdSnowflake => {
                             config.test_standard_library =

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -435,8 +435,8 @@ impl Processor {
                                 ]));
                             config.use_native_runner = true;
                             // TODO: Remove
-                            let two_mb = "-XX:MaxHeapSize=2097152";
-                            config.add_java_tool_opt(two_mb);
+                            let thirty_mb = "-XX:MaxHeapSize=369377280";
+                            config.add_java_tool_opt(thirty_mb);
                         }
                         Tests::StdSnowflake => {
                             config.test_standard_library =

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -550,11 +550,7 @@ impl Processor {
     }
 
     fn add_heapdump_opts(&self, config: &mut enso_build::engine::BuildConfigurationFlags) {
-        let hprof_path = self.repo_root.target.dump_hprof.path.clone();
         config.add_java_tool_opt("-XX:+HeapDumpOnOutOfMemoryError");
-        config.add_java_tool_opt(
-            format!("-XX:HeapDumpPath={}", hprof_path.to_string_lossy()).as_str(),
-        );
     }
 
     /// Get a handle to the release by its identifier.

--- a/build_tools/cli/src/lib.rs
+++ b/build_tools/cli/src/lib.rs
@@ -435,8 +435,8 @@ impl Processor {
                                 ]));
                             config.use_native_runner = true;
                             // TODO: Remove
-                            let one_hundred_mb = "-XX:MaxHeapSize=104857600";
-                            config.add_java_tool_opt(one_hundred_mb);
+                            let two_mb = "-XX:MaxHeapSize=2097152";
+                            config.add_java_tool_opt(two_mb);
                         }
                         Tests::StdSnowflake => {
                             config.test_standard_library =


### PR DESCRIPTION
Relates to #13963

### Pull Request Description

If any JVM process, either HotSpotVM or SubstrateVM (NI), crashes with `OutOfMemoryError`, a heap dump is generated and uploaded as an artifact. Multiple heapdumps can be bundled in the same artifact. All engine and stdlib related GH Workflows were modified to support this.

### Important Notes

- engine-runner native image is built with `--enable-monitoring=heapdump`
  - Only if not release build.
  - See https://github.com/enso-org/enso/blob/902bbc4a4144bed4eda98038885b813951a826fc/build.sbt#L3854-L3859
  - Does not work on Windows.
- All backend commands are executed with `-XX:+HeapDumpOnOutOfMemoryError`
  - See https://github.com/enso-org/enso/blob/3b55ac63b8728c2d48b2a46b187a584bc9fe9452/build_tools/cli/src/lib.rs#L552-L554
- Every GH Action that executes stdlib or engine test has an additional `Upload Heap Dumps` step that uploads any `**/*.hprof` file.
  - Note that it is possible, although unlikely, that multiple processes will crash with OutOfMemoryError. In such exceptional case, there will be multiple `.hprof` files uploaded as a single artifact.
  - To prevent storage waste, retention period for those artifacts is set just to **3 days**.
  - Also note that it is possible that multiple jobs in the whole `1Engine Checks` workflow will have multiple crashed processes. That is why heapdump artifacts have [unique names](https://github.com/enso-org/enso/pull/13981#issuecomment-3279902355).
- The functionality was tested by setting low max heap size with `-XX:MaxHeapSize=<low-number>` to trigger multiple OOM crashes.
  - See https://github.com/enso-org/enso/pull/13981#issuecomment-3275359999

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
