### PR TITLE
Check IR cache sizes on the CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,22 @@ packageBuilder := {
   )
 }
 
+lazy val checkIRCacheSizes = taskKey[Unit](
+  "Checks that the IR caches of all standard libraries are within the size limit."
+)
+checkIRCacheSizes := Def
+  .task {
+    val stdLibRoot =
+      engineDistributionRoot.value / "lib" / "Standard"
+    IRCaches.checkCacheSizes(
+      stdLibRoot  = stdLibRoot,
+      ensoVersion = ensoVersion,
+      log         = streams.value.log
+    )
+  }
+  .dependsOn(buildEngineDistribution)
+  .value
+
 Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / excludeLintKeys += logManager
 

--- a/build_tools/build/src/engine/context.rs
+++ b/build_tools/build/src/engine/context.rs
@@ -336,6 +336,11 @@ impl RunContext {
 
         // === End of Build project-manager distribution and native image ===
 
+        if self.config.build_engine_package {
+            debug!("Checking IR cache sizes of std libs.");
+            sbt.call_arg("checkIRCacheSizes").await?;
+        }
+
         let ret = self.expected_artifacts();
 
         // Native images built by GraalVM on Windows use MSVC build tools. Thus, the generated

--- a/project/IRCaches.scala
+++ b/project/IRCaches.scala
@@ -1,0 +1,62 @@
+import sbt.*
+
+import java.io.File
+
+object IRCaches {
+
+  /** As of 2025-09-12, on latest develop (https://github.com/enso-org/enso/commit/b1f5f661b9ad45604b6e419d79b8bcb2d2cd59e6),
+    * the total cache size is 114.91 MB.
+    */
+  val EXPECTED_MAX_SIZE_MB = 116
+
+  /** Ensures that IR caches of all standard libraries
+    * are within the size limit.
+    * @param stdLibRoot Root dir for std libs inside `built-distribution`
+    */
+  def checkCacheSizes(
+    stdLibRoot: File,
+    ensoVersion: String,
+    log: Logger
+  ): Unit = {
+    var totalBytes: Double = 0
+    for (libName <- stdLibRoot.listFiles()) {
+      val libDir    = libName / ensoVersion
+      val cacheSize = getCacheSizeForLib(libDir, log)
+      totalBytes += cacheSize
+    }
+    val totalMBs = totalBytes / (1024 * 1024)
+    if (totalMBs > EXPECTED_MAX_SIZE_MB) {
+      throw new IllegalStateException(
+        f"IR cache size $totalMBs%.2f MB exceeds the expected maximum of $EXPECTED_MAX_SIZE_MB MB"
+      )
+    }
+    log.info(
+      f"Libs cache size check successful: $totalMBs%.2f/$EXPECTED_MAX_SIZE_MB MB"
+    )
+  }
+
+  /** Lib cache size in bytes.
+    * @param libDir Root lib dir.
+    * @return
+    */
+  private def getCacheSizeForLib(
+    libDir: File,
+    log: Logger
+  ): Double = {
+    object FileOnlyFilter extends sbt.io.FileFilter {
+      def accept(arg: File): Boolean = arg.isFile
+    }
+    val cacheDir   = libDir / ".enso"
+    val glob       = cacheDir.globRecursive(FileOnlyFilter)
+    val cacheFiles = glob.get()
+    if (cacheFiles.isEmpty) {
+      throw new IllegalStateException(
+        s"No IR cache files found in $libDir." +
+        "Ensure buildEngineDistribution was run prior to this check."
+      )
+    }
+    val cacheSize: Long = cacheFiles.map(_.length()).sum
+    log.debug(s"IR cache size for ${libDir.getAbsolutePath}: $cacheSize B")
+    cacheSize
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Ensures that all the IR cache directories of all the std libraries are within the expected limit. This will ensure that the cache sizes will not regress over time.

### Important Notes

- Implemented as a new `checkIRCacheSizes` sbt task.
- Called from Rust build script after it builds the engine distribution.
- Principally similar to [Native image size check](https://github.com/enso-org/enso/pull/12996)
- Current size of all caches is [114.91 MB](https://github.com/enso-org/enso/blob/5c5ca6df012a40bd6f14035276611d9a36590132/project/IRCaches.scala#L7-L8).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
