### PR TITLE
Fix for issue with SQL Server IIF

### DIFF
--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -238,10 +238,8 @@ type SQLServer_Dialect
         query_text = case statement of
             text : Text -> text
             _ : SQL_Statement -> statement.prepare.first
-        ## If not executed, getMetaData on a query containing dateadd was failing with:
-           Argument data type NULL is invalid for argument 2 of dateadd function.
-        needs_execute = query_text.contains "dateadd" case_sensitivity=..Insensitive
-        needs_execute
+        ## Looks like if a parameter is present in the query then getMetadata has a bug
+        query_text.contains "?"
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -413,3 +413,4 @@ make_table_name_selector connection =
         Option ((schema_text sch) + name) "(..Table_Name "+name.pretty+(if sch == schema then "" else " "+sch.pretty)+")"
     values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
     Single_Choice display=Display.Always values=values
+

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -391,7 +391,7 @@ type SQLServer_Connection
    private: true
    ---
 Table_Viz_Data.from (that:SQLServer_Connection) =
-    tables = that.connection.tables schema="*" . filter "Schema" (..Is_In schema_black_list ..Remove)
+    tables = that.tables schema="*" . filter "Schema" (..Is_In schema_black_list ..Remove)
     Table_Viz_Data.GenericGrid [Table_Viz_Header.Link "Table" "table" "query (..Table_Name {{@Table}} {{@Schema}})", Table_Viz_Header.Label "Schema"] [tables.at "Name" . to_vector, tables.at "Schema" . to_vector]
 
 ## ---
@@ -413,4 +413,3 @@ make_table_name_selector connection =
         Option ((schema_text sch) + name) "(..Table_Name "+name.pretty+(if sch == schema then "" else " "+sch.pretty)+")"
     values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
     Single_Choice display=Display.Always values=values
-    


### PR DESCRIPTION
### Pull Request Description

- Fix for `Table_Viz_Data` on `SQLServer_Connection`.
- Due to some issue with the SQL Server JDBC driver, getMetadata doesn't seem to work if parameters are present.
- Altered `needs_execute_query_for_type_inference` to require execution if a placeholder is present.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
