### PR TITLE
Update the format for SQL Server DataLinks

### DIFF
--- a/app/gui/src/dashboard/data/datalinkSchema.json
+++ b/app/gui/src/dashboard/data/datalinkSchema.json
@@ -270,25 +270,97 @@
         },
         "credentials": {
           "title": "Credentials",
-          "type": "object",
-          "properties": {
-            "username": {
-              "title": "Username",
-              "$ref": "#/$defs/SecureValue"
-            },
-            "password": {
-              "title": "Password",
-              "$ref": "#/$defs/SecureValue"
-            }
-          },
-          "required": ["username", "password"]
+          "$ref": "#/$defs/SQLServerCredentials"
         },
         "table": {
           "title": "Table to access",
-          "$ref": "#/$defs/DatabaseTableDefinition"
+          "$ref": "#/$defs/SQLServerTableDefinition"
         }
       },
       "required": ["type", "libraryName", "host", "port", "database_name"]
+    },
+
+    "SQLServerCredentials" : {
+      "title": "Credentials",
+      "anyOf": [
+        { "$ref": "#/$defs/SQLServerSqlAuth" },
+        { "$ref": "#/$defs/SQLServerNoAuth" },
+        { "$ref": "#/$defs/SQLServerADDefault" },
+        { "$ref": "#/$defs/SQLServerADIntegrated" },
+        { "$ref": "#/$defs/SQLServerADPassword" },
+        { "$ref": "#/$defs/SQLServerADServicePrincipal" }
+      ]
+    },
+    "SQLServerNoAuth": {
+      "title": "None",
+      "type": "object",
+      "properties": {
+      },
+      "required": []
+    },
+    "SQLServerSqlAuth": {
+      "title": "Username/Password",
+      "type": "object",
+      "properties": {
+        "type": { "title": "Type", "const": "UsernameAndPassword", "type": "string" },
+        "username": {
+          "title": "Username",
+          "$ref": "#/$defs/SecureValue"
+        },
+        "password": {
+          "title": "Password",
+          "$ref": "#/$defs/SecureValue"
+        }
+      },
+      "required": ["type", "username", "password"]
+    },
+    "SQLServerADDefault": {
+      "title": "Active Directory (Default)",
+      "type": "object",
+      "properties": {
+        "type": { "title": "Type", "const": "ActiveDirectoryDefault", "type": "string" }
+      },
+      "required": ["type"]
+    },
+    "SQLServerADIntegrated": {
+      "title": "Active Directory (Integrated)",
+      "type": "object",
+      "properties": {
+        "type": { "title": "Type", "const": "ActiveDirectoryIntegrated", "type": "string" }
+      },
+      "required": ["type"]
+    },
+    "SQLServerADPassword": {
+      "title": "Active Directory (Username/Password)",
+      "type": "object",
+      "properties": {
+        "type": { "title": "Type", "const": "ActiveDirectoryPassword", "type": "string" },
+        "username": {
+          "title": "Username",
+          "$ref": "#/$defs/SecureValue"
+        },
+        "password": {
+          "title": "Password",
+          "$ref": "#/$defs/SecureValue"
+        }
+      },
+      "required": ["type", "username", "password"]
+    },
+    "SQLServerADServicePrincipal": {
+      "title": "Active Directory (Service Principal)",
+      "type": "object",
+      "properties": {
+        "type": { "title": "Type", "const": "ActiveDirectoryServicePrincipal", "type": "string" },
+        "id": {
+          "title": "Principal ID",
+          "$ref": "#/$defs/SecureValue"
+        },
+        "secret": {
+          "title": "Principal Secret",
+          "$ref": "#/$defs/SecureValue"
+        }
+      },
+      "required": ["type", "id", "secret"]
     },
 
     "Format": {
@@ -501,6 +573,49 @@
       "required": ["type", "subType"]
     },
 
