### PR TITLE
Turn `EnsoDateTimeFormatter` into an API facade

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
@@ -139,7 +139,7 @@ type Date_Time_Formatter
             analyzer = Analyzer.new parsed
             java_formatter = analyzer.validate_after_parsing <|
                 As_Java_Formatter_Interpreter.interpret used_locale parsed
-            Date_Time_Formatter.Value (EnsoDateTimeFormatter.new java_formatter pattern FormatterKind.SIMPLE) deferred_parsing_warnings=analyzer.get_parsing_only_warnings
+            Date_Time_Formatter.Value (EnsoDateTimeFormatter.create java_formatter pattern FormatterKind.SIMPLE) deferred_parsing_warnings=analyzer.get_parsing_only_warnings
 
     ## ---
        icon: convert
@@ -193,7 +193,7 @@ type Date_Time_Formatter
             analyzer = Analyzer.new parsed
             java_formatter = analyzer.validate_after_parsing <|
                 As_Java_Formatter_Interpreter.interpret used_locale parsed
-            Date_Time_Formatter.Value (EnsoDateTimeFormatter.new java_formatter pattern FormatterKind.ISO_WEEK_DATE) deferred_parsing_warnings=analyzer.get_parsing_only_warnings
+            Date_Time_Formatter.Value (EnsoDateTimeFormatter.create java_formatter pattern FormatterKind.ISO_WEEK_DATE) deferred_parsing_warnings=analyzer.get_parsing_only_warnings
 
     ## ---
        advanced: true
@@ -221,7 +221,7 @@ type Date_Time_Formatter
             used_locale = if locale == Locale.default then Locale.us else locale
             java_locale = (used_locale.if_nothing Locale.us).java_locale
             java_formatter = DateTimeFormatter.ofPattern pattern java_locale
-            Date_Time_Formatter.Value (EnsoDateTimeFormatter.new java_formatter pattern FormatterKind.RAW_JAVA)
+            Date_Time_Formatter.Value (EnsoDateTimeFormatter.create java_formatter pattern FormatterKind.RAW_JAVA)
         _ -> Error.throw (Illegal_Argument.Error "The pattern must either be a string or a Java DateTimeFormatter instance.")
 
     ## ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time_Formatter.enso
@@ -301,18 +301,7 @@ type Date_Time_Formatter
        ---
        Returns a text representation of this formatter.
     to_text : Text
-    to_text self = case self.underlying.getFormatterKind of
-        FormatterKind.CONSTANT ->
-            "Date_Time_Formatter." + self.underlying.getOriginalPattern
-        FormatterKind.SIMPLE ->
-            # TODO locale too?
-            "Date_Time_Formatter.from_simple_pattern " + self.underlying.getOriginalPattern.pretty
-        FormatterKind.ISO_WEEK_DATE ->
-            "Date_Time_Formatter.from_iso_week_date_pattern " + self.underlying.getOriginalPattern.pretty
-        FormatterKind.RAW_JAVA -> case self.underlying.getOriginalPattern of
-            original_pattern : Text -> "Date_Time_Formatter.from_java " + original_pattern.pretty
-            Nothing -> "Date_Time_Formatter.from_java " + self.underlying.getFormatter.to_text
-
+    to_text self = self.underlying.describe
     ## ---
        private: true
        ---

