### PR TITLE
Add support for Decimal types in SQL Server

### DIFF
--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -107,6 +107,8 @@ type SQLServer_Type_Mapping
                 "varbinary" -> Value_Type.Binary size=sql_type.precision variable_length=True
                 "binary" -> Value_Type.Binary size=sql_type.precision variable_length=False
                 _ -> on_unknown_type sql_type
+            Types.DECIMAL -> Value_Type.Decimal sql_type.precision sql_type.scale
+            Types.NUMERIC -> Value_Type.Decimal sql_type.precision sql_type.scale
             Types.NULL -> Value_Type.Null
             _ -> case sql_type.name of
                 "datetimeoffset" -> Value_Type.Date_Time with_timezone=True


### PR DESCRIPTION
### Pull Request Description

- Add the missing type mapping so we read Decimals correctly from SQL Server.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
