### PR TITLE
Add refactoring/renameProject HTTP endpoint

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -24,7 +24,8 @@ import org.enso.languageserver.libraries._
 import org.enso.languageserver.monitoring.{
   HealthCheckEndpoint,
   IdlenessEndpoint,
-  IdlenessMonitor
+  IdlenessMonitor,
+  RenameProjectEndpoint
 }
 import org.enso.languageserver.profiling.{EventsMonitorActor, ProfilingManager}
 import org.enso.languageserver.protocol.binary.{
@@ -448,6 +449,13 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   private val idlenessEndpoint =
     new IdlenessEndpoint(idlenessMonitor)
 
+  private val renameProjectEndpoint =
+    RenameProjectEndpoint(
+      timeout          = 10.seconds,
+      runtimeConnector = runtimeConnector,
+      actorFactory     = system
+    )(serverConfig.computeExecutionContext)
+
   private val jsonRpcProtocolFactory = new JsonRpcProtocolFactory
 
   private val initializationComponent =
@@ -503,7 +511,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
           lazyMessageTimeout = 10.seconds,
           secureConfig       = secureConfig
         ),
-      List(healthCheckEndpoint, idlenessEndpoint),
+      List(healthCheckEndpoint, idlenessEndpoint, renameProjectEndpoint),
       messagesCallback
     )(system, materializer)
   log.trace("Created JSON RPC Server [{}]", jsonRpcServer)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/ReadinessMonitor.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/ReadinessMonitor.scala
@@ -8,6 +8,8 @@ import org.enso.languageserver.event.InitializedEvent.{
 }
 import org.enso.languageserver.monitoring.MonitoringProtocol.{IsReady, KO, OK}
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /** An actor that monitors if the system is ready to accept requests. */
 class ReadinessMonitor() extends Actor with LazyLogging {
 
@@ -26,6 +28,7 @@ class ReadinessMonitor() extends Actor with LazyLogging {
 
   private def stateTransition(): Receive = {
     case InitializationFinished =>
+      ReadinessMonitor.readyState.set(true)
       context.become(ready())
 
     case InitializationFailed =>
@@ -36,6 +39,12 @@ class ReadinessMonitor() extends Actor with LazyLogging {
 }
 
 object ReadinessMonitor {
+
+  /** The readiness state. */
+  private val readyState: AtomicBoolean = new AtomicBoolean(false)
+
+  /** Checks the readiness. */
+  def isReady: Boolean = readyState.get()
 
   /** Creates a configuration object used to create a
     * [[ReadinessMonitor]]

--- a/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/RenameProjectEndpoint.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/RenameProjectEndpoint.scala
@@ -1,0 +1,141 @@
+package org.enso.languageserver.monitoring
+
+import akka.actor.{ActorRef, ActorRefFactory}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.pattern.ask
+import akka.util.Timeout
+import com.typesafe.scalalogging.LazyLogging
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.parser._
+import org.enso.jsonrpc._
+import org.enso.languageserver.refactoring.RefactoringApi
+import org.enso.languageserver.requesthandler.refactoring.RenameProjectHandler
+
+import java.util.UUID
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+/** An HTTP endpoint that handles rename requests of the opened project.
+  *
+  * @param timeout the runtime request timeout
+  * @param runtimeConnector the runtime connector
+  * @param actorFactory the actor creation factory
+  * @param ec the execution context
+  */
+class RenameProjectEndpoint(
+  timeout: FiniteDuration,
+  runtimeConnector: ActorRef,
+  actorFactory: ActorRefFactory
+)(implicit ec: ExecutionContext)
+    extends Endpoint
+    with LazyLogging {
+
+  implicit private val askTimeout: Timeout = Timeout(timeout)
+
+  implicit val renameProjectParamsDecoder
+    : Decoder[RefactoringApi.RenameProject.Params] =
+    deriveDecoder[RefactoringApi.RenameProject.Params]
+
+  implicit val renameProjectParamsEncoder
+    : Encoder[RefactoringApi.RenameProject.Params] =
+    deriveEncoder[RefactoringApi.RenameProject.Params]
+
+  override def route: Route =
+    renameProject
+
+  private val renameProject = {
+    path("refactoring" / "renameProject") {
+      post {
+        entity(as[String]) { body =>
+          if (ReadinessMonitor.isReady) {
+            handleRenameProject(body)
+          } else {
+            complete(
+              StatusCodes.InternalServerError,
+              Json.obj("error" -> Json.fromString("Not initialized")).noSpaces
+            )
+          }
+        }
+      }
+    }
+  }
+
+  private def handleRenameProject(body: String): Route = {
+    parse(body).flatMap(_.as[RefactoringApi.RenameProject.Params]) match {
+      case Right(params) =>
+        val handler = actorFactory.actorOf(
+          RenameProjectHandler.props(timeout, runtimeConnector),
+          s"rename-project-handler-${UUID.randomUUID()}"
+        )
+
+        val requestId = Id.String(UUID.randomUUID().toString)
+        val request   = Request(RefactoringApi.RenameProject, requestId, params)
+
+        val future = (handler ? request).map {
+          case ResponseResult(
+                RefactoringApi.RenameProject,
+                `requestId`,
+                Unused
+              ) =>
+            StatusCodes.OK -> Json
+              .obj("status" -> Json.fromString("success"))
+              .noSpaces
+          case ResponseError(Some(`requestId`), error) =>
+            StatusCodes.BadRequest -> Json
+              .obj("error" -> Json.fromString(error.message))
+              .noSpaces
+          case _ =>
+            StatusCodes.InternalServerError -> Json
+              .obj("error" -> Json.fromString("Unexpected response"))
+              .noSpaces
+        }
+
+        onComplete(future) {
+          case Success((status, responseBody)) =>
+            complete(status, responseBody)
+          case Failure(ex) =>
+            logger.error("Failed to rename project", ex)
+            complete(
+              StatusCodes.InternalServerError,
+              Json.obj("error" -> Json.fromString(ex.getMessage)).noSpaces
+            )
+        }
+
+      case Left(error) =>
+        logger.error(s"Failed to parse rename project request: $error")
+        complete(
+          StatusCodes.BadRequest,
+          Json
+            .obj(
+              "error" -> Json.fromString(
+                s"Invalid request format: ${error.getMessage}"
+              )
+            )
+            .noSpaces
+        )
+    }
+  }
+}
+
+object RenameProjectEndpoint {
+
+  /** Create a new endpoint for renaming the opened project.
+    *
+    * @param timeout the runtime request timeout
+    * @param runtimeConnector the runtime connector
+    * @param actorFactory the actor creation factory
+    * @param ec the execution context
+    * @return an instance of [[RenameProjectEndpoint]]
+    */
+  def apply(
+    timeout: FiniteDuration,
+    runtimeConnector: ActorRef,
+    actorFactory: ActorRefFactory
+  )(implicit ec: ExecutionContext): RenameProjectEndpoint =
+    new RenameProjectEndpoint(timeout, runtimeConnector, actorFactory)
+}


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

part of #13891 

Changelog:
- add: HTTP endpoint that behaves like `refactoring/renameProject` JSONRPC message handler. This will help to keep the gui implementation of project manager simple by avoiding the usage of WebSocket client.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
