### PR TITLE
Simplify MethodResolver configuration

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -2,8 +2,11 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Type_Error
 from Standard.Base.Metadata import Widget
 
+import project.Internal.Expression_Statics as Expression_Statics_Module
 import project.Internal.Expression_Statics.Expression_Statics
+import project.Column as Column_Module
 import project.Column.Column
+import project.Refined_Types.Numeric_Column as Numeric_Column_Module
 import project.Refined_Types.Numeric_Column.Numeric_Column
 import project.Table.Table
 
@@ -52,9 +55,9 @@ type Expression
         ## Helper for the expression to tell it which functions needs a Vector
         var_args_functions = ['is_in', 'coalesce', 'min', 'max']
         ## Define which enso types we will look in to resolve methods in the expression
-        mr1 = MethodResolver.new Standard.Table.Internal.Expression_Statics Expression_Statics isStaticMethod=True makeTypedColumn=Nothing
-        mr2 = MethodResolver.new Standard.Table.Column Column isStaticMethod=False makeTypedColumn=c->c
-        mr3 = MethodResolver.new Standard.Table.Refined_Types.Numeric_Column Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
+        mr1 = ExpressionVisitorImpl.newMethodResolver Expression_Statics_Module Expression_Statics isStaticMethod=True makeTypedColumn=Nothing
+        mr2 = ExpressionVisitorImpl.newMethodResolver Column_Module Column isStaticMethod=False makeTypedColumn=c->c
+        mr3 = ExpressionVisitorImpl.newMethodResolver Numeric_Column_Module Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         method_resolvers = [mr1, mr2, mr3]
         handle_parse_error = Panic.catch SyntaxErrorException handler=(cause-> Error.throw (Expression_Error.Syntax_Error cause.payload.getMessage cause.payload.getLine cause.payload.getColumn))
         handle_unsupported = handle_java_error UnsupportedOperationException Expression_Error.Unsupported_Operation

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Type_Error
 from Standard.Base.Metadata import Widget
 
+import project.Internal.Expression_Statics.Expression_Statics
 import project.Column.Column
 import project.Refined_Types.Numeric_Column.Numeric_Column
 import project.Table.Table
@@ -9,6 +10,7 @@ import project.Table.Table
 polyglot java import java.lang.IllegalArgumentException
 polyglot java import java.lang.UnsupportedOperationException
 polyglot java import org.enso.table.expressions.ExpressionVisitorImpl
+polyglot java import org.enso.table.expressions.ExpressionVisitorImpl.MethodResolver
 polyglot java import org.enso.table.expressions.ExpressionVisitorImpl.SyntaxErrorException
 polyglot java import org.enso.table.expressions.ExpressionVisitorImpl.TypeErrorException
 
@@ -50,9 +52,9 @@ type Expression
         ## Helper for the expression to tell it which functions needs a Vector
         var_args_functions = ['is_in', 'coalesce', 'min', 'max']
         ## Define which enso types we will look in to resolve methods in the expression
-        mr1 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Internal.Expression_Statics" "Expression_Statics" isStaticMethod=True makeTypedColumn=Nothing
-        mr2 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Column" "Column" isStaticMethod=False makeTypedColumn=c->c
-        mr3 = ExpressionVisitorImpl.newMethodResolver "Standard.Table.Refined_Types.Numeric_Column" "Numeric_Column" isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
+        mr1 = MethodResolver.new Standard.Table.Internal.Expression_Statics Expression_Statics isStaticMethod=True makeTypedColumn=Nothing
+        mr2 = MethodResolver.new Standard.Table.Column Column isStaticMethod=False makeTypedColumn=c->c
+        mr3 = MethodResolver.new Standard.Table.Refined_Types.Numeric_Column Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         method_resolvers = [mr1, mr2, mr3]
         handle_parse_error = Panic.catch SyntaxErrorException handler=(cause-> Error.throw (Expression_Error.Syntax_Error cause.payload.getMessage cause.payload.getLine cause.payload.getColumn))
         handle_unsupported = handle_java_error UnsupportedOperationException Expression_Error.Unsupported_Operation

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -171,6 +172,46 @@ public class AtomInteropTest {
     var atom = ctxRule.unwrapValue(myTypeAtom);
     var interop = InteropLibrary.getUncached();
     assertThat("field a is internal", interop.isMemberInternal(atom, "a"), is(true));
+  }
+
+  @Test
+  public void methodsAreVisibleEvenWithPrivateConstructors() throws Exception {
+    var myTypeAtom =
+        ctxRule.evalModule(
+            """
+        type My_Type
+            private Cons a
+
+            read self = self.a
+
+        main = My_Type.Cons "a"
+        """);
+    var atom = ctxRule.unwrapValue(myTypeAtom);
+    var interop = InteropLibrary.getUncached();
+    var read = interop.readMember(atom, "read");
+    assertNotNull("Found read member", read);
+    assertEquals("a", read.toString());
+  }
+
+  @Test
+  public void methodsAreVisibleOnTypeEvenWithPrivateConstructors() throws Exception {
+    var atom =
+        ctxRule.evalModule(
+            """
+        type My_Type
+            private Cons a
+
+            read self = self.a
+
+        main = My_Type.Cons "a"
+        """);
+    var type = ctxRule.unwrapValue(atom.getMetaObject());
+    var rawAtom = ctxRule.unwrapValue(atom);
+    var interop = InteropLibrary.getUncached();
+    var read = interop.readMember(type, "read");
+    assertNotNull("Found read member", read);
+    assertTrue("Can read", interop.isExecutable(read));
+    assertEquals("a", interop.execute(read, rawAtom).toString());
   }
 
   @Test

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -403,10 +403,13 @@ public final class Type extends EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   boolean isMemberReadable(String member) {
+    if (methods().containsKey(member)) {
+      return true;
+    }
     if (hasAllConstructorsPrivate) {
       return false;
     } else {
-      return constructors.containsKey(member) || methods().containsKey(member);
+      return constructors.containsKey(member);
     }
   }
 
