### PR TITLE
Fix exporting archives with many files on Local backend

### DIFF
--- a/app/gui/src/dashboard/services/LocalBackend.ts
+++ b/app/gui/src/dashboard/services/LocalBackend.ts
@@ -12,7 +12,6 @@ import * as projectManager from '#/services/ProjectManager'
 import type { ProjectManager } from '#/services/ProjectManager/ProjectManager'
 import { download } from '#/utilities/download'
 import { tryGetMessage } from '#/utilities/error'
-import { unsafeEntries } from '#/utilities/object'
 import { getDirectoryAndName, joinPath } from '#/utilities/path'
 import type { GetText } from '$/providers/text'
 import { PRODUCT_NAME } from 'enso-common'
@@ -834,16 +833,12 @@ export default class LocalBackend extends Backend {
   override async exportArchive(
     params: backend.ExportArchiveParams,
   ): Promise<backend.ExportedArchive> {
-    const entries = unsafeEntries(params).flatMap<[string, string]>(([paramName, v]) =>
-      paramName === 'assetIds' ? v.map<[string, string]>((id) => ['asset', id])
-      : v != null ? [[paramName, v]]
-      : [],
-    )
-    const searchParams = new URLSearchParams(entries).toString()
+    const { filePath, ...body } = params
+    const searchParams = new URLSearchParams(filePath != null ? { filePath } : {}).toString()
     const path = `${EXPORT_ARCHIVE_PATH}?${searchParams}`
     if (params.filePath != null) {
       // Assume it is Electron, copy files through Electron server directly
-      const response = await this.post<backend.ExportedArchive>(path, {})
+      const response = await this.post<backend.ExportedArchive>(path, body)
       if (!response.ok) {
         return this.throw(response, 'exportArchiveBackendError')
       }

--- a/app/ide-desktop/client/src/server.ts
+++ b/app/ide-desktop/client/src/server.ts
@@ -5,6 +5,7 @@ import * as http from 'node:http'
 import * as https from 'node:https'
 import * as path from 'node:path'
 import * as stream from 'node:stream'
+import * as streamConsumers from 'node:stream/consumers'
 
 import createServer from 'create-servers'
 import * as mime from 'mime-types'
@@ -850,43 +851,49 @@ export class Server {
 
   /** Response handler for "download archive" endpoint. */
   async httpDownloadArchive(
-    _request: http.IncomingMessage,
+    request: http.IncomingMessage,
     response: http.ServerResponse,
     params: URLSearchParams,
   ) {
-    const assets = params.getAll('asset') as AssetId[]
-    const filePath = params.get('filePath')
-    const archive = this.apiArchiveStream(assets)
-    let promise: Promise<void> | undefined
-    if (filePath != null) {
-      promise = finished(archive.stream.pipe(createWriteStream(filePath)))
-    } else {
-      response.writeHead(HTTP_STATUS_OK, [
-        ['Content-Type', 'application/octet-stream'],
-        ...COOP_COEP_CORP_HEADERS,
-      ])
-      await finished(archive.stream.pipe(response))
-    }
-
-    if (filePath == null) {
-      // The HTTP headers were already sent
-      return
-    }
-    const error = await archive.promise
-    if (error) {
-      const content = JSON.stringify({ error: `Asset '${error.id}' not found` })
-      response
-        .writeHead(HTTP_STATUS_NOT_FOUND, [
-          ['Content-Length', String(content.length)],
-          ['Content-Type', 'application/json'],
+    try {
+      // This is SAFE because it is wrapped in a try-catch.
+      // If the body is invalid, an error will be thrown and handled.
+      const { assetIds } = (await streamConsumers.json(request)) as { assetIds: readonly AssetId[] }
+      const filePath = params.get('filePath')
+      const archive = this.apiArchiveStream(assetIds)
+      let promise: Promise<void> | undefined
+      if (filePath != null) {
+        promise = finished(archive.stream.pipe(createWriteStream(filePath)))
+      } else {
+        response.writeHead(HTTP_STATUS_OK, [
+          ['Content-Type', 'application/octet-stream'],
           ...COOP_COEP_CORP_HEADERS,
         ])
-        .end(content)
+        await finished(archive.stream.pipe(response))
+      }
+
+      if (filePath == null) {
+        // The HTTP headers were already sent
+        return
+      }
+      const error = await archive.promise
+      if (error) {
+        const content = JSON.stringify({ error: `Asset '${error.id}' not found` })
+        response
+          .writeHead(HTTP_STATUS_NOT_FOUND, [
+            ['Content-Length', String(content.length)],
+            ['Content-Type', 'application/json'],
+            ...COOP_COEP_CORP_HEADERS,
+          ])
+          .end(content)
+      }
+      await promise
+      this.httpOkJson<ExportedArchive>(response, {
+        filePath: Path(filePath),
+      })
+    } catch (error) {
+      this.httpError(response, error instanceof Error ? error.message : String(error))
     }
-    await promise
-    this.httpOkJson<ExportedArchive>(response, {
-      filePath: Path(filePath),
-    })
   }
 
   /** Get details for an asset by its path. */

--- a/app/ide-desktop/client/src/server.ts
+++ b/app/ide-desktop/client/src/server.ts
@@ -857,8 +857,22 @@ export class Server {
   ) {
     try {
       // This is SAFE because it is wrapped in a try-catch.
-      // If the body is invalid, an error will be thrown and handled.
-      const { assetIds } = (await streamConsumers.json(request)) as { assetIds: readonly AssetId[] }
+      // If the body is not valid JSON, an error will be thrown and handled.
+      const body = await streamConsumers.json(request)
+      const assetIds =
+        (
+          typeof body === 'object' &&
+          body &&
+          'assetIds' in body &&
+          Array.isArray(body.assetIds) &&
+          body.assetIds.every((id) => typeof id === 'string')
+        ) ?
+          body.assetIds.map((id) => AssetId(id))
+        : null
+      if (!assetIds) {
+        this.httpError(response, 'Asset IDs invalid or missing.')
+        return
+      }
       const filePath = params.get('filePath')
       const archive = this.apiArchiveStream(assetIds)
       let promise: Promise<void> | undefined


### PR DESCRIPTION
### Pull Request Description
- Fix exporting archives with many files on the Local backend
  - This was happening because we were providing the asset list (for the Local backend only) in the URL, which has a size limit. The asset list is now being sent in the body which has no such size limit.

### Reproduction Steps
- Import this archive to the Local backend. It contains a large number of folders (~480)
[even more folders.zip](https://github.com/user-attachments/files/22275660/even.more.folders.zip)
- Hold down <kbd>End</kbd> until all assets are loaded
- Click last asset, scroll, shift-click first asset to select all assets
- Export archive using any method (the button on the toolbar, or the right click context menu)
- Observe an error on `develop`, which is fixed in this PR

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
