### PR TITLE
Table expression editor: Adjust colours

### DIFF
--- a/app/gui/src/project-view/components/CodeMirrorRoot.vue
+++ b/app/gui/src/project-view/components/CodeMirrorRoot.vue
@@ -57,7 +57,7 @@ defineExpose({ highlightClasses })
 
 .literal,
 .string {
-  color: #a11;
+  color: #650000;
 }
 .escape {
   color: #e40;

--- a/app/table-expression/src/highlight.ts
+++ b/app/table-expression/src/highlight.ts
@@ -6,7 +6,7 @@ export const highlight = styleTags({
   Regex: t.quote,
   LiteralKeyword: t.keyword,
   Date: t.string,
-  Column: t.string,
+  Column: t.variableName,
   String: t.string,
   Atom: t.atom,
   TypeOp: t.typeOperator,


### PR DESCRIPTION
### Pull Request Description

Fixes confusing colouring noted by @jdunkerley during yesterday's demo.

<img width="293" height="52" alt="Screenshot 2025-09-30 at 14 06 36" src="https://github.com/user-attachments/assets/548b5d4a-238d-4575-b079-707fa7ffed9e" />

- Column colour is now highlighted as a variable name (blue), rather than string (red)
- The red colour used for strings is now a darker shade that looks less like an error colour

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
