### PR TITLE
Excel Connection Pool Cleanup - part 2

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
@@ -17,7 +17,6 @@ polyglot java import java.io.IOException
 polyglot java import org.enso.table.error.InvalidLocationException
 polyglot java import org.enso.table.excel.ExcelFileFormat
 polyglot java import org.enso.table.excel.ExcelHeaders
-polyglot java import org.enso.table.excel.ExcelConnectionPool.ExcelFileFormatMismatchException
 polyglot java import org.enso.table.read.ExcelReader
 
 ## ---
@@ -96,9 +95,8 @@ handle_bad_format file ~action =
    A helper that handles the Java exceptions reported when a malformed XLS file
    is opened.
 handle_bad_format_with_handler handler ~action =
-    Panic.catch ExcelFileFormatMismatchException handler=handler <|
-        Panic.catch IOException handler=handler <|
-            action
+    Panic.catch IOException handler=handler <|
+        action
 
 ## ---
    private: true

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.function.Function;
-
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OLE2NotOfficeXmlFileException;
@@ -260,16 +259,16 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
           throw new IllegalStateException("The workbook is already open.");
         }
 
-          try {
-            workbook =
-                format == ExcelFileFormat.XLSX
-                    ? new XSSFReaderWorkbook(file.getAbsolutePath())
-                    : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
-          } catch (OLE2NotOfficeXmlFileException | NotOLE2FileException e) {
-            throw new IOException(
-                "Invalid format encountered when opening the file " + file + " as " + format + ".",
-                e);
-          }
+        try {
+          workbook =
+              format == ExcelFileFormat.XLSX
+                  ? new XSSFReaderWorkbook(file.getAbsolutePath())
+                  : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
+        } catch (OLE2NotOfficeXmlFileException | NotOLE2FileException e) {
+          throw new IOException(
+              "Invalid format encountered when opening the file " + file + " as " + format + ".",
+              e);
+        }
       }
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -8,9 +8,9 @@ import java.io.OutputStream;
 import java.nio.file.AccessMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.function.Function;
+
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OLE2NotOfficeXmlFileException;
@@ -53,28 +53,17 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
         throw new FileNotFoundException(file.toString());
       }
 
-      String key = getKeyForFile(file);
+      String key = getKeyForFile(file, format);
       ConnectionRecord existingRecord = records.get(key);
       if (existingRecord != null) {
         // Adapt the existing record
-        if (existingRecord.format != format) {
-          throw new ExcelFileFormatMismatchException(
-              "Requesting to open "
-                  + file
-                  + " as "
-                  + format
-                  + ", but it was "
-                  + "already opened as "
-                  + existingRecord.format
-                  + ".");
-        }
         return new ReadOnlyExcelConnection(this, key, existingRecord);
       } else {
         // Create the new record
         ConnectionRecord record = new ConnectionRecord();
         record.file = file;
         record.format = format;
-        record.reopen(true);
+        record.reopen();
         records.put(key, record);
         return new ReadOnlyExcelConnection(this, key, record);
       }
@@ -87,7 +76,7 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
           "Cannot close a Excel connection while an Excel file is being "
               + "written to. This is a bug in the Table library.");
     }
