### PR TITLE
chore: Fix IDE builds under Bazel 8.2.0 + macOS + Nix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,13 @@ bazel_dep(name = "rules_rust", version = "0.59.2")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
+    # Add the custom directory for libiconv to the library search path.
+    # The exact path comes from `nixpkgs2` in `flake.lock` and must be kept in sync.
+    # NOTE [NP]: Required to be able to build under macOS + Bazel + Nix.
+    extra_exec_rustc_flags = [
+        "-L",
+        "/nix/store/pff8c9a4l487r0jaipibq21mkww5f1yw-libiconv-109/lib",
+    ],
     extra_target_triples = ["wasm32-unknown-unknown"],
     versions = ["nightly/2024-08-08"],
 )

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1731738660,
-        "narHash": "sha256-tIXhc9lX1b030v812yVJanSR37OnpTb/OY5rU3TbShA=",
+        "lastModified": 1757572889,
+        "narHash": "sha256-tPmVhFoet1ijKduGpmh1uHw5eayjcaHvu3GodIVF9ac=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e10ba121773f754a30d31b6163919a3e404a434f",
+        "rev": "4e37fff6b22c58717577a2006c3907c9eef452dc",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731890469,
-        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -39,17 +39,17 @@
     },
     "nixpkgs2": {
       "locked": {
-        "lastModified": 1756734560,
-        "narHash": "sha256-ea0O/1aE5obS9nacuUvey6s85tayo6nXzDAM5DAhKgk=",
+        "lastModified": 1757105348,
+        "narHash": "sha256-w7/DCw7RsSaFkci45CbsjbyojNhO29Ssmer9qni0M/k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0feb4cf3d7931133c4e8e7a558e8153f13fe6b6a",
+        "rev": "ebf9d4445d9e916239caa8d12a510e94a6d58a2f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0feb4cf3d7931133c4e8e7a558e8153f13fe6b6a",
+        "rev": "ebf9d4445d9e916239caa8d12a510e94a6d58a2f",
         "type": "github"
       }
     },
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1731693936,
-        "narHash": "sha256-uHUUS1WPyW6ohp5Bt3dAZczUlQ22vOn7YZF8vaPKIEw=",
+        "lastModified": 1757362324,
+        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "1b90e979aeee8d1db7fe14603a00834052505497",
+        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
     fenix.url = github:nix-community/fenix;
     fenix.inputs.nixpkgs.follows = "nixpkgs";
-    nixpkgs2.url = "github:nixos/nixpkgs?rev=0feb4cf3d7931133c4e8e7a558e8153f13fe6b6a";
+    nixpkgs2.url = "github:nixos/nixpkgs?rev=ebf9d4445d9e916239caa8d12a510e94a6d58a2f";
   };
   outputs = { self, nixpkgs, nixpkgs2, fenix }:
     let
@@ -27,8 +27,9 @@
                 minimal.rustc
                 targets.x86_64-unknown-linux-musl.latest.rust-std
               ] else fenix.packages.${system}.minimal.toolchain;
+
             # https://github.com/NixOS/nixpkgs/blob/618c81f7b15d3e2dd73d9d413d9e7b13fbc9520f/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix#L58
