### PR TITLE
Fix calling useFeatureFlag function without vue effect scope

### DIFF
--- a/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
+++ b/app/gui/src/dashboard/services/ProjectManager/ProjectManager.ts
@@ -7,7 +7,7 @@ import * as backend from '#/services/Backend'
 import { getFileName, getFolderPath } from '#/utilities/fileInfo'
 import { omit } from '#/utilities/object'
 import { getDirectoryAndName, normalizeSlashes } from '#/utilities/path'
-import { useFeatureFlag } from '$/providers/featureFlags'
+import { getFeatureFlag } from '$/providers/featureFlags'
 import { normalizeName } from '@/util/nameValidation'
 import * as dateTime from 'enso-common/src/utilities/data/dateTime'
 import invariant from 'tiny-invariant'
@@ -63,10 +63,7 @@ export class ProjectManager {
     private readonly connectionUrl: string,
     public readonly rootDirectory: Path,
   ) {
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
-    if (!enableProjectService.value) {
+    if (!getFeatureFlag('enableProjectService')) {
       this.socketPromise = this.reconnect()
     }
   }
@@ -164,11 +161,8 @@ export class ProjectManager {
     if (cached) {
       return cached.data
     } else {
-      // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const enableProjectService = useFeatureFlag('enableProjectService')
       let promise: Promise<OpenProject>
-      if (enableProjectService.value) {
+      if (getFeatureFlag('enableProjectService')) {
         promise = this.runProjectServiceCommandJson('project/open', fullParams)
       } else {
         promise = this.sendRequest<OpenProject>('project/open', fullParams)
@@ -205,10 +199,7 @@ export class ProjectManager {
     }
     const fullParams: CloseProjectParams = this.paramsWithPathToWithId(params)
     this.projects.delete(fullParams.projectId)
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
-    if (enableProjectService.value) {
+    if (getFeatureFlag('enableProjectService')) {
       return this.runProjectServiceCommandJson('project/close', fullParams)
     } else {
       return this.sendRequest('project/close', fullParams)
@@ -217,11 +208,8 @@ export class ProjectManager {
 
   /** Create a new project. */
   async createProject(params: CreateProjectParams): Promise<CreateProject> {
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
     let result: Omit<CreateProject, 'projectPath'>
-    if (enableProjectService.value) {
+    if (getFeatureFlag('enableProjectService')) {
       result = await this.runProjectServiceCommandJson('project/create', { ...params })
     } else {
       result = await this.sendRequest('project/create', {
@@ -255,10 +243,7 @@ export class ProjectManager {
   /** Rename a project. */
   async renameProject(params: WithProjectPath<RenameProjectParams>): Promise<void> {
     const fullParams: RenameProjectParams = this.paramsWithPathToWithId(params)
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
-    if (enableProjectService.value) {
+    if (getFeatureFlag('enableProjectService')) {
       await this.runProjectServiceCommandJson('project/rename', fullParams)
     } else {
       await this.sendRequest('project/rename', fullParams)
@@ -285,11 +270,8 @@ export class ProjectManager {
     params: WithProjectPath<DuplicateProjectParams>,
   ): Promise<DuplicatedProject> {
     const fullParams: DuplicateProjectParams = this.paramsWithPathToWithId(params)
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
     let result: Omit<DuplicatedProject, 'projectPath'>
-    if (enableProjectService.value) {
+    if (getFeatureFlag('enableProjectService')) {
       result = await this.runProjectServiceCommandJson('project/duplicate', fullParams)
     } else {
       result = await this.sendRequest('project/duplicate', fullParams)
@@ -314,10 +296,7 @@ export class ProjectManager {
     if (cached && backend.IS_OPENING_OR_OPENED[cached.state]) {
       await this.closeProject({ projectPath: params.projectPath })
     }
-    // This is a Vue function, not a React hook, so the React hooks rule doesn't apply
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const enableProjectService = useFeatureFlag('enableProjectService')
-    if (enableProjectService.value) {
+    if (getFeatureFlag('enableProjectService')) {
       await this.runProjectServiceCommandJson('project/delete', fullParams)
     } else {
       await this.sendRequest('project/delete', fullParams)

--- a/app/gui/src/providers/featureFlags.ts
+++ b/app/gui/src/providers/featureFlags.ts
@@ -132,6 +132,11 @@ export function useFeatureFlag<Key extends keyof FeatureFlags>(key: Key) {
   return useZustandStoreRef(flagsStore, (store) => store.featureFlags[key])
 }
 
+/** Get a single feature flag. Similar to `useFeatureFlag` but without using Vue reactivity. */
+export function getFeatureFlag<Key extends keyof FeatureFlags>(key: Key) {
+  return flagsStore.getState().featureFlags[key]
+}
+
 /** Set a subset of feature flags. */
 export function setFeatureFlags(flags: Partial<FeatureFlags>) {
   return flagsStore.getState().setFeatureFlags(flags)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

followup #13891

Fixes warnings produced by Vue:

```
chunk-IU52POIJ.js?v=f66fd2b7:307 [Vue warn] onScopeDispose() is called when there is no active effect scope to be associated with.
warn    @    chunk-IU52POIJ.js?v=f66fd2b7:307
onScopeDispose    @    chunk-IU52POIJ.js?v=f66fd2b7:426
useZustandStoreRef    @    zustand.ts:11
useFeatureFlag    @    featureFlags.ts:98
openProject    @    ProjectManager.ts:122
openProject    @    LocalBackend.ts:313
mutationFn    @    projectHooks.ts:178
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