+    "SQLServerTableDefinition": {
+      "title": "Query to read",
+      "anyOf": [
+        { "title": "Table", "type": "string" },
+        {
+          "title": "Table and Schema",
+          "type": "object",
+          "properties": {
+            "table": {
+              "title": "Table",
+              "type": "string"
+            },
+            "schema": {
+              "title": "Schema",
+              "type": "string"
+            }
+          },
+          "required": ["table", "schema"]
+        },
+        {
+          "title": "SQL Query",
+          "type": "object",
+          "properties": {
+            "query": {
+              "title": "SQL",
+              "type": "string"
+            }
+          },
+          "required": ["query"]
+        },
+        {
+          "title": "(Advanced) JSON serialized interpolated SQL statement",
+          "type": "object",
+          "properties": {
+            "sql_statement": {
+              "title": "SQL_Statement (JSON)",
+              "type": "string"
+            }
+          },
+          "required": ["sql_statement"]
+        }
+      ]
+    },
     "DatabaseTableDefinition": {
       "title": "Query to read",
       "anyOf": [

--- a/app/gui/src/dashboard/data/datalinkSchema.json
+++ b/app/gui/src/dashboard/data/datalinkSchema.json
@@ -280,7 +280,7 @@
       "required": ["type", "libraryName", "host", "port", "database_name"]
     },
 
-    "SQLServerCredentials" : {
+    "SQLServerCredentials": {
       "title": "Credentials",
       "anyOf": [
         { "$ref": "#/$defs/SQLServerSqlAuth" },
@@ -294,8 +294,7 @@
     "SQLServerNoAuth": {
       "title": "None",
       "type": "object",
-      "properties": {
-      },
+      "properties": {},
       "required": []
     },
     "SQLServerSqlAuth": {

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
@@ -10,6 +10,7 @@
     - make_column self internal:Standard.Database.Internal.IR.Internal_Column.Internal_Column -> (Standard.Base.Any.Any|Standard.Base.Any.Any)
     - name self -> Standard.Base.Data.Text.Text
     - save_as_data_link self destination:Standard.Base.Any.Any on_existing_file:Standard.Base.System.File.Existing_File_Behavior.Existing_File_Behavior= -> Standard.Base.Any.Any
+    - table_name_schema self -> Standard.Base.Any.Any
     - to_select_query self -> Standard.Base.Any.Any
     - to_sql self -> Standard.Database.SQL.SQL_Statement
     - updated_columns self internal_columns:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Data_Link_Setup.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Data_Link_Setup.md
@@ -5,6 +5,7 @@
     - Query query:Standard.Base.Data.Text.Text
     - SQL_Statement sql_statement:Standard.Database.SQL.SQL_Statement
     - Table name:Standard.Base.Data.Text.Text
+    - Table_Schema name:Standard.Base.Data.Text.Text schema:Standard.Base.Data.Text.Text
     - add_to_data_link_description self connection_description:Standard.Base.Data.Json.JS_Object -> Standard.Base.Data.Json.JS_Object
     - from_js value:Standard.Base.Any.Any -> Standard.Database.Internal.Data_Link_Setup.DB_Data_Link_Type!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
     - interpret self connection:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -268,6 +268,16 @@ type DB_Table
             _ -> False
 
     ## ---
+       private: true
+       ---
+    table_name_schema self =
+        case self.context.from_spec of
+            SQL_IR_From_Part.Table table_name schema_name _ _ ->
+                if schema_name.is_nothing || schema_name == "" then [table_name] else [schema_name, table_name]
+            _ -> Nothing
+
+
+    ## ---
        group: Standard.Base.Output
        icon: data_output
        ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Data_Link_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Data_Link_Helpers.enso
@@ -29,13 +29,17 @@ save_table_as_data_link table destination on_existing_file:Existing_File_Behavio
         Error.throw (Illegal_Argument.Error "Saving a Table as data link is currently not supported in this backend.")
 
     # For a trivial query we return the table name.
-    link_type = if table.is_trivial_query fail_if_not_found=False then DB_Data_Link_Type.Table table.name else
-        sql_statement = table.to_sql
-        prepared = sql_statement.prepare
-        # If there are no interpolations, we can do a raw query represented by Text (more friendly in the GUI).
-        if prepared.second.is_empty then DB_Data_Link_Type.Query prepared.first else
-            # Lastly, if there are interpolations, we need to fully serialize
-            DB_Data_Link_Type.SQL_Statement sql_statement
+    table_schema_name = table.table_name_schema
+    link_type = case table_schema_name of
+        _ : Text -> DB_Data_Link_Type.Table table.name
+        _ : Vector -> DB_Data_Link_Type.Table_Schema table_schema_name.first table_schema_name.second
+        Nothing ->
+            sql_statement = table.to_sql
+            prepared = sql_statement.prepare
+            # If there are no interpolations, we can do a raw query represented by Text (more friendly in the GUI).
+            if prepared.second.is_empty then DB_Data_Link_Type.Query prepared.first else
+                # Lastly, if there are interpolations, we need to fully serialize
+                DB_Data_Link_Type.SQL_Statement sql_statement
     result = data_link_setup.save_as_data_link destination on_existing_file link_type
     referred_temporary_tables = _find_referred_temporary_tables table.connection table.context
     if referred_temporary_tables.is_nothing then result else

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Data_Link_Setup.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Data_Link_Setup.enso
@@ -84,6 +84,11 @@ type DB_Data_Link_Type
     ## ---
        private: true
        ---
+    Table_Schema name:Text schema:Text
+
+    ## ---
+       private: true
+       ---
     Query query:Text
 
     ## ---
@@ -111,6 +116,8 @@ type DB_Data_Link_Type
             Nothing
         DB_Data_Link_Type.Table name ->
             name
+        DB_Data_Link_Type.Table_Schema name schema ->
+            JS_Object.from_pairs [["name", name], ["schema", schema]]
         DB_Data_Link_Type.Query query ->
             JS_Object.from_pairs [["query", query]]
         DB_Data_Link_Type.SQL_Statement sql_statement ->
@@ -134,6 +141,11 @@ type DB_Data_Link_Type
             DB_Data_Link_Type.Table table_name
         obj : JS_Object ->
             fields = obj.field_names
+            parse_table_with_schema =
+                name = obj.get "name"
+                schema = obj.get "schema"
+                if name.is_a Text && schema.is_a Text then DB_Data_Link_Type.Table_Schema name schema else
+                    Error.throw (Illegal_Argument.Error "Invalid JSON inside of data link: expected `name` and `schema` fields to be Text but got: "+obj.to_display_text)
             parse_simple_query =
                 query = obj.get "query"
                 if query.is_a Text then DB_Data_Link_Type.Query query else
@@ -142,9 +154,10 @@ type DB_Data_Link_Type
                 sql_statement_json = obj.get "sql_statement"
                 if sql_statement_json.is_a Text then DB_Data_Link_Type.SQL_Statement (SQL_Statement.deserialize sql_statement_json) else
                     Error.throw (Illegal_Argument.Error "Invalid JSON inside of data link: expected `sql_statement` field to be a Text containing JSON but got: "+sql_statement_json.to_display_text)
-            if fields == ["query"] then parse_simple_query else
-                if fields == ["sql_statement"] then parse_serialized_statement else
-                    Error.throw (Illegal_Argument.Error "Invalid JSON inside of data link: expected exactly one field: `query` or `sql_statement`, but got: "+obj.to_display_text)
+            if fields == ["name"] then parse_table_with_schema else
+                if fields == ["query"] then parse_simple_query else
+                    if fields == ["sql_statement"] then parse_serialized_statement else
+                        Error.throw (Illegal_Argument.Error "Invalid JSON inside of data link: expected exactly one field: `query` or `sql_statement`, but got: "+obj.to_display_text)
         _ -> Error.throw (Illegal_Argument.Error "Invalid JSON inside of data link: expected Text or object but got: "+value.to_display_text)
 
     ## ---
@@ -158,6 +171,8 @@ type DB_Data_Link_Type
             connection
         DB_Data_Link_Type.Table name ->
             connection.query (..Table_Name name)
+        DB_Data_Link_Type.Table_Schema name schema ->
+            connection.query (..Table_Name name schema)
         DB_Data_Link_Type.Query raw_sql ->
             connection.query (..Raw_SQL raw_sql)
         DB_Data_Link_Type.SQL_Statement sql_statement ->

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -24,5 +24,6 @@
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- make_table_name_selector connection:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - schema_black_list -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Microsoft.SQLServer_Connection.SQLServer_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -18,7 +18,7 @@ import Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup
 import Standard.Database.Internal.JDBC_Connection
 import Standard.Database.SQL.SQL_Statement
 import Standard.Database.SQL_Query.SQL_Query
-from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
+from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
 
@@ -391,7 +391,7 @@ type SQLServer_Connection
    private: true
    ---
 Table_Viz_Data.from (that:SQLServer_Connection) =
-    tables = that.connection.tables.filter "Schema" (..Is_In schema_black_list ..Remove)
+    tables = that.connection.tables schema="*" . filter "Schema" (..Is_In schema_black_list ..Remove)
     Table_Viz_Data.GenericGrid [Table_Viz_Header.Link "Table" "table" "query (..Table_Name {{@Table}} {{@Schema}})", Table_Viz_Header.Label "Schema"] [tables.at "Name" . to_vector, tables.at "Schema" . to_vector]
 
 ## ---
@@ -399,3 +399,17 @@ Table_Viz_Data.from (that:SQLServer_Connection) =
    ---
 schema_black_list =
     ["INFORMATION_SCHEMA", "sys", "db_accessadmin", "db_backupoperator", "db_datareader", "db_datawriter", "db_ddladmin", "db_denydatareader", "db_denydatawriter", "db_owner", "db_securityadmin"]
+
+## ---
+   private: true
+   ---
+make_table_name_selector connection =
+    schema = connection.schema
+    schema_text sch = if sch == schema then "" else sch+"."
+    tables = connection.tables schema="*" . filter "Schema" (..Is_In schema_black_list ..Remove)
+    table_name_values = tables.rows.map r->
+        name = r.at "Name"
+        sch = r.at "Schema"
+        Option ((schema_text sch) + name) "(..Table_Name "+name.pretty+(if sch == schema then "" else " "+sch.pretty)+")"
+    values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
+    Single_Choice display=Display.Always values=values

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -413,3 +413,4 @@ make_table_name_selector connection =
         Option ((schema_text sch) + name) "(..Table_Name "+name.pretty+(if sch == schema then "" else " "+sch.pretty)+")"
     values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
     Single_Choice display=Display.Always values=values
+    

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Data_Link.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Data_Link.enso
@@ -3,11 +3,11 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 from Standard.Base.Enso_Cloud.Data_Link_Helpers import Data_Link_Source_Metadata, parse_secure_value
 from Standard.Base.Enso_Cloud.Public_Utils import get_optional_field, get_required_field
 
-import Standard.Database.Connection.Credentials.Credentials
 import Standard.Database.Internal.Data_Link_Setup.DB_Data_Link_Type
 import Standard.Database.Internal.DB_Data_Link_Helpers
 
 import project.Connection.SQLServer_Details.SQLServer_Details
+import project.Connection.SQLServer_Credentials.SQLServer_Credentials
 
 ## ---
    private: true
@@ -27,9 +27,23 @@ type SQLServer_Data_Link
         db_name = get_required_field "database_name" json expected_type=Text
 
         credentials_json = get_required_field "credentials" json
-        username = get_required_field "username" credentials_json |> parse_secure_value
-        password = get_required_field "password" credentials_json |> parse_secure_value
-        credentials = Credentials.Username_And_Password username password
+        credentials = if credentials_json.length == 0 then SQLServer_Credentials.None else
+            type_name = get_optional_field "type" credentials_json if_missing="UsernameAndPassword"
+            case type_name of
+                "UsernameAndPassword" ->
+                    username = get_required_field "username" credentials_json |> parse_secure_value
+                    password = get_required_field "password" credentials_json |> parse_secure_value
+                    SQLServer_Credentials.Username_And_Password username password
+                "ActiveDirectoryDefault" -> SQLServer_Credentials.Active_Directory_Default
+                "ActiveDirectoryIntegrated" -> SQLServer_Credentials.Active_Directory_Integrated
+                "ActiveDirectoryPassword" ->
+                    username = get_required_field "username" credentials_json |> parse_secure_value
+                    password = get_required_field "password" credentials_json |> parse_secure_value
+                    SQLServer_Credentials.Active_Directory_Password username password
+                "ActiveDirectoryServicePrincipal" ->
+                    id = get_required_field "id" credentials_json |> parse_secure_value
+                    secret = get_required_field "secret" credentials_json |> parse_secure_value
+                    SQLServer_Credentials.Active_Directory_Service_Principal id secret
 
         details = SQLServer_Details.SQLServer host=host credentials=credentials port=port database=db_name
         link_type = DB_Data_Link_Type.from_js (get_optional_field "table" json)


### PR DESCRIPTION
### Pull Request Description

- Update the types and JSON format for SQL Server DataLinks (new credentials and Table/Schema support).
- Alter the dropdown table list for SQL Server to be schema aware.

Testing DataLinks is hard as the `connect` method initiates a connection to the server so to test must all exist. Will look into make connection "lazy" and what the implications might be there.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
