### PR TITLE
Fix undo/redo in doc panel, component comments

### DIFF
--- a/app/gui/src/project-view/components/DocumentationEditor.vue
+++ b/app/gui/src/project-view/components/DocumentationEditor.vue
@@ -85,7 +85,7 @@ const editorMarkdown = computed(() =>
 )
 const editorContent = computed(() => unwrapOr(editorMarkdown.value, undefined))
 
-const { syncExt, connectSync } = useYTextSync(editorContent)
+const { syncExt, connectSync } = useYTextSync(editorContent, 'local:userAction:DocEditor')
 const editorPersistenceExt = editorPersistence({
   documentViewId: useDocumentViewId({
     projectId,

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeComment.vue
@@ -15,7 +15,7 @@ const textEditorContent = computed(() => textEditor.value?.contentElement)
 
 const documentation = computed(() => nodeMutableDocumentation(props.node))
 
-const { syncExt, connectSync } = useYTextSync(documentation)
+const { syncExt, connectSync } = useYTextSync(documentation, 'local:userAction:CommentEditor')
 
 syncRef(editing, useFocusDelayed(textEditorContent).focused)
 </script>

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -44,6 +44,7 @@ import {
 import { Awareness } from 'y-protocols/awareness.js'
 import { assert } from 'ydoc-shared/util/assert'
 import { Range } from 'ydoc-shared/util/data/range'
+import type { LocalUserActionOrigin } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
 
 function disableEditContextApi() {
@@ -257,7 +258,7 @@ export function useStringSync({ onTextEdited, onUserAction }: StringSyncOptions 
 }
 
 /** An extension synchronizing CM with a Y.Text node in the ref. */
-export function useYTextSync(content: ToValue<Y.Text | undefined>) {
+export function useYTextSync(content: ToValue<Y.Text | undefined>, origin?: LocalUserActionOrigin) {
   const syncCompartment = new Compartment()
   const awareness = new Awareness(new Y.Doc())
 
@@ -266,7 +267,7 @@ export function useYTextSync(content: ToValue<Y.Text | undefined>) {
     if (contentValue != null) {
       assert(contentValue.doc !== null)
       const yTextWithDoc: Y.Text & { doc: Y.Doc } = contentValue as any
-      return { text: contentValue.toString(), extensions: yCollab(yTextWithDoc, awareness) }
+      return { text: contentValue.toString(), extensions: yCollab(yTextWithDoc, awareness, origin) }
     } else {
       return { text: '', extensions: [] }
     }

--- a/app/gui/src/project-view/util/codemirror/yCollab/index.ts
+++ b/app/gui/src/project-view/util/codemirror/yCollab/index.ts
@@ -6,20 +6,14 @@
  * - Changes to match project code style.
  */
 
-import * as cmView from '@codemirror/view'
+import type { Extension } from '@codemirror/state'
 import { type Awareness } from 'y-protocols/awareness.js'
+import type { LocalUserActionOrigin } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
 import { YRange } from './y-range'
 import { yRemoteSelections, yRemoteSelectionsTheme } from './y-remote-selections'
 import { YSyncConfig, ySync, ySyncAnnotation, ySyncFacet } from './y-sync'
-import {
-  YUndoManagerConfig,
-  redo,
-  undo,
-  yUndoManager,
-  yUndoManagerFacet,
-  yUndoManagerKeymap,
-} from './y-undomanager'
+import { yUndoManagerKeymap } from './y-undomanager'
 export {
   YRange,
   YSyncConfig,
@@ -31,35 +25,16 @@ export {
   yUndoManagerKeymap,
 }
 
-/* CodeMirror Extension for synchronizing the editor state with a {@link Y.Text}. */
-export const yCollab = (
+/** CodeMirror Extension for synchronizing the editor state with a {@link Y.Text}. */
+export function yCollab(
   ytext: Y.Text & { doc: Y.Doc },
   awareness: Awareness | null,
-  {
-    undoManager = new Y.UndoManager(ytext),
-  }: {
-    /** Set to false to disable the undo-redo plugin */
-    undoManager?: Y.UndoManager | false
-  } = {},
-) => {
-  const ySyncConfig = new YSyncConfig(ytext, awareness)
+  origin?: LocalUserActionOrigin | undefined,
+): Extension {
+  const ySyncConfig = new YSyncConfig(ytext, awareness, origin)
   const plugins = [ySyncFacet.of(ySyncConfig), ySync]
   if (awareness) {
     plugins.push(yRemoteSelectionsTheme, yRemoteSelections)
-  }
-  if (undoManager !== false) {
-    // By default, only track changes that are produced by the sync plugin (local edits)
-    plugins.push(
-      yUndoManagerFacet.of(new YUndoManagerConfig(undoManager)),
-      yUndoManager,
-      cmView.EditorView.domEventHandlers({
-        beforeinput(e, view) {
-          if (e.inputType === 'historyUndo') return undo(view)
-          if (e.inputType === 'historyRedo') return redo(view)
-          return false
-        },
-      }),
-    )
   }
   return plugins
 }

--- a/app/gui/src/project-view/util/codemirror/yCollab/y-sync.ts
+++ b/app/gui/src/project-view/util/codemirror/yCollab/y-sync.ts
@@ -1,7 +1,9 @@
 import * as cmState from '@codemirror/state'
 import * as cmView from '@codemirror/view'
+import { markRaw } from 'vue'
 import { type Awareness } from 'y-protocols/awareness.js'
 import { assertDefined } from 'ydoc-shared/util/assert'
+import type { LocalUserActionOrigin } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
 import { YRange } from './y-range'
 
@@ -9,14 +11,18 @@ import { YRange } from './y-range'
 export class YSyncConfig {
   readonly undoManager: Y.UndoManager
   readonly ytext: Y.Text & { doc: Y.Doc }
+  readonly origin: unknown
 
   /** TODO: Add docs */
   constructor(
     ytext: Y.Text & { doc: Y.Doc },
     readonly awareness: Awareness | null,
+    origin: LocalUserActionOrigin | undefined,
   ) {
     this.ytext = ytext as Y.Text & { doc: Y.Doc }
     this.undoManager = new Y.UndoManager(ytext)
+    markRaw(this)
+    this.origin = origin ?? this
   }
 
   /**
@@ -99,7 +105,7 @@ class YSyncPluginValue implements cmView.PluginValue {
   constructor(private readonly view: cmView.EditorView) {
     this.conf = view.state.facet(ySyncFacet)
     this._observer = (event: Y.YTextEvent, tr: Y.Transaction) => {
-      if (tr.origin !== this.conf) {
+      if (tr.origin !== this.conf.origin) {
         const delta = event.delta
         const changes: { from: number; to: number; insert: string }[] = []
         let pos = 0
@@ -145,7 +151,7 @@ class YSyncPluginValue implements cmView.PluginValue {
         }
         adj += insertText.length - (toA - fromA)
       })
-    }, this.conf)
+    }, this.conf.origin)
   }
 
   destroy() {

--- a/app/ydoc-shared/src/yjsModel.ts
+++ b/app/ydoc-shared/src/yjsModel.ts
@@ -149,7 +149,12 @@ export class DistributedModule {
   }
 }
 
-export const localUserActionOrigins = ['local:userAction', 'local:userAction:CodeEditor'] as const
+export const localUserActionOrigins = [
+  'local:userAction',
+  'local:userAction:CodeEditor',
+  'local:userAction:DocEditor',
+  'local:userAction:CommentEditor',
+] as const
 export type LocalUserActionOrigin = (typeof localUserActionOrigins)[number]
 export type Origin = LocalUserActionOrigin | 'remote' | 'local:autoLayout'
 /** Locally-originated changes not otherwise specified. */


### PR DESCRIPTION
### Pull Request Description

Fix undo/redo in doc panel, component comments

- Add support for providing an origin in `yCollab` config
- Introduce `local:userAction` origins for doc/comment editors

Only graph view editors are affected; undo/redo in the dashboard doc editor must be implemented separately.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