-    String key = getKeyForFile(file);
+    String key = getKeyForFile(file, format);
     ConnectionRecord existingRecord = records.get(key);
     if (existingRecord != null) {
       existingRecord.close();
@@ -169,8 +158,7 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
 
       isCurrentlyWriting = true;
       try {
-        String key = getKeyForFile(file);
-        ArrayList<ConnectionRecord> recordsToReopen = new ArrayList<>(1 + accompanyingFiles.length);
+        String key = getKeyForFile(file, format);
 
         try {
           // Close the existing connection, if any - to avoid the write operation failing due to the
@@ -178,17 +166,15 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
           ConnectionRecord existingRecord = records.get(key);
           if (existingRecord != null) {
             existingRecord.close();
-            recordsToReopen.add(existingRecord);
           }
 
           verifyIsWritable(file);
 
           for (File accompanyingFile : accompanyingFiles) {
-            String accompanyingKey = getKeyForFile(accompanyingFile);
+            String accompanyingKey = getKeyForFile(accompanyingFile, format);
             ConnectionRecord accompanyingRecord = records.get(accompanyingKey);
             if (accompanyingRecord != null) {
               accompanyingRecord.close();
-              recordsToReopen.add(accompanyingRecord);
             }
 
             verifyIsWritable(accompanyingFile);
@@ -197,10 +183,6 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
           WriteHelper helper = new WriteHelper(format);
           return action.apply(helper);
         } finally {
-          // Reopen the closed connections
-          for (ConnectionRecord record : recordsToReopen) {
-            record.reopen(false);
-          }
         }
 
       } finally {
@@ -220,8 +202,9 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
     path.getFileSystem().provider().checkAccess(path, AccessMode.WRITE, AccessMode.READ);
   }
 
-  private String getKeyForFile(File file) throws IOException {
-    return file.getCanonicalPath();
+  private String getKeyForFile(File file, ExcelFileFormat format) throws IOException {
+    String pathPart = file.getCanonicalPath();
+    return pathPart + "::" + format.name();
   }
 
   private final HashMap<String, ConnectionRecord> records = new HashMap<>();
@@ -271,44 +254,29 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
       }
     }
 
-    void reopen(boolean throwOnFailure) throws IOException, InterruptedException {
+    void reopen() throws IOException, InterruptedException {
       synchronized (this) {
         if (workbook != null) {
           throw new IllegalStateException("The workbook is already open.");
         }
 
-        try {
           try {
             workbook =
                 format == ExcelFileFormat.XLSX
                     ? new XSSFReaderWorkbook(file.getAbsolutePath())
                     : ExcelWorkbook.forPOIUserModel(openWorkbook(file, format, false));
-          } catch (OLE2NotOfficeXmlFileException e) {
-            throw new IOException(
-                "Invalid format encountered when opening the file " + file + " as " + format + ".",
-                e);
-          } catch (NotOLE2FileException e) {
+          } catch (OLE2NotOfficeXmlFileException | NotOLE2FileException e) {
             throw new IOException(
                 "Invalid format encountered when opening the file " + file + " as " + format + ".",
                 e);
           }
-        } catch (IOException e) {
-          initializationException = e;
-          if (throwOnFailure) {
-            throw e;
-          }
-        }
       }
     }
 
-    private ExcelWorkbook accessCurrentWorkbook() throws IOException {
+    private ExcelWorkbook accessCurrentWorkbook() throws IOException, InterruptedException {
       synchronized (this) {
         if (workbook == null) {
-          if (initializationException != null) {
-            throw initializationException;
-          } else {
-            throw new IllegalStateException("The workbook is used after being closed.");
-          }
+          reopen();
         }
 
         return workbook;
@@ -365,11 +333,5 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
       case XLS -> new HSSFWorkbook();
       case XLSX, XLSX_FALLBACK -> new SXSSFWorkbook();
     };
-  }
-
-  public static class ExcelFileFormatMismatchException extends IllegalArgumentException {
-    public ExcelFileFormatMismatchException(String message) {
-      super(message);
-    }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import org.apache.poi.ss.util.CellReference;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.InferredBuilder;
@@ -74,7 +75,7 @@ public class ExcelReader {
    * @param workbook a {@link ExcelWorkbook} to read the sheet names from.
    * @return a String[] containing the sheet names.
    */
-  public static String[] readSheetNames(ExcelWorkbook workbook) {
+  private static String[] readSheetNames(ExcelWorkbook workbook) {
     int sheetCount = workbook.getNumberOfSheets();
     var output = new String[sheetCount];
     Context context = Context.getCurrent();
@@ -179,7 +180,7 @@ public class ExcelReader {
    * @return a {@link Table} containing the specified data.
    * @throws InvalidLocationException when the sheet index is not valid.
    */
-  public static Table readSheetByIndex(
+  private static Table readSheetByIndex(
       ExcelWorkbook workbook,
       int index,
       ExcelHeaders.HeaderBehavior headers,
@@ -246,7 +247,7 @@ public class ExcelReader {
    * @return a {@link Table} containing the specified data.
    * @throws InvalidLocationException when the range name or address is not found.
    */
-  public static Table readRangeByName(
+  private static Table readRangeByName(
       ExcelWorkbook workbook,
       String rangeNameOrAddress,
       ExcelHeaders.HeaderBehavior headers,
@@ -317,7 +318,7 @@ public class ExcelReader {
     }
   }
 
-  public static Table readRange(
+  private static Table readRange(
       ExcelWorkbook workbook,
       ExcelRange excelRange,
       ExcelHeaders.HeaderBehavior headers,

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.poi.ss.util.CellReference;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.InferredBuilder;


### PR DESCRIPTION
### Pull Request Description

Last incremental change to the ExcelConnectionPool before I do something more transformative to it.

This change:
- Removes the ExcelFileFormatMismatchException. We now let the user open the file again with the wrong format and fail in the same way as if they hadn't opened the file already with the right format.
- Adds the format into the cache key to facilitate the above. My belief is it will be impossible to open the same file with multiple formats.
- When we close workbooks that are open for read, because we are about to write to them, we no longer reopen them automatically. Instead we reopen if the user tries to use them again.
- As a result of these 2 changes we no longer need to sometimes throw and sometimes not when we reopen a file. So more simplification there.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