-            defaultShellUtils = with pkgs; [
+            defaultShellUtils = with pkgs2; [
               bash
               coreutils
               diffutils
@@ -46,16 +47,69 @@
               zip
               makeWrapper
             ];
+            # First: override stdenv like upstream did.
+            # NOTE [NP]: This workaround should not be necessary from Bazel 8.4.0 onwards.
+            version = "8.2.1";
+            bazelBase = pkgs2.bazel_8.override {
+              inherit version;
+              stdenv =
+                if pkgs2.stdenv.cc.isClang
+                then pkgs2.llvmPackages_17.stdenv
+                else pkgs2.stdenv;
+            };
             # https://github.com/NixOS/nixpkgs/blob/618c81f7b15d3e2dd73d9d413d9e7b13fbc9520f/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix#L257
-            defaultShellPath = pkgs.lib.makeBinPath defaultShellUtils;
-            bazel = (pkgs2.bazel_8.overrideAttrs (self: super: {
-              patches = super.patches ++ [
-                (pkgs.substituteAll {
-                  src = ./nix/patches/bazel_actions_path.patch;
-                  actionsPathPatch = defaultShellPath;
-                })
-              ];
-            }));
+            defaultShellPath = pkgs2.lib.makeBinPath defaultShellUtils;
+            bazel =
+              (bazelBase.overrideAttrs (final: prev: {
+                # Downgrade the version from 8.4.0 to 8.2.1 (needs to match our `.bazelversion`).
+                inherit version;
+                src = pkgs2.fetchzip {
+                  url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
+                  hash = "sha256-aMvIadR0pXgdkz/8dzLfS79ubmYdwOLu4yECI06wvgI=";
+                  stripRoot = false;
+                };
+
+                patches =
+                  let
+                    isDarwin = pkgs2.stdenv.isDarwin;
+                    # Wrap the `codesign` binary required by Bazel on macOS so that `cctools` is
+                    # present in the `PATH` and therefore the binary can find `codesign_allocate`.
+                    sigtoolWrapped = pkgs2.runCommand "sigtool-wrapped" { buildInputs = [ pkgs2.makeWrapper ]; } ''
+                      mkdir -p $out/bin
+                      makeWrapper ${pkgs2.darwin.sigtool}/bin/codesign $out/bin/codesign \
+                        --prefix PATH : ${pkgs2.darwin.cctools}/bin
+                    '';
+                  in
+                  # Filter out upstream patches that are not compatible with our version.
+                    # Drop the Darwin-only pathches only on Darwin; drop `deps_patches` everywhere.
+                  (builtins.filter (p:
+                    let matches = a: b: pkgs2.lib.hasSuffix a (baseNameOf (toString b));
+                    in !(matches "deps_patches.patch" p)
+                    && (!isDarwin || !(matches "apple_cc_toolchain.patch" p || matches "xcode.patch" p))
+                  )) prev.patches
+                  # Add our non-conditional patch replacements.
+                  ++ [
+                    ./nix/patches/deps_patches.patch
+                  ]
+                  # Add our Darwin-only replacements.
+                  ++ pkgs2.lib.optionals isDarwin [
+                    ./nix/patches/apple_cc_toolchain.patch
+                    (pkgs2.replaceVars ./nix/patches/xcode.patch {
+                      usrBinEnv = "${pkgs2.coreutils}/bin/env";
+                      clangDarwin = "${pkgs2.stdenv.cc}/bin/clang";
+                      # Replace the upstream `${darwin.sigtool}/bin/codesign` with an actual `codesign`.
+                      # Necessary to properly sign binaries on macOS.
+                      codesign = "${sigtoolWrapped}/bin/codesign";
+                    })
+                  ]
+                  # Apply extra patch to fix the `$PATH` issues with `pnpm`.
+                  ++ [
+                    (pkgs2.replaceVars ./nix/patches/bazel_actions_path.patch {
+                      actionsPathPatch = defaultShellPath;
+                    })
+                  ];
+              }));
+
             pnpm-shim = pkgs.writeShellScriptBin "pnpm" ''
               set -euo pipefail
               PACKAGE_JSON=$(git rev-parse --show-toplevel)/package.json
@@ -88,8 +142,7 @@
               pkg-config
             ] ++ (if !isOnLinux then [
               # === macOS-specific dependencies ===
-              darwin.apple_sdk.frameworks.IOKit # Required by `enso-formatter`.
-              darwin.apple_sdk.frameworks.Security # Required by `enso-formatter`.
+              libiconv # Required by `sysinfo` (via `ide_ci`).
             ] else [ ]);
 
             packages = with pkgs; [
@@ -109,10 +162,6 @@
             ];
 
             shellHook = ''
-              # `sccache` can be used to speed up compile times for Rust crates.
-              # `~/.cargo/bin/sccache` is provided by `cargo install sccache`.
-              # `~/.cargo/bin` must be in the `PATH` for the binary to be accessible.
-              export PATH=$HOME/.cargo/bin:$PATH
               export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
             '';
           });

