### PR TITLE
Add shm-size option to RunOptions for docker in CI

### DIFF
--- a/build_tools/ci_utils/src/programs/docker.rs
+++ b/build_tools/ci_utils/src/programs/docker.rs
@@ -461,6 +461,8 @@ pub struct RunOptions {
     pub ports:             HashMap<u16, u16>,
     pub network:           Option<Network>,
     pub storage_size_gb:   Option<usize>,
+    /// Size of /dev/shm for the container, e.g. "1gb". Passed as --shm-size.
+    pub shm_size:          Option<OsString>,
     /// Proxy all received signals to the process (non-TTY mode only).
     pub sig_proxy:         Option<bool>,
 }
@@ -478,6 +480,7 @@ impl RunOptions {
             ports: default(),
             network: default(),
             storage_size_gb: default(),
+            shm_size: Some(OsString::from("1gb")),
             sig_proxy: default(),
         }
     }
@@ -511,6 +514,11 @@ impl RunOptions {
 
     pub fn storage_size_gb(&mut self, storage_size_in_gb: usize) -> &mut Self {
         self.storage_size_gb = Some(storage_size_in_gb);
+        self
+    }
+
+    pub fn shm_size(&mut self, size: impl Into<OsString>) -> &mut Self {
+        self.shm_size = Some(size.into());
         self
     }
 
@@ -563,6 +571,11 @@ impl RunOptions {
             // e.g. --storage-opt size=120G
             ret.push("--storage-opt".into());
             ret.push(format!("size={storage_size_gb}G").into());
+        }
+
+        if let Some(shm_size) = self.shm_size.as_ref() {
+            ret.push("--shm-size".into());
+            ret.push(shm_size.clone());
         }
 
         if let Some(sig_proxy) = self.sig_proxy {


### PR DESCRIPTION
### Pull Request Description

See #14119

I’m not sure what value would be sufficient; 1 GB seems reasonable for now. No changes to `ci` repository would be needed — we just need to recreate containers.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
