### PR TITLE
Documenting unexpected cmdline opts handling of NI

### DIFF
--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -15,6 +15,8 @@ up as follows:
 - [**sbt:**](sbt.md) The build tools that are used for building the project.
 - [**Native Image:**](native-image.md) Description of the Native Image build
   used for building the `ensoup` native binary.
+- [**Dual JVM mode:**](dual_jvm.md) Description of the Dual JVM mode that allows
+  running both native-compiled code and JVM bytecode in the same process.
 - [**Rust:**](rust.md) Description of integration of the Scala project with the
   Rust components.
 - [**Upgrading GraalVM:**](upgrading-graalvm.md) Description of steps that have

--- a/docs/infrastructure/dual_jvm.md
+++ b/docs/infrastructure/dual_jvm.md
@@ -81,8 +81,8 @@ sbt:enso> runEngineDistribution --jvm
 
 ## Observing the Channel Communication
 
-- Since #13780 enable histogram of messages with `org.enso.jvm.interop.limit`
-  property
+- Since [#13780](https://github.com/enso-org/enso/pull/13780) enable histogram
+  of messages with `org.enso.jvm.interop.limit` property
 - For example by:
 
 ```bash
@@ -92,8 +92,8 @@ sbt:enso> runEngineDistribution --jvm
   --run test/Generic_JDBC_Tests
 ```
 
-- one instructs then after each 100000 messages a histogram with most frequently
-  used messages is printed
+- one instructs the system to process messages and after each 100000 messages
+- print a histogram with most frequently used message types
 
 ## References
 

--- a/docs/infrastructure/dual_jvm.md
+++ b/docs/infrastructure/dual_jvm.md
@@ -27,14 +27,15 @@ that require the JVM.
 - Native compilation can make executables very large and slow to build.
 - Maintaining NI configuration is complex, especially for third-party libraries.
 - Fast startup is important, so NI is the entry point.
-- Some components must run as JVM bytecode.
-- Running JVM code in a separate process is not efficient.
+- Some components will only be compiled to the JVM bytecode.
+- Executing JVM bytecode in a separate process is not efficient.
 
 ## When Is Dual JVM Mode Used?
 
-- When the `--jvm` option is passed to the engine runner, NI delegates execution
-  to the HotSpot VM.
-- When a library that is not NI-friendly (contains JAR files) is loaded.
+- When the `--jvm` option is passed to the engine runner, NI immediately
+  delegates execution to the HotSpot VM.
+  - This is called **JVM mode**.
+- When a library that is not NI-ready (contains JAR files) is loaded.
 - A library can require JVM mode by setting `jvm: true` in its descriptor.
 
 ## References

--- a/docs/infrastructure/dual_jvm.md
+++ b/docs/infrastructure/dual_jvm.md
@@ -1,0 +1,58 @@
+# Dual JVM Mode
+
+## Introduction
+
+Dual JVM mode allows Enso to run both native-compiled code and JVM bytecode in
+the same process. This enables fast startup and efficient execution of libraries
+that require the JVM.
+
+## Terminology
+
+- **Native Image (NI):** A compiled native executable.
+- **Substrate VM (SVM):** The runtime for NI, an alternative to the standard
+  HotSpot VM.
+- **HotSpot VM:** The standard Java Virtual Machine.
+
+## How It Works
+
+- The core of Enso is compiled to a native executable (NI).
+- Some standard, non-essential, libraries are only compiled to JVM bytecode.
+- NI cannot run JVM bytecode directly.
+  - SVM is not JVM bytecode interpreter.
+- When JVM bytecode is needed, SVM loads the HotSpot VM as a shared library.
+- Both VMs run in the same process and communicate efficiently.
+
+## Motivation
+
+- Native compilation can make executables very large and slow to build.
+- Maintaining NI configuration is complex, especially for third-party libraries.
+- Fast startup is important, so NI is the entry point.
+- Some components must run as JVM bytecode.
+- Running JVM code in a separate process is not efficient.
+
+## When Is Dual JVM Mode Used?
+
+- When the `--jvm` option is passed to the engine runner, NI delegates execution
+  to the HotSpot VM.
+- When a library that is not NI-friendly (contains JAR files) is loaded.
+- A library can require JVM mode by setting `jvm: true` in its descriptor.
+
+## References
+
+- [GraalVM Isolates](https://medium.com/graalvm/isolates-and-compressed-references-more-flexible-and-efficient-memory-management-for-graalvm-a044cc50b67e)
+- [Launching Enso programs instantly](https://github.com/orgs/enso-org/discussions/10121)
+- [Make native enso launcher smaller](https://github.com/orgs/enso-org/discussions/12446)
+
+## Related Work
+
+- [Emit a warning on non-AOT ready libraries](https://github.com/enso-org/enso/pull/12468)
+- [Handle --jvm flag in process with JNI instantiated JVM](https://github.com/enso-org/enso/pull/12843)
+- [Callback to native executable from HotSpot JVM](https://github.com/enso-org/enso/pull/13076)
+- [Channel connecting two JVM instances](https://github.com/enso-org/enso/pull/13206)
+- [Using Channel to load Java classes](https://github.com/enso-org/enso/pull/13238)
+- [Moving polyglot java import handling into EpbLanguage](https://github.com/enso-org/enso/pull/13483)
+- [Use Dual JVM mode to run StdLib Native tests](https://github.com/enso-org/enso/pull/13570)
+- [Benchmark and speed dual JVM mode up](https://github.com/enso-org/enso/pull/13780)
+- [Distributed GC between the dual JVMs](https://github.com/enso-org/enso/pull/13855)
+- [No need for jvm:true when running Generic_JDBC_Tests](https://github.com/enso-org/enso/pull/13900)
+- [Exchanging direct ByteBuffers between the dual JVMs](https://github.com/enso-org/enso/pull/13904)

--- a/docs/infrastructure/dual_jvm.md
+++ b/docs/infrastructure/dual_jvm.md
@@ -1,10 +1,27 @@
+---
+layout: developer-doc
+title: Dual JVM mode
+category: infrastructure
+tags: [infrastructure, build, native, native-image, dual-jvm]
+order: 4
+---
+
 # Dual JVM Mode
 
-## Introduction
-
-Dual JVM mode allows Enso to run both native-compiled code and JVM bytecode in
+_Dual JVM mode_ allows Enso to run both native-compiled code and JVM bytecode in
 the same process. This enables fast startup and efficient execution of libraries
 that require the JVM.
+
+<!-- MarkdownTOC levels="2,3" autolink="true" -->
+
+- [Terminology](#terminology)
+- [How It Works](#how-it-works)
+- [Motivation](#motivation)
+- [When Is Dual JVM Mode Used?](#when-is-dual-jvm-mode-used)
+- [References](#references)
+- [Related Work](#related-work)
+
+<!-- /MarkdownTOC -->
 
 ## Terminology
 

--- a/docs/infrastructure/dual_jvm.md
+++ b/docs/infrastructure/dual_jvm.md
@@ -17,7 +17,7 @@ that require the JVM.
 - [Terminology](#terminology)
 - [How It Works](#how-it-works)
 - [Motivation](#motivation)
-- [When Is Dual JVM Mode Used?](#when-is-dual-jvm-mode-used)
+- [Forcing JVM Mode](#forcing-jvm-mode)
 - [References](#references)
 - [Related Work](#related-work)
 
@@ -26,15 +26,21 @@ that require the JVM.
 ## Terminology
 
 - **Native Image (NI):** A compiled native executable.
-- **Substrate VM (SVM):** The runtime for NI, an alternative to the standard
-  HotSpot VM.
+- **Substrate VM (SVM):** Java runtime for NI
+  - "host JVM" in the production mode
 - **HotSpot VM:** The standard Java Virtual Machine.
+  - "guest JVM" in the production mode
+  - the only JVM when `--jvm` switch is used
+- [Channel](https://github.com/enso-org/enso/pull/13206) connects the two JVMs
+  together
+  - can be [mocked in a single JVM](#debugging-a-mock-mode)
 
 ## How It Works
 
 - The core of Enso is compiled to a native executable (NI).
-- Some standard, non-essential, libraries are only compiled to JVM bytecode.
-- NI cannot run JVM bytecode directly.
+- Some standard, essential libraries are compiled into NI as well
+- Other less essential libraries are only compiled to JVM bytecode.
+  - NI cannot run JVM bytecode directly.
   - SVM is not JVM bytecode interpreter.
 - When JVM bytecode is needed, SVM loads the HotSpot VM as a shared library.
 - Both VMs run in the same process and communicate efficiently.
@@ -47,13 +53,47 @@ that require the JVM.
 - Some components will only be compiled to the JVM bytecode.
 - Executing JVM bytecode in a separate process is not efficient.
 
-## When Is Dual JVM Mode Used?
+## Forcing JVM Mode
 
 - When the `--jvm` option is passed to the engine runner, NI immediately
   delegates execution to the HotSpot VM.
   - This is called **JVM mode**.
 - When a library that is not NI-ready (contains JAR files) is loaded.
 - A library can require JVM mode by setting `jvm: true` in its descriptor.
+
+## Debugging a Mock Mode
+
+- to mock "dual JVM" mode in HotSpot JVM specify which libraries should use the
+  _"host JVM"_ (e.g. behave like being compiled into NI in production) and which
+  the _"guest JVM"_ (e.g. be loaded via HotSpot in production).
+- For example:
+
+```bash
+sbt:enso> runEngineDistribution --jvm
+  --vm.D=polyglot.enso.classLoading=Standard.Base:hosted,guest
+  --run test/Base_Tests/ --debug
+```
+
+- says that `Standard.Base` should use _host JVM_ and all other libraries should
+  use the _guest JVM_
+- this mode is then **easy to debug** as everything is mocked inside of a single
+  HotSpot JVM
+
+## Observing the Channel Communication
+
+- Since #13780 enable histogram of messages with `org.enso.jvm.interop.limit`
+  property
+- For example by:
+
+```bash
+sbt:enso> runEngineDistribution --jvm
+  --vm.D=org.enso.jvm.interop.limit=100000
+  --vm.D=polyglot.enso.classLoading=Standard.Base:hosted,guest
+  --run test/Generic_JDBC_Tests
+```
+
+- one instructs then after each 100000 messages a histogram with most frequently
+  used messages is printed
 
 ## References
 

--- a/docs/infrastructure/logging.md
+++ b/docs/infrastructure/logging.md
@@ -3,7 +3,7 @@ layout: developer-doc
 title: Logging Service
 category: infrastructure
 tags: [infrastructure, logging, debug]
-order: 6
+order: 7
 ---
 
 # Logging

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -364,3 +364,8 @@ Also note that the output of the aforementioned command will be different based
 on how the native image was built. For example, if it was built with
 `--enable-monitoring=heapdump`, the `Debug` section will contain help for
 `HeapDumpOnOutOfMemoryError` flag.
+
+In context of [Dual JVM mode](dual_jvm.md):
+
+- `JAVA_TOOL_OPTIONS` env var is only handled by HotSpot VM.
+  - Substrate VM ignores this env var.

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -331,7 +331,10 @@ once can generate a
 that allows to inspect classes, fields, methods, and other contents of the
 generated binary.
 
-### Helpful cmdline options
+### Helpful cmdline build options
+
+This subsection talks about some command line options that may be useful when
+building the native image via the `native-image` tool.
 
 - Since
   [GraalVM JDK 24](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.0),
@@ -340,3 +343,24 @@ generated binary.
   `env NATIVE_IMAGE_OPTIONS=--verbose sbt engine-runner/buildNativeImage`.
 - `--diagnostics` - generates a report with information about the generated
   image - classes initialized at runtime and buildtime, cmdline options, etc.
+
+### Runtime cmdline options
+
+When NI is build, there will be a special cmdline option handling procedure
+executed before the `main` method, which ensures that, e.g., `-XX:...` options
+are correctly passed to the Substrate VM. To see available options, run:
+
+```
+$ ./built-distribution/enso-engine-*/enso-*/bin/enso -XX:PrintFlags=[User|Debug|Expert]
+```
+
+Note that this is a **different behavior** than when running on a regular
+HotSpot VM, where `-XX:...` options need to be passed via `JAVA_TOOL_OPTIONS`
+env var. In other words, in the aforementioned example, if `enso` is not a
+binary produced by native image, that command will fail with
+`Unrecognized option: -XX:PrintFlags=User`.
+
+Also note that the output of the aforementioned command will be different based
+on how the native image was built. For example, if it was built with
+`--enable-monitoring=heapdump`, the `Debug` section will contain help for
+`HeapDumpOnOutOfMemoryError` flag.

--- a/docs/infrastructure/native-image.md
+++ b/docs/infrastructure/native-image.md
@@ -344,7 +344,7 @@ building the native image via the `native-image` tool.
 - `--diagnostics` - generates a report with information about the generated
   image - classes initialized at runtime and buildtime, cmdline options, etc.
 
-### Runtime cmdline options
+### Runtime VM options
 
 When NI is build, there will be a special cmdline option handling procedure
 executed before the `main` method, which ensures that, e.g., `-XX:...` options

--- a/docs/infrastructure/rust.md
+++ b/docs/infrastructure/rust.md
@@ -3,7 +3,7 @@ layout: developer-doc
 title: Rust
 category: infrastructure
 tags: [infrastructure, build, rust]
-order: 4
+order: 5
 ---
 
 # Rust

--- a/docs/infrastructure/upgrading-graalvm.md
+++ b/docs/infrastructure/upgrading-graalvm.md
@@ -3,7 +3,7 @@ layout: developer-doc
 title: Upgrading GraalVM
 category: infrastructure
 tags: [infrastructure, build, graalvm, graal, jvm]
-order: 5
+order: 6
 ---
 
 # Upgrading GraalVM


### PR DESCRIPTION
### Pull Request Description

When experimenting with NI, I found out that I have to pass `-XX` options directly to the native executable, rather than via `JAVA_TOOL_OPTIONS` env var. Adding docs for this unexpected behavior.

Demonstrating on few examples. `enso-native` is a binary produced with `ENSO_LAUNCHER=native`, whereas, `enso-jvm` is a shell script launcher produced with `ENSO_LAUNCHER=shell`. Let's set max heap size to 2 MB and try to run Base_Tests.

```
$ enso-native -XX:MaxHeapSize=2097152 --run test/Base_Tests
Garbage-collected heap size exceeded. Consider increasing the maximum Java heap size, for example with '-Xmx'.

$ env JAVA_TOOLS_OPTIONS='-XX:MaxHeapSize=2097152' enso-native --run test/Base_Tests
... (succeeds) ...
```

But it is different for `enso-jvm`:
```
$ enso-jvm -XX:MaxHeapSize=2097152 --run test/Base_Tests
...
Unrecognized option: -XX:MaxHeapSize=2097152

$ env JAVA_TOOLS_OPTIONS='-XX:MaxHeapSize=2097152' enso-jvm --run test/Base_Tests
Error occurred during initialization of boot layer
java.lang.OutOfMemoryError: Java heap space
```

### TL;DR
**!!! `JAVA_TOOL_OPTIONS` env var is completely ignored by NI !!!**