@@ -493,12 +496,11 @@ public final class Type extends EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   Object readMember(String member) throws UnknownIdentifierException {
-    if (hasAllConstructorsPrivate) {
-      throw UnknownIdentifierException.create(member);
-    }
-    var cons = constructors.get(member);
-    if (cons != null) {
-      return cons;
+    if (!hasAllConstructorsPrivate) {
+      var cons = constructors.get(member);
+      if (cons != null) {
+        return cons;
+      }
     }
     var method = methods().get(member);
     if (method != null) {

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -187,7 +187,12 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
                 name,
                 setVariableArgumentFunctions.contains(name));
     Function<String, Value> makeConstructor =
-        name -> methodResolvers[0].module.invokeMember("eval_expression", ".." + name);
+        name -> {
+          var m = methodResolvers[0].module.getContext().eval("enso", "main=.." + name);
+          var cons = m.invokeMember("eval_expression", "main");
+          assert cons != null;
+          return cons;
+        };
 
     return evaluateImpl(
         expression, getColumn, makeConstantColumn, isColumn, getMethod, makeConstructor);

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -67,41 +67,14 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
 
   public record MethodResolver(
       Value module, Value type, boolean isStaticMethod, Function<Object, Value> makeTypedColumn) {
-    public MethodResolver(
-        String moduleName,
-        String typeName,
-        boolean isStaticMethod,
-        Function<Object, Value> makeTypedColumn) {
-      this(
-          Context.getCurrent().getBindings("enso").invokeMember("get_module", moduleName),
-          typeName,
-          isStaticMethod,
-          makeTypedColumn);
-    }
-
-    private MethodResolver(
-        Value module,
-        String typeName,
-        boolean isStaticMethod,
-        Function<Object, Value> makeTypedColumn) {
-      this(module, module.invokeMember("get_type", typeName), isStaticMethod, makeTypedColumn);
-    }
-
     public boolean canResolve(String methodName) {
       return resolve(methodName).canExecute();
     }
 
     public Value resolve(String methodName) {
-      return module.invokeMember("get_method", type, methodName);
+      var m = type.getMember(methodName);
+      return m == null ? Value.asValue(null) : m;
     }
-  }
-
-  public static MethodResolver newMethodResolver(
-      String moduleName,
-      String typeName,
-      boolean isStaticMethod,
-      Function<Object, Value> makeTypedColumn) {
-    return new MethodResolver(moduleName, typeName, isStaticMethod, makeTypedColumn);
   }
 
   public static class Method implements MethodInterface {

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -67,14 +67,42 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
 
   public record MethodResolver(
       Value module, Value type, boolean isStaticMethod, Function<Object, Value> makeTypedColumn) {
+    private MethodResolver(
+        Context ctx,
+        String moduleName,
+        String typeName,
+        boolean isStaticMethod,
+        Function<Object, Value> makeTypedColumn) {
+      this(
+          ctx.getBindings("enso").invokeMember("get_module", moduleName),
+          typeName,
+          isStaticMethod,
+          makeTypedColumn);
+    }
+
+    private MethodResolver(
+        Value module,
+        String typeName,
+        boolean isStaticMethod,
+        Function<Object, Value> makeTypedColumn) {
+      this(module, module.invokeMember("get_type", typeName), isStaticMethod, makeTypedColumn);
+    }
+
     public boolean canResolve(String methodName) {
       return resolve(methodName).canExecute();
     }
 
     public Value resolve(String methodName) {
-      var m = type.getMember(methodName);
-      return m == null ? Value.asValue(null) : m;
+      return module.invokeMember("get_method", type, methodName);
     }
+  }
+
+  public static MethodResolver newMethodResolver(
+      Value module, Value type, boolean isStaticMethod, Function<Object, Value> makeTypedColumn) {
+    var moduleName = module.getMetaQualifiedName();
+    var typeName = type.getMetaSimpleName();
+    return new MethodResolver(
+        module.getContext(), moduleName, typeName, isStaticMethod, makeTypedColumn);
   }
 
   public static class Method implements MethodInterface {
@@ -187,12 +215,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
                 name,
                 setVariableArgumentFunctions.contains(name));
     Function<String, Value> makeConstructor =
-        name -> {
-          var m = methodResolvers[0].module.getContext().eval("enso", "main=.." + name);
-          var cons = m.invokeMember("eval_expression", "main");
-          assert cons != null;
-          return cons;
-        };
+        name -> methodResolvers[0].module.invokeMember("eval_expression", ".." + name);
 
     return evaluateImpl(
         expression, getColumn, makeConstantColumn, isColumn, getMethod, makeConstructor);


### PR DESCRIPTION
### Pull Request Description

Rather than trying to lookup module, type and method by name. Pass the module and type instance into the `MethodResolver` and use them directly.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
