### PR TITLE
Isolate use of HideableValue in Enso code

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_Secret.md
@@ -3,6 +3,7 @@
 - type Derived_Secret_Value
     - Base_64_Encode value:Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
     - Concat left:Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value right:Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
+    - Interpret_As_Private_Key secret:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret
     - Plain_Text text:Standard.Base.Data.Text.Text
     - Secret_Value secret:Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret
     - + self other:Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_Secret.enso
@@ -26,6 +26,7 @@ polyglot java import org.enso.base.enso_cloud.HideableValue.Base64EncodeValue
 polyglot java import org.enso.base.enso_cloud.HideableValue.ConcatValues
 polyglot java import org.enso.base.enso_cloud.HideableValue.PlainValue
 polyglot java import org.enso.base.enso_cloud.HideableValue.SecretValue
+polyglot java import org.enso.base.enso_cloud.InterpretAsPrivateKey
 
 ## A reference to a secret stored in the Enso Cloud.
 type Enso_Secret
@@ -281,6 +282,12 @@ type Derived_Secret_Value
     ## ---
        private: true
        ---
+       Interprets the value as a Private Key.
+    Interpret_As_Private_Key (secret : Enso_Secret)
+
+    ## ---
+       private: true
+       ---
     + self (other : Derived_Secret_Value) = Derived_Secret_Value.Concat self other
 
     ## ---
@@ -338,6 +345,7 @@ as_hideable_value (value : Text | Enso_Secret | Derived_Secret_Value) = case val
     Derived_Secret_Value.Secret_Value secret -> as_hideable_value secret
     Derived_Secret_Value.Concat left right -> HideableValue.ConcatValues.new (as_hideable_value left) (as_hideable_value right)
     Derived_Secret_Value.Base_64_Encode inner -> HideableValue.Base64EncodeValue.new (as_hideable_value inner)
+    Derived_Secret_Value.Interpret_As_Private_Key secret -> InterpretAsPrivateKey.new (as_hideable_value secret)
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -21,7 +21,6 @@ polyglot java import java.sql.DatabaseMetaData
 polyglot java import java.sql.PreparedStatement
 polyglot java import java.sql.SQLException
 polyglot java import java.sql.SQLTimeoutException
-polyglot java import org.enso.base.enso_cloud.HideableValue
 polyglot java import org.enso.database.dryrun.OperationSynchronizer
 polyglot java import org.enso.database.JDBCProxy
 polyglot java import org.graalvm.collections.Pair as Java_Pair
@@ -303,10 +302,7 @@ create url properties = handle_sql_errors <|
    ---
 properties_as_java_props properties =
     properties.map pair->
-        # Some parameters may be passed by the dialect as a `HideableValue` directly, so they do not need to be converted.
-        value = pair.second
-        java_value = if value.is_a HideableValue then value else
-            as_hideable_value value
+        java_value = as_hideable_value pair.second
         Java_Pair.create pair.first java_value
 
 ## ---

--- a/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/src/Generic_JDBC_Connection.enso
+++ b/distribution/lib/Standard/Generic_JDBC/0.0.0-dev/src/Generic_JDBC_Connection.enso
@@ -22,7 +22,6 @@ from Standard.Database.Internal.Result_Set import result_set_to_table
 polyglot java import java.sql.DatabaseMetaData
 polyglot java import java.sql.SQLException
 polyglot java import java.sql.SQLTimeoutException
-polyglot java import org.enso.base.enso_cloud.HideableValue
 polyglot java import org.enso.database.dryrun.OperationSynchronizer
 polyglot java import org.enso.database.JDBCProxy
 polyglot java import org.enso.database.JDBCUtils
@@ -379,10 +378,7 @@ private create_jdbc_connection url properties = handle_sql_errors <|
    ---
 private properties_as_java_props properties =
     properties.map pair->
-        # Some parameters may be passed by the dialect as a `HideableValue` directly, so they do not need to be converted.
-        value = pair.second
-        java_value = if value.is_a HideableValue then value else
-            as_hideable_value value
+        java_value = as_hideable_value pair.second
         Java_Pair.create pair.first java_value
 
 ## ---

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -441,10 +441,10 @@ private auth_jdbc_properties credentials = case credentials of
     _ : Enso_Secret ->
         Panic.throw (Illegal_Argument.Error "Cannot extract `auth_jdbc_properties` from a Cloud Credential. This is a bug in Snowflake library.")
 
-private _resolve_passphrase passphrase:Text|Enso_Secret =
-    case passphrase of
-      _ : Text -> if passphrase.is_empty then Nothing else passphrase
-      secret : Enso_Secret -> as_hideable_value secret
+private _resolve_passphrase passphrase:Text|Enso_Secret = case passphrase of
+    _ : Text -> if passphrase.is_empty then Nothing else passphrase
+    _ : Enso_Secret -> passphrase
+
 ## ---
    private: true
    ---

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.Display
 from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference, as_hideable_value
@@ -26,7 +27,6 @@ from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_co
 import project.Connection.Key_Pair_Credentials.Key_Pair_Credentials
 import project.Internal.Snowflake_Dialect
 
-polyglot java import org.enso.base.enso_cloud.InterpretAsPrivateKey
 polyglot java import org.enso.snowflake.SnowflakeCloudCredentials
 
 type Snowflake_Connection
@@ -436,8 +436,7 @@ private auth_jdbc_properties credentials = case credentials of
             secret : Enso_Secret ->
                 if resolved_passphrase != Nothing then
                     Error.throw (Illegal_Argument.Error "Passphrase is not applicable when using a secret as a private key.")
-                secret_as_private_key = InterpretAsPrivateKey.new (as_hideable_value secret)
-                [Pair.new 'privateKey' secret_as_private_key]
+                [Pair.new 'privateKey' (Derived_Secret_Value.Interpret_As_Private_Key secret)]
         [Pair.new 'user' username] + key_part
     _ : Enso_Secret ->
         Panic.throw (Illegal_Argument.Error "Cannot extract `auth_jdbc_properties` from a Cloud Credential. This is a bug in Snowflake library.")

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.Display
-from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference, as_hideable_value
+from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference
 from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import Single_Choice, Text_Input
 from Standard.Base.Visualization.Table_Viz_Data import Table_Viz_Data, Table_Viz_Header


### PR DESCRIPTION
### Pull Request Description

- Secret's as Private Key should be a `Derived_Secret_Value` (was used by Snowflake).
- `HideableValue` only used in Enso_Secret.enso.
- Only called by Enso just before going to Java.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
