### PR TITLE
Avoid using JNI when not in Native Image code

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -55,6 +55,7 @@ import org.enso.runner.common.ProfilingConfig;
 import org.enso.runner.common.WrongOption;
 import org.enso.version.BuildVersion;
 import org.enso.version.VersionDescription;
+import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.PolyglotException.StackFrame;
 import org.graalvm.polyglot.SourceSection;
@@ -1481,7 +1482,20 @@ public class Main {
       File component,
       File javaExecutable)
       throws IOException, InterruptedException {
-    var useJNI = true;
+    /* Cannot use JNI when not in Native Image code. Otherwise:
+     Exception in thread "main" java.lang.Error: 
+     The class ImageSingletons can only be used when building native images, 
+     i.e., when using the native-image command.
+        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.checkInstalled(ImageSingletonsSupport.java:69)
+        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.get(ImageSingletonsSupport.java:63)
+        at org.graalvm.nativeimage/org.graalvm.nativeimage.ImageSingletons.lookup(ImageSingletons.java:86)
+        at org.graalvm.nativeimage/org.graalvm.nativeimage.Platform.includedIn(Platform.java:84)
+        at org.enso.jvm.channel/org.enso.jvm.channel.JVM.create(JVM.java:34)
+        at org.enso.runner/org.enso.runner.Main.launchJvm(Main.java:1513)
+        at org.enso.runner/org.enso.runner.Main.launch(Main.java:1602)
+        at org.enso.runner/org.enso.runner.Main.main(Main.java:1116)
+     */
+    var useJNI = ImageInfo.inImageCode();
     var commandAndArgs = new ArrayList<String>();
     if (originalCwdOrNull != null) {
       commandAndArgs.add("-Denso.user.dir=" + originalCwdOrNull);

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1482,19 +1482,7 @@ public class Main {
       File component,
       File javaExecutable)
       throws IOException, InterruptedException {
-    /* Cannot use JNI when not in Native Image code. Otherwise:
-     Exception in thread "main" java.lang.Error: 
-     The class ImageSingletons can only be used when building native images, 
-     i.e., when using the native-image command.
-        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.checkInstalled(ImageSingletonsSupport.java:69)
-        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.get(ImageSingletonsSupport.java:63)
-        at org.graalvm.nativeimage/org.graalvm.nativeimage.ImageSingletons.lookup(ImageSingletons.java:86)
-        at org.graalvm.nativeimage/org.graalvm.nativeimage.Platform.includedIn(Platform.java:84)
-        at org.enso.jvm.channel/org.enso.jvm.channel.JVM.create(JVM.java:34)
-        at org.enso.runner/org.enso.runner.Main.launchJvm(Main.java:1513)
-        at org.enso.runner/org.enso.runner.Main.launch(Main.java:1602)
-        at org.enso.runner/org.enso.runner.Main.main(Main.java:1116)
-     */
+    /* Cannot use JNI when not in Native Image code. Fallback to launching a process. */
     var useJNI = ImageInfo.inImageCode();
     var commandAndArgs = new ArrayList<String>();
     if (originalCwdOrNull != null) {


### PR DESCRIPTION
### Pull Request Description

- while working on #13983
- I realized I cannot just `sbt buildEngineDistribution` (e.g. no native launcher) and then
- `runEngineDistribution --jvm /path/to/jvm`
- we need to avoid `useJni` when already in HotSpot JVM

### Important Notes

```
/* Cannot use JNI when not in Native Image code. Otherwise:
     Exception in thread "main" java.lang.Error: 
     The class ImageSingletons can only be used when building native images, 
     i.e., when using the native-image command.
        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.checkInstalled(ImageSingletonsSupport.java:69)
        at org.graalvm.nativeimage/org.graalvm.nativeimage.impl.ImageSingletonsSupport.get(ImageSingletonsSupport.java:63)
        at org.graalvm.nativeimage/org.graalvm.nativeimage.ImageSingletons.lookup(ImageSingletons.java:86)
        at org.graalvm.nativeimage/org.graalvm.nativeimage.Platform.includedIn(Platform.java:84)
        at org.enso.jvm.channel/org.enso.jvm.channel.JVM.create(JVM.java:34)
        at org.enso.runner/org.enso.runner.Main.launchJvm(Main.java:1513)
        at org.enso.runner/org.enso.runner.Main.launch(Main.java:1602)
        at org.enso.runner/org.enso.runner.Main.main(Main.java:1116)
     */
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
