### PR TITLE
Table expression autocomplete doc popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Autocompletion for Column names in table expressions][13848]
 - [When connecting to port a value with additional type, a necessary type cast
   is included][14028]
+- [Function docs in autocomplete in table expressions][14059]
 
 [13685]: https://github.com/enso-org/enso/pull/13685
 [13658]: https://github.com/enso-org/enso/pull/13658
@@ -22,6 +23,7 @@
 [13848]: https://github.com/enso-org/enso/pull/13848
 [14028]: https://github.com/enso-org/enso/pull/14028
 [13976]: https://github.com/enso-org/enso/pull/13976
+[14059]: https://github.com/enso-org/enso/pull/14059
 
 #### Enso Standard Library
 

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -816,19 +816,20 @@ test.describe('Table expression', () => {
   })
 
   async function getTableNodeExprAutocomplete(page: Page) {
-    const exprText = locate.graphNodeByBinding(page, 'table').locator('.WidgetText')
+    const node = locate.graphNodeByBinding(page, 'table')
+    const exprText = node.locator('.WidgetText')
     await expect(exprText).toHaveAttribute('data-text-syntax', 'enso-table-expression')
     await exprText.click()
     await expect(exprText.getByTestId('widget-text-content')).toBeFocused()
-    return await AutocompleteMenu.ForEditor(exprText)
+    return await AutocompleteMenu.ForEditorInNode(node)
   }
 })
 
 class AutocompleteMenu {
   private constructor(private readonly root: Locator) {}
 
-  static async ForEditor(editor: Locator): Promise<AutocompleteMenu> {
-    const root = editor.locator('.cm-tooltip-autocomplete')
+  static async ForEditorInNode(node: Locator): Promise<AutocompleteMenu> {
+    const root = node.locator('.cm-tooltip-autocomplete')
     await expect(root).toBeVisible()
     return new AutocompleteMenu(root)
   }

--- a/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
+++ b/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
+import VueHostRender, { VueHostInstance } from '@/components/VueHostRender.vue'
 import type { HandledUpdate, WidgetInput, WidgetTypeId } from '@/providers/widgetRegistry'
 import { WidgetEditHandler } from '@/providers/widgetRegistry/editHandler'
 import { Ast } from '@/util/ast'
@@ -15,9 +16,7 @@ const props = defineProps<{
   widgetTypeId: WidgetTypeId
   input: WidgetInput
   placeholder?: string | undefined
-  /**
-   * Additional extensions to provide to codemirror editor. Usually useful for language definition.
-   */
+  /** Additional extensions to provide to codemirror editor. */
   extensions?: Extension
   /**
    * If provided, the element with class `cm-content` will also have the given `data-testid`.
@@ -45,6 +44,7 @@ const { syncExt, getText, setText } = useStringSync({
   },
   onUserAction: (text, selection) => emit('userAction', text, selection),
 })
+const vueHost = new VueHostInstance()
 const { editorView } = useCodeMirror(editorRoot, {
   placeholder: () => props.placeholder ?? ' ',
   extensions: [
@@ -57,6 +57,7 @@ const { editorView } = useCodeMirror(editorRoot, {
   readonly: false,
   contentTestId: props.contentTestId,
   lineMode: () => props.lineMode ?? 'single',
+  vueHost: () => vueHost,
 })
 
 watch(model, (text) => setText(editorView, text), { immediate: true })
@@ -139,7 +140,9 @@ defineExpose({
     @keydown.down.stop
     @click.stop
     @wheel.stop.passive
-  />
+  >
+    <VueHostRender :host="vueHost" />
+  </CodeMirrorRoot>
 </template>
 
 <style scoped>

--- a/app/gui/src/project-view/components/MarkdownEditor.vue
+++ b/app/gui/src/project-view/components/MarkdownEditor.vue
@@ -11,7 +11,7 @@ const { toolbar = true, ...props } = defineProps<{
   extensions?: Extension
   contentTestId?: string
   scrollerTestId?: string | undefined
-  editorReadyCallback: (view: EditorView) => void
+  editorReadyCallback?: ((view: EditorView) => void) | undefined
 }>()
 
 defineOptions({

--- a/app/gui/src/project-view/components/TableExpressionFunctionDocs.vue
+++ b/app/gui/src/project-view/components/TableExpressionFunctionDocs.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import MarkdownEditor from '@/components/MarkdownEditor.vue'
+import type { MethodSuggestionEntry } from '@/stores/suggestionDatabase/entry'
+import { useStringSync } from '@/util/codemirror'
+import { computed } from 'vue'
+
+const { documentation } = defineProps<{
+  documentation: MethodSuggestionEntry
+}>()
+
+const name = computed(() => documentation.name)
+const args = computed(() =>
+  documentation.arguments
+    .filter((arg) => !arg.hasDefault)
+    .map((arg) => (arg.name === 'self' ? '[column]' : arg.name)),
+)
+const summary = computed(() =>
+  (documentation.documentationSummary ?? '').replaceAll('`self`', '`column`'),
+)
+const { syncExt, setText } = useStringSync()
+</script>
+
+<template>
+  <div class="TableExpressionFunctionDocs">
+    <div class="usage">{{ name }}({{ args.join(', ') }})</div>
+    <MarkdownEditor
+      :extensions="syncExt"
+      :toolbar="false"
+      :editorReadyCallback="(view) => setText(view, summary)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.TableExpressionFunctionDocs {
+  padding: 1px 4px;
+}
+
+.usage {
+  font-family: var(--font-mono);
+}
+</style>

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -2,6 +2,7 @@ import { textEditorsBindings } from '@/bindings'
 import type CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
 import type { VueHost } from '@/components/VueHostRender.vue'
 import { injectKeyboard } from '@/providers/keyboard'
+import { usePopoverRoot } from '@/providers/popoverRoot'
 import {
   contentFocused,
   contentFocusedExt,
@@ -9,7 +10,7 @@ import {
 } from '@/util/codemirror/contentFocusedExt'
 import { extendCmEvent, keyBindings, type CmEventExt } from '@/util/codemirror/keymap'
 import { useCompartment, useDispatch, useStateEffect } from '@/util/codemirror/reactivity'
-import { setVueHost } from '@/util/codemirror/vueHostExt'
+import { setVueHost, vueHostExt } from '@/util/codemirror/vueHostExt'
 import { yCollab } from '@/util/codemirror/yCollab'
 import type { Vec2 } from '@/util/data/vec2'
 import { elementHierarchy } from '@/util/dom'
@@ -26,7 +27,7 @@ import {
   type StateEffectType,
   type TransactionSpec,
 } from '@codemirror/state'
-import { EditorView, placeholder } from '@codemirror/view'
+import { EditorView, placeholder, tooltips } from '@codemirror/view'
 import { find, takeUntil } from 'enso-common/src/utilities/data/iter'
 import { LINE_BOUNDARIES } from 'enso-common/src/utilities/data/string'
 import { createDebouncer } from 'lib0/eventloop.js'
@@ -35,6 +36,7 @@ import {
   isRef,
   markRaw,
   onUnmounted,
+  readonly,
   ref,
   toValue,
   watch,
@@ -82,7 +84,7 @@ interface CodeMirrorOptions {
  * Creates a CodeMirror editor instance.
  *
  * The editor will be empty. To set and synchronize its contents, use proper extension, like
- * {@link useStringSync}, {@link yCollab} or {@link useYTextSync}. If they require {@link EditorView},
+ * {@link useStringSync}, {@link yCollab}, or {@link useYTextSync}. If they require {@link EditorView},
  * they may be attached with `setExtraExtensions` method.
  */
 export function useCodeMirror(
@@ -99,10 +101,14 @@ export function useCodeMirror(
 ) {
   const dispatch = { dispatch: (...specs: TransactionSpec[]) => view.dispatch(...specs) }
   const readonlyExt = useCompartment(dispatch, () =>
-    toValue(readonly) ? [EditorState.readOnly.of(true), EditorView.editable.of(false)] : [],
+    toValue(readonly) ?
+      [EditorState.readOnly.of(true), EditorView.editable.of(false)]
+    : NULL_EXTENSION,
   )
   const placeholderExt =
-    placeholderText ? useCompartment(dispatch, () => placeholder(toValue(placeholderText))) : []
+    placeholderText ?
+      useCompartment(dispatch, () => placeholder(toValue(placeholderText)))
+    : NULL_EXTENSION
   const { bindingsExt } = useBindings()
   const extrasCompartment = markRaw(new Compartment())
   const bindingsCompartment = useCompartment(dispatch, () => keyBindings(toValue(lineMode)))
@@ -113,13 +119,25 @@ export function useCodeMirror(
   const themeCompartment = useCompartment(dispatch, () =>
     theme({ singleLine: singleLineState.value }),
   )
+  const popoverRoot = usePopoverRoot(true)
+  const tooltipsConfigExt =
+    popoverRoot == null ? NULL_EXTENSION : (
+      useCompartment(dispatch, () =>
+        popoverRoot.value == null ?
+          NULL_EXTENSION
+        : tooltips({
+            position: 'absolute',
+            parent: popoverRoot.value,
+          }),
+      )
+    )
 
   const reactiveExtensions =
     extensions ?
       extensions.map((ext) =>
         isRef(ext) || typeof ext === 'function' ? useCompartment(dispatch, ext) : ext,
       )
-    : []
+    : NULL_EXTENSION
   const view = markRaw(
     new EditorView({
       state: EditorState.create({
@@ -129,8 +147,10 @@ export function useCodeMirror(
           placeholderExt,
           bindingsCompartment,
           themeCompartment,
-          extrasCompartment.of([]),
+          extrasCompartment.of(NULL_EXTENSION),
           reactiveExtensions,
+          tooltipsConfigExt,
+          vueHost ? vueHostExt : NULL_EXTENSION,
         ],
       }),
     }),
@@ -158,12 +178,12 @@ export function useCodeMirror(
      * Update a set of additional extensions for the editor.
      *
      * This function can be used to provide extensions that are not ready before `useCodeMirror` can
-     * be called, e.g. because they require an {@link EditorView} instance to be created. If called
+     * be called, e.g., because they require an {@link EditorView} instance to be created. If called
      * more than once, the new collection of extra extensions will replace the previous collection.
      *
      * The change will be dispatched asynchronously; this avoids observing an inconsistent state:
      * When an extension is removed, its event handlers may still fire if they were triggered in the
-     * same tick (i.e. by the same event that caused the extension to be removed); in that case, the
+     * same tick (i.e., by the same event that caused the extension to be removed); in that case, the
      * handler would likely misbehave due to its extension not being installed, and all its state
      * fields being missing.
      *
@@ -174,7 +194,7 @@ export function useCodeMirror(
     setExtraExtensions: (extensions: Extension | undefined) => {
       extraExtsDebouncer(() =>
         view.dispatch({
-          effects: extrasCompartment.reconfigure(extensions ?? []),
+          effects: extrasCompartment.reconfigure(extensions ?? NULL_EXTENSION),
         }),
       )
     },
@@ -182,6 +202,8 @@ export function useCodeMirror(
     contentElement: view.contentDOM,
   }
 }
+
+const NULL_EXTENSION: Extension = readonly([])
 
 function useBindings() {
   const keyboard = injectKeyboard(true)
@@ -288,7 +310,7 @@ export function useYTextSync(content: ToValue<Y.Text | undefined>, origin?: Loca
   }
 
   return {
-    syncExt: syncCompartment.of([]),
+    syncExt: syncCompartment.of(NULL_EXTENSION),
     connectSync: (view: EditorView) => {
       useDispatch(
         view,
@@ -297,7 +319,7 @@ export function useYTextSync(content: ToValue<Y.Text | undefined>, origin?: Loca
         // yText), but can handle being removed and reinstalled.
         () =>
           view.dispatch({
-            effects: syncCompartment.reconfigure([]),
+            effects: syncCompartment.reconfigure(NULL_EXTENSION),
           }),
       )
     },

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/__tests__/completionData.test.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/__tests__/completionData.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { escapeColumn } from '../completions'
+import { escapeColumn } from '../completionData'
 
 test.each([
   { name: 'A Column' },

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/autocomplete.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/autocomplete.ts
@@ -1,0 +1,16 @@
+import { tableExpressionLang } from 'lezer-enso-table-expr'
+import { type MethodCompletionInfo, completionSource } from './completionSource'
+import { functionDocs } from './functionDocs'
+export type { MethodCompletionInfo }
+
+/** A CodeMirror extension adding autocomplete support for the Enso Table Expression DSL. */
+export function tableExpressionAutocomplete(options: {
+  methods: (() => MethodCompletionInfo[]) | undefined
+  columns: (() => string[]) | undefined
+}) {
+  const completionProvider = tableExpressionLang.data.of({
+    autocomplete: completionSource(options.methods, options.columns),
+  })
+  const docsPopups = functionDocs(options.methods)
+  return [completionProvider, docsPopups]
+}

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/completionData.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/completionData.ts
@@ -2,6 +2,7 @@
  * @file This module supports maintaining a collection of CodeMirror completions, based on provided
  * method information and the rules of the syntax.
  */
+import type { MethodSuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import type { Completion } from '@codemirror/autocomplete'
 import { record } from 'enso-common/src/utilities/data/object'
 import { computed } from 'vue'
@@ -11,6 +12,7 @@ export interface MethodCompletionInfo {
   name: string
   description?: string | undefined
   args: boolean
+  documentation: MethodSuggestionEntry
 }
 
 interface StringCompletion extends Completion {

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
@@ -1,12 +1,16 @@
+import {
+  type MethodCompletionInfo,
+  useCompletionData,
+} from '@/util/codemirror/language/tableExpression/completionData'
 import type {
   CompletionContext,
   CompletionResult,
   CompletionSource,
 } from '@codemirror/autocomplete'
 import { completionTypeAt } from 'lezer-enso-table-expr'
-import { type MethodCompletionInfo, useCompletionData } from './completionData'
 export type { MethodCompletionInfo }
 
+/** Creates a {@link CompletionSource} from the provided data. */
 export function completionSource(
   methods: (() => MethodCompletionInfo[]) | undefined,
   columns: (() => string[]) | undefined,

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
@@ -3,8 +3,8 @@ import type {
   CompletionResult,
   CompletionSource,
 } from '@codemirror/autocomplete'
-import { type MethodCompletionInfo, useCompletionData } from './completionData'
 import { completionTypeAt } from 'lezer-enso-table-expr'
+import { type MethodCompletionInfo, useCompletionData } from './completionData'
 export type { MethodCompletionInfo }
 
 export function completionSource(

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/completionSource.ts
@@ -1,0 +1,41 @@
+import type {
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from '@codemirror/autocomplete'
+import { type MethodCompletionInfo, useCompletionData } from './completionData'
+import { completionTypeAt } from 'lezer-enso-table-expr'
+export type { MethodCompletionInfo }
+
+export function completionSource(
+  methods: (() => MethodCompletionInfo[]) | undefined,
+  columns: (() => string[]) | undefined,
+): CompletionSource {
+  const {
+    valueOptions,
+    valueOptionsStartingWithIdentifier,
+    methodOptions,
+    columnOptions,
+    columnsWithBracket,
+  } = useCompletionData(methods, columns)
+  return (context: CompletionContext): CompletionResult | null => {
+    const completion = completionTypeAt(context.pos, context.state)
+    if (!completion) return null
+    if (completion.auto === false && !context.explicit) return null
+    const options =
+      completion.type === 'value' ? valueOptions.value
+      : completion.type === 'functionName' ?
+        completion.insertDelim ?
+          valueOptionsStartingWithIdentifier.value
+        : methodOptions.value.methods
+      : completion.type === 'columnName' ?
+        completion.insertDelim ?
+          columnsWithBracket.value
+        : columnOptions.value
+      : completion.type === 'binop' ?
+        [...methodOptions.value.binaryOperators, ...methodOptions.value.postfixOperators]
+      : null
+    if (options == null) return null
+    return { from: completion.pos ?? context.pos, options }
+  }
+}

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/functionDocs.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/functionDocs.ts
@@ -1,0 +1,63 @@
+import TableExpressionFunctionDocs from '@/components/TableExpressionFunctionDocs.vue'
+import { getVueHost, vueHostExt } from '@/util/codemirror/vueHostExt'
+import type { EditorState, Extension } from '@codemirror/state'
+import type { Tooltip } from '@codemirror/view'
+import { completionTypeAt } from 'lezer-enso-table-expr'
+import { computed } from 'vue'
+import type { MethodCompletionInfo } from '@/util/codemirror/language/tableExpression/completionData'
+import { singleCursorTooltipExtension } from '@/util/codemirror/tooltips/showTooltip'
+import { vueTooltipView } from '@/util/codemirror/tooltips/tooltipView'
+
+function memoizeIf<Value, Args extends unknown[]>(
+  getValue: (...args: Args) => Value,
+  isEquivalent: (a: Value, b: Value) => boolean,
+) {
+  let prev: { value: Value } | undefined = undefined
+  return (...args: Args) => {
+    const newValue = getValue(...args)
+    if (prev != null && isEquivalent(newValue, prev.value)) return prev.value
+    prev = { value: newValue }
+    return newValue
+  }
+}
+
+/**
+ * Wraps a tooltip function to return the same object if the `pos` hasn't changed; this prevents flickering when moving
+ * the cursor.
+ */
+function memoizeTooltip<Args extends unknown[]>(getTooltip: (...args: Args) => Tooltip | null) {
+  return memoizeIf(getTooltip, (a, b) => a?.pos === b?.pos)
+}
+
+function docsTooltip(
+  state: EditorState,
+  getMethod: (name: string) => MethodCompletionInfo | undefined,
+) {
+  const pos = state.selection.ranges[0]!.anchor
+  const completion = completionTypeAt(pos, state)
+  if (completion?.type !== 'functionInfo') return null
+  const vueHost = state.field(getVueHost)
+  if (vueHost == null) return null
+  const method = getMethod(completion.functionName)
+  if (method == null) return null
+  const documentation = method.documentation
+  return {
+    pos: completion.pos,
+    create: () => vueTooltipView(vueHost, TableExpressionFunctionDocs, { documentation }),
+    clip: false,
+  }
+}
+
+/**
+ * CodeMirror extension adding a tooltip showing the documentation of a function in the table expression language,
+ * complementing the autocomplete feature.
+ */
+export function functionDocs(methods: (() => MethodCompletionInfo[]) | undefined): Extension {
+  const methodByName = computed(
+    () => new Map<string, MethodCompletionInfo>((methods?.() ?? []).map((m) => [m.name, m])),
+  )
+  const getMethod = (name: string) => methodByName.value.get(name)
+  const getTooltip = memoizeTooltip(docsTooltip)
+  const tooltipExt = singleCursorTooltipExtension((state) => getTooltip(state, getMethod))
+  return [tooltipExt, vueHostExt]
+}

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/functionDocs.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/functionDocs.ts
@@ -1,12 +1,12 @@
 import TableExpressionFunctionDocs from '@/components/TableExpressionFunctionDocs.vue'
+import type { MethodCompletionInfo } from '@/util/codemirror/language/tableExpression/completionData'
+import { singleCursorTooltipExtension } from '@/util/codemirror/tooltips/showTooltip'
+import { vueTooltipView } from '@/util/codemirror/tooltips/tooltipView'
 import { getVueHost, vueHostExt } from '@/util/codemirror/vueHostExt'
 import type { EditorState, Extension } from '@codemirror/state'
 import type { Tooltip } from '@codemirror/view'
 import { completionTypeAt } from 'lezer-enso-table-expr'
 import { computed } from 'vue'
-import type { MethodCompletionInfo } from '@/util/codemirror/language/tableExpression/completionData'
-import { singleCursorTooltipExtension } from '@/util/codemirror/tooltips/showTooltip'
-import { vueTooltipView } from '@/util/codemirror/tooltips/tooltipView'
 
 function memoizeIf<Value, Args extends unknown[]>(
   getValue: (...args: Args) => Value,

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -8,9 +8,11 @@ import { ProjectPath } from '@/util/projectPath'
 import type { QualifiedName } from '@/util/qualifiedName'
 import type { ToValue } from '@/util/reactivity'
 import type { Extension } from '@codemirror/state'
-import { tableExpression, type MethodCompletionInfo } from 'lezer-enso-table-expr'
+import { tableExpression } from 'lezer-enso-table-expr'
 import { computed, toRef, toValue } from 'vue'
 import type { Opt } from 'ydoc-shared/util/data/opt'
+import { tableExpressionAutocomplete } from './autocomplete'
+import type { MethodCompletionInfo } from './completionData'
 
 export interface TableExpressionExtensionOptions {
   project: ToValue<Opt<ProjectStore>>
@@ -43,10 +45,11 @@ export function useTableExpressionExtension(
       project ?
         useTableColumns({ project, projectNames, expressionId: useTableContext(true)?.externalId })
       : undefined
-    return tableExpression({
+    const autocomplete = tableExpressionAutocomplete({
       methods: () => methodInfos.value,
       columns: () => columns?.value ?? [],
     })
+    return [tableExpression(), autocomplete]
   }
 }
 
@@ -73,6 +76,7 @@ function methodInfoFromEntry(entry: MethodSuggestionEntry): MethodCompletionInfo
     name: entry.name,
     description: entry.documentationSummary,
     args: entry.arguments.length > 0,
+    documentation: entry,
   }
 }
 

--- a/app/gui/src/project-view/util/codemirror/tooltips/showTooltip.ts
+++ b/app/gui/src/project-view/util/codemirror/tooltips/showTooltip.ts
@@ -1,0 +1,23 @@
+import type { EditorState, Extension } from '@codemirror/state'
+import { StateField } from '@codemirror/state'
+import { type Tooltip, showTooltip } from '@codemirror/view'
+
+/**
+ * Creates an extension that uses the given function to provide a tooltip based on the cursor position. If there are
+ * multiple cursors, no tooltip is shown.
+ */
+export function singleCursorTooltipExtension(
+  getTooltip: (state: EditorState) => Tooltip | null,
+): Extension {
+  return StateField.define<Tooltip | null>({
+    create: getTooltip,
+
+    update(prev, tr) {
+      if (!tr.docChanged && !tr.selection) return prev
+      if (tr.state.selection.ranges.length !== 1) return null
+      return getTooltip(tr.state)
+    },
+
+    provide: (f) => showTooltip.from(f),
+  })
+}

--- a/app/gui/src/project-view/util/codemirror/tooltips/tooltipView.ts
+++ b/app/gui/src/project-view/util/codemirror/tooltips/tooltipView.ts
@@ -2,6 +2,7 @@ import type { VueHost } from '@/components/VueHostRender.vue'
 import type { TooltipView } from '@codemirror/view'
 import { h, markRaw, type Component } from 'vue'
 
+/** Creates a {@link TooltipView} for a Vue component. */
 export function vueTooltipView<Props>(
   vueHost: VueHost,
   widget: Component,

--- a/app/gui/src/project-view/util/codemirror/tooltips/tooltipView.ts
+++ b/app/gui/src/project-view/util/codemirror/tooltips/tooltipView.ts
@@ -1,0 +1,13 @@
+import type { VueHost } from '@/components/VueHostRender.vue'
+import type { TooltipView } from '@codemirror/view'
+import { h, markRaw, type Component } from 'vue'
+
+export function vueTooltipView<Props>(
+  vueHost: VueHost,
+  widget: Component,
+  props: Props,
+): TooltipView {
+  const container = markRaw(document.createElement('div'))
+  const { unregister } = vueHost.register(h(widget, props), container)
+  return { dom: container, destroy: unregister, resize: false }
+}

--- a/app/lang-markdown/package.json
+++ b/app/lang-markdown/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/autocomplete": "catalog:",
-    "@codemirror/lang-html": "^6.0.0",
+    "@codemirror/lang-html": "^6.4.10",
     "@codemirror/language": "catalog:",
     "@codemirror/state": "catalog:",
     "@codemirror/view": "catalog:",

--- a/app/table-expression/package.json
+++ b/app/table-expression/package.json
@@ -15,14 +15,11 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "enso-common": "workspace:*",
-    "@codemirror/autocomplete": "catalog:",
     "@codemirror/language": "catalog:",
     "@codemirror/state": "catalog:",
     "@lezer/lr": "^1.3.0",
     "@lezer/common": "^1.2.3",
-    "@lezer/highlight": "^1.2.1",
-    "vue": "*"
+    "@lezer/highlight": "^1.2.1"
   },
   "scripts": {
     "test:unit": "vitest run",

--- a/app/table-expression/src/autocomplete/__tests__/completionType.test.ts
+++ b/app/table-expression/src/autocomplete/__tests__/completionType.test.ts
@@ -1,7 +1,7 @@
 import { EditorState } from '@codemirror/state'
 import { expect, test } from 'vitest'
+import { completionTypeAt } from '..'
 import { tableExpression } from '../..'
-import { completionTypeAt } from '../completionType'
 
 function completionTypeCase(source: string) {
   const anchor = source.indexOf('|')
@@ -11,7 +11,7 @@ function completionTypeCase(source: string) {
   const doc = source.replaceAll('|', '')
   const state = EditorState.create({
     doc,
-    extensions: [tableExpression({ methods: () => [] })],
+    extensions: tableExpression(),
   })
   return { completion: completionTypeAt(pos, state), anchor }
 }
@@ -65,7 +65,7 @@ test.each([
   'a_function(1, 2, 3|)',
 ])('Function info completion: %s', (source) => {
   const { completion } = completionTypeCase(source)
-  expect(completion).toStrictEqual({ type: 'functionInfo', functionName: 'a_function' })
+  expect(completion).toStrictEqual({ type: 'functionInfo', pos: 0, functionName: 'a_function' })
 })
 
 test.each([

--- a/app/table-expression/src/autocomplete/completionTypeAt.ts
+++ b/app/table-expression/src/autocomplete/completionTypeAt.ts
@@ -1,53 +1,7 @@
-/**
- * @file This module supports determining the types of completions to be shown, based on syntactic
- * analysis and the cursor position.
- */
 import { syntaxTree } from '@codemirror/language'
 import type { EditorState } from '@codemirror/state'
 import { parseNode } from './syntax'
-
-export interface AnyCompletion {
-  type: string
-  pos?: number
-  /**
-   * True if the completion dialog should be opened automatically; otherwise, it may be triggered
-   * with a hotkey.
-   */
-  auto?: boolean
-}
-
-export interface NameCompletion extends AnyCompletion {
-  type: 'functionName' | 'columnName'
-  pos: number
-  auto: boolean
-  /**
-   * True if a delimiter should be inserted after the completion; false if it is unnecessary, e.g.,
-   * when editing a name already followed by a delimiter.
-   */
-  insertDelim: boolean
-}
-
-export interface FunctionInfoCompletion extends AnyCompletion {
-  type: 'functionInfo'
-  functionName: string
-}
-
-export interface ValueCompletion extends AnyCompletion {
-  type: 'value'
-}
-
-export interface BinOpCompletion extends AnyCompletion {
-  type: 'binop'
-  pos: number
-  auto: boolean
-  insertDelim: boolean
-}
-
-export type CompletionType =
-  | NameCompletion
-  | FunctionInfoCompletion
-  | ValueCompletion
-  | BinOpCompletion
+import type { CompletionType } from './types'
 
 const INITIAL_COMPLETION_TYPE: CompletionType = {
   type: 'value',
@@ -90,7 +44,7 @@ export function completionTypeAt(pos: number, state: EditorState): CompletionTyp
     const { name, open } = node
     return pos <= name.to ?
         { type: 'functionName', pos: name.from, auto: pos === name.to, insertDelim: open == null }
-      : { type: 'functionInfo', functionName: doc.sliceString(name.from, name.to) }
+      : { type: 'functionInfo', pos: name.from, functionName: doc.sliceString(name.from, name.to) }
   } else if (node.type === 'Column') {
     const { name, close } = node
     return {

--- a/app/table-expression/src/autocomplete/index.ts
+++ b/app/table-expression/src/autocomplete/index.ts
@@ -1,38 +1,6 @@
-import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete'
-import { useCompletionData, type MethodCompletionInfo } from './completions'
-import { completionTypeAt } from './completionType'
-export type { MethodCompletionInfo }
+/**
+ * @file This module supports determining the types of completions to be shown, based on syntactic
+ * analysis and the cursor position.
+ */
 
-/** @returns a function that can be used as a completion provider. */
-export function useCompletions(
-  methods: (() => MethodCompletionInfo[]) | undefined,
-  columns: (() => string[]) | undefined,
-) {
-  const {
-    valueOptions,
-    valueOptionsStartingWithIdentifier,
-    methodOptions,
-    columnOptions,
-    columnsWithBracket,
-  } = useCompletionData(methods, columns)
-  return (context: CompletionContext): CompletionResult | null => {
-    const completion = completionTypeAt(context.pos, context.state)
-    if (!completion) return null
-    if (completion.auto === false && !context.explicit) return null
-    const options =
-      completion.type === 'value' ? valueOptions.value
-      : completion.type === 'functionName' ?
-        completion.insertDelim ?
-          valueOptionsStartingWithIdentifier.value
-        : methodOptions.value.methods
-      : completion.type === 'columnName' ?
-        completion.insertDelim ?
-          columnsWithBracket.value
-        : columnOptions.value
-      : completion.type === 'binop' ?
-        [...methodOptions.value.binaryOperators, ...methodOptions.value.postfixOperators]
-      : null
-    if (options == null) return null
-    return { from: completion.pos ?? context.pos, options }
-  }
-}
+export { completionTypeAt } from './completionTypeAt'

--- a/app/table-expression/src/autocomplete/types.ts
+++ b/app/table-expression/src/autocomplete/types.ts
@@ -1,0 +1,43 @@
+export interface AnyCompletion {
+  type: string
+  pos?: number
+  /**
+   * True if the completion dialog should be opened automatically; otherwise, it may be triggered
+   * with a hotkey.
+   */
+  auto?: boolean
+}
+
+export interface NameCompletion extends AnyCompletion {
+  type: 'functionName' | 'columnName'
+  pos: number
+  auto: boolean
+  /**
+   * True if a delimiter should be inserted after the completion; false if it is unnecessary, e.g.,
+   * when editing a name already followed by a delimiter.
+   */
+  insertDelim: boolean
+}
+
+export interface FunctionInfoCompletion extends AnyCompletion {
+  type: 'functionInfo'
+  pos: number
+  functionName: string
+}
+
+export interface ValueCompletion extends AnyCompletion {
+  type: 'value'
+}
+
+export interface BinOpCompletion extends AnyCompletion {
+  type: 'binop'
+  pos: number
+  auto: boolean
+  insertDelim: boolean
+}
+
+export type CompletionType =
+  | NameCompletion
+  | FunctionInfoCompletion
+  | ValueCompletion
+  | BinOpCompletion

--- a/app/table-expression/src/index.ts
+++ b/app/table-expression/src/index.ts
@@ -1,22 +1,15 @@
-import { LanguageSupport, LRLanguage } from '@codemirror/language'
-import { useCompletions, type MethodCompletionInfo } from './autocomplete'
+import { LanguageSupport, LRLanguage, type Language } from '@codemirror/language'
 import { parser } from './generated/parser'
 import { highlight } from './highlight'
+export { completionTypeAt } from './autocomplete'
 
-export type { MethodCompletionInfo }
-export interface TableExpressionOptions {
-  methods?: () => MethodCompletionInfo[]
-  columns?: () => string[]
-}
+export const tableExpressionLang: Language = LRLanguage.define({
+  name: 'table-expression',
+  parser: parser.configure({ props: [highlight] }),
+})
+const langSupport = new LanguageSupport(tableExpressionLang, [])
 
 /** @returns A CodeMirror extension supporting the Enso Table Expression DSL. */
-export function tableExpression({ methods, columns }: TableExpressionOptions): LanguageSupport {
-  const lang = LRLanguage.define({
-    name: 'table-expression',
-    parser: parser.configure({ props: [highlight] }),
-    languageData: {
-      autocomplete: useCompletions(methods, columns),
-    },
-  })
-  return new LanguageSupport(lang, [])
+export function tableExpression(): LanguageSupport {
+  return langSupport
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@codemirror/autocomplete':
-      specifier: ^6.18.6
-      version: 6.18.6
+      specifier: ^6.18.7
+      version: 6.18.7
     '@codemirror/language':
-      specifier: ^6.11.2
-      version: 6.11.2
+      specifier: ^6.11.3
+      version: 6.11.3
     '@codemirror/state':
       specifier: ^6.5.2
       version: 6.5.2
     '@codemirror/view':
-      specifier: ^6.38.1
-      version: 6.38.1
+      specifier: ^6.38.2
+      version: 6.38.2
     '@fast-check/vitest':
       specifier: ^0.2.1
       version: 0.2.1
@@ -181,7 +181,7 @@ importers:
         version: 7.28.0
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.18.6
+        version: 6.18.7
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.8.1
@@ -190,7 +190,7 @@ importers:
         version: link:../lang-markdown
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.2
+        version: 6.11.3
       '@codemirror/lint':
         specifier: ^6.8.5
         version: 6.8.5
@@ -202,7 +202,7 @@ importers:
         version: 6.5.2
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.1
+        version: 6.38.2
       '@floating-ui/vue':
         specifier: ^1.1.5
         version: 1.1.5(vue@3.5.13(typescript@5.7.2))
@@ -780,19 +780,19 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.18.6
+        version: 6.18.7
       '@codemirror/lang-html':
-        specifier: ^6.0.0
-        version: 6.4.9
+        specifier: ^6.4.10
+        version: 6.4.10
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.2
+        version: 6.11.3
       '@codemirror/state':
         specifier: 'catalog:'
         version: 6.5.2
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.1
+        version: 6.38.2
       '@lezer/common':
         specifier: ^1.2.1
         version: 1.2.3
@@ -851,10 +851,10 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.18.6
+        version: 6.18.7
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.2
+        version: 6.11.3
       '@codemirror/state':
         specifier: 'catalog:'
         version: 6.5.2
@@ -1478,8 +1478,8 @@ packages:
   '@bazel/runfiles@6.3.1':
     resolution: {integrity: sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==}
 
-  '@codemirror/autocomplete@6.18.6':
-    resolution: {integrity: sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==}
+  '@codemirror/autocomplete@6.18.7':
+    resolution: {integrity: sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==}
 
   '@codemirror/buildhelper@1.0.2':
     resolution: {integrity: sha512-aVewtDPZptq9dTvYqIjpu9HTEmMaKAE4VL22z5E1ycgY5e1LdAiRd5YYjqzQeqLjxpWsHy+emO3n5UUcxpUmSg==}
@@ -1491,14 +1491,14 @@ packages:
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
 
-  '@codemirror/lang-html@6.4.9':
-    resolution: {integrity: sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==}
+  '@codemirror/lang-html@6.4.10':
+    resolution: {integrity: sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==}
 
   '@codemirror/lang-javascript@6.2.2':
     resolution: {integrity: sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==}
 
-  '@codemirror/language@6.11.2':
-    resolution: {integrity: sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==}
+  '@codemirror/language@6.11.3':
+    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
 
   '@codemirror/lint@6.8.5':
     resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
@@ -1512,8 +1512,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.38.1':
-    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
+  '@codemirror/view@6.38.2':
+    resolution: {integrity: sha512-bTWAJxL6EOFLPzTx+O5P5xAO3gTqpatQ2b/ARQ8itfU/v2LlpS3pH2fkL0A3E/Fx8Y2St2KES7ZEV0sHTsSW/A==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -8528,11 +8528,11 @@ snapshots:
 
   '@bazel/runfiles@6.3.1': {}
 
-  '@codemirror/autocomplete@6.18.6':
+  '@codemirror/autocomplete@6.18.7':
     dependencies:
-      '@codemirror/language': 6.11.2
+      '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/common': 1.2.3
 
   '@codemirror/buildhelper@1.0.2':
@@ -8547,45 +8547,45 @@ snapshots:
 
   '@codemirror/commands@6.8.1':
     dependencies:
-      '@codemirror/language': 6.11.2
+      '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/common': 1.2.3
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
-      '@codemirror/language': 6.11.2
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
       '@lezer/css': 1.1.9
 
-  '@codemirror/lang-html@6.4.9':
+  '@codemirror/lang-html@6.4.10':
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/autocomplete': 6.18.7
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.2
-      '@codemirror/language': 6.11.2
+      '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/common': 1.2.3
       '@lezer/css': 1.1.9
       '@lezer/html': 1.3.10
 
   '@codemirror/lang-javascript@6.2.2':
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
-      '@codemirror/language': 6.11.2
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.4.21
 
-  '@codemirror/language@6.11.2':
+  '@codemirror/language@6.11.3':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -8594,13 +8594,13 @@ snapshots:
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
@@ -8609,12 +8609,12 @@ snapshots:
 
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
-      '@codemirror/language': 6.11.2
+      '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
       '@lezer/highlight': 1.2.1
 
-  '@codemirror/view@6.38.1':
+  '@codemirror/view@6.38.2':
     dependencies:
       '@codemirror/state': 6.5.2
       crelt: 1.0.6
@@ -11847,13 +11847,13 @@ snapshots:
 
   codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/autocomplete': 6.18.7
       '@codemirror/commands': 6.8.1
-      '@codemirror/language': 6.11.2
+      '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.2
 
   color-convert@1.9.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,9 +849,6 @@ importers:
 
   app/table-expression:
     dependencies:
-      '@codemirror/autocomplete':
-        specifier: 'catalog:'
-        version: 6.18.7
       '@codemirror/language':
         specifier: 'catalog:'
         version: 6.11.3
@@ -867,12 +864,6 @@ importers:
       '@lezer/lr':
         specifier: ^1.3.0
         version: 1.4.2
-      enso-common:
-        specifier: workspace:*
-        version: link:../common
-      vue:
-        specifier: '*'
-        version: 3.5.13(typescript@5.7.2)
     devDependencies:
       '@lezer/generator':
         specifier: ^1.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,8 @@ catalog:
   vite: ^7.1.2
   vitest: ^3.2.4
   playwright: 1.50.1
-  "@codemirror/autocomplete": ^6.18.6
-  "@codemirror/language": ^6.11.2
+  "@codemirror/autocomplete": ^6.18.7
+  "@codemirror/language": ^6.11.3
   "@codemirror/state": ^6.5.2
-  "@codemirror/view": ^6.38.1
+  "@codemirror/view": ^6.38.2
   "@fast-check/vitest": ^0.2.1


### PR DESCRIPTION
### Pull Request Description

Table expression autocomplete: Show abbreviated docs of function when editing args

https://github.com/user-attachments/assets/0b557836-8b94-4369-ac10-313602a51b1f

Fixes #12307.

### Important Notes

In `Column` methods, `self` arguments are renamed to `[column]` in the argument list and the documentation summary.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