--- a/nix/patches/apple_cc_toolchain.patch
+++ b/nix/patches/apple_cc_toolchain.patch
@@ -1,0 +1,18 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 11a6075175..f53f0c732b 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -35,10 +35,10 @@ bazel_dep(name = "with_cfg.bzl", version = "0.6.0")
+ bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
+ bazel_dep(name = "rules_shell", version = "0.2.0")
+
+-# Depend on apple_support first and then rules_cc so that the Xcode toolchain
+-# from apple_support wins over the generic Unix toolchain from rules_cc.
+-bazel_dep(name = "apple_support", version = "1.18.1")
++# Not Depend on apple_support first and then rules_cc so that the Xcode toolchain
++# from apple_support not wins over the generic Unix toolchain from rules_cc.
+ bazel_dep(name = "rules_cc", version = "0.0.17")
++bazel_dep(name = "apple_support", version = "1.18.1")
+
+ # repo_name needs to be used, until WORKSPACE mode is to be supported in bazel_tools
+ bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")

--- a/nix/patches/bazel_actions_path.patch
+++ b/nix/patches/bazel_actions_path.patch
@@ -14,7 +14,7 @@ index 6fff2af..7e2877e 100644
 +    // See, https://github.com/NixOS/nixpkgs/issues/94222
 +    // So we ensure that minimal dependencies are present.
 +    result.put("PATH", "@actionsPathPatch@");
-+ 
++
      String p = clientEnv.get("TMPDIR");
      if (Strings.isNullOrEmpty(p)) {
        // Do not use `fallbackTmpDir`, use `/tmp` instead. This way if the user didn't export TMPDIR

--- a/nix/patches/deps_patches.patch
+++ b/nix/patches/deps_patches.patch
@@ -1,0 +1,23 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 11a6075175..e31249490c 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -25,10 +25,18 @@ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
+ bazel_dep(name = "blake3", version = "1.5.1.bcr.1")
+ bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+ bazel_dep(name = "rules_java", version = "8.11.0")
++single_version_override(
++    module_name = "rules_java",
++    patches = ["//third_party:rules_java.patch"],
++)
+ bazel_dep(name = "rules_graalvm", version = "0.11.1")
+ bazel_dep(name = "rules_proto", version = "7.0.2")
+ bazel_dep(name = "rules_jvm_external", version = "6.0")
+ bazel_dep(name = "rules_python", version = "0.40.0")
++single_version_override(
++    module_name = "rules_python",
++    patches = ["//third_party:rules_python.patch"],
++)
+ bazel_dep(name = "rules_testing", version = "0.6.0")
+ bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+ bazel_dep(name = "with_cfg.bzl", version = "0.6.0")

--- a/nix/patches/xcode.patch
+++ b/nix/patches/xcode.patch
@@ -1,0 +1,30 @@
+diff --git a/scripts/bootstrap/compile.sh b/scripts/bootstrap/compile.sh
+index 1bad14cba7..d312fe08bb 100755
+--- a/scripts/bootstrap/compile.sh
++++ b/scripts/bootstrap/compile.sh
+@@ -402,7 +402,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
+ # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
+ log "Compiling xcode-locator..."
+ if [[ $PLATFORM == "darwin" ]]; then
+-  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
++  run @clangDarwin@ -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/xcode-locator tools/osx/xcode_locator.m
+ else
+   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/xcode-locator
+ fi
+diff --git a/tools/osx/BUILD b/tools/osx/BUILD
+index 0358fb0ffe..1e6eae1f33 100644
+--- a/tools/osx/BUILD
++++ b/tools/osx/BUILD
+@@ -27,9 +27,9 @@ exports_files([
+ ])
+
+ DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
+-  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
+-      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
+-  env -i codesign --identifier $@ --force --sign - $@
++  @clangDarwin@ -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
++      -framework Foundation -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
++  @usrBinEnv@ @codesign@ --identifier $@ --force --sign - $@
+ """
+
+ genrule(


### PR DESCRIPTION
### Pull Request Description

Previously, IDE builds were broken under Bazel 8.2.0 + macOS + Nix. This commit fixes that issue by:

1. Repairing the Bazel 8.2.0 package to successfully compile under macOS;
2. Modifying the library search path for the Rust toolchain under Bazel to be aware of the Nix store path to libiconv, which is required when compiling Rust binaries under macOS.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
