### PR TITLE
Fix tab default width

### DIFF
--- a/app/gui/src/components/AppContainer/RightPanel.vue
+++ b/app/gui/src/components/AppContainer/RightPanel.vue
@@ -61,13 +61,14 @@ function tabEnabled(id: RightPanelTabId, enabled: ToValue<Result<void>>) {
 const contentElement = useTemplateRef('contentElement')
 const size = useResizeObserver(contentElement)
 const bounds = computed(() => new Rect(Vec2.Zero, size.value))
+const style = computed(() => (data.width == null ? {} : { '--panel-width': `${data.width}px` }))
 </script>
 
 <template>
   <div
     class="RightPanel withBackgroundColor bg-dashboard"
     data-testid="right-panel"
-    :style="{ '--panel-width': `${data.width}px` }"
+    :style="style"
   >
     <SizeTransition width :duration="250">
       <div v-if="component != null" class="sizeWrapper">
@@ -123,10 +124,10 @@ const bounds = computed(() => new Rect(Vec2.Zero, size.value))
   display: flex;
   justify-content: stretch;
   min-width: var(--min-panel-width);
+  /*noinspection CssUnresolvedCustomProperty*/
   width: var(--panel-width, var(--default-panel-width));
   max-width: var(--max-panel-width);
   height: 100%;
-  /* overflow: auto; */
 }
 
 /* This element's visible width will be overwritten by the size transition, but the inner content's

--- a/app/gui/src/components/AppContainer/RightPanel.vue
+++ b/app/gui/src/components/AppContainer/RightPanel.vue
@@ -65,11 +65,7 @@ const style = computed(() => (data.width == null ? {} : { '--panel-width': `${da
 </script>
 
 <template>
-  <div
-    class="RightPanel withBackgroundColor bg-dashboard"
-    data-testid="right-panel"
-    :style="style"
-  >
+  <div class="RightPanel withBackgroundColor bg-dashboard" data-testid="right-panel" :style="style">
     <SizeTransition width :duration="250">
       <div v-if="component != null" class="sizeWrapper">
         <div ref="contentElement" class="content">


### PR DESCRIPTION
### Pull Request Description

Right panel tabs now default to `--default-panel-width` (which was previously unused), rather than being sized by content. Fixes #13977.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
