### PR TITLE
Fix blank arguments in signature

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/XML/XML_Format.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/XML/XML_Format.md
@@ -8,4 +8,4 @@
     - read self file:Standard.Base.System.File.File on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior -> Standard.Base.Any.Any
     - read_stream self stream:Standard.Base.System.Input_Stream.Input_Stream metadata:Standard.Base.System.File_Format_Metadata.File_Format_Metadata= -> Standard.Base.Any.Any
     - resolve constructor:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- Standard.Base.System.File_Format.File_Format_SPI.from that:Standard.Base.Data.XML.XML_Format.XML_Format -> Standard.Base.System.File_Format.File_Format_SPI
+- Standard.Base.System.File_Format.File_Format_SPI.from _:Standard.Base.Data.XML.XML_Format.XML_Format -> Standard.Base.System.File_Format.File_Format_SPI

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
@@ -76,20 +76,36 @@ final class DocsUtils {
   }
 
   static String toSignature(DefinitionArgument a) {
-    var sb = new StringBuilder();
-    if (a.suspended()) {
-      sb.append("~");
+    if (isBlankArg(a)) {
+      return "_";
+    } else {
+      var sb = new StringBuilder();
+      if (a.suspended()) {
+        sb.append("~");
+      }
+      var name = a.name().name();
+      sb.append(name);
+      if (!ConstantsNames.SELF_ARGUMENT.equals(name)) {
+        var type = extractTypeOrAny(a);
+        sb.append(":").append(type);
+      }
+      if (a.defaultValue().isDefined()) {
+        sb.append("=");
+      }
+      return sb.toString();
     }
-    var name = a.name().name();
-    sb.append(name);
-    if (!ConstantsNames.SELF_ARGUMENT.equals(name)) {
-      var type = extractTypeOrAny(a);
-      sb.append(":").append(type);
+  }
+
+  /** Returns true if the argument represents an underscore (blank) argument. */
+  private static boolean isBlankArg(DefinitionArgument arg) {
+    if (arg.name() instanceof Name.Literal lit) {
+      var loc = lit.identifiedLocation();
+      if (loc != null) {
+        // This checks if the argument used to be an underscore.
+        return loc.length() == 1 && lit.name().length() > 1;
+      }
     }
-    if (a.defaultValue().isDefined()) {
-      sb.append("=");
-    }
-    return sb.toString();
+    return false;
   }
 
   private static String extractTypeOrAny(IR ir) {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsUtils.java
@@ -76,23 +76,27 @@ final class DocsUtils {
   }
 
   static String toSignature(DefinitionArgument a) {
-    if (isBlankArg(a)) {
+    var sb = new StringBuilder();
+    if (a.suspended()) {
+      sb.append("~");
+    }
+    var name = argName(a);
+    sb.append(name);
+    if (!ConstantsNames.SELF_ARGUMENT.equals(name)) {
+      var type = extractTypeOrAny(a);
+      sb.append(":").append(type);
+    }
+    if (a.defaultValue().isDefined()) {
+      sb.append("=");
+    }
+    return sb.toString();
+  }
+
+  private static String argName(DefinitionArgument arg) {
+    if (isBlankArg(arg)) {
       return "_";
     } else {
-      var sb = new StringBuilder();
-      if (a.suspended()) {
-        sb.append("~");
-      }
-      var name = a.name().name();
-      sb.append(name);
-      if (!ConstantsNames.SELF_ARGUMENT.equals(name)) {
-        var type = extractTypeOrAny(a);
-        sb.append(":").append(type);
-      }
-      if (a.defaultValue().isDefined()) {
-        sb.append("=");
-      }
-      return sb.toString();
+      return arg.name().name();
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -1,8 +1,10 @@
 package org.enso.compiler.dump.test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -401,6 +403,41 @@ public class DocsGenerateTest {
         "Generates thrown dataflow errors in the signature",
         "one a:local.Error.Main.A -> (local.Error.Main.A&local.Error.Main.B)!local.Error.Main.C",
         sig);
+  }
+
+  @Test
+  public void blankArgumentIsNotPrinted_ConsolidatedLambda() throws Exception {
+    // This will get consolidated into:
+    // foo _ = 42
+    // See `LambdaConsolidate` compiler pass
+    var code =
+        """
+        foo =
+            _ -> 42
+        """;
+    var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
+    assertThat(sig, not(containsString("internal")));
+    var sigLine = lastLine(sig);
+    assertThat("No argument", sigLine.matches("foo\\s+->.*"), is(true));
+  }
+
+  @Test
+  public void blankArgumentIsNotPrinted_DefinedBlank() throws Exception {
+    var code =
+        """
+        foo _ =
+            42
+        """;
+    var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
+    assertThat(sig, not(containsString("internal")));
+    var sigLine = lastLine(sig);
+    assertThat("No argument", sigLine.matches("foo\\s+->.*"), is(true));
+  }
+
+  private static String lastLine(String text) {
+    var lines = text.lines().toList();
+    assert !lines.isEmpty();
+    return lines.get(lines.size() - 1);
   }
 
   private static void generateDocumentation(String projectName, String code, DocsVisit v)

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -1,5 +1,6 @@
 package org.enso.compiler.dump.test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
@@ -440,6 +441,22 @@ public class DocsGenerateTest {
     var any = "Standard.Base.Any.Any";
     var regex = ".*foo _:${any} x:${any} _:${any} y:${any} ->.*".replace("${any}", any);
     assertThat("Two blank (underscore) arguments: " + sigLine, sigLine.matches(regex), is(true));
+  }
+
+  @Test
+  public void conversionBlank() throws Exception {
+    var code =
+        """
+        type Source
+        type Target
+        Target.from (_:Source) = 42
+        """;
+    var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
+    var sigLine = lastLine(sig);
+    assertThat(
+        "Single blank argument in conversion: " + sigLine,
+        sigLine,
+        containsString("Main.Target.from _:Main.Source -> Main.Target"));
   }
 
   private static void assertSingleBlankArgument(String methodName, String sig) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -1,10 +1,8 @@
 package org.enso.compiler.dump.test;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -416,9 +414,7 @@ public class DocsGenerateTest {
             _ -> 42
         """;
     var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
-    assertThat(sig, not(containsString("internal")));
-    var sigLine = lastLine(sig);
-    assertThat("No argument", sigLine.matches("foo\\s+->.*"), is(true));
+    assertSingleBlankArgument("foo", sig);
   }
 
   @Test
@@ -429,9 +425,13 @@ public class DocsGenerateTest {
             42
         """;
     var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
-    assertThat(sig, not(containsString("internal")));
+    assertSingleBlankArgument("foo", sig);
+  }
+
+  private static void assertSingleBlankArgument(String methodName, String sig) {
     var sigLine = lastLine(sig);
-    assertThat("No argument", sigLine.matches("foo\\s+->.*"), is(true));
+    var regex = ".*" + methodName + " _ ->.*";
+    assertThat("Single blank (underscore) argument: " + sigLine, sigLine.matches(regex), is(true));
   }
 
   private static String lastLine(String text) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -404,7 +404,7 @@ public class DocsGenerateTest {
   }
 
   @Test
-  public void blankArgumentIsNotPrinted_ConsolidatedLambda() throws Exception {
+  public void blankArgument_ConsolidatedLambda() throws Exception {
     // This will get consolidated into:
     // foo _ = 42
     // See `LambdaConsolidate` compiler pass
@@ -418,7 +418,7 @@ public class DocsGenerateTest {
   }
 
   @Test
-  public void blankArgumentIsNotPrinted_DefinedBlank() throws Exception {
+  public void blankArgument_DefinedBlank() throws Exception {
     var code =
         """
         foo _ =
@@ -426,6 +426,19 @@ public class DocsGenerateTest {
         """;
     var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
     assertSingleBlankArgument("foo", sig);
+  }
+
+  @Test
+  public void moreBlankArguments() throws Exception {
+    var code =
+        """
+        foo _ x _ y =
+            42
+        """;
+    var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
+    var sigLine = lastLine(sig);
+    var regex = ".*foo _ x:Standard.Base.Any.Any _ y:Standard.Base.Any.Any ->.*";
+    assertThat("Two blank (underscore) arguments: " + sigLine, sigLine.matches(regex), is(true));
   }
 
   private static void assertSingleBlankArgument(String methodName, String sig) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/DocsGenerateTest.java
@@ -437,13 +437,14 @@ public class DocsGenerateTest {
         """;
     var sig = DumpTestUtils.generateSignatures(ctxRule, code, "Main");
     var sigLine = lastLine(sig);
-    var regex = ".*foo _ x:Standard.Base.Any.Any _ y:Standard.Base.Any.Any ->.*";
+    var any = "Standard.Base.Any.Any";
+    var regex = ".*foo _:${any} x:${any} _:${any} y:${any} ->.*".replace("${any}", any);
     assertThat("Two blank (underscore) arguments: " + sigLine, sigLine.matches(regex), is(true));
   }
 
   private static void assertSingleBlankArgument(String methodName, String sig) {
     var sigLine = lastLine(sig);
-    var regex = ".*" + methodName + " _ ->.*";
+    var regex = ".*" + methodName + " _:Standard.Base.Any.Any ->.*";
     assertThat("Single blank (underscore) argument: " + sigLine, sigLine.matches(regex), is(true));
   }
 


### PR DESCRIPTION
Fixes #14077 

Unblocks #14071

### Pull Request Description

Signature generator prints blank (underscore) arguments, instead of `<internal-*>`.

On develop, signature for
```
func _ =
    42
```
is `func <internal-0> -> Standard.Base.Any.Any`, on this PR, the signature is `func _ -> Standard.Base.Any.Any`

### Important Notes

The compiler transform all blank (underscore) arguments into arguments with `<internal-\d+>` literal names. The information that the argument was created from an underscore is lost in the compilation pipeline. This PR adds a workaround to signature generator: if such argument is encountered, simple `_` is printed instead of its internal name.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
