### PR TITLE
Improvements to Enso4Igv plugin

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B -Pvsix package --file tools/enso4igv/pom.xml -Denso.parser.lib=`pwd`/enso_parser/ -DskipTests
 
-      - name: Archive NBM file
+      - name: Archive NBM files
         uses: actions/upload-artifact@v4
         with:
           name: Enso IGV Plugin

--- a/tools/enso4igv/IGV.md
+++ b/tools/enso4igv/IGV.md
@@ -36,21 +36,27 @@ IGV understands Enso when
 [Enso Language Support module](https://github.com/enso-org/enso/actions/workflows/enso4igv.yml)
 is installed. Login to GitHub, follow the
 [GitHub actions link](https://github.com/enso-org/enso/actions/workflows/enso4igv.yml)
-and select a build. Unless you have some special needs choose the latest one.
-The build summary page provides various information as well as list of artifacts
-at the bottom. Download the _Enso IGV Plugin_ ZIP file (make sure you are logged
-into GitHub - artifacts are only available to those logged in). Unzip it and get
-`enso*.nbm` file. This file can be installed into _IGV_ (or any other
+and select a build. Unless you have some special need choose the latest one from
+`develop` branch. The build summary page provides various information as well as
+list of artifacts at the bottom.
+
+<img width="1718" height="704" alt="Download page" src="https://github.com/user-attachments/assets/28b69e13-e547-4946-a0f1-dfac5d6b5a78" />
+
+Download the _Enso IGV Plugin_ ZIP file (make sure you are logged into GitHub -
+artifacts are only available to those logged in). Unzip it and get `*.nbm`
+files. These file can be installed into _IGV_ (or any other
 [NetBeans](http://netbeans.apache.org) based application). Go to
 _Tools_/_Plugins_/_Downloaded_/_Add Plugins_ and select the NBM file.
 
-![Tools/Plugins/Downloaded](https://user-images.githubusercontent.com/26887752/174608153-9f0b54fa-b507-45be-83de-d7911186d121.png)
+<img width="1140" height="607" alt="Tools/Plugins/Downloaded" src="https://github.com/user-attachments/assets/30ecdcaf-4cee-424b-a685-5bcfa37c986b" />
 
-Proceed by clicking _Install_. You may be asked to download _TextMate Lexer_ - a
-necessary dependency of the _Enso support_ module. Continue through the wizard
-to _finish_ the installation.
+Proceed by clicking _Install_.
 
-![Tools/Plugins/Downloaded](https://user-images.githubusercontent.com/26887752/174608219-1faf2728-0045-478b-a297-e3c06f691b19.png)
+<img width="1140" height="607" alt="Click Install" src="https://github.com/user-attachments/assets/0ac8c3e5-2980-41b9-b6ad-ba6dc42e7820" />
+
+Continue through the wizard to _finish_ the installation.
+
+<img width="1140" height="607" alt="Tools/Plugins/Downloaded" src="https://github.com/user-attachments/assets/5fe3d81b-50ed-4b9b-bde3-b3eba3cabcd3" />
 
 ## Using the IGV
 
@@ -136,12 +142,6 @@ icon in the _Stack View_ to get from graph node to source. Select a drop down
 widget in the editor toolbar to show you what compiler nodes as associated with
 currently selected line.
 
-## Syntax Coloring
-
-To enable syntax coloring you may need to download and install text mate
-module into IGV. Download [its NBM file](https://repo1.maven.org/maven2/org/netbeans/api/org-netbeans-modules-textmate-lexer/RELEASE260/org-netbeans-modules-textmate-lexer-RELEASE260.nbm)
-and install in _Plugins_ dialog.
-
 ## Building
 
 The plugin can be rebuilt using [Apache Maven](http://maven.apache.org). The
@@ -149,13 +149,14 @@ build is platform independent. The following instructions are for Unix like
 environment. Switch to this directory and invoke:
 
 ```bash
-enso/tools/enso4igv$ mvn clean install
-enso/tools/enso4igv$ ls target/*.nbm
-target/enso4igv-*-SNAPSHOT.nbm
+enso/tools/enso4igv$ mvn clean install -DskipTests
+enso/tools/enso4igv$ ls -1 target/*.nbm
+target/enso4igv-*.nbm
+target/org-netbeans-modules-textmate-lexer-*.nbm
 ```
 
-an NBM file is generated which can be installed into IGV, NetBeans or any other
-NetBeans based application.
+the NBM files are generated which can be installed into IGV, NetBeans or any
+other NetBeans based application.
 
 ## VSCode Extension
 

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -91,6 +91,26 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.15</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="module" value="org-netbeans-modules-textmate-lexer"/>
+                                <get src="https://repo1.maven.org/maven2/org/netbeans/api/${module}/${netbeans.version}/${module}-${netbeans.version}.nbm"
+                                     dest="${project.build.directory}/${module}-${netbeans.version}.nbm"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -103,7 +123,7 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-textmate-lexer</artifactId>
             <version>${netbeans.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -104,8 +104,10 @@
                         <configuration>
                             <target>
                                 <property name="module" value="org-netbeans-modules-textmate-lexer"/>
-                                <get src="https://repo1.maven.org/maven2/org/netbeans/api/${module}/${netbeans.version}/${module}-${netbeans.version}.nbm"
-                                     dest="${project.build.directory}/${module}-${netbeans.version}.nbm"/>
+                                <!-- could be ${netbeans.version}, but that has too old deps using latest -->
+                                <property name="modver" value="${netbeans.runtime.version}"/>
+                                <get src="https://repo1.maven.org/maven2/org/netbeans/api/${module}/${modver}/${module}-${modver}.nbm"
+                                     dest="${project.build.directory}/${module}-${modver}.nbm"/>
                             </target>
                         </configuration>
                     </execution>
@@ -251,7 +253,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-lsp</artifactId>
-            <version>RELEASE160</version>
+            <version>${netbeans.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -305,7 +307,8 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netbeans.version>RELEASE140</netbeans.version>
+        <netbeans.version>RELEASE220</netbeans.version>
+        <netbeans.runtime.version>RELEASE270</netbeans.runtime.version>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <enso.root>${basedir}/../../</enso.root>
         <enso.parser.lib>${enso.root}/lib/rust/parser/target/classes/</enso.parser.lib>

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>enso4igv</artifactId>
     <packaging>nbm</packaging>
     <name>Enso Language Support for NetBeans &amp; Ideal Graph Visualizer</name>
-    <version>1.50-SNAPSHOT</version>
+    <version>1.51-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java
@@ -14,6 +14,8 @@ import org.enso.tools.enso4igv.enso.EnsoActionProvider;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.api.project.Sources;
 import org.netbeans.spi.project.ProjectContainerProvider;
 import org.netbeans.spi.project.ProjectState;
 import org.netbeans.spi.project.SubprojectProvider;
@@ -44,7 +46,8 @@ final class EnsoRootProject implements Project {
             this,
             new LogicalView(),
             new Subprojects(),
-            new BuiltDistributionEnsoBin()
+            new BuiltDistributionEnsoBin(),
+            new RootSources()
     );
   }
 
@@ -254,5 +257,21 @@ final class EnsoRootProject implements Project {
       }
       return null;
     }
+  }
+
+  private final class RootSources implements Sources {
+        @Override
+        public SourceGroup[] getSourceGroups(String type) {
+            return new SourceGroup[0];
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener listener) {
+        }
+
+        @Override
+        public void removeChangeListener(ChangeListener listener) {
+        }
+
   }
 }

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -180,7 +180,7 @@ final class EnsoSbtClassPathProvider extends ProjectOpenedHook
       var dir = project.getProjectDirectory();
       var displayname = FileUtil.getFileDisplayName(dir);
       var icon = ImageUtilities.loadImageIcon("org/enso/tools/enso4igv/enso-duke.svg", true);
-      var genericGroup = GenericSources.group(project, dir, dir.getNameExt(), displayname, icon, icon);
+      var genericGroup = GenericSources.group(project, dir.getFileObject("src", false), dir.getNameExt(), displayname, icon, icon);
       return new SourceGroup[]{genericGroup};
     }
     return sources;

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -85,7 +85,7 @@ public class EnsoSbtProjectTest extends NbTestCase {
 
     var genericGroups = s.getSourceGroups(Sources.TYPE_GENERIC);
     assertEquals("One", 1, genericGroups.length);
-    assertEquals("One at root", root, genericGroups[0].getRootFolder());
+    assertEquals("One at root", root.getFileObject("src"), genericGroups[0].getRootFolder());
 
     var javaGroups = s.getSourceGroups("java");
     assertEquals("1 bench, 2 tests, 4 main: " + Arrays.toString(javaGroups), 7, javaGroups.length);


### PR DESCRIPTION
### Pull Request Description

- Go To File now performs better, up to a point when it is usable
- TextMate NetBeans module is included in the distribution because it is missing in IGV
- and since NetBeans 26 it can no longer be downloaded

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The [documentation has been updated](https://github.com/enso-org/enso/blob/13200542212a9e3f545ddb2b0a76d97342ece6c4/tools/enso4igv/IGV.md)
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
