### PR TITLE
Avoid reopening project on reload if it was already closed

### DIFF
--- a/app/gui/src/providers/container.ts
+++ b/app/gui/src/providers/container.ts
@@ -131,6 +131,7 @@ export const [provideContainerData, useContainerData] = createContextStore(
       },
     })
 
+    // When the current tab is no longer valid (e.g. the project was closed), switch to the fallback tab.
     watchEffect(() => {
       const name = normalizeRouteParamToString(route.params.path)
       if (!isValidTab(name)) {

--- a/app/gui/src/providers/container.ts
+++ b/app/gui/src/providers/container.ts
@@ -3,7 +3,7 @@ import LocalStorage from '#/utilities/LocalStorage'
 import { createContextStore } from '@/providers'
 import { proxyRefs } from '@/util/reactivity'
 import { normalizeRouteParamToString } from '@/util/router'
-import { computed, reactive, type Ref } from 'vue'
+import { computed, reactive, watchEffect, type Ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import * as z from 'zod'
 
@@ -129,6 +129,13 @@ export const [provideContainerData, useContainerData] = createContextStore(
       set: (page) => {
         router.push({ params: { path: page.split('/') }, query: route.query })
       },
+    })
+
+    watchEffect(() => {
+      const name = normalizeRouteParamToString(route.params.path)
+      if (!isValidTab(name)) {
+        tab.value = fallbackTab
+      }
     })
 
     const addLaunchedProject = (project: LaunchedProject) => {


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/2175
  - Avoid reopening project on reload if it was already closed

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - ~~If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