--- a/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatter.java
+++ b/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatter.java
@@ -14,6 +14,8 @@ import java.util.Locale;
  * making the `T` in ISO dates optional and tracking how it was constructed.
  */
 public interface EnsoDateTimeFormatter {
+  public String describe();
+
   public LocalDate parseLocalDate(String dateString);
 
   public ZonedDateTime parseZonedDateTime(String dateString);

--- a/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatter.java
+++ b/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatter.java
@@ -1,188 +1,48 @@
 package org.enso.base.time;
 
-import static java.time.temporal.ChronoField.INSTANT_SECONDS;
-import static java.time.temporal.ChronoField.NANO_OF_SECOND;
-
-import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalQueries;
-import java.util.Arrays;
 import java.util.Locale;
-import org.enso.polyglot.common_utils.Core_Date_Utils;
-import org.graalvm.collections.Pair;
 
 /**
- * An Enso representation of the DateTimeFormatter.
+ * Enso abstraction over the {@link DateTimeFormatter}.
  *
  * <p>It adds some additional functionality to the Java formatter - including a workaround for
  * making the `T` in ISO dates optional and tracking how it was constructed.
  */
-public class EnsoDateTimeFormatter {
-  private final DateTimeFormatter formatter;
-  private final Pair<Character, String> isoReplacementPair;
-  private final String originalPattern;
-  private final FormatterKind formatterKind;
+public interface EnsoDateTimeFormatter {
+  public LocalDate parseLocalDate(String dateString);
 
-  private EnsoDateTimeFormatter(
-      DateTimeFormatter formatter,
-      Pair<Character, String> isoReplacementPair,
-      String originalPattern,
-      FormatterKind formatterKind) {
-    this.formatter = formatter;
-    this.isoReplacementPair = isoReplacementPair;
-    this.originalPattern = originalPattern;
-    this.formatterKind = formatterKind;
-  }
+  public ZonedDateTime parseZonedDateTime(String dateString);
 
-  public EnsoDateTimeFormatter(
-      DateTimeFormatter formatter, String originalPattern, FormatterKind formatterKind) {
-    this(formatter, null, originalPattern, formatterKind);
-  }
+  public LocalTime parseLocalTime(String text);
 
-  public static EnsoDateTimeFormatter makeISOConstant(DateTimeFormatter formatter, String name) {
-    return new EnsoDateTimeFormatter(
-        formatter, Pair.create(' ', "T"), name, FormatterKind.CONSTANT);
+  public String formatLocalDate(LocalDate date);
+
+  public String formatZonedDateTime(ZonedDateTime dateTime);
+
+  public String formatLocalTime(LocalTime time);
+
+  public String formatLocalDateTime(LocalDateTime dateTime);
+
+  //
+  // factory methods
+  //
+
+  public static EnsoDateTimeFormatter create(DateTimeFormatter f, String p, FormatterKind k) {
+    return new EnsoDateTimeFormatterImpl(f, p, k);
   }
 
   public static EnsoDateTimeFormatter default_enso_zoned_date_time_formatter() {
-    return new EnsoDateTimeFormatter(
-        Core_Date_Utils.defaultZonedDateTimeFormatter,
-        Pair.create('T', " "),
-        "default_enso_zoned_date_time",
-        FormatterKind.CONSTANT);
+    return EnsoDateTimeFormatterImpl.default_enso_zoned_date_time_formatter();
   }
 
-  public EnsoDateTimeFormatter withLocale(Locale locale) {
-    return new EnsoDateTimeFormatter(
-        formatter.withLocale(locale), isoReplacementPair, originalPattern, formatterKind);
+  public static EnsoDateTimeFormatter makeISOConstant(DateTimeFormatter formatter, String name) {
+    return EnsoDateTimeFormatterImpl.makeISOConstant(formatter, name);
   }
 
-  public DateTimeFormatter getRawJavaFormatter() {
-    return formatter;
-  }
-
-  public String getOriginalPattern() {
-    return originalPattern;
-  }
-
-  public FormatterKind getFormatterKind() {
-    return formatterKind;
-  }
-
-  private String normaliseInput(String dateString) {
-    if (isoReplacementPair == null) {
-      // Nothing to do
-      return dateString;
-    }
-
-    char from = isoReplacementPair.getLeft();
-    String to = isoReplacementPair.getRight();
-
-    if (dateString != null && dateString.length() > 10 && dateString.charAt(10) == from) {
-      var builder = new StringBuilder(dateString);
-      builder.replace(10, 11, to);
-      return builder.toString();
-    }
-
-    return dateString;
-  }
-
-  @Override
-  public String toString() {
-    return switch (formatterKind) {
-      case SIMPLE -> originalPattern;
-      case ISO_WEEK_DATE -> "(ISO Week Date Format) " + originalPattern;
-      case RAW_JAVA -> "(Java DateTimeFormatter) "
-          + (originalPattern != null ? originalPattern : formatter.toString());
-      case CONSTANT -> originalPattern;
-    };
-  }
-
-  public LocalDate parseLocalDate(String dateString) {
-    dateString = normaliseInput(dateString);
-    return LocalDate.parse(dateString, formatter);
-  }
-
-  public ZonedDateTime parseZonedDateTime(String dateString) {
-    dateString = normaliseInput(dateString);
-
-    var resolved = formatter.parse(dateString);
-
-    try {
-      // Resolve Zone
-      var zone = resolved.query(TemporalQueries.zoneId());
-      zone =
-          zone != null
-              ? zone
-              : (resolved.isSupported(ChronoField.OFFSET_SECONDS)
-                  ? ZoneOffset.ofTotalSeconds(resolved.get(ChronoField.OFFSET_SECONDS))
-                  : ZoneId.systemDefault());
-
-      // Instant Based
-      if (resolved.isSupported(INSTANT_SECONDS)) {
-        long epochSecond = resolved.getLong(INSTANT_SECONDS);
-        int nanoOfSecond = resolved.get(NANO_OF_SECOND);
-        return ZonedDateTime.ofInstant(
-            java.time.Instant.ofEpochSecond(epochSecond, nanoOfSecond), zone);
-      }
-
-      // Local Based
-      var localDate = LocalDate.from(resolved);
-      var localTime = LocalTime.from(resolved);
-      return ZonedDateTime.of(localDate, localTime, zone);
-    } catch (DateTimeException e) {
-      throw new DateTimeException(
-          "Unable to parse Text '" + dateString + "' to Date_Time: " + e.getMessage(), e);
-    } catch (ArithmeticException e) {
-      throw new DateTimeException(
-          "Unable to parse Text '" + dateString + "' to Date_Time due to arithmetic error.", e);
-    }
-  }
-
-  public LocalTime parseLocalTime(String text) {
-    text = normaliseInput(text);
-    return LocalTime.parse(text, formatter);
-  }
-
-  public String formatLocalDate(LocalDate date) {
-    return formatter.format(date);
-  }
-
-  public String formatZonedDateTime(ZonedDateTime dateTime) {
-    return formatter.format(dateTime);
-  }
-
-  public String formatLocalTime(LocalTime time) {
-    return formatter.format(time);
-  }
-
-  @Override
-  public int hashCode() {
-    // We ignore formatter here because it has identity semantics.
-    return Arrays.hashCode(new Object[] {isoReplacementPair, originalPattern, formatterKind});
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (obj instanceof EnsoDateTimeFormatter other) {
-      // The DateTimeFormatter has identity semantics, so instead we try to check the pattern
-      // instead, if available.
-      if (originalPattern != null) {
-        return formatterKind == other.formatterKind
-            && originalPattern.equals(other.originalPattern)
-            && isoReplacementPair.equals(other.isoReplacementPair)
-            && formatter.getLocale().equals(other.formatter.getLocale());
-      } else {
-        return formatterKind == other.formatterKind && formatter.equals(other.formatter);
-      }
-    } else {
-      return false;
-    }
-  }
+  public EnsoDateTimeFormatter withLocale(Locale locale);
 }

--- a/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatterImpl.java
+++ b/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatterImpl.java
@@ -59,6 +59,7 @@ final class EnsoDateTimeFormatterImpl implements EnsoDateTimeFormatter {
         FormatterKind.CONSTANT);
   }
 
+  @Override
   public EnsoDateTimeFormatter withLocale(Locale locale) {
     return new EnsoDateTimeFormatterImpl(
         formatter.withLocale(locale), isoReplacementPair, originalPattern, formatterKind);
@@ -95,6 +96,19 @@ final class EnsoDateTimeFormatterImpl implements EnsoDateTimeFormatter {
   }
 
   @Override
+  public String describe() {
+    return switch (formatterKind) {
+      case SIMPLE -> "Date_Time_Formatter.from_simple_pattern " + getOriginalPattern();
+      case ISO_WEEK_DATE -> "Date_Time_Formatter.from_iso_week_date_pattern "
+          + getOriginalPattern();
+      case RAW_JAVA -> originalPattern != null
+          ? "Date_Time_Formatter.from_java " + getOriginalPattern()
+          : "Date_Time_Formatter.from_java " + formatter.toString();
+      case CONSTANT -> "Date_Time_Formatter." + getOriginalPattern();
+    };
+  }
+
+  @Override
   public String toString() {
     return switch (formatterKind) {
       case SIMPLE -> originalPattern;
@@ -105,11 +119,13 @@ final class EnsoDateTimeFormatterImpl implements EnsoDateTimeFormatter {
     };
   }
 
+  @Override
   public LocalDate parseLocalDate(String dateString) {
     dateString = normaliseInput(dateString);
     return LocalDate.parse(dateString, formatter);
   }
 
+  @Override
   public ZonedDateTime parseZonedDateTime(String dateString) {
     dateString = normaliseInput(dateString);
 
@@ -146,23 +162,28 @@ final class EnsoDateTimeFormatterImpl implements EnsoDateTimeFormatter {
     }
   }
 
+  @Override
   public LocalTime parseLocalTime(String text) {
     text = normaliseInput(text);
     return LocalTime.parse(text, formatter);
   }
 
+  @Override
   public String formatLocalDate(LocalDate date) {
     return formatter.format(date);
   }
 
+  @Override
   public String formatZonedDateTime(ZonedDateTime dateTime) {
     return formatter.format(dateTime);
   }
 
+  @Override
   public String formatLocalDateTime(LocalDateTime dateTime) {
     return formatter.format(dateTime);
   }
 
+  @Override
   public String formatLocalTime(LocalTime time) {
     return formatter.format(time);
   }

--- a/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatterImpl.java
+++ b/std-bits/base/src/main/java/org/enso/base/time/EnsoDateTimeFormatterImpl.java
@@ -1,0 +1,193 @@
+package org.enso.base.time;
+
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalQueries;
+import java.util.Arrays;
+import java.util.Locale;
+import org.enso.polyglot.common_utils.Core_Date_Utils;
+import org.graalvm.collections.Pair;
+
+/**
+ * An Enso representation of the DateTimeFormatter.
+ *
+ * <p>It adds some additional functionality to the Java formatter - including a workaround for
+ * making the `T` in ISO dates optional and tracking how it was constructed.
+ */
+final class EnsoDateTimeFormatterImpl implements EnsoDateTimeFormatter {
+  private final DateTimeFormatter formatter;
+  private final Pair<Character, String> isoReplacementPair;
+  private final String originalPattern;
+  private final FormatterKind formatterKind;
+
+  private EnsoDateTimeFormatterImpl(
+      DateTimeFormatter formatter,
+      Pair<Character, String> isoReplacementPair,
+      String originalPattern,
+      FormatterKind formatterKind) {
+    this.formatter = formatter;
+    this.isoReplacementPair = isoReplacementPair;
+    this.originalPattern = originalPattern;
+    this.formatterKind = formatterKind;
+  }
+
+  EnsoDateTimeFormatterImpl(
+      DateTimeFormatter formatter, String originalPattern, FormatterKind formatterKind) {
+    this(formatter, null, originalPattern, formatterKind);
+  }
+
+  public static EnsoDateTimeFormatter makeISOConstant(DateTimeFormatter formatter, String name) {
+    return new EnsoDateTimeFormatterImpl(
+        formatter, Pair.create(' ', "T"), name, FormatterKind.CONSTANT);
+  }
+
+  public static EnsoDateTimeFormatter default_enso_zoned_date_time_formatter() {
+    return new EnsoDateTimeFormatterImpl(
+        Core_Date_Utils.defaultZonedDateTimeFormatter,
+        Pair.create('T', " "),
+        "default_enso_zoned_date_time",
+        FormatterKind.CONSTANT);
+  }
+
+  public EnsoDateTimeFormatter withLocale(Locale locale) {
+    return new EnsoDateTimeFormatterImpl(
+        formatter.withLocale(locale), isoReplacementPair, originalPattern, formatterKind);
+  }
+
+  public DateTimeFormatter getRawJavaFormatter() {
+    return formatter;
+  }
+
+  public String getOriginalPattern() {
+    return originalPattern;
+  }
+
+  public FormatterKind getFormatterKind() {
+    return formatterKind;
+  }
+
+  private String normaliseInput(String dateString) {
+    if (isoReplacementPair == null) {
+      // Nothing to do
+      return dateString;
+    }
+
+    char from = isoReplacementPair.getLeft();
+    String to = isoReplacementPair.getRight();
+
+    if (dateString != null && dateString.length() > 10 && dateString.charAt(10) == from) {
+      var builder = new StringBuilder(dateString);
+      builder.replace(10, 11, to);
+      return builder.toString();
+    }
+
+    return dateString;
+  }
+
+  @Override
+  public String toString() {
+    return switch (formatterKind) {
+      case SIMPLE -> originalPattern;
+      case ISO_WEEK_DATE -> "(ISO Week Date Format) " + originalPattern;
+      case RAW_JAVA -> "(Java DateTimeFormatter) "
+          + (originalPattern != null ? originalPattern : formatter.toString());
+      case CONSTANT -> originalPattern;
+    };
+  }
+
+  public LocalDate parseLocalDate(String dateString) {
+    dateString = normaliseInput(dateString);
+    return LocalDate.parse(dateString, formatter);
+  }
+
+  public ZonedDateTime parseZonedDateTime(String dateString) {
+    dateString = normaliseInput(dateString);
+
+    var resolved = formatter.parse(dateString);
+
+    try {
+      // Resolve Zone
+      var zone = resolved.query(TemporalQueries.zoneId());
+      zone =
+          zone != null
+              ? zone
+              : (resolved.isSupported(ChronoField.OFFSET_SECONDS)
+                  ? ZoneOffset.ofTotalSeconds(resolved.get(ChronoField.OFFSET_SECONDS))
+                  : ZoneId.systemDefault());
+
+      // Instant Based
+      if (resolved.isSupported(INSTANT_SECONDS)) {
+        long epochSecond = resolved.getLong(INSTANT_SECONDS);
+        int nanoOfSecond = resolved.get(NANO_OF_SECOND);
+        return ZonedDateTime.ofInstant(
+            java.time.Instant.ofEpochSecond(epochSecond, nanoOfSecond), zone);
+      }
+
+      // Local Based
+      var localDate = LocalDate.from(resolved);
+      var localTime = LocalTime.from(resolved);
+      return ZonedDateTime.of(localDate, localTime, zone);
+    } catch (DateTimeException e) {
+      throw new DateTimeException(
+          "Unable to parse Text '" + dateString + "' to Date_Time: " + e.getMessage(), e);
+    } catch (ArithmeticException e) {
+      throw new DateTimeException(
+          "Unable to parse Text '" + dateString + "' to Date_Time due to arithmetic error.", e);
+    }
+  }
+
+  public LocalTime parseLocalTime(String text) {
+    text = normaliseInput(text);
+    return LocalTime.parse(text, formatter);
+  }
+
+  public String formatLocalDate(LocalDate date) {
+    return formatter.format(date);
+  }
+
+  public String formatZonedDateTime(ZonedDateTime dateTime) {
+    return formatter.format(dateTime);
+  }
+
+  public String formatLocalDateTime(LocalDateTime dateTime) {
+    return formatter.format(dateTime);
+  }
+
+  public String formatLocalTime(LocalTime time) {
+    return formatter.format(time);
+  }
+
+  @Override
+  public int hashCode() {
+    // We ignore formatter here because it has identity semantics.
+    return Arrays.hashCode(new Object[] {isoReplacementPair, originalPattern, formatterKind});
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof EnsoDateTimeFormatterImpl other) {
+      // The DateTimeFormatter has identity semantics, so instead we try to check the pattern
+      // instead, if available.
+      if (originalPattern != null) {
+        return formatterKind == other.formatterKind
+            && originalPattern.equals(other.originalPattern)
+            && isoReplacementPair.equals(other.isoReplacementPair)
+            && formatter.getLocale().equals(other.formatter.getLocale());
+      } else {
+        return formatterKind == other.formatterKind && formatter.equals(other.formatter);
+      }
+    } else {
+      return false;
+    }
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/formatting/DateFormatter.java
+++ b/std-bits/table/src/main/java/org/enso/table/formatting/DateFormatter.java
@@ -1,15 +1,14 @@
 package org.enso.table.formatting;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import org.enso.base.time.EnsoDateTimeFormatter;
 import org.graalvm.polyglot.Value;
 
 public class DateFormatter implements DataFormatter {
-  private final DateTimeFormatter formatter;
+  private final EnsoDateTimeFormatter formatter;
 
   public DateFormatter(EnsoDateTimeFormatter ensoFormatter) {
-    formatter = ensoFormatter.getRawJavaFormatter();
+    formatter = ensoFormatter;
   }
 
   @Override
@@ -23,7 +22,7 @@ public class DateFormatter implements DataFormatter {
     }
 
     if (value instanceof LocalDate date) {
-      return date.format(formatter);
+      return formatter.formatLocalDate(date);
     }
 
     throw new IllegalArgumentException("Unsupported type for DateFormatter.");

--- a/std-bits/table/src/main/java/org/enso/table/formatting/DateTimeFormatter.java
+++ b/std-bits/table/src/main/java/org/enso/table/formatting/DateTimeFormatter.java
@@ -6,10 +6,10 @@ import org.enso.base.time.EnsoDateTimeFormatter;
 import org.graalvm.polyglot.Value;
 
 public class DateTimeFormatter implements DataFormatter {
-  private final java.time.format.DateTimeFormatter formatter;
+  private final EnsoDateTimeFormatter formatter;
 
   public DateTimeFormatter(EnsoDateTimeFormatter ensoFormatter) {
-    formatter = ensoFormatter.getRawJavaFormatter();
+    formatter = ensoFormatter;
   }
 
   @Override
@@ -26,11 +26,11 @@ public class DateTimeFormatter implements DataFormatter {
     }
 
     if (value instanceof LocalDateTime date) {
-      return date.format(formatter);
+      return formatter.formatLocalDateTime(date);
     }
 
     if (value instanceof ZonedDateTime date) {
-      return date.format(formatter);
+      return formatter.formatZonedDateTime(date);
     }
 
     throw new IllegalArgumentException("Unsupported type for DateTimeFormatter.");

--- a/std-bits/table/src/main/java/org/enso/table/formatting/TimeFormatter.java
+++ b/std-bits/table/src/main/java/org/enso/table/formatting/TimeFormatter.java
@@ -1,15 +1,14 @@
 package org.enso.table.formatting;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import org.enso.base.time.EnsoDateTimeFormatter;
 import org.graalvm.polyglot.Value;
 
 public class TimeFormatter implements DataFormatter {
-  private final DateTimeFormatter formatter;
+  private final EnsoDateTimeFormatter formatter;
 
   public TimeFormatter(EnsoDateTimeFormatter ensoFormatter) {
-    formatter = ensoFormatter.getRawJavaFormatter();
+    formatter = ensoFormatter;
   }
 
   @Override
@@ -23,7 +22,7 @@ public class TimeFormatter implements DataFormatter {
     }
 
     if (value instanceof LocalTime date) {
-      return date.format(formatter);
+      return formatter.formatLocalTime(date);
     }
 
     throw new IllegalArgumentException("Unsupported type for TimeFormatter.");


### PR DESCRIPTION
### Pull Request Description

- as part of work on #13851 turned out that
- `EnsoDataTimeFormatter` is _"leaking its implementation"_ details
- this PR fixes that by making the current implementation package private
- and turning `EnsoDateTimeFormatter` into an API with
   - factories
   - formatting methods

### Important Notes

- by making `EnsoDateTimeFormatter` an interface, it is now possible
   - to exchange it as a _remote API facade_ between two JVMs

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
