### PR TITLE
Moving `|>` operator to Function

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Any.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Any.md
@@ -15,4 +15,3 @@
     - to self target_type:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
-    - |> self ~function:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Function.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Function.md
@@ -9,3 +9,4 @@
 - flip f:Standard.Base.Any.Any x:Standard.Base.Any.Any y:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - identity x:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - uncurry f:Standard.Base.Any.Any pair:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- Standard.Base.Any.Any.|> self ~function:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -426,32 +426,3 @@ type Any
         Nothing -> Nothing
         a -> f a
 
-    ## ---
-       private: true
-       advanced: true
-       group: Operators
-       ---
-       Applies the function on the right hand side to the argument on the left.
-
-       ## Arguments
-        - `function`: The function to apply to `self`.
-
-       ## Examples
-       ### Applying multiple functions in a pipeline to compute a number and transform
-         it to text.
-
-       ```
-             1 |> (* 2) |> (/ 100) |> .to_text
-       ```
-
-       ## Remarks
-
-       ### `|>` or `.`?
-       The eagle-eyed reader will notice that the operator dot (`.`) is very
-       similar to the operator `|>`. In Enso, with the variable precedence of
-       operators, this makes perfect sense. In general, we recommend using `.`.
-       However, there are some contexts where variable precedence might be
-       unclear or confusing, or where the function being applied is not a method.
-       In these contexts we recommend using `|>`.
-    |> : (Any -> Any) -> Any
-    |> self ~function = function self

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
@@ -15,6 +15,8 @@ import project.Internal.Time.Format.Tokenizer.Tokenizer
 import project.Nothing.Nothing
 import project.Panic.Panic
 
+from project.Function import all
+
 polyglot java import java.lang.Exception as JException
 polyglot java import java.time.format.DateTimeFormatter
 polyglot java import org.enso.base.time.EnsoDateTimeFormatter

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -42,6 +42,7 @@ import project.System.File_Format_Metadata.File_Format_Metadata
 import project.System.Input_Stream.Input_Stream
 import project.System.Output_Stream.Output_Stream
 from project.Error import all
+from project.Function import all
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
 from project.Enso_Cloud.Internal.Enso_File_Helpers import all

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Function.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Function.enso
@@ -155,3 +155,33 @@ curry f = x -> y -> f [x, y]
     - `f`: function accepting multiple arguments
 uncurry : (Any -> Any -> Any) -> (Vector Any -> Any)
 uncurry f = (pair -> f pair.first pair.second)
+
+## ---
+   private: true
+   advanced: true
+   group: Operators
+   ---
+   Applies the function on the right hand side to the argument on the left.
+
+   ## Arguments
+    - `function`: The function to apply to `self`.
+
+   ## Examples
+   ### Applying multiple functions in a pipeline to compute a number and transform
+     it to text.
+
+   ```
+         1 |> (* 2) |> (/ 100) |> .to_text
+   ```
+
+   ## Remarks
+
+   ### `|>` or `.`?
+   The eagle-eyed reader will notice that the operator dot (`.`) is very
+   similar to the operator `|>`. In Enso, with the variable precedence of
+   operators, this makes perfect sense. In general, we recommend using `.`.
+   However, there are some contexts where variable precedence might be
+   unclear or confusing, or where the function being applied is not a method.
+   In these contexts we recommend using `|>`.
+Any.|> : (Any -> Any) -> Any
+Any.|> self ~function = function self

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/Writable_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/Writable_File.enso
@@ -8,6 +8,8 @@ import project.System.File.Generic.File_Like.File_Like
 import project.System.File.Generic.File_Write_Strategy.File_Write_Strategy
 import project.System.File_Format_Metadata.File_Format_Metadata
 import project.System.Output_Stream.Output_Stream
+
+from project.Function import all
 from project.Data.Boolean import Boolean
 
 ## ---


### PR DESCRIPTION
### Pull Request Description

- continuation of #13978 
- and of #14003 
- let's make `|>` operator an extension operator provided by `Function`
- there is no API change for those who `from Standard.Base import all`


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the style guides. 
- [x] Unit tests have been written where possible.
