### PR TITLE
Added check for parent folder existing prior to write

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/S3/S3_File.md
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/S3/S3_File.md
@@ -2,6 +2,7 @@
 ## module Standard.AWS.S3.S3_File
 - type S3_File
     - / self subpath:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - can_write_into_parent self -> Standard.Base.Data.Boolean.Boolean
     - copy_to self destination:Standard.Base.System.File.Generic.File_Like.File_Like replace_existing:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - create_directory self -> Standard.Base.Any.Any
     - creation_time self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -714,6 +714,14 @@ type S3_File
     ## ---
        private: true
        ---
+    can_write_into_parent self -> Boolean =
+        path = S3_Path.parse self.uri
+        bucket = path.bucket
+        (S3_File.Value bucket).exists
+
+    ## ---
+       private: true
+       ---
        Return the absolute path of this S3_File.
     to_text : Text
     to_text self = self.uri

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -715,9 +715,7 @@ type S3_File
        private: true
        ---
     can_write_into_parent self -> Boolean =
-        path = S3_Path.parse self.uri
-        bucket = path.bucket
-        (S3_File.Value bucket).exists
+        (S3_File.new self.s3_path.bucket_root.to_text self.credentials).exists
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_File.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Enso_File.md
@@ -10,6 +10,7 @@
     - / self name:Standard.Base.Data.Text.Text -> (Standard.Base.Enso_Cloud.Enso_File.Enso_File|Standard.Base.Any.Any)!Standard.Base.Errors.Common.Not_Found
     - add_label self label:Standard.Base.Data.Text.Text -> Standard.Base.Enso_Cloud.Enso_File.Enso_File
     - asset_type self -> Standard.Base.Enso_Cloud.Enso_File.Enso_Asset_Type
+    - can_write_into_parent self -> Standard.Base.Data.Boolean.Boolean
     - cloud_project_parent_directory -> Standard.Base.Any.Any
     - copy_to self destination:Standard.Base.System.File.Generic.File_Like.File_Like replace_existing:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - create_directory self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/File.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/File.md
@@ -3,6 +3,7 @@
 - type File
     - / self subpath:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
     - absolute self -> Standard.Base.Any.Any
+    - can_write_into_parent self -> Standard.Base.Data.Boolean.Boolean
     - copy_to self destination:Standard.Base.System.File.Generic.File_Like.File_Like replace_existing:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - create_directory self -> Standard.Base.Any.Any
     - create_dry_run_file self copy_original:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/File/Generic/File_Like.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/System/File/Generic/File_Like.md
@@ -2,6 +2,8 @@
 ## module Standard.Base.System.File.Generic.File_Like
 - type File_Like
     - Value underlying:Standard.Base.Any.Any
+    - can_write_into_parent self -> Standard.Base.Any.Any
+    - exists self -> Standard.Base.Any.Any
     - name self -> Standard.Base.Data.Text.Text
     - parent self -> Standard.Base.System.File.Generic.File_Like.File_Like
     - path self -> Standard.Base.Data.Text.Text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -390,6 +390,11 @@ type Enso_File
     ## ---
        private: true
        ---
+    can_write_into_parent self -> Boolean = self.parent.exists
+
+    ## ---
+       private: true
+       ---
        Convert to a display representation of this S3_File.
     to_display_text : Text
     to_display_text self = "Enso_File {" + self.path + "}"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -1007,6 +1007,11 @@ type File
     ## ---
        private: true
        ---
+    can_write_into_parent self -> Boolean = self.parent.exists
+
+    ## ---
+       private: true
+       ---
        Return the path that this file represents.
     to_text : Text
     to_text self = self.path

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/File_Like.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/File_Like.enso
@@ -40,6 +40,11 @@ type File_Like
        ---
     exists self = self.underlying.exists
 
+    ## ---
+       private: true
+       ---
+    can_write_into_parent self = self.underlying.can_write_into_parent
+
 ## ---
    private: true
    ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/File_Like.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File/Generic/File_Like.enso
@@ -1,3 +1,4 @@
+import project.Data.Boolean
 import project.Data.Text.Text
 import project.System.File.File
 import project.System.File_Format_Metadata.File_Format_Metadata
@@ -33,6 +34,11 @@ type File_Like
        private: true
        ---
     to_display_text self -> Text = self.underlying.to_display_text
+
+    ## ---
+       private: true
+       ---
+    exists self = self.underlying.exists
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
@@ -690,7 +690,7 @@ type In_Memory_Table_Implementation
                     if is_write.not then Panic.throw caught_panic else
                         Error.throw (File_Error.Unsupported_Output_Type resolved_format Table)
                 Panic.catch No_Such_Method handler=handle_no_write_method <|
-                    if (path:File_Like).parent.exists.not then Error.throw (File_Error.Not_Found (path:File_Like).parent) else
+                    if (path:File_Like).can_write_into_parent.not then Error.throw (File_Error.Not_Found (path:File_Like).parent) else
                         to_write = if Context.Output.is_enabled then this_table else this_table.take 1000
                         resolved_format.write_table path to_write on_existing_file match_columns on_problems
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
@@ -16,6 +16,7 @@ import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Unimplemented.Unimplemented
 import Standard.Base.Runtime.Context
+import Standard.Base.System.File.Generic.File_Like.File_Like
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
 from Standard.Base.Data.Index_Sub_Range import drop_helper, normalize_ranges, take_helper
 
@@ -689,8 +690,9 @@ type In_Memory_Table_Implementation
                     if is_write.not then Panic.throw caught_panic else
                         Error.throw (File_Error.Unsupported_Output_Type resolved_format Table)
                 Panic.catch No_Such_Method handler=handle_no_write_method <|
-                    to_write = if Context.Output.is_enabled then this_table else this_table.take 1000
-                    resolved_format.write_table path to_write on_existing_file match_columns on_problems
+                    if (path:File_Like).parent.exists.not then Error.throw (File_Error.Not_Found (path:File_Like).parent) else
+                        to_write = if Context.Output.is_enabled then this_table else this_table.take 1000
+                        resolved_format.write_table path to_write on_existing_file match_columns on_problems
 
     to_csv (this_table : Table & In_Memory_Table) =
         Text.from this_table (..Delimited delimiter=",")

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -724,6 +724,8 @@ spec_write suite_builder suffix test_sheet_name =
             Test.with_clue "("+r1.catch.to_display_text+") " <|
                 r1.should_fail_with File_Error
                 r1.catch.should_be_a File_Error.Not_Found
+                ## We want the Not found error to point to the nonexistent directory, not some file that is just being written.
+                r1.catch.file.path . should_equal parent.path
 
         group_builder.specify "should allow to write and read-back Unicode characters" <|
             encodings = enso_project.data / "transient" / ("encodings."+suffix)


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a new `can_write_into_parent` method

The main goal is to ensure that write operations fail gracefully with a clear error if the parent directory does not exist

For AWS files the existence of "directories" is not so relevant to we just check if the bucket exists.

Fixes #11516 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
