### PR TITLE
Fibonacci benchmark comparing hosted and dual JVM modes

### DIFF
--- a/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
+++ b/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
@@ -45,6 +45,7 @@ public final class RuntimeOptions {
 
   public static final String HOST_CLASS_LOADING = optionName("classLoading");
   public static final String HOST_CLASS_LOADING_HOSTED = "hosted";
+  public static final String HOST_CLASS_LOADING_GUEST = "guest";
   public static final OptionKey<String> HOST_CLASS_LOADING_KEY =
       new OptionKey<>(HOST_CLASS_LOADING_HOSTED);
   private static final OptionDescriptor HOST_CLASS_LOADING_DESCRIPTOR =

--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibBenchmarks.java
@@ -1,0 +1,83 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.enso.common.MethodNames;
+import org.enso.compiler.benchmarks.Utils;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+/**
+ * Base class for {@link FibHostJavaPolyglotBenchmarks} and {@link FibGuestJavaPolyglotBenchmarks}.
+ */
+public abstract class FibBenchmarks {
+
+  private ContextUtils ctx;
+  private Value fib;
+
+  protected Context.Builder withModifiedContext(Context.Builder b) {
+    return b;
+  }
+
+  @Setup()
+  public void initializeBench(BenchmarkParams params) throws IOException {
+    ctx =
+        Utils.createDefaultContextBuilder().withModifiedContext(this::withModifiedContext).build();
+
+    var code =
+        """
+        polyglot java import java.lang.Math
+
+        main n=10 =
+            fib n
+
+        private fib n = if Math.max n 1 == 1 then 1 else
+            n1 = Math.decrementExact n
+            n2 = Math.decrementExact n1
+
+            f1 = fib n1
+            f2 = fib n2
+
+            Math.addExact f1 f2
+        """;
+
+    var benchmarkName = SrcUtil.findName(params);
+    var src = SrcUtil.source(benchmarkName, code);
+    var module = ctx.eval(src);
+    fib = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fib"));
+  }
+
+  @TearDown
+  public void tearDown() {
+    ctx.close();
+  }
+
+  @Benchmark
+  public void fib10() {
+    runBench(10, 89);
+  }
+
+  @Benchmark
+  public void fib17() {
+    runBench(17, 2584);
+  }
+
+  @Benchmark
+  public void fib21() {
+    runBench(21, 17711);
+  }
+
+  /** Call this method to perform the benchmark of certain magnitude. */
+  protected final void runBench(long value, long expValue) {
+    var res = fib.execute(value);
+    if (res.asLong() != expValue) {
+      throw new AssertionError(
+          "Expected result for fib(%d) is %d, but got %d".formatted(value, expValue, res.asInt()));
+    }
+  }
+}

--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibGuestJavaPolyglotBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibGuestJavaPolyglotBenchmarks.java
@@ -1,7 +1,8 @@
 package org.enso.interpreter.bench.benchmarks.semantic;
 
 import java.util.concurrent.TimeUnit;
-import org.openjdk.jmh.annotations.Benchmark;
+import org.enso.common.RuntimeOptions;
+import org.graalvm.polyglot.Context;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -17,14 +18,10 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 3, time = 1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-public class FibHostJavaPolyglotBenchmarks extends FibBenchmarks {
-  @Benchmark
-  public void fib27() {
-    runBench(27, 317811);
-  }
+public class FibGuestJavaPolyglotBenchmarks extends FibBenchmarks {
 
-  @Benchmark
-  public void fib33() {
-    runBench(33, 5702887);
+  @Override
+  protected Context.Builder withModifiedContext(Context.Builder b) {
+    return b.option(RuntimeOptions.HOST_CLASS_LOADING, RuntimeOptions.HOST_CLASS_LOADING_GUEST);
   }
 }

--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibHostJavaPolyglotBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/FibHostJavaPolyglotBenchmarks.java
@@ -1,0 +1,93 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.enso.common.MethodNames.Module;
+import org.enso.compiler.benchmarks.Utils;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Value;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Warmup(iterations = 2, time = 5)
+@Measurement(iterations = 3, time = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class FibHostJavaPolyglotBenchmarks {
+
+  private ContextUtils ctx;
+  private Value fib;
+
+  @Setup()
+  public void initializeBench(BenchmarkParams params) throws IOException {
+    ctx = Utils.createDefaultContextBuilder().build();
+
+    var code =
+        """
+        polyglot java import java.lang.Math
+
+        main n=10 =
+            fib n
+
+        private fib n = if Math.max n 1 == 1 then 1 else
+            n1 = Math.decrementExact n
+            n2 = Math.decrementExact n1
+
+            f1 = fib n1
+            f2 = fib n2
+
+            Math.addExact f1 f2
+        """;
+
+    var benchmarkName = SrcUtil.findName(params);
+    var src = SrcUtil.source(benchmarkName, code);
+    var module = ctx.eval(src);
+    fib = Objects.requireNonNull(module.invokeMember(Module.EVAL_EXPRESSION, "fib"));
+  }
+
+  @TearDown
+  public void tearDown() {
+    ctx.close();
+  }
+
+  @Benchmark
+  public void fib17() {
+    runBench(17, 2584);
+  }
+
+  @Benchmark
+  public void fib21() {
+    runBench(21, 17711);
+  }
+
+  @Benchmark
+  public void fib27() {
+    runBench(27, 317811);
+  }
+
+  @Benchmark
+  public void fib33() {
+    runBench(33, 5702887);
+  }
+
+  private void runBench(long value, long expValue) {
+    var res = fib.execute(value);
+    if (res.asLong() != expValue) {
+      throw new AssertionError(
+          "Expected result for fib(%d) is %d, but got %d".formatted(value, expValue, res.asInt()));
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -293,7 +293,11 @@ final class EnsoPolyglotJava {
       for (var entry : ctx.getHostClassLoading().split(",")) {
         var libState = entry.split(":");
         switch (libState.length) {
-          case 2 -> hostClassLoading.putIfAbsent(libState[0], libState[1]);
+          case 2 -> {
+            assert RuntimeOptions.HOST_CLASS_LOADING_HOSTED.equals(libState[1])
+                || RuntimeOptions.HOST_CLASS_LOADING_GUEST.equals(libState[1]);
+            hostClassLoading.putIfAbsent(libState[0], libState[1]);
+          }
           case 1 -> hostClassLoading.putIfAbsent("", libState[0]);
           default ->
               throw new IllegalStateException(

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
@@ -19,8 +19,7 @@ final class PerMap {
     versionStamp = hash;
   }
 
-  private int registerPersistance(Persistance<?> orig, int hash) throws IllegalStateException {
-    var p = orig.newClone();
+  private int registerPersistance(Persistance<?> p, int hash) throws IllegalStateException {
     var prevId = ids.put(p.id, p);
     if (prevId != null) {
       throw new IllegalStateException(

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
  *
  * @param <T> type this persistance subclass operates on
  */
-public abstract class Persistance<T> implements Cloneable {
+public abstract class Persistance<T> {
   final Class<T> clazz;
   final boolean includingSubclasses;
   final int id;
@@ -68,14 +68,6 @@ public abstract class Persistance<T> implements Cloneable {
     this.clazz = clazz;
     this.includingSubclasses = includingSubclasses;
     this.id = id;
-  }
-
-  final Persistance<?> newClone() {
-    try {
-      return (Persistance<?>) clone();
-    } catch (CloneNotSupportedException ex) {
-      throw raise(RuntimeException.class, ex);
-    }
   }
 
   /**
@@ -188,6 +180,7 @@ public abstract class Persistance<T> implements Cloneable {
     private final Function<Object, Object> readResolve;
     private final Function<Object, Object> writeReplace;
     private final Persistance[] all;
+    private final PerMap map;
 
     /**
      * Constructor for subclasses to create a new pool with provided persistance instances. The IDs
@@ -212,6 +205,7 @@ public abstract class Persistance<T> implements Cloneable {
       this.readResolve = readResolve;
       this.writeReplace = writeReplace;
       this.all = instances;
+      this.map = new PerMap(all);
     }
 
     /**
@@ -291,7 +285,6 @@ public abstract class Persistance<T> implements Cloneable {
      * @throws java.io.IOException when an I/O problem happens
      */
     public Reference<?> read(ByteBuffer buf) throws IOException {
-      var map = new PerMap(all);
       return PerInputImpl.readObject(map, buf, readResolve);
     }
 
@@ -304,7 +297,6 @@ public abstract class Persistance<T> implements Cloneable {
      * @throws IOException when an I/O problem happens
      */
     public byte[] write(Object obj) throws IOException {
-      var map = new PerMap(all);
       return PerGenerator.writeObject(map, obj, writeReplace);
     }
   }


### PR DESCRIPTION
### Pull Request Description

Let's write simple, scalable benchmark to compare the cost of invoking `polyglot java import` methods:
```ruby
polyglot java import java.lang.Math

main n=10 =
    fib n

private fib n = if Math.max n 1 == 1 then 1 else
    n1 = Math.decrementExact n
    n2 = Math.decrementExact n1

    f1 = fib n1
    f2 = fib n2

    Math.addExact f1 f2
```
run with either:
```bash
enso$ time ./enso --jvm --run fib_dual.enso 20
10946

real    0m1,894s

```
or in dual JVM mode:
```bash
time ./enso --run fib_dual.enso 20 # if compiled by native image
SEVERE: Using experimental OtherJvm support!
10946

real    0m3,627s
```
or in a mock mode:
```bash
enso$ time ./enso --jvm --vm.D=polyglot.enso.classLoading=guest --run fib_dual.enso 20
[ERROR] [2025-10-02T11:11:58+02:00] [org.enso.interpreter.runtime.EnsoPolyglotJava] Using experimental OtherJvm support!
10946

real    0m4,864s
```
This PR introduces two JMH benchmarks using the same program but properly (micro) benchmarking the necessary operations.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Benchmarks have [been written and executed](https://github.com/enso-org/enso/actions/runs/18188743438)
