### PR TITLE
Let `withDebug --debugger` work for `runtime-benchmarks`

### DIFF
--- a/docs/infrastructure/benchmarks.md
+++ b/docs/infrastructure/benchmarks.md
@@ -48,15 +48,13 @@ sbt:runtime-benchmarks> run -w 3 -i 2 <bench-name>
 
 ### Debugging the benchmarks
 
-Currently, the best way to debug the benchmark is to set the `@Fork` annotation
-to 0, and to run `withDebug` command like this:
+The most straighforward way to debug the benchmark is to run `withDebug` command
+while listening for a JPDA connection on port 5005:
 
-```
-withDebug --debugger benchOnly -- <fully qualified benchmark name>
-```
+<img width="1137" height="594" alt="Debug" src="https://github.com/user-attachments/assets/384d5de4-19a8-45ae-81cd-cb466433e0b2" />
 
-Another option that does not require changing the source code is to run
-something like
+Should one need more control over the parameters, one can use the `run` command
+directly
 
 ```
 sbt:runtime-benchmarks> run -w 1 -i 1 -f 1 -jvmArgs -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000 org.enso.compiler.benchmarks.module.ImportStandardLibrariesBenchmark.importStandardLibraries

--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -16,7 +16,9 @@ import sbt._
   */
 object WithDebugCommand {
   val DEBUG_OPTION =
-    "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y";
+    "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
+
+  private val debugOptions = Seq(DEBUG_OPTION, "-Dbench.compileOnly=true")
 
   val truffleNoBackgroundCompilationOptions = Seq(
     "-Dpolyglot.engine.BackgroundCompilation=false"
@@ -82,7 +84,7 @@ object WithDebugCommand {
         else Seq()
       val debuggerOpts =
         if (debugFlags.contains(debuggerOption))
-          Seq(DEBUG_OPTION)
+          debugOptions
         else Seq()
       val javaOpts: Seq[String] = Seq(
         if (debugFlags.contains(debuggerOption)) Seq()


### PR DESCRIPTION
### Pull Request Description

Let 
```
sbt:runtime-benchmarks> withDebug --debugger benchOnly -- AtomBenchmarks
```
work.

<img width="1137" height="594" alt="Debug" src="https://github.com/user-attachments/assets/384d5de4-19a8-45ae-81cd-cb466433e0b2" />

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The [documentation has been updated](https://github.com/enso-org/enso/blob/cdd04b5785265279527e3e4d39878e248074496e/docs/infrastructure/benchmarks.md#debugging-the-benchmarks)
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually tested
