### PR TITLE
Dialect and Connection Restructure (part 1)

### DIFF
--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -194,11 +194,13 @@ export class EnsoRunner implements Runner {
       setTimeout(startHealthCheck, 250)
 
       serverProcess.stderr.on('data', (data) => {
+        console.error(data.toString())
         const dataStr = data.toString()
         stderr += dataStr
       })
 
       serverProcess.on('error', (error) => {
+        console.error(error.toString())
         if (!resolved) {
           reject(new Error(`Failed to start language server: ${error.message}`))
         }

--- a/distribution/bin/enso.bat
+++ b/distribution/bin/enso.bat
@@ -1,5 +1,5 @@
 @echo off
 set comp-dir=%~dp0\..\component
-set java-opts=-Dpolyglot.compiler.IterativePartialEscape=true --enable-native-access=org.graalvm.truffle --sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED
+set java-opts=--enable-native-access=org.graalvm.truffle --sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED
 java --module-path %comp-dir%  %java-opts% -m org.enso.runner/org.enso.runner.Main %*
 exit /B %errorlevel%

--- a/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/Database/Redshift/Internal/Redshift_Dialect.md
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/Database/Redshift/Internal/Redshift_Dialect.md
@@ -2,7 +2,7 @@
 ## module Standard.AWS.Database.Redshift.Internal.Redshift_Dialect
 - type Redshift_Dialect
     - Value dialect_operations:Standard.Base.Any.Any
-    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any mapping:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - cast_aggregate_columns self op_kind:Standard.Base.Data.Text.Text columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) -> Standard.Base.Any.Any
     - cast_op_type self op_kind:Standard.Base.Data.Text.Text args:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) expression:Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression -> Standard.Base.Any.Any
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
@@ -17,11 +17,9 @@
     - get_error_mapper self -> Standard.Base.Any.Any
     - get_limit_sql_modifier self limit:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_part_order self part:Standard.Database.Internal.SQL_Part.SQL_Part -> Standard.Base.Data.Numbers.Integer
-    - get_statement_setter self -> Standard.Base.Any.Any
-    - get_type_mapping self -> Standard.Base.Any.Any
     - is_feature_supported self feature:Standard.Database.Dialects.Feature.Feature -> Standard.Base.Data.Boolean.Boolean
     - is_operation_supported self operation:Standard.Base.Data.Text.Text -> Standard.Base.Data.Boolean.Boolean
-    - make_cast self column:Standard.Base.Any.Any target_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - make_cast self column:Standard.Base.Any.Any mapping:Standard.Base.Any.Any target_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - make_table_literal self vecs:Standard.Base.Any.Any column_names:Standard.Base.Any.Any as_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - name self -> Standard.Base.Any.Any
     - needs_execute_query_for_type_inference self statement:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -21,7 +21,6 @@ import Standard.Database.Internal.Postgres.Postgres_Dialect
 import Standard.Database.Internal.SQL_Part.SQL_Part
 import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
-import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
 import Standard.Database.SQL.SQL_Statement
 import Standard.Database.SQL.SQL_Type
@@ -132,12 +131,6 @@ type Redshift_Dialect
     prepare_order_descriptor : Internal_Column -> Sort_Direction -> Nothing | Text_Ordering -> Order_Descriptor
     prepare_order_descriptor self internal_column sort_direction text_ordering =
         Postgres_Dialect.make_order_descriptor internal_column sort_direction text_ordering
-
-    ## ---
-       private: true
-       ---
-    get_statement_setter : Statement_Setter
-    get_statement_setter self = Statement_Setter.default
 
     ## ---
        private: true

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -18,9 +18,7 @@ import Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
 import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Postgres.Postgres_Dialect
-import Standard.Database.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 import Standard.Database.Internal.SQL_Part.SQL_Part
-import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -133,14 +131,6 @@ type Redshift_Dialect
     prepare_order_descriptor : Internal_Column -> Sort_Direction -> Nothing | Text_Ordering -> Order_Descriptor
     prepare_order_descriptor self internal_column sort_direction text_ordering =
         Postgres_Dialect.make_order_descriptor internal_column sort_direction text_ordering
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self = Postgres_Type_Mapping
 
     ## ---
        private: true

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -19,6 +19,7 @@ import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Postgres.Postgres_Dialect
 import Standard.Database.Internal.SQL_Part.SQL_Part
+import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -141,9 +142,8 @@ type Redshift_Dialect
     ## ---
        private: true
        ---
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self column target_type infer_result_type_from_database_callback =
-        mapping = self.get_type_mapping
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self column mapping target_type infer_result_type_from_database_callback =
         sql_type_text = mapping.sql_type_to_text target_type
         new_expression = SQL_IR_Expression.Operation "CAST" [column.expression, SQL_IR_Expression.Literal sql_type_text]
         new_sql_type_reference = infer_result_type_from_database_callback new_expression

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -303,7 +303,7 @@ type Redshift_Dialect
        Returns `Nothing` if the key is not defined.
     fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
     fetch_primary_key self connection table_name schema_name =
-        Dialect.default_fetch_primary_key connection table_name schema_name
+        Connection.default_fetch_primary_key connection table_name schema_name
 
     ## ---
        private: true

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -167,9 +167,9 @@ type Redshift_Dialect
     ## ---
        private: true
        ---
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
-        _ = [approximate_result_type, infer_result_type_from_database_callback]
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
+        _ = [column, approximate_result_type, infer_result_type_from_database_callback, mapping]
         column
 
     ## ---

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Redshift_Details.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Redshift_Details.enso
@@ -10,6 +10,7 @@ import Standard.Database.Connection.SSL_Mode.SSL_Mode
 import Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties
 import Standard.Database.Internal.JDBC_Connection
 import Standard.Database.Internal.Postgres.Pgpass
+import Standard.Database.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 from Standard.Database.Internal.Postgres.Helpers import get_encoding_name, parse_postgres_encoding
 
 import project.AWS_Credential.AWS_Credential
@@ -69,7 +70,7 @@ type Redshift_Details
         encoding = parse_postgres_encoding (get_encoding_name jdbc_connection)
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection encoding is_case_sensitive=True
 
-        Connection.new jdbc_connection Redshift_Dialect.redshift entity_naming_properties
+        Connection.new jdbc_connection Redshift_Dialect.redshift Postgres_Type_Mapping entity_naming_properties
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
@@ -1,7 +1,7 @@
 ## Enso Signatures 1.0
 ## module Standard.Database.Connection.Connection
 - type Connection
-    - Value jdbc_connection:Standard.Base.Any.Any dialect:Standard.Base.Any.Any entity_naming_properties:Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties supports_large_update:(Standard.Base.Runtime.Ref.Ref Standard.Base.Data.Boolean.Boolean) hidden_table_registry:Standard.Database.Internal.Hidden_Table_Registry.Hidden_Table_Registry data_link_setup:(Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup|Standard.Base.Nothing.Nothing)=
+    - Value jdbc_connection:Standard.Base.Any.Any dialect:Standard.Base.Any.Any type_mapping:Standard.Base.Any.Any statement_setter:Standard.Database.Internal.Statement_Setter.Statement_Setter entity_naming_properties:Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties supports_large_update:(Standard.Base.Runtime.Ref.Ref Standard.Base.Data.Boolean.Boolean) hidden_table_registry:Standard.Database.Internal.Hidden_Table_Registry.Hidden_Table_Registry data_link_setup:(Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup|Standard.Base.Nothing.Nothing)=
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - column_naming_helper self -> Standard.Base.Any.Any
@@ -9,6 +9,7 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
+    - default_fetch_primary_key connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
@@ -17,7 +18,7 @@
     - get_tables_advanced self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= include_hidden:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - internal_allocate_dry_run_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - maybe_run_maintenance self -> Standard.Base.Any.Any
-    - new jdbc_connection:Standard.Database.Internal.JDBC_Connection.JDBC_Connection dialect:Standard.Base.Any.Any entity_naming_properties:Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties data_link_setup:(Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup|Standard.Base.Nothing.Nothing)= try_large_update:Standard.Base.Data.Boolean.Boolean= -> Standard.Database.Connection.Connection.Connection
+    - new jdbc_connection:Standard.Database.Internal.JDBC_Connection.JDBC_Connection dialect:Standard.Base.Any.Any type_mapping:Standard.Base.Any.Any entity_naming_properties:Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties data_link_setup:(Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup|Standard.Base.Nothing.Nothing)= try_large_update:Standard.Base.Data.Boolean.Boolean= statement_setter:Standard.Database.Internal.Statement_Setter.Statement_Setter= -> Standard.Database.Connection.Connection.Connection
     - query self query:Standard.Base.Any.Any alias:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - read self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any
     - read_statement self statement:Standard.Base.Any.Any column_types:Standard.Base.Any.Any= last_row_only:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -24,4 +24,5 @@
     - tables self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - type_mapping self -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Database.Connection.Postgres_Connection.Postgres_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -20,6 +20,7 @@
     - schemas self -> Standard.Base.Any.Any
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -24,4 +24,5 @@
     - tables self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - type_mapping self -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Database.Connection.SQLite_Connection.SQLite_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -20,6 +20,7 @@
     - schemas self -> Standard.Base.Any.Any
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Dialects/Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Dialects/Dialect.md
@@ -1,7 +1,7 @@
 ## Enso Signatures 1.0
 ## module Standard.Database.Dialects.Dialect
 - type Dialect
-    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any mapping:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - custom_build_aggregate self base_table:Standard.Database.DB_Table.DB_Table key_columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) resolved_aggregates:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any) problem_builder:Standard.Table.Internal.Problem_Builder.Problem_Builder -> (Standard.Base.Data.Pair.Pair Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source Standard.Base.Any.Any)
     - default_table_types self -> Standard.Base.Any.Any
@@ -15,12 +15,10 @@
     - get_error_mapper self -> Standard.Base.Any.Any
     - get_limit_sql_modifier self limit:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_part_order self part:Standard.Database.Internal.SQL_Part.SQL_Part -> Standard.Base.Data.Numbers.Integer
-    - get_statement_setter self -> Standard.Base.Any.Any
-    - get_type_mapping self -> Standard.Base.Any.Any
     - if_replace_params_supports self replace_params:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - is_feature_supported self feature:Standard.Database.Dialects.Feature.Feature -> Standard.Base.Data.Boolean.Boolean
     - is_operation_supported self operation:Standard.Base.Data.Text.Text -> Standard.Base.Data.Boolean.Boolean
-    - make_cast self column:Standard.Base.Any.Any target_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - make_cast self column:Standard.Base.Any.Any mapping:Standard.Base.Any.Any target_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - name self -> Standard.Base.Any.Any
     - needs_execute_query_for_type_inference self statement:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - prepare_distinct self table:Standard.Base.Any.Any key_columns:Standard.Base.Any.Any case_sensitivity:Standard.Base.Any.Any problem_builder:Standard.Base.Any.Any -> Standard.Base.Any.Any
@@ -33,6 +31,5 @@
 - type Temp_Table_Style
     - Hash_Prefix
     - Temporary_Table
-- default_fetch_primary_key connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - postgres -> Standard.Base.Any.Any
 - sqlite -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Aggregate_Helper.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Aggregate_Helper.md
@@ -7,6 +7,6 @@
 - default_build_aggregate build_aggregate:Standard.Base.Any.Any dialect:Standard.Base.Any.Any base_table:Standard.Base.Any.Any key_columns:Standard.Base.Any.Any resolved_aggregates:Standard.Base.Any.Any problem_builder:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - is_non_empty_selector v:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_aggregate_column table:Standard.Base.Any.Any aggregate:Standard.Base.Any.Any as:Standard.Base.Any.Any dialect:Standard.Base.Any.Any infer_return_type:Standard.Base.Any.Any problem_builder:Standard.Base.Any.Any -> Standard.Database.Internal.IR.Internal_Column.Internal_Column
-- make_infer_return_type dialect:Standard.Base.Any.Any connection:Standard.Base.Any.Any context:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- make_infer_return_type connection:Standard.Base.Any.Any context:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - map_column_inputs f:Standard.Base.Function.Function aggregate_column:Standard.Table.Aggregate_Column.Aggregate_Column -> Standard.Table.Aggregate_Column.Aggregate_Column
 - throw_ordering_required op_name:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Common/Lookup_Query_Helper.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Common/Lookup_Query_Helper.md
@@ -9,6 +9,6 @@
 - check_initial_invariants base_table:Standard.Base.Any.Any lookup_table:Standard.Base.Any.Any lookup_columns:Standard.Base.Any.Any allow_unmatched_rows:Standard.Base.Any.Any ~continuation:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_context_for_lookup_join lookup_columns:Standard.Base.Any.Any subquery_setup:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - make_invariant_check lookup_counter:Standard.Base.Any.Any allow_unmatched_rows:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- make_lookup_counter_column dialect:Standard.Base.Any.Any lookup_columns:Standard.Base.Any.Any unique_name_strategy:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- make_lookup_counter_column connection:Standard.Base.Any.Any lookup_columns:Standard.Base.Any.Any unique_name_strategy:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - precheck_for_duplicate_matches lookup_columns:Standard.Base.Any.Any subquery_setup:Standard.Base.Any.Any connection:Standard.Base.Any.Any new_ctx:Standard.Base.Any.Any ~continuation:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - prepare_subqueries base_table:Standard.Base.Any.Any lookup_table:Standard.Base.Any.Any lookup_columns:Standard.Base.Any.Any unique_name_strategy:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Common/Lookup_Query_Helper.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Common/Lookup_Query_Helper.md
@@ -2,7 +2,7 @@
 ## module Standard.Database.Internal.Common.Lookup_Query_Helper
 - type Lookup_Subquery_Setup
     - Value self_sub:Standard.Base.Any.Any lookup_sub:Standard.Base.Any.Any lookup_counter:Standard.Base.Any.Any new_table_name:Standard.Base.Any.Any
-    - create_merged_column self ix:Standard.Base.Any.Any expected_type:Standard.Base.Any.Any dialect:Standard.Base.Any.Any infer_type_in_result:Standard.Base.Any.Any allow_unmatched_rows:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - create_merged_column self ix:Standard.Base.Any.Any expected_type:Standard.Base.Any.Any dialect:Standard.Base.Any.Any infer_type_in_result:Standard.Base.Any.Any allow_unmatched_rows:Standard.Base.Any.Any mapping:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_lookup_column self ix:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_self_column self ix:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - build_lookup_query base_table:Standard.Base.Any.Any lookup_table:Standard.Base.Any.Any key_columns:Standard.Base.Any.Any add_new_columns:Standard.Base.Any.Any allow_unmatched_rows:Standard.Base.Any.Any on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Helpers.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Helpers.md
@@ -4,6 +4,6 @@
 - check_connection entity1:Standard.Base.Any.Any entity2:Standard.Base.Any.Any -> Standard.Base.Data.Boolean.Boolean
 - check_integrity entity1:Standard.Base.Any.Any entity2:Standard.Base.Any.Any -> Standard.Base.Data.Boolean.Boolean
 - ensure_same_connection name:Standard.Base.Any.Any entities:Standard.Base.Any.Any ~continuation:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- expect_dialect_specific_integer_type related_column:Standard.Base.Any.Any argument:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- expect_specific_integer_type related_column:Standard.Base.Any.Any argument:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - rename_internal_columns columns:Standard.Base.Any.Any new_names:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - unify_vector_singleton x:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Postgres/Postgres_Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Postgres/Postgres_Dialect.md
@@ -2,7 +2,7 @@
 ## module Standard.Database.Internal.Postgres.Postgres_Dialect
 - type Postgres_Dialect
     - Value dialect_operations:Standard.Base.Any.Any
-    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any mapping:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - cast_aggregate_columns self op_kind:Standard.Base.Data.Text.Text columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) -> Standard.Base.Any.Any
     - cast_op_type self op_kind:Standard.Base.Data.Text.Text args:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) expression:Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression -> Standard.Base.Any.Any
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
@@ -17,12 +17,10 @@
     - get_error_mapper self -> Standard.Base.Any.Any
     - get_limit_sql_modifier self limit:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_part_order self part:Standard.Database.Internal.SQL_Part.SQL_Part -> Standard.Base.Data.Numbers.Integer
-    - get_statement_setter self -> Standard.Base.Any.Any
-    - get_type_mapping self -> Standard.Base.Any.Any
     - if_replace_params_supports self replace_params:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - is_feature_supported self feature:Standard.Database.Dialects.Feature.Feature -> Standard.Base.Data.Boolean.Boolean
     - is_operation_supported self operation:Standard.Base.Data.Text.Text -> Standard.Base.Data.Boolean.Boolean
-    - make_cast self column:Standard.Database.Internal.IR.Internal_Column.Internal_Column target_type:Standard.Database.SQL.SQL_Type infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - make_cast self column:Standard.Database.Internal.IR.Internal_Column.Internal_Column mapping:Standard.Base.Any.Any target_type:Standard.Database.SQL.SQL_Type infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - make_table_literal self vecs:Standard.Base.Any.Any column_names:Standard.Base.Any.Any as_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - name self -> Standard.Base.Any.Any
     - needs_execute_query_for_type_inference self statement:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQLite/SQLite_Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQLite/SQLite_Dialect.md
@@ -2,7 +2,7 @@
 ## module Standard.Database.Internal.SQLite.SQLite_Dialect
 - type SQLite_Dialect
     - Value dialect_operations:Standard.Base.Any.Any
-    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - adapt_unified_column self column:Standard.Base.Any.Any approximate_result_type:Standard.Base.Any.Any infer_result_type_from_database_callback:Standard.Base.Any.Any mapping:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - cast_aggregate_columns self op_kind:Standard.Base.Data.Text.Text columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) -> Standard.Base.Any.Any
     - cast_op_type self op_kind:Standard.Base.Data.Text.Text args:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) expression:Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression -> Standard.Base.Any.Any
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
@@ -18,13 +18,11 @@
     - get_error_mapper self -> Standard.Base.Any.Any
     - get_limit_sql_modifier self limit:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - get_part_order self part:Standard.Database.Internal.SQL_Part.SQL_Part -> Standard.Base.Data.Numbers.Integer
-    - get_statement_setter self -> Standard.Base.Any.Any
-    - get_type_mapping self -> Standard.Base.Any.Any
     - if_replace_params_supports self replace_params:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - is_feature_supported self feature:Standard.Database.Dialects.Feature.Feature -> Standard.Base.Data.Boolean.Boolean
     - is_operation_supported self operation:Standard.Base.Data.Text.Text -> Standard.Base.Data.Boolean.Boolean
-    - make_cast self column:Standard.Database.Internal.IR.Internal_Column.Internal_Column target_type:Standard.Database.SQL.SQL_Type infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
-    - make_cast_expression self column:Standard.Base.Any.Any target_type:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - make_cast self column:Standard.Database.Internal.IR.Internal_Column.Internal_Column mapping:Standard.Base.Any.Any target_type:Standard.Database.SQL.SQL_Type infer_result_type_from_database_callback:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - make_cast_expression self column:Standard.Base.Any.Any mapping:Standard.Base.Any.Any target_type:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - make_table_literal self vecs:Standard.Base.Any.Any column_names:Standard.Base.Any.Any as_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - name self -> Standard.Base.Any.Any
     - needs_execute_query_for_type_inference self statement:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -203,7 +203,7 @@ type Connection
             Nothing -> Nothing
             _ : Vector -> types
             _ -> [types]
-        tm = self.dialect.get_type_mapping
+        tm = self.get_type_mapping
         result = get_tables_advanced self.jdbc_connection name_like database schema types_vector tm.sql_type_to_value_type tm.column_fetcher_factory all_fields
         case include_hidden of
             True -> result
@@ -339,7 +339,7 @@ type Connection
           fetched. Defaults to false.
     read_statement : SQL_Statement -> (Nothing | Vector SQL_Type_Reference) -> Boolean -> Table
     read_statement self statement column_types=Nothing last_row_only=False =
-        type_overrides = self.dialect.get_type_mapping.prepare_type_overrides column_types
+        type_overrides = self.get_type_mapping.prepare_type_overrides column_types
         statement_setter = self.dialect.get_statement_setter
         self.jdbc_connection.with_prepared_statement statement statement_setter stmt->
             rs = stmt.executeQuery
@@ -351,7 +351,7 @@ type Connection
                     sql_type_reference.cache_computed_type <| SQL_Type.from_metadata metadata ix+1
 
             # And finally, materialize the results.
-            tm = self.dialect.get_type_mapping
+            tm = self.get_type_mapping
             SQL_Warning_Helper.process_warnings stmt <|
                 result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory type_overrides last_row_only
 
@@ -400,7 +400,7 @@ type Connection
             self.jdbc_connection.with_prepared_statement query statement_setter stmt->
                 _check_statement_is_allowed self stmt
                 rs = stmt.executeQuery
-                tm = self.dialect.get_type_mapping
+                tm = self.get_type_mapping
                 table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory row_limit=(limit.rows_to_read.if_nothing -1)
                 limit.attach_warning table
 
@@ -557,6 +557,21 @@ type Connection
                 case self.data_link_setup of
                     Nothing -> Error.throw (Illegal_State.Error "The connection does not support saving as a data link.")
                     data_link_setup -> data_link_setup.save_as_data_link path on_existing_file
+
+    ## ---
+       private: true
+       ---
+       Default implementation relying on DatabaseMetaData for fetching primary key.
+    default_fetch_primary_key connection table_name schema_name =
+        connection.jdbc_connection.with_metadata metadata->
+            used_schema = if schema_name == "" then Nothing else schema_name
+            rs = metadata.getPrimaryKeys Nothing used_schema table_name
+            tm = connection.get_type_mapping
+            keys_table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory
+            # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
+            selected = keys_table.select_columns ["COLUMN_NAME", "KEY_SEQ"] case_sensitivity=Case_Sensitivity.Insensitive reorder=True
+            key_column_names = selected.sort 1 . at 0 . to_vector
+            if key_column_names.is_empty then Nothing else key_column_names
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -52,6 +52,8 @@ type Connection
           connection.
         - `dialect`: the dialect associated with the database we are connected
           to.
+        - `type_mapping`: the type mapping associated with the database we are
+          connected to.
         - `entity_naming_properties`: a helper allowing to manage properties of
           entity naming rules of the given backend.
         - `supports_large_update`: whether the connection should try to use
@@ -62,7 +64,7 @@ type Connection
           to the user, but are used internally by the dry-run system.
         - `data_link_setup`: an optional setup allowing for saving the connection
           as a data link.
-    Value jdbc_connection dialect (entity_naming_properties : Entity_Naming_Properties) (supports_large_update : Ref Boolean) (hidden_table_registry : Hidden_Table_Registry.Hidden_Table_Registry) (data_link_setup : Data_Link_Setup | Nothing = Nothing)
+    Value jdbc_connection dialect type_mapping (entity_naming_properties : Entity_Naming_Properties) (supports_large_update : Ref Boolean) (hidden_table_registry : Hidden_Table_Registry.Hidden_Table_Registry) (data_link_setup : Data_Link_Setup | Nothing = Nothing)
 
     ## ---
        private: true
@@ -74,15 +76,17 @@ type Connection
           connection.
         - `dialect`: the dialect associated with the database we are connected
           to.
+        - `type_mapping`: the type mapping associated with the database we are
+          connected to.
         - `entity_naming_properties`: a helper allowing to manage properties of
           entity naming rules of the given backend.
         - `data_link_setup`: an optional setup allowing for saving the connection
           as a data link.
         - `try_large_update`: whether the connection should try to use
           `executeLargeUpdate`.
-    new jdbc_connection:JDBC_Connection dialect entity_naming_properties:Entity_Naming_Properties (data_link_setup : Data_Link_Setup | Nothing = Nothing) (try_large_update : Boolean = True) -> Connection =
+    new jdbc_connection:JDBC_Connection dialect type_mapping entity_naming_properties:Entity_Naming_Properties (data_link_setup : Data_Link_Setup | Nothing = Nothing) (try_large_update : Boolean = True) -> Connection =
         registry = Hidden_Table_Registry.new
-        Connection.Value jdbc_connection dialect entity_naming_properties (Ref.new try_large_update) registry data_link_setup
+        Connection.Value jdbc_connection dialect type_mapping entity_naming_properties (Ref.new try_large_update) registry data_link_setup
 
     ## ---
        private: true
@@ -92,7 +96,6 @@ type Connection
        The connection is not usable afterwards.
     close : Nothing
     close self = self.jdbc_connection.close
-
 
     ## ---
        private: true
@@ -203,7 +206,7 @@ type Connection
             Nothing -> Nothing
             _ : Vector -> types
             _ -> [types]
-        tm = self.get_type_mapping
+        tm = self.type_mapping
         result = get_tables_advanced self.jdbc_connection name_like database schema types_vector tm.sql_type_to_value_type tm.column_fetcher_factory all_fields
         case include_hidden of
             True -> result
@@ -339,7 +342,7 @@ type Connection
           fetched. Defaults to false.
     read_statement : SQL_Statement -> (Nothing | Vector SQL_Type_Reference) -> Boolean -> Table
     read_statement self statement column_types=Nothing last_row_only=False =
-        type_overrides = self.get_type_mapping.prepare_type_overrides column_types
+        type_overrides = self.type_mapping.prepare_type_overrides column_types
         statement_setter = self.dialect.get_statement_setter
         self.jdbc_connection.with_prepared_statement statement statement_setter stmt->
             rs = stmt.executeQuery
@@ -351,7 +354,7 @@ type Connection
                     sql_type_reference.cache_computed_type <| SQL_Type.from_metadata metadata ix+1
 
             # And finally, materialize the results.
-            tm = self.get_type_mapping
+            tm = self.type_mapping
             SQL_Warning_Helper.process_warnings stmt <|
                 result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory type_overrides last_row_only
 
@@ -400,7 +403,7 @@ type Connection
             self.jdbc_connection.with_prepared_statement query statement_setter stmt->
                 _check_statement_is_allowed self stmt
                 rs = stmt.executeQuery
-                tm = self.get_type_mapping
+                tm = self.type_mapping
                 table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory row_limit=(limit.rows_to_read.if_nothing -1)
                 limit.attach_warning table
 
@@ -566,7 +569,7 @@ type Connection
         connection.jdbc_connection.with_metadata metadata->
             used_schema = if schema_name == "" then Nothing else schema_name
             rs = metadata.getPrimaryKeys Nothing used_schema table_name
-            tm = connection.get_type_mapping
+            tm = connection.type_mapping
             keys_table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory
             # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
             selected = keys_table.select_columns ["COLUMN_NAME", "KEY_SEQ"] case_sensitivity=Case_Sensitivity.Insensitive reorder=True

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -54,6 +54,8 @@ type Connection
           to.
         - `type_mapping`: the type mapping associated with the database we are
           connected to.
+        - `statement_setter`: a helper for setting parameters on prepared
+          statements.
         - `entity_naming_properties`: a helper allowing to manage properties of
           entity naming rules of the given backend.
         - `supports_large_update`: whether the connection should try to use
@@ -64,7 +66,7 @@ type Connection
           to the user, but are used internally by the dry-run system.
         - `data_link_setup`: an optional setup allowing for saving the connection
           as a data link.
-    Value jdbc_connection dialect type_mapping (entity_naming_properties : Entity_Naming_Properties) (supports_large_update : Ref Boolean) (hidden_table_registry : Hidden_Table_Registry.Hidden_Table_Registry) (data_link_setup : Data_Link_Setup | Nothing = Nothing)
+    Value jdbc_connection dialect type_mapping (statement_setter:Statement_Setter) (entity_naming_properties : Entity_Naming_Properties) (supports_large_update : Ref Boolean) (hidden_table_registry : Hidden_Table_Registry.Hidden_Table_Registry) (data_link_setup : Data_Link_Setup | Nothing = Nothing)
 
     ## ---
        private: true
@@ -84,9 +86,11 @@ type Connection
           as a data link.
         - `try_large_update`: whether the connection should try to use
           `executeLargeUpdate`.
-    new jdbc_connection:JDBC_Connection dialect type_mapping entity_naming_properties:Entity_Naming_Properties (data_link_setup : Data_Link_Setup | Nothing = Nothing) (try_large_update : Boolean = True) -> Connection =
+        - `statement_setter`: a helper for setting parameters on prepared
+          statements.
+    new jdbc_connection:JDBC_Connection dialect type_mapping entity_naming_properties:Entity_Naming_Properties (data_link_setup : Data_Link_Setup | Nothing = Nothing) (try_large_update : Boolean = True) (statement_setter : Statement_Setter = Statement_Setter.default) -> Connection =
         registry = Hidden_Table_Registry.new
-        Connection.Value jdbc_connection dialect type_mapping entity_naming_properties (Ref.new try_large_update) registry data_link_setup
+        Connection.Value jdbc_connection dialect type_mapping statement_setter entity_naming_properties (Ref.new try_large_update) registry data_link_setup
 
     ## ---
        private: true
@@ -343,7 +347,7 @@ type Connection
     read_statement : SQL_Statement -> (Nothing | Vector SQL_Type_Reference) -> Boolean -> Table
     read_statement self statement column_types=Nothing last_row_only=False =
         type_overrides = self.type_mapping.prepare_type_overrides column_types
-        statement_setter = self.dialect.get_statement_setter
+        statement_setter = self.statement_setter
         self.jdbc_connection.with_prepared_statement statement statement_setter stmt->
             rs = stmt.executeQuery
 
@@ -399,7 +403,7 @@ type Connection
             Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot execute the query. Press the Write button ▶ to perform the operation." panic=False
                 (self.execute_query query limit False)
         False ->
-            statement_setter = self.dialect.get_statement_setter
+            statement_setter = self.statement_setter
             self.jdbc_connection.with_prepared_statement query statement_setter stmt->
                 _check_statement_is_allowed self stmt
                 rs = stmt.executeQuery
@@ -421,7 +425,7 @@ type Connection
     execute_update : Text | SQL_Statement -> Integer
     execute_update self query =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot execute an update query. Press the Write button ▶ to perform the operation." panic=False <|
-            statement_setter = self.dialect.get_statement_setter
+            statement_setter = self.statement_setter
             self.jdbc_connection.with_prepared_statement query statement_setter stmt->
                 _check_statement_is_allowed self stmt
                 result = case self.supports_large_update.get of

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -330,6 +330,12 @@ type Postgres_Connection
     ## ---
        private: true
        ---
+       Access the Statement Setter.
+    statement_setter self = self.connection.statement_setter
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -15,6 +15,7 @@ import project.Internal.Common.Connections_Helpers
 import project.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties
 import project.Internal.Data_Link_Setup.Data_Link_Setup
 import project.Internal.JDBC_Connection
+import project.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 import project.SQL.SQL_Statement
 import project.SQL_Query.SQL_Query
 from project.Connection.Connection import make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
@@ -44,7 +45,7 @@ type Postgres_Connection
            Our generator is supposed to always quote identifiers
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection encoding is_case_sensitive=True
 
-        Postgres_Connection.Value (Connection.new jdbc_connection Dialect.postgres entity_naming_properties data_link_setup) make_new
+        Postgres_Connection.Value (Connection.new jdbc_connection Dialect.postgres Postgres_Type_Mapping entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true
@@ -319,6 +320,12 @@ type Postgres_Connection
        ---
        Access the dialect.
     dialect self = self.connection.dialect
+
+    ## ---
+       private: true
+       ---
+       Access the Type Mapping.
+    type_mapping self = self.connection.type_mapping
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -316,6 +316,12 @@ type SQLite_Connection
     ## ---
        private: true
        ---
+       Access the Statement Setter.
+    statement_setter self = self.connection.statement_setter
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -310,6 +310,12 @@ type SQLite_Connection
     ## ---
        private: true
        ---
+       Access the Type Mapping.
+    type_mapping self = self.connection.type_mapping
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -14,6 +14,7 @@ import project.Dialects.Dialect
 import project.Internal.Common.Connections_Helpers
 import project.Internal.JDBC_Connection
 import project.Internal.SQLite.SQLite_Entity_Naming_Properties
+import project.Internal.SQLite.SQLite_Type_Mapping.SQLite_Type_Mapping
 import project.SQL.SQL_Statement
 import project.SQL_Query.SQL_Query
 from project.Connection.Connection import make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
@@ -32,7 +33,7 @@ type SQLite_Connection
     create : Text -> Vector -> SQLite_Connection
     create url properties =
         jdbc_connection = JDBC_Connection.create url properties
-        SQLite_Connection.Value (Connection.new jdbc_connection Dialect.sqlite SQLite_Entity_Naming_Properties.new)
+        SQLite_Connection.Value (Connection.new jdbc_connection Dialect.sqlite SQLite_Type_Mapping SQLite_Entity_Naming_Properties.new)
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -350,7 +350,7 @@ make_literal_table connection column_vectors column_names alias =
 
     if total_size == 0 then Error.throw (Illegal_Argument.Error "Vectors cannot be empty") else
         if total_size > MAX_LITERAL_ELEMENT_COUNT then Error.throw (Illegal_Argument.Error "Too many elements for table literal ("+total_size.to_text+"): materialize a table into the database instead") else
-            type_mapping = connection.dialect.get_type_mapping
+            type_mapping = connection.get_type_mapping
             from_spec = SQL_IR_From_Part.Literal_Values column_vectors column_names alias
             context = SQL_IR_Source.for_subquery from_spec
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -350,7 +350,7 @@ make_literal_table connection column_vectors column_names alias =
 
     if total_size == 0 then Error.throw (Illegal_Argument.Error "Vectors cannot be empty") else
         if total_size > MAX_LITERAL_ELEMENT_COUNT then Error.throw (Illegal_Argument.Error "Too many elements for table literal ("+total_size.to_text+"): materialize a table into the database instead") else
-            type_mapping = connection.type_mapping
+            mapping = connection.type_mapping
             from_spec = SQL_IR_From_Part.Literal_Values column_vectors column_names alias
             context = SQL_IR_Source.for_subquery from_spec
 
@@ -364,13 +364,13 @@ make_literal_table connection column_vectors column_names alias =
                 value_type = Value_Type_Helpers.find_common_type_for_arguments column_vector.to_vector
                 sql_type = case value_type of
                    Nothing -> SQL_Type.null
-                   _ -> type_mapping.value_type_to_sql value_type Problem_Behavior.Ignore
+                   _ -> mapping.value_type_to_sql value_type Problem_Behavior.Ignore
                 type_ref = SQL_Type_Reference.from_constant sql_type
                 sql_expression = SQL_IR_Expression.Column alias column_name
                 base_column = Internal_Column.Value column_name type_ref sql_expression
 
                 needs_cast = value_type.is_nothing.not && connection.dialect.needs_literal_table_cast value_type
                 if needs_cast.not then base_column else
-                    connection.dialect.make_cast base_column sql_type infer_type_from_database
+                    connection.dialect.make_cast base_column mapping sql_type infer_type_from_database
 
             DB_Table.new alias connection internal_columns context

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -350,7 +350,7 @@ make_literal_table connection column_vectors column_names alias =
 
     if total_size == 0 then Error.throw (Illegal_Argument.Error "Vectors cannot be empty") else
         if total_size > MAX_LITERAL_ELEMENT_COUNT then Error.throw (Illegal_Argument.Error "Too many elements for table literal ("+total_size.to_text+"): materialize a table into the database instead") else
-            type_mapping = connection.get_type_mapping
+            type_mapping = connection.type_mapping
             from_spec = SQL_IR_From_Part.Literal_Values column_vectors column_names alias
             context = SQL_IR_Source.for_subquery from_spec
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -22,6 +22,7 @@ import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Postgres.Postgres_Dialect
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
+import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Dialect
 import project.Internal.Statement_Setter.Statement_Setter
@@ -129,13 +130,14 @@ type Dialect
 
        ## Arguments
         - `column`: the input column to transform.
+        - `mapping`: the type mapping of the connection.
         - `target_type`: the target type.
         - `infer_result_type_from_database_callback`: A callback that can be used
           to infer the type of the newly built expression from the Database. It
           should be used by default, unless an override is chosen.
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self column target_type infer_result_type_from_database_callback =
-        _ = [column, target_type, infer_result_type_from_database_callback]
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self column mapping target_type infer_result_type_from_database_callback =
+        _ = [column, mapping, target_type, infer_result_type_from_database_callback]
         Unimplemented.throw "This is an interface only."
 
     ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -22,7 +22,6 @@ import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Postgres.Postgres_Dialect
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
-import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Dialect
 import project.Internal.Statement_Setter.Statement_Setter
@@ -109,15 +108,6 @@ type Dialect
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
         _ = [table, key_columns, case_sensitivity, problem_builder]
-        Unimplemented.throw "This is an interface only."
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self =
         Unimplemented.throw "This is an interface only."
 
     ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -361,21 +361,6 @@ postgres = Postgres_Dialect.postgres
 ## ---
    private: true
    ---
-   Default implementation relying on DatabaseMetaData.
-default_fetch_primary_key connection table_name schema_name =
-    connection.jdbc_connection.with_metadata metadata->
-        used_schema = if schema_name == "" then Nothing else schema_name
-        rs = metadata.getPrimaryKeys Nothing used_schema table_name
-        tm = connection.dialect.get_type_mapping
-        keys_table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory
-        # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
-        selected = keys_table.select_columns ["COLUMN_NAME", "KEY_SEQ"] case_sensitivity=Case_Sensitivity.Insensitive reorder=True
-        key_column_names = selected.sort 1 . at 0 . to_vector
-        if key_column_names.is_empty then Nothing else key_column_names
-
-## ---
-   private: true
-   ---
 type Temp_Table_Style
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -25,7 +25,6 @@ import project.Internal.SQL_Part.SQL_Part
 import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Dialect
-import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
 import project.SQL.SQL_Statement
 import project.SQL.SQL_Type
@@ -108,17 +107,6 @@ type Dialect
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
         _ = [table, key_columns, case_sensitivity, problem_builder]
-        Unimplemented.throw "This is an interface only."
-
-    ## ---
-       private: true
-       ---
-       Returns a helper object that handles the logic of setting values in a
-       prepared statement.
-       This object may provide custom logic for handling dialect-specific
-       handling of some types.
-    get_statement_setter : Statement_Setter
-    get_statement_setter self =
         Unimplemented.throw "This is an interface only."
 
     ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -29,7 +29,6 @@ import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
 import project.SQL.SQL_Statement
 import project.SQL.SQL_Type
-from project.Internal.Result_Set import result_set_to_table
 
 ## ---
    private: true
@@ -172,9 +171,9 @@ type Dialect
        columns.
        These transformations depend on the dialect. They can be used to align the
        result types, for example.
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
-        _ = [column, approximate_result_type, infer_result_type_from_database_callback]
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
+        _ = [column, approximate_result_type, infer_result_type_from_database_callback, mapping]
         Unimplemented.throw "This is an interface only."
 
     ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
@@ -185,9 +185,9 @@ make_infer_return_type connection context =
        See #6118.
     infer_from_database_callback expression =
         SQL_Type_Reference.new connection context expression
-    type_mapping = connection.get_type_mapping
+    mapping = connection.type_mapping
     infer_return_type op_kind columns expression =
-        type_mapping.infer_return_type infer_from_database_callback op_kind columns expression
+        mapping.infer_return_type infer_from_database_callback op_kind columns expression
     infer_return_type
 
 ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Aggregate_Helper.enso
@@ -161,7 +161,7 @@ aggregate table:DB_Table group_by:(Vector | Text | Integer | Regex) columns:Vect
 default_build_aggregate build_aggregate dialect base_table key_columns resolved_aggregates problem_builder =
     key_expressions = key_columns.map .expression
     new_ctx = base_table.context.set_groups key_expressions
-    infer_return_type = make_infer_return_type dialect base_table.connection new_ctx
+    infer_return_type = make_infer_return_type base_table.connection new_ctx
     results = resolved_aggregates.map p->
         agg = p.second
         as = p.first
@@ -175,7 +175,7 @@ default_build_aggregate build_aggregate dialect base_table key_columns resolved_
 ## ---
    private: true
    ---
-make_infer_return_type dialect connection context =
+make_infer_return_type connection context =
     ## TODO [RW] here we will perform as many fetches as there are
        aggregate columns, but technically we could perform just one
        fetch fetching all column types - TODO we should do that. We can
@@ -185,7 +185,7 @@ make_infer_return_type dialect connection context =
        See #6118.
     infer_from_database_callback expression =
         SQL_Type_Reference.new connection context expression
-    type_mapping = dialect.get_type_mapping
+    type_mapping = connection.get_type_mapping
     infer_return_type op_kind columns expression =
         type_mapping.infer_return_type infer_from_database_callback op_kind columns expression
     infer_return_type
@@ -247,7 +247,7 @@ type Aggregate_With_Helper_Expressions
                 helper_columns_for_aggregates = helper_expressions_for_aggregates.map requested_expressions->
                     requested_expressions.map helper_columns_mapping.at
 
-                infer_return_type_in_new_context = make_infer_return_type dialect base_table.connection new_ctx
+                infer_return_type_in_new_context = make_infer_return_type base_table.connection new_ctx
                 results = resolved_aggregates.zip helper_columns_for_aggregates p-> helper_columns->
                     original_aggregate = p.second
                     as = p.first

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
@@ -96,7 +96,7 @@ make_lookup_counter_column connection lookup_columns unique_name_strategy =
         Lookup_Column.Key_Column _ lookup_column -> [(lookup_column:Internal_Column).expression]
         _ -> []
     row_number_expression = SQL_IR_Expression.Operation "ROW_NUMBER_IN_GROUP" grouping_expressions
-    sql_type = connection.get_type_mapping.value_type_to_sql Value_Type.Integer Problem_Behavior.Ignore
+    sql_type = connection.type_mapping.value_type_to_sql Value_Type.Integer Problem_Behavior.Ignore
     Internal_Column.Value (unique_name_strategy.make_unique "lookup_counter") (SQL_Type_Reference.from_constant sql_type) row_number_expression
 
 ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
@@ -91,12 +91,12 @@ check_initial_invariants base_table lookup_table lookup_columns allow_unmatched_
    2. It allows us to find duplicate matches - if a row with counter >1 is found,
       that means that a single row has matched multiple rows in the lookup table
       and we should report an error.
-make_lookup_counter_column dialect lookup_columns unique_name_strategy =
+make_lookup_counter_column connection lookup_columns unique_name_strategy =
     grouping_expressions = lookup_columns.flat_map c-> case c of
         Lookup_Column.Key_Column _ lookup_column -> [(lookup_column:Internal_Column).expression]
         _ -> []
     row_number_expression = SQL_IR_Expression.Operation "ROW_NUMBER_IN_GROUP" grouping_expressions
-    sql_type = dialect.get_type_mapping.value_type_to_sql Value_Type.Integer Problem_Behavior.Ignore
+    sql_type = connection.get_type_mapping.value_type_to_sql Value_Type.Integer Problem_Behavior.Ignore
     Internal_Column.Value (unique_name_strategy.make_unique "lookup_counter") (SQL_Type_Reference.from_constant sql_type) row_number_expression
 
 ## ---
@@ -162,7 +162,7 @@ prepare_subqueries base_table lookup_table lookup_columns unique_name_strategy =
     new_table_name = table_name_deduplicator.make_unique <|
         base_table.name + "_" + lookup_table.name
 
-    lookup_counter_base = make_lookup_counter_column lookup_table.connection.dialect lookup_columns unique_name_strategy
+    lookup_counter_base = make_lookup_counter_column lookup_table.connection lookup_columns unique_name_strategy
 
     vecs = Vector.build_multiple 2 builders->
         self_requested_columns = builders.at 0

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Lookup_Query_Helper.enso
@@ -46,7 +46,8 @@ build_lookup_query base_table lookup_table key_columns add_new_columns allow_unm
             Lookup_Column.Keep_Column _  -> subquery_setup.get_self_column ix
             Lookup_Column.Replace_Column _ _ expected_type ->
                 dialect = base_table.connection.dialect
-                subquery_setup.create_merged_column ix expected_type dialect infer_type_in_result allow_unmatched_rows
+                mapping = base_table.connection.type_mapping
+                subquery_setup.create_merged_column ix expected_type dialect infer_type_in_result allow_unmatched_rows mapping
             Lookup_Column.Add_Column _ -> subquery_setup.get_lookup_column ix
 
         ## Originally, I wanted to add invariant checks to all columns (or some of them),
@@ -136,7 +137,7 @@ type Lookup_Subquery_Setup
        otherwise.
        This method also ensure that the column has the expected type, unifying
        types of the two sources.
-    create_merged_column self ix expected_type dialect infer_type_in_result allow_unmatched_rows =
+    create_merged_column self ix expected_type dialect infer_type_in_result allow_unmatched_rows mapping =
         self_col = self.get_self_column ix
         lookup_col = self.get_lookup_column ix
         is_lookup_found = SQL_IR_Expression.Operation "==" [self.lookup_counter.expression, SQL_IR_Expression.Literal "1"]
@@ -144,7 +145,7 @@ type Lookup_Subquery_Setup
             True  -> SQL_IR_Expression.Operation "CASE" [is_lookup_found, lookup_col.expression, self_col.expression]
             False -> Error.throw (Illegal_State.Error "Assumed that prepare_columns_for_lookup never returns Replace_Column if allow_unmatched_rows=False. This is a bug in the Database library.")
         input_column = Internal_Column.Value self_col.name (infer_type_in_result expression) expression
-        adapted = dialect.adapt_unified_column input_column expected_type infer_type_in_result
+        adapted = dialect.adapt_unified_column input_column expected_type infer_type_in_result mapping
         Internal_Column.Value self_col.name adapted.sql_type_reference adapted.expression
 
 ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -588,12 +588,12 @@ make_unary_op this_column op_kind new_name=Nothing =
 
 internal_do_cast : Column & DB_Column -> Value_Type -> Problem_Behavior -> Column
 internal_do_cast this_column value_type on_problems:Problem_Behavior =
-    dialect = this_column.connection.dialect
-    target_sql_type = this_column.connection.type_mapping.value_type_to_sql value_type on_problems
+    mapping = this_column.connection.type_mapping
+    target_sql_type = mapping.value_type_to_sql value_type on_problems
     target_sql_type.if_not_error <|
         infer_from_database new_expression =
             SQL_Type_Reference.new this_column.connection this_column.context new_expression
-        new_column = dialect.make_cast (Internal_Column.from this_column) target_sql_type infer_from_database
+        new_column = this_column.connection.dialect.make_cast (Internal_Column.from this_column) mapping target_sql_type infer_from_database
         DB_Column.new new_column.name this_column.connection new_column.sql_type_reference new_column.expression this_column.context
 
 should_use_builtin_round : Column & DB_Column -> Integer -> Boolean -> Boolean

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -70,15 +70,15 @@ type DB_Column_Implementation
     first (this_column : Column & DB_Column) = this_column.at 0
 
     value_type (this_column : Column & DB_Column) =
-        mapping = this_column.connection.get_type_mapping
+        mapping = this_column.connection.type_mapping
         mapping.sql_type_to_value_type this_column.sql_type_reference.get
 
     inferred_precise_value_type (this_column : Column & DB_Column) =
         this_column.value_type
 
     should_be_selected_by_type (this_column : Column & DB_Column) (value_type : Value_Type) =
-        type_mapping = this_column.connection.get_type_mapping
-        type_mapping.is_same_type this_column.value_type value_type
+        mapping = this_column.connection.type_mapping
+        mapping.is_same_type this_column.value_type value_type
 
     to_sql (this_column : Column & DB_Column) = this_column.to_table.to_sql
 
@@ -458,7 +458,7 @@ type DB_Column_Implementation
                 in_subquery = SQL_IR_Statement.Select [Pair.new column.name (column:DB_Column).expression] (column:DB_Column).context
                 new_expr = SQL_IR_Expression.Operation "IS_IN_COLUMN" [this_column.expression, in_subquery]
                 # This mapping should never be imprecise, if there are errors we need to amend the implementation.
-                sql_type = this_column.connection.get_type_mapping.value_type_to_sql Value_Type.Boolean Problem_Behavior.Report_Error
+                sql_type = this_column.connection.type_mapping.value_type_to_sql Value_Type.Boolean Problem_Behavior.Report_Error
                 new_type_ref = SQL_Type_Reference.from_constant sql_type . catch Inexact_Type_Coercion _->
                     Error.throw (Illegal_State.Error "The dialect "+this_column.connection.dialect.name+" does not support a boolean type. The implementation of `is_in` should be revised to account for this. This is an internal issue with the Database library.")
                 DB_Column.new new_name this_column.connection new_type_ref new_expr this_column.context
@@ -556,7 +556,7 @@ make_op this_column op_kind operands new_name metadata=Nothing =
     checked_support = if this_column.connection.dialect.is_operation_supported op_kind then True else
         Error.throw (Unsupported_Database_Operation.Error op_kind)
     checked_support.if_not_error <|
-        type_mapping = this_column.connection.get_type_mapping
+        mapping = this_column.connection.type_mapping
         prepare_operand operand = case operand of
             other_column : Column ->
                 if Helpers.check_integrity this_column other_column then (other_column:DB_Column).expression else
@@ -571,7 +571,7 @@ make_op this_column op_kind operands new_name metadata=Nothing =
 
         infer_from_database_callback expression =
             SQL_Type_Reference.new this_column.connection this_column.context expression
-        new_type_ref = type_mapping.infer_return_type infer_from_database_callback op_kind [this_column]+operands new_expr
+        new_type_ref = mapping.infer_return_type infer_from_database_callback op_kind [this_column]+operands new_expr
         DB_Column.new new_name this_column.connection new_type_ref new_expr this_column.context
 
 make_binary_op : Column & DB_Column -> Text -> Text -> (Text | Nothing) -> Column
@@ -589,8 +589,7 @@ make_unary_op this_column op_kind new_name=Nothing =
 internal_do_cast : Column & DB_Column -> Value_Type -> Problem_Behavior -> Column
 internal_do_cast this_column value_type on_problems:Problem_Behavior =
     dialect = this_column.connection.dialect
-    type_mapping = this_column.connection.get_type_mapping
-    target_sql_type = type_mapping.value_type_to_sql value_type on_problems
+    target_sql_type = this_column.connection.type_mapping.value_type_to_sql value_type on_problems
     target_sql_type.if_not_error <|
         infer_from_database new_expression =
             SQL_Type_Reference.new this_column.connection this_column.context new_expression

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -545,9 +545,10 @@ make_equality_check_with_floating_point_handling column other op =
 
 adapt_unified_column (column : Column & DB_Column) expected_type =
     dialect = column.connection.dialect
+    mapping = column.connection.type_mapping
     infer_return_type expression =
         SQL_Type_Reference.new column.connection column.context expression
-    adapted = dialect.adapt_unified_column (Internal_Column.from column) expected_type infer_return_type
+    adapted = dialect.adapt_unified_column (Internal_Column.from column) expected_type infer_return_type mapping
     DB_Column.new column.name column.connection adapted.sql_type_reference adapted.expression column.context
 
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Column_Implementation.enso
@@ -70,14 +70,14 @@ type DB_Column_Implementation
     first (this_column : Column & DB_Column) = this_column.at 0
 
     value_type (this_column : Column & DB_Column) =
-        mapping = this_column.connection.dialect.get_type_mapping
+        mapping = this_column.connection.get_type_mapping
         mapping.sql_type_to_value_type this_column.sql_type_reference.get
 
     inferred_precise_value_type (this_column : Column & DB_Column) =
         this_column.value_type
 
     should_be_selected_by_type (this_column : Column & DB_Column) (value_type : Value_Type) =
-        type_mapping = this_column.connection.dialect.get_type_mapping
+        type_mapping = this_column.connection.get_type_mapping
         type_mapping.is_same_type this_column.value_type value_type
 
     to_sql (this_column : Column & DB_Column) = this_column.to_table.to_sql
@@ -331,13 +331,13 @@ type DB_Column_Implementation
             make_unary_op this_column "LENGTH" new_name
 
     text_left (this_column : Column & DB_Column) n:Column|Integer =
-        Value_Type.expect_text this_column <| Helpers.expect_dialect_specific_integer_type this_column n <|
+        Value_Type.expect_text this_column <| Helpers.expect_specific_integer_type this_column n <|
             n2 = n.max 0
             new_name = (naming_helper this_column).function_name "text_left" [this_column, n]
             make_binary_op this_column "LEFT" n2 new_name
 
     text_right (this_column : Column & DB_Column) n:Column|Integer =
-        Value_Type.expect_text this_column <| Helpers.expect_dialect_specific_integer_type this_column n <|
+        Value_Type.expect_text this_column <| Helpers.expect_specific_integer_type this_column n <|
             n2 = n.max 0
             new_name = (naming_helper this_column).function_name "text_right" [this_column, n]
             make_binary_op this_column "RIGHT" n2 new_name
@@ -429,7 +429,7 @@ type DB_Column_Implementation
     date_add (this_column : Column & DB_Column) (amount : Column | Integer) (period : Date_Period | Time_Period) =
         Value_Type.expect_type this_column .is_date_or_time "date/time" <|
             my_type = this_column.inferred_precise_value_type
-            Helpers.expect_dialect_specific_integer_type this_column amount <|
+            Helpers.expect_specific_integer_type this_column amount <|
                 aligned_period = Date_Time_Helpers.align_period_with_value_type my_type period
                 aligned_period.if_not_error <|
                     new_name = (naming_helper this_column).function_name "date_add" [this_column, amount, period]
@@ -458,7 +458,7 @@ type DB_Column_Implementation
                 in_subquery = SQL_IR_Statement.Select [Pair.new column.name (column:DB_Column).expression] (column:DB_Column).context
                 new_expr = SQL_IR_Expression.Operation "IS_IN_COLUMN" [this_column.expression, in_subquery]
                 # This mapping should never be imprecise, if there are errors we need to amend the implementation.
-                sql_type = this_column.connection.dialect.get_type_mapping.value_type_to_sql Value_Type.Boolean Problem_Behavior.Report_Error
+                sql_type = this_column.connection.get_type_mapping.value_type_to_sql Value_Type.Boolean Problem_Behavior.Report_Error
                 new_type_ref = SQL_Type_Reference.from_constant sql_type . catch Inexact_Type_Coercion _->
                     Error.throw (Illegal_State.Error "The dialect "+this_column.connection.dialect.name+" does not support a boolean type. The implementation of `is_in` should be revised to account for this. This is an internal issue with the Database library.")
                 DB_Column.new new_name this_column.connection new_type_ref new_expr this_column.context
@@ -556,7 +556,7 @@ make_op this_column op_kind operands new_name metadata=Nothing =
     checked_support = if this_column.connection.dialect.is_operation_supported op_kind then True else
         Error.throw (Unsupported_Database_Operation.Error op_kind)
     checked_support.if_not_error <|
-        type_mapping = this_column.connection.dialect.get_type_mapping
+        type_mapping = this_column.connection.get_type_mapping
         prepare_operand operand = case operand of
             other_column : Column ->
                 if Helpers.check_integrity this_column other_column then (other_column:DB_Column).expression else
@@ -589,7 +589,7 @@ make_unary_op this_column op_kind new_name=Nothing =
 internal_do_cast : Column & DB_Column -> Value_Type -> Problem_Behavior -> Column
 internal_do_cast this_column value_type on_problems:Problem_Behavior =
     dialect = this_column.connection.dialect
-    type_mapping = dialect.get_type_mapping
+    type_mapping = this_column.connection.get_type_mapping
     target_sql_type = type_mapping.value_type_to_sql value_type on_problems
     target_sql_type.if_not_error <|
         infer_from_database new_expression =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -255,7 +255,7 @@ type DB_Table_Implementation
 
                 new_expr = Row_Number_Helpers.make_row_number from step order_descriptors grouping_expressions
 
-                type_mapping = this_table.connection.dialect.get_type_mapping
+                type_mapping = this_table.connection.get_type_mapping
                 infer_from_database_callback expression =
                     SQL_Type_Reference.new this_table.connection this_table.context expression
                 new_type_ref = type_mapping.infer_return_type infer_from_database_callback "ROW_NUMBER" [] new_expr
@@ -281,7 +281,7 @@ type DB_Table_Implementation
 
                         new_expr = Group_Number_Helpers.make_group_number from step grouping_expressions
 
-                        type_mapping = this_table.connection.dialect.get_type_mapping
+                        type_mapping = this_table.connection.get_type_mapping
                         infer_from_database_callback expression =
                             SQL_Type_Reference.new this_table.connection this_table.context expression
                         new_type_ref = type_mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER" [] new_expr
@@ -302,7 +302,7 @@ type DB_Table_Implementation
 
                         new_expr = Group_Number_Helpers.make_group_number_equal_count from step group_count order_descriptors
 
-                        type_mapping = this_table.connection.dialect.get_type_mapping
+                        type_mapping = this_table.connection.get_type_mapping
                         infer_from_database_callback expression =
                             SQL_Type_Reference.new this_table.connection this_table.context expression
                         new_type_ref = type_mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER_EQUAL_COUNT" [] new_expr
@@ -376,7 +376,7 @@ type DB_Table_Implementation
 
     make_constant_column (this_table : Table & DB_Table) value =
         if Column.is_column value then Error.throw (Illegal_Argument.Error "A constant value may only be created from a scalar, not a DB_Column") else
-            type_mapping = this_table.connection.dialect.get_type_mapping
+            type_mapping = this_table.connection.get_type_mapping
             argument_value_type = Value_Type_Helpers.find_argument_type value
             sql_type = case argument_value_type of
                 Nothing -> SQL_Type.null
@@ -488,7 +488,7 @@ type DB_Table_Implementation
                 problem_builder_for_unification = Problem_Builder.new
                 matched_column_sets = Match_Columns_Helpers.match_columns all_tables match_columns columns_to_keep problem_builder_for_matching
                 dialect = this_table.connection.dialect
-                type_mapping = dialect.get_type_mapping
+                type_mapping = this_table.connection.get_type_mapping
                 merged_columns = matched_column_sets.map column_set->
                     sql_type_from_value_type value_type =
                         type_mapping.value_type_to_sql value_type Problem_Behavior.Report_Error . catch Inexact_Type_Coercion error->
@@ -662,7 +662,7 @@ type DB_Table_Implementation
             actual_types = materialized_table.columns.map .value_type
             expected_types.zip actual_types expected_type-> actual_type->
                 if expected_type == actual_type then Nothing else
-                    if this_table.connection.dialect.get_type_mapping.should_warn_on_materialize expected_type actual_type then
+                    if this_table.connection.get_type_mapping.should_warn_on_materialize expected_type actual_type then
                         warnings_builder.append (Inexact_Type_Coercion.Warning expected_type actual_type)
 
             result = max_rows.attach_warning materialized_table
@@ -686,7 +686,7 @@ type DB_Table_Implementation
             this_table.connection.dialect.generate_sql query
         count_table = this_table.connection.read_statement count_query
         counts = if cols.is_empty then [] else count_table.columns.map c-> c.at 0
-        type_mapping = this_table.connection.dialect.get_type_mapping
+        type_mapping = this_table.connection.get_type_mapping
         types = cols.map col->
             type_mapping.sql_type_to_value_type col.sql_type_reference.get
         Table.new [["Column", cols.map .name], ["Items Count", counts], ["Value Type", types]]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -255,10 +255,10 @@ type DB_Table_Implementation
 
                 new_expr = Row_Number_Helpers.make_row_number from step order_descriptors grouping_expressions
 
-                type_mapping = this_table.connection.get_type_mapping
+                mapping = this_table.connection.type_mapping
                 infer_from_database_callback expression =
                     SQL_Type_Reference.new this_table.connection this_table.context expression
-                new_type_ref = type_mapping.infer_return_type infer_from_database_callback "ROW_NUMBER" [] new_expr
+                new_type_ref = mapping.infer_return_type infer_from_database_callback "ROW_NUMBER" [] new_expr
 
                 new_column = Internal_Column.Value name new_type_ref new_expr
 
@@ -281,10 +281,10 @@ type DB_Table_Implementation
 
                         new_expr = Group_Number_Helpers.make_group_number from step grouping_expressions
 
-                        type_mapping = this_table.connection.get_type_mapping
+                        mapping = this_table.connection.type_mapping
                         infer_from_database_callback expression =
                             SQL_Type_Reference.new this_table.connection this_table.context expression
-                        new_type_ref = type_mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER" [] new_expr
+                        new_type_ref = mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER" [] new_expr
 
                         new_column = Internal_Column.Value name new_type_ref new_expr
 
@@ -302,10 +302,10 @@ type DB_Table_Implementation
 
                         new_expr = Group_Number_Helpers.make_group_number_equal_count from step group_count order_descriptors
 
-                        type_mapping = this_table.connection.get_type_mapping
+                        mapping = this_table.connection.type_mapping
                         infer_from_database_callback expression =
                             SQL_Type_Reference.new this_table.connection this_table.context expression
-                        new_type_ref = type_mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER_EQUAL_COUNT" [] new_expr
+                        new_type_ref = mapping.infer_return_type infer_from_database_callback "GROUP_NUMBER_EQUAL_COUNT" [] new_expr
 
                         new_column = Internal_Column.Value name new_type_ref new_expr
 
@@ -376,11 +376,11 @@ type DB_Table_Implementation
 
     make_constant_column (this_table : Table & DB_Table) value =
         if Column.is_column value then Error.throw (Illegal_Argument.Error "A constant value may only be created from a scalar, not a DB_Column") else
-            type_mapping = this_table.connection.get_type_mapping
+            mapping = this_table.connection.type_mapping
             argument_value_type = Value_Type_Helpers.find_argument_type value
             sql_type = case argument_value_type of
                 Nothing -> SQL_Type.null
-                _ -> type_mapping.value_type_to_sql argument_value_type Problem_Behavior.Ignore
+                _ -> mapping.value_type_to_sql argument_value_type Problem_Behavior.Ignore
             expr = SQL_IR_Expression.Constant value
             new_type_ref = SQL_Type_Reference.from_constant sql_type
             base_column = Internal_Column.Value value.pretty new_type_ref expr
@@ -488,10 +488,10 @@ type DB_Table_Implementation
                 problem_builder_for_unification = Problem_Builder.new
                 matched_column_sets = Match_Columns_Helpers.match_columns all_tables match_columns columns_to_keep problem_builder_for_matching
                 dialect = this_table.connection.dialect
-                type_mapping = this_table.connection.get_type_mapping
+                mapping = this_table.connection.type_mapping
                 merged_columns = matched_column_sets.map column_set->
                     sql_type_from_value_type value_type =
-                        type_mapping.value_type_to_sql value_type Problem_Behavior.Report_Error . catch Inexact_Type_Coercion error->
+                        mapping.value_type_to_sql value_type Problem_Behavior.Report_Error . catch Inexact_Type_Coercion error->
                             Panic.throw <|
                                 Illegal_State.Error "Unexpected inexact type coercion in Union. The union logic should only operate in types supported by the given backend. This is a bug in the Database library. The coercion was: "+error.to_display_text cause=error
                     case Table_Helpers.unify_result_type_for_union column_set all_tables problem_builder_for_unification of
@@ -662,7 +662,7 @@ type DB_Table_Implementation
             actual_types = materialized_table.columns.map .value_type
             expected_types.zip actual_types expected_type-> actual_type->
                 if expected_type == actual_type then Nothing else
-                    if this_table.connection.get_type_mapping.should_warn_on_materialize expected_type actual_type then
+                    if this_table.connection.type_mapping.should_warn_on_materialize expected_type actual_type then
                         warnings_builder.append (Inexact_Type_Coercion.Warning expected_type actual_type)
 
             result = max_rows.attach_warning materialized_table
@@ -686,9 +686,9 @@ type DB_Table_Implementation
             this_table.connection.dialect.generate_sql query
         count_table = this_table.connection.read_statement count_query
         counts = if cols.is_empty then [] else count_table.columns.map c-> c.at 0
-        type_mapping = this_table.connection.get_type_mapping
+        mapping = this_table.connection.type_mapping
         types = cols.map col->
-            type_mapping.sql_type_to_value_type col.sql_type_reference.get
+            mapping.sql_type_to_value_type col.sql_type_reference.get
         Table.new [["Column", cols.map .name], ["Items Count", counts], ["Value Type", types]]
 
     ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -388,7 +388,7 @@ type DB_Table_Implementation
             result_internal_column = if needs_cast.not then base_column else
                 infer_type_from_database new_expression =
                     SQL_Type_Reference.new this_table.connection this_table.context new_expression
-                this_table.connection.dialect.make_cast base_column sql_type infer_type_from_database
+                this_table.connection.dialect.make_cast base_column mapping sql_type infer_type_from_database
             this_table.make_column result_internal_column
 
     make_temp_column_name (this_table : Table & DB_Table) = this_table.column_naming_helper.make_temp_column_name this_table.column_names
@@ -526,13 +526,13 @@ type DB_Table_Implementation
                                           This is a possible future improvement to make queries lighter, but the benefit is unlikely to be worth it.
                                         needs_cast = column.value_type != result_type
                                         if needs_cast.not then internal_named_column else
-                                            dialect.make_cast internal_named_column sql_type infer_return_type
+                                            dialect.make_cast internal_named_column mapping sql_type infer_return_type
                                     Nothing ->
                                         typ = SQL_Type_Reference.from_constant SQL_Type.null
                                         expr = SQL_IR_Expression.Literal "NULL"
                                         null_column = Internal_Column.Value column_name typ expr
                                         if sql_type == SQL_Type.null then null_column else
-                                            dialect.make_cast null_column sql_type infer_return_type
+                                            dialect.make_cast null_column mapping sql_type infer_return_type
                             pairs = columns_to_select.map c->
                                 [c.name, c.expression]
                             SQL_IR_Statement.Select pairs t.context

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -555,7 +555,7 @@ type DB_Table_Implementation
                             name = column_set.name
                             expression = SQL_IR_Expression.Column union_alias name
                             input_column = Internal_Column.Value name (infer_return_type expression) expression
-                            dialect.adapt_unified_column input_column result_type infer_return_type
+                            dialect.adapt_unified_column input_column result_type infer_return_type mapping
 
                         DB_Table.new union_alias this_table.connection new_columns new_ctx
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Helpers.enso
@@ -92,9 +92,9 @@ rename_internal_columns columns new_names =
 ## ---
    private: true
    ---
-   Checks if the `argument` has an integer type (as defined by the dialect
+   Checks if the `argument` has an integer type (as defined by the type_mapping
    associated with `related_column`).
    See `SQL_Type_Mapping.is_integer_type` for details.
-expect_dialect_specific_integer_type related_column argument ~action =
-    type_mapping = related_column.connection.dialect.get_type_mapping
+expect_specific_integer_type related_column argument ~action =
+    type_mapping = related_column.connection.get_type_mapping
     Value_Type.expect_type argument type_mapping.is_integer_type "Integer" action

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Helpers.enso
@@ -96,5 +96,4 @@ rename_internal_columns columns new_names =
    associated with `related_column`).
    See `SQL_Type_Mapping.is_integer_type` for details.
 expect_specific_integer_type related_column argument ~action =
-    type_mapping = related_column.connection.get_type_mapping
-    Value_Type.expect_type argument type_mapping.is_integer_type "Integer" action
+    Value_Type.expect_type argument related_column.connection.type_mapping.is_integer_type "Integer" action

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -31,10 +31,8 @@ import project.Internal.IR.SQL_IR_Source.SQL_IR_Source_Extension
 import project.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Postgres.Postgres_Error_Mapper.Postgres_Error_Mapper
-import project.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
-import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
@@ -161,20 +159,12 @@ type Postgres_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        type_mapping = self.get_type_mapping
+        mapping = self.get_type_mapping
         distinct_expressions = new_key_columns.map column->
-            value_type = type_mapping.sql_type_to_value_type column.sql_type_reference.get
+            value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self = Postgres_Type_Mapping
 
     ## ---
        private: true
@@ -230,13 +220,13 @@ type Postgres_Dialect
             _ -> False
         case needs_char_length_override_check of
             True ->
-                type_mapping = self.get_type_mapping
-                db_type = type_mapping.sql_type_to_value_type column.sql_type_reference.get
+                mapping = self.get_type_mapping
+                db_type = mapping.sql_type_to_value_type column.sql_type_reference.get
                 case db_type of
                     Value_Type.Char _ _ -> case db_type == approximate_result_type of
                         True -> column
                         False ->
-                            type_override = type_mapping.value_type_to_sql approximate_result_type Problem_Behavior.Report_Error
+                            type_override = mapping.value_type_to_sql approximate_result_type Problem_Behavior.Report_Error
                             type_override.catch Inexact_Type_Coercion _->
                                 Panic.throw <|
                                     Illegal_State.Error "The target type ("+db_type.to_display_text+") that we need to cast to seems to not be supported by the Dialect. This is not expected. It is a bug in the Database library."

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -33,6 +33,7 @@ import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Postgres.Postgres_Error_Mapper.Postgres_Error_Mapper
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
+import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
@@ -159,7 +160,7 @@ type Postgres_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = self.get_type_mapping
+        mapping = table.connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
@@ -175,9 +176,8 @@ type Postgres_Dialect
     ## ---
        private: true
        ---
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self (column : Internal_Column) (target_type : SQL_Type) (infer_result_type_from_database_callback : SQL_IR_Expression -> SQL_Type_Reference) =
-        mapping = self.get_type_mapping
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self (column : Internal_Column) mapping (target_type : SQL_Type) (infer_result_type_from_database_callback : SQL_IR_Expression -> SQL_Type_Reference) =
         source_type = mapping.sql_type_to_value_type column.sql_type_reference.get
         target_value_type = mapping.sql_type_to_value_type target_type
         # Boolean to Numeric casts need special handling:
@@ -230,7 +230,7 @@ type Postgres_Dialect
                             type_override.catch Inexact_Type_Coercion _->
                                 Panic.throw <|
                                     Illegal_State.Error "The target type ("+db_type.to_display_text+") that we need to cast to seems to not be supported by the Dialect. This is not expected. It is a bug in the Database library."
-                            self.make_cast column type_override infer_result_type_from_database_callback
+                            self.make_cast column mapping type_override infer_result_type_from_database_callback
                     _ -> Panic.throw <|
                         Illegal_State.Error "The type computed by our logic is Char, but the Database computed a non-text type ("+db_type.to_display_text+"). This should never happen and should be reported as a bug in the Database library."
             False -> column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -213,14 +213,13 @@ type Postgres_Dialect
        a **fixed-length** column of length max_int4. This is wrong, and in
        practice the column is just a variable-length text. This method detects
        this situations and overrides the type to make it correct.
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
         needs_char_length_override_check = case approximate_result_type of
             Value_Type.Char _ _ -> True
             _ -> False
         case needs_char_length_override_check of
             True ->
-                mapping = self.get_type_mapping
                 db_type = mapping.sql_type_to_value_type column.sql_type_reference.get
                 case db_type of
                     Value_Type.Char _ _ -> case db_type == approximate_result_type of

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -379,7 +379,7 @@ type Postgres_Dialect
        Returns `Nothing` if the key is not defined.
     fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
     fetch_primary_key self connection table_name schema_name =
-        Dialect.default_fetch_primary_key connection table_name schema_name
+        Connection.default_fetch_primary_key connection table_name schema_name
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -35,7 +35,6 @@ import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
 import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
-import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
 import project.SQL.SQL_Fragment
 import project.SQL.SQL_Statement
@@ -166,12 +165,6 @@ type Postgres_Dialect
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-    get_statement_setter : Statement_Setter
-    get_statement_setter self = Statement_Setter.default
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
@@ -121,7 +121,7 @@ get_or_compute (ref : Ref (SQL_Type_Recipe | SQL_Type)) -> SQL_Type =
         computed : SQL_Type -> computed
         SQL_Type_Recipe.Value connection context expression ->
             statement = connection.dialect.prepare_fetch_types_query expression context
-            statement_setter = connection.dialect.get_statement_setter
+            statement_setter = connection.statement_setter
             columns = connection.fetch_columns statement statement_setter
             only_column = columns.first
             computed_type = only_column.second

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -33,7 +33,6 @@ import project.Internal.SQL_Part.SQL_Part
 import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Error_Mapper.SQLite_Error_Mapper
-import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
 import project.SQL.SQL_Statement
 import project.SQL.SQL_Type
@@ -176,12 +175,6 @@ type SQLite_Dialect
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . set_groups distinct_expressions
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-    get_statement_setter : Statement_Setter
-    get_statement_setter self = Statement_Setter.default
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -223,12 +223,11 @@ type SQLite_Dialect
        ---
        SQLite allows mixed type columns, but we want our columns to be uniform.
        So after unifying columns with mixed types, we add a cast to ensure that.
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
         _ = infer_result_type_from_database_callback
         needs_cast = approximate_result_type != Value_Type.Null
         if needs_cast.not then column else
-            mapping = self.get_type_mapping
             sql_type = mapping.value_type_to_sql approximate_result_type Problem_Behavior.Ignore
             new_expression = self.make_cast_expression column mapping sql_type
             new_sql_type_reference = SQL_Type_Reference.from_constant sql_type

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -30,10 +30,8 @@ import project.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
-import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Error_Mapper.SQLite_Error_Mapper
-import project.Internal.SQLite.SQLite_Type_Mapping.SQLite_Type_Mapping
 import project.Internal.Statement_Setter.Statement_Setter
 import project.SQL.SQL_Builder
 import project.SQL.SQL_Statement
@@ -171,20 +169,12 @@ type SQLite_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        type_mapping = self.get_type_mapping
+        mapping = self.get_type_mapping
         distinct_expressions = new_key_columns.map column->
-            value_type = type_mapping.sql_type_to_value_type column.sql_type_reference.get
+            value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . set_groups distinct_expressions
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self = SQLite_Type_Mapping
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -30,6 +30,7 @@ import project.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import project.Internal.JDBC_Connection.JDBC_Connection
 import project.Internal.Replace_Params.Replace_Params
 import project.Internal.SQL_Part.SQL_Part
+import project.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 import project.Internal.SQLite.SQLite_Error_Mapper.SQLite_Error_Mapper
 import project.Internal.Statement_Setter.Statement_Setter
@@ -169,7 +170,7 @@ type SQLite_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = self.get_type_mapping
+        mapping = table.connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
@@ -185,22 +186,20 @@ type SQLite_Dialect
     ## ---
        private: true
        ---
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self (column : Internal_Column) (target_type : SQL_Type) (infer_result_type_from_database_callback : SQL_IR_Expression -> SQL_Type_Reference) =
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self (column : Internal_Column) mapping (target_type : SQL_Type) (infer_result_type_from_database_callback : SQL_IR_Expression -> SQL_Type_Reference) =
         _ = [infer_result_type_from_database_callback]
-        mapping = self.get_type_mapping
         target_value_type = mapping.sql_type_to_value_type target_type
         custom_cast = make_custom_cast column target_value_type mapping
         new_expression = custom_cast.if_nothing <|
-            self.make_cast_expression column target_type
+            self.make_cast_expression column mapping target_type
         new_sql_type_reference = SQL_Type_Reference.from_constant target_type
         Internal_Column.Value column.name new_sql_type_reference new_expression
 
     ## ---
        private: true
        ---
-    make_cast_expression self column target_type =
-        mapping = self.get_type_mapping
+    make_cast_expression self column mapping target_type =
         sql_type_text = mapping.sql_type_to_text target_type
         SQL_IR_Expression.Operation "CAST" [column.expression, SQL_IR_Expression.Literal sql_type_text]
 
@@ -229,8 +228,9 @@ type SQLite_Dialect
         _ = infer_result_type_from_database_callback
         needs_cast = approximate_result_type != Value_Type.Null
         if needs_cast.not then column else
-            sql_type = self.get_type_mapping.value_type_to_sql approximate_result_type Problem_Behavior.Ignore
-            new_expression = self.make_cast_expression column sql_type
+            mapping = self.get_type_mapping
+            sql_type = mapping.value_type_to_sql approximate_result_type Problem_Behavior.Ignore
+            new_expression = self.make_cast_expression column mapping sql_type
             new_sql_type_reference = SQL_Type_Reference.from_constant sql_type
             Internal_Column.Value column.name new_sql_type_reference new_expression
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/Argument_Checks.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/Argument_Checks.enso
@@ -72,7 +72,7 @@ check_update_arguments_structure_match source_table:Table (target_table : Table 
         source_type = source_column.value_type
         target_type = target_column.value_type
         if source_type == target_type then [] else
-            if target_table.connection.dialect.get_type_mapping.is_implicit_conversion source_type target_type then [] else
+            if target_table.connection.get_type_mapping.is_implicit_conversion source_type target_type then [] else
                 if source_type.can_be_widened_to target_type then [Inexact_Type_Coercion.Warning source_type target_type unavailable=False] else
                     Error.throw (Column_Type_Mismatch.Error source_column.name target_type source_type)
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/Argument_Checks.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/Argument_Checks.enso
@@ -72,7 +72,7 @@ check_update_arguments_structure_match source_table:Table (target_table : Table 
         source_type = source_column.value_type
         target_type = target_column.value_type
         if source_type == target_type then [] else
-            if target_table.connection.get_type_mapping.is_implicit_conversion source_type target_type then [] else
+            if target_table.connection.type_mapping.is_implicit_conversion source_type target_type then [] else
                 if source_type.can_be_widened_to target_type then [Inexact_Type_Coercion.Warning source_type target_type unavailable=False] else
                     Error.throw (Column_Type_Mismatch.Error source_column.name target_type source_type)
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/SQL_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/SQL_Helpers.enso
@@ -34,13 +34,13 @@ make_batched_insert_template connection table_name column_names =
    will be invalid.
 prepare_create_table_statement : Connection -> Text -> Vector Column_Description -> Vector Text -> Boolean -> Problem_Behavior -> SQL_Statement
 prepare_create_table_statement connection table_name columns primary_key temporary on_problems:Problem_Behavior =
-    type_mapping = connection.get_type_mapping
+    mapping = connection.type_mapping
     column_descriptors = columns.map on_problems=No_Wrap.Value def->
-        sql_type = type_mapping.value_type_to_sql def.value_type on_problems
+        sql_type = mapping.value_type_to_sql def.value_type on_problems
             . catch Unsupported_Database_Type error->
                 Error.throw (Illegal_Argument.Error "Definition for column ["+def.name+"] is invalid: "+error.to_display_text)
 
-        sql_type_text = type_mapping.sql_type_to_text sql_type
+        sql_type_text = mapping.sql_type_to_text sql_type
         Create_Column_Descriptor.Value def.name sql_type_text def.constraints
     connection.dialect.generate_sql <|
         SQL_IR_Statement.Create_Table table_name column_descriptors primary_key temporary

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/SQL_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Helpers/SQL_Helpers.enso
@@ -34,7 +34,7 @@ make_batched_insert_template connection table_name column_names =
    will be invalid.
 prepare_create_table_statement : Connection -> Text -> Vector Column_Description -> Vector Text -> Boolean -> Problem_Behavior -> SQL_Statement
 prepare_create_table_statement connection table_name columns primary_key temporary on_problems:Problem_Behavior =
-    type_mapping = connection.dialect.get_type_mapping
+    type_mapping = connection.get_type_mapping
     column_descriptors = columns.map on_problems=No_Wrap.Value def->
         sql_type = type_mapping.value_type_to_sql def.value_type on_problems
             . catch Unsupported_Database_Type error->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Upload_Table.enso
@@ -95,7 +95,7 @@ private _create_in_memory_table_upload_op (source_table : Table) connection tabl
 
     column_names = source_table.column_names
     insert_template = make_batched_insert_template connection table_name column_names
-    statement_setter = connection.dialect.get_statement_setter
+    statement_setter = connection.statement_setter
     structure = structure_hint.if_nothing source_table
     aligned_structure = align_structure connection structure
     expected_type_hints = aligned_structure.map .value_type

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
@@ -78,7 +78,7 @@ make_table_for_name connection name schema alias internal_temporary_keep_alive_r
     result = handle_sql_errors <|
         ctx = SQL_IR_Source.for_table name schema (if alias == "" then name else alias) internal_temporary_keep_alive_reference
         statement = connection.dialect.generate_sql (SQL_IR_Statement.Select Nothing ctx)
-        statement_setter = connection.dialect.get_statement_setter
+        statement_setter = connection.statement_setter
         columns = connection.base_connection.fetch_columns statement statement_setter
         ## In case of accessing an existing table, we assume that column names
            are distinguishable by the backend, so any issues that are caught
@@ -100,7 +100,7 @@ make_table_from_query connection query:Text|SQL_Statement alias:Text -> Table & 
         _ : Text -> False
         _ : SQL_Statement -> True
 
-    statement_setter = if expect_interpolations then connection.dialect.get_statement_setter else Statement_Setter.null
+    statement_setter = if expect_interpolations then connection.statement_setter else Statement_Setter.null
     columns = connection.base_connection.fetch_columns query statement_setter
     name = if alias == "" then (UUID.randomUUID.to_text) else alias
     ctx = SQL_IR_Source.for_query query name

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
@@ -23,6 +23,7 @@
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - type_mapping self -> Standard.Base.Any.Any
     - version self -> Standard.Base.Data.Text.Text
 - schema_black_list -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.DuckDB.DuckDB_Connection.DuckDB_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
@@ -19,6 +19,7 @@
     - schemas self -> Standard.Base.Any.Any
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -344,6 +344,12 @@ type DuckDB_Connection
     ## ---
        private: true
        ---
+       Access the Type Mapping.
+    type_mapping self = self.connection.type_mapping
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -350,6 +350,12 @@ type DuckDB_Connection
     ## ---
        private: true
        ---
+       Access the Statement Setter.
+    statement_setter self = self.connection.statement_setter
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -11,6 +11,7 @@ from Standard.Database import Column_Description, DB_Table, SQL_Query, SQL_Query
 import Standard.Database.Connection.Connection.Connection
 import Standard.Database.Dialects.Dialect
 import Standard.Database.Internal.JDBC_Connection
+import Standard.Database.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 import Standard.Database.SQL.SQL_Statement
 from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_with_schema_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
@@ -53,7 +54,7 @@ type DuckDB_Connection
         jdbc_connection = JDBC_Connection.from_java sql_exception=SQLException java_connection
 
         ## For initial work using DuckDB, we will use the Postgres dialect.
-        DuckDB_Connection.Value (Connection.new jdbc_connection Dialect.postgres DuckDB_Entity_Naming_Properties.new) make_new
+        DuckDB_Connection.Value (Connection.new jdbc_connection Dialect.postgres Postgres_Type_Mapping DuckDB_Entity_Naming_Properties.new) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -24,5 +24,6 @@
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - type_mapping self -> Standard.Base.Any.Any
 - schema_black_list -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Microsoft.SQLServer_Connection.SQLServer_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -20,6 +20,7 @@
     - schemas self -> Standard.Base.Any.Any
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -34,7 +34,6 @@ import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
 import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
-import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
 import Standard.Database.SQL.SQL_Statement
 import Standard.Database.SQL.SQL_Type
@@ -42,7 +41,6 @@ from Standard.Database.Errors import Unsupported_Database_Operation
 from Standard.Database.Internal.Base_Generator import lift_binary_op
 from Standard.Database.Internal.IR.Operation_Metadata import Date_Period_Metadata
 from Standard.Database.Internal.JDBC_Connection import JDBC_Connection
-from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 import project.Internal.SQLServer_Error_Mapper.SQLServer_Error_Mapper
 
@@ -180,28 +178,6 @@ type SQLServer_Dialect
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-    get_statement_setter : Statement_Setter
-    get_statement_setter self =
-        custom_fill_hole stmt i type_hint value = case value of
-            Nothing ->
-                java_type = case type_hint of
-                    Nothing -> Java_Types.NULL
-                    _ ->
-                        ## SQLServer needs its NULLS to be typed at least for TIME.
-                        mapping = self.get_type_mapping
-                        sql_type = mapping.value_type_to_sql type_hint Problem_Behavior.Ignore
-                        sql_type.typeid                            
-                stmt.setNull i java_type
-            _ : Float     -> 
-                if value.is_nan || value.is_infinite then stmt.setNull i Java_Types.REAL else
-                    stmt.setDouble i value
-            # Fallback to default logic for everything else
-            _ -> fill_hole_default stmt i type_hint value JDBCUtils
-        Statement_Setter.Value custom_fill_hole
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -241,9 +241,9 @@ type SQLServer_Dialect
     ## ---
        private: true
        ---
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
-        _ = [approximate_result_type, infer_result_type_from_database_callback]
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
+        _ = [column, approximate_result_type, infer_result_type_from_database_callback, mapping]
         column
 
     ## ---

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -32,7 +32,6 @@ import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source_Extension
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
-import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -45,7 +44,6 @@ from Standard.Database.Internal.JDBC_Connection import JDBC_Connection
 from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 import project.Internal.SQLServer_Error_Mapper.SQLServer_Error_Mapper
-import project.Internal.SQLServer_Type_Mapping.SQLServer_Type_Mapping
 
 polyglot java import java.sql.Types as Java_Types
 polyglot java import org.enso.database.JDBCUtils
@@ -175,20 +173,12 @@ type SQLServer_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        type_mapping = self.get_type_mapping
+        mapping = self.get_type_mapping
         distinct_expressions = new_key_columns.map column->
-            value_type = type_mapping.sql_type_to_value_type column.sql_type_reference.get
+            value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self = SQLServer_Type_Mapping
 
     ## ---
        private: true
@@ -201,8 +191,8 @@ type SQLServer_Dialect
                     Nothing -> Java_Types.NULL
                     _ ->
                         ## SQLServer needs its NULLS to be typed at least for TIME.
-                        type_mapping = self.get_type_mapping
-                        sql_type = type_mapping.value_type_to_sql type_hint Problem_Behavior.Ignore
+                        mapping = self.get_type_mapping
+                        sql_type = mapping.value_type_to_sql type_hint Problem_Behavior.Ignore
                         sql_type.typeid                            
                 stmt.setNull i java_type
             _ : Float     -> 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -416,7 +416,7 @@ type SQLServer_Dialect
        Returns `Nothing` if the key is not defined.
     fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
     fetch_primary_key self connection table_name schema_name =
-        Dialect.default_fetch_primary_key connection table_name schema_name
+        Connection.default_fetch_primary_key connection table_name schema_name
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -32,6 +32,7 @@ import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source_Extension
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
+import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -173,7 +174,7 @@ type SQLServer_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = self.get_type_mapping
+        mapping = table.connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
@@ -205,9 +206,8 @@ type SQLServer_Dialect
     ## ---
        private: true
        ---
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self column target_type infer_result_type_from_database_callback =
-        mapping = self.get_type_mapping
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self column mapping target_type infer_result_type_from_database_callback =
         source_type = mapping.sql_type_to_value_type column.sql_type_reference.get
         target_value_type = mapping.sql_type_to_value_type target_type
         # Boolean to String casts need special handling:

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -18,6 +18,7 @@ from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 polyglot java import java.sql.Types
 polyglot java import org.enso.database.fetchers.ColumnFetcherFactory
+polyglot java import org.enso.database.JDBCUtils
 
 ## ---
    private: true
@@ -189,14 +190,14 @@ type SQLServer_Type_Mapping
         custom_fill_hole stmt i type_hint value = case value of
             Nothing ->
                 java_type = case type_hint of
-                    Nothing -> Java_Types.NULL
+                    Nothing -> Types.NULL
                     _ ->
                         ## SQLServer needs its NULLS to be typed at least for TIME.
                         sql_type = SQLServer_Type_Mapping.value_type_to_sql type_hint Problem_Behavior.Ignore
                         sql_type.typeid
                 stmt.setNull i java_type
             _ : Float     ->
-                if value.is_nan || value.is_infinite then stmt.setNull i Java_Types.REAL else
+                if value.is_nan || value.is_infinite then stmt.setNull i Types.REAL else
                     stmt.setDouble i value
             # Fallback to default logic for everything else
             _ -> fill_hole_default stmt i type_hint value JDBCUtils

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Type_Mapping.enso
@@ -11,8 +11,10 @@ from Standard.Table.Errors import Inexact_Type_Coercion
 import Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
 import Standard.Database.Internal.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
+import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Type
 from Standard.Database.Errors import Unsupported_Database_Type
+from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 polyglot java import java.sql.Types
 polyglot java import org.enso.database.fetchers.ColumnFetcherFactory
@@ -178,6 +180,27 @@ type SQLServer_Type_Mapping
        ---
     is_same_type (value_type1 : Value_Type) (value_type2 : Value_Type) -> Boolean =
         value_type1.is_same_type value_type2
+
+    ## ---
+       private: true
+       ---
+       Creates a SQL Server customised Statement_Setter.
+    statement_setter =
+        custom_fill_hole stmt i type_hint value = case value of
+            Nothing ->
+                java_type = case type_hint of
+                    Nothing -> Java_Types.NULL
+                    _ ->
+                        ## SQLServer needs its NULLS to be typed at least for TIME.
+                        sql_type = SQLServer_Type_Mapping.value_type_to_sql type_hint Problem_Behavior.Ignore
+                        sql_type.typeid
+                stmt.setNull i java_type
+            _ : Float     ->
+                if value.is_nan || value.is_infinite then stmt.setNull i Java_Types.REAL else
+                    stmt.setDouble i value
+            # Fallback to default logic for everything else
+            _ -> fill_hole_default stmt i type_hint value JDBCUtils
+        Statement_Setter.Value custom_fill_hole
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -350,6 +350,12 @@ type SQLServer_Connection
     ## ---
        private: true
        ---
+       Access the Type Mapping.
+    type_mapping self = self.connection.type_mapping
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -62,7 +62,7 @@ type SQLServer_Connection
         ## jdbc reports table name length limit as 128, but it actually seems to be 116 for temp tables so we override it
         limited = Encoding_Limited_Naming_Properties.Instance Encoding.utf_8 limit=116 is_case_sensitive=True
         modified_entity_naming_properties = Entity_Naming_Properties.Value for_table_names=limited for_column_names=jdbc_entity_naming_properties.for_column_names for_generated_column_names=jdbc_entity_naming_properties.for_generated_column_names
-        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver SQLServer_Type_Mapping SQLServer_Type_Mapping.statement_setter modified_entity_naming_properties data_link_setup) make_new
+        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver SQLServer_Type_Mapping modified_entity_naming_properties data_link_setup statement_setter=SQLServer_Type_Mapping.statement_setter) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -24,6 +24,7 @@ from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_co
 
 import project.Connection.SQLServer_Query.SQLServer_Query
 import project.Internal.SQLServer_Dialect
+import project.Internal.SQLServer_Type_Mapping.SQLServer_Type_Mapping
 
 polyglot java import java.sql.SQLException
 polyglot java import org.enso.database.JDBCProxy
@@ -61,7 +62,7 @@ type SQLServer_Connection
         ## jdbc reports table name length limit as 128, but it actually seems to be 116 for temp tables so we override it
         limited = Encoding_Limited_Naming_Properties.Instance Encoding.utf_8 limit=116 is_case_sensitive=True
         modified_entity_naming_properties = Entity_Naming_Properties.Value for_table_names=limited for_column_names=jdbc_entity_naming_properties.for_column_names for_generated_column_names=jdbc_entity_naming_properties.for_generated_column_names
-        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver modified_entity_naming_properties data_link_setup) make_new
+        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver SQLServer_Type_Mapping modified_entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -62,7 +62,7 @@ type SQLServer_Connection
         ## jdbc reports table name length limit as 128, but it actually seems to be 116 for temp tables so we override it
         limited = Encoding_Limited_Naming_Properties.Instance Encoding.utf_8 limit=116 is_case_sensitive=True
         modified_entity_naming_properties = Entity_Naming_Properties.Value for_table_names=limited for_column_names=jdbc_entity_naming_properties.for_column_names for_generated_column_names=jdbc_entity_naming_properties.for_generated_column_names
-        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver SQLServer_Type_Mapping modified_entity_naming_properties data_link_setup) make_new
+        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Dialect.sqlserver SQLServer_Type_Mapping SQLServer_Type_Mapping.statement_setter modified_entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -356,6 +356,12 @@ type SQLServer_Connection
     ## ---
        private: true
        ---
+       Access the Statement Setter.
+    statement_setter self = self.connection.statement_setter
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -20,6 +20,7 @@
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_warehouse self warehouse:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -24,6 +24,7 @@
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - truncate_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - type_mapping self -> Standard.Base.Any.Any
     - warehouse self -> Standard.Base.Any.Any
     - warehouses self -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Snowflake.Snowflake_Connection.Snowflake_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -238,9 +238,9 @@ type Snowflake_Dialect
     ## ---
        private: true
        ---
-    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback =
-        _ = [approximate_result_type, infer_result_type_from_database_callback]
+    adapt_unified_column : Internal_Column -> Value_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> SQL_Type_Mapping -> Internal_Column
+    adapt_unified_column self column approximate_result_type infer_result_type_from_database_callback mapping =
+        _ = [column, approximate_result_type, infer_result_type_from_database_callback, mapping]
         column
 
     ## ---

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -37,19 +37,16 @@ import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
 import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
-import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
 import Standard.Database.SQL.SQL_Statement
 import Standard.Database.SQL.SQL_Type
 from Standard.Database.Errors import Unsupported_Database_Operation
 from Standard.Database.Internal.IR.Operation_Metadata import Date_Period_Metadata
 from Standard.Database.Internal.JDBC_Connection import JDBC_Connection
-from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 import project.Internal.Snowflake_Error_Mapper.Snowflake_Error_Mapper
 
 polyglot java import org.enso.database.JDBCUtils
-polyglot java import org.enso.snowflake.SnowflakeJDBCUtils
 
 ## ---
    private: true
@@ -181,23 +178,6 @@ type Snowflake_Dialect
         new_context = SQL_IR_Source.for_subquery setup.subquery
             . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-    get_statement_setter : Statement_Setter
-    get_statement_setter self =
-        custom_fill_hole stmt i type_hint value = case value of
-            _ : Date_Time ->
-                keep_offset = case type_hint of
-                    Value_Type.Date_Time with_timezone -> with_timezone
-                    _ -> True
-                SnowflakeJDBCUtils.setDateTime stmt i value keep_offset
-            _ : Time_Of_Day -> SnowflakeJDBCUtils.setTimeOfDay stmt i value
-            _ : Date        -> SnowflakeJDBCUtils.setDate stmt i value
-            # Fallback to default logic for everything else
-            _ -> fill_hole_default stmt i type_hint value
-        Statement_Setter.Value custom_fill_hole
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -35,6 +35,7 @@ import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source_Extension
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
+import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -172,7 +173,7 @@ type Snowflake_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = self.get_type_mapping
+        mapping = table.connection.type_mapping
         # TODO simpler distinct if distinct_expressions are all columns?
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
@@ -201,9 +202,8 @@ type Snowflake_Dialect
     ## ---
        private: true
        ---
-    make_cast : Internal_Column -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
-    make_cast self column target_type infer_result_type_from_database_callback =
-        mapping = self.get_type_mapping
+    make_cast : Internal_Column -> SQL_Type_Mapping -> SQL_Type -> (SQL_IR_Expression -> SQL_Type_Reference) -> Internal_Column
+    make_cast self column mapping target_type infer_result_type_from_database_callback =
         source_type = mapping.sql_type_to_value_type column.sql_type_reference.get
         target_value_type = mapping.sql_type_to_value_type target_type
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -373,7 +373,7 @@ type Snowflake_Dialect
        Returns `Nothing` if the key is not defined.
     fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
     fetch_primary_key self connection table_name schema_name =
-        Dialect.default_fetch_primary_key connection table_name schema_name
+        Connection.default_fetch_primary_key connection table_name schema_name
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -35,7 +35,6 @@ import Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source_Extension
 import Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Part.SQL_Part
-import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
 import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Builder
@@ -47,7 +46,6 @@ from Standard.Database.Internal.JDBC_Connection import JDBC_Connection
 from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 import project.Internal.Snowflake_Error_Mapper.Snowflake_Error_Mapper
-import project.Internal.Snowflake_Type_Mapping.Snowflake_Type_Mapping
 
 polyglot java import org.enso.database.JDBCUtils
 polyglot java import org.enso.snowflake.SnowflakeJDBCUtils
@@ -174,22 +172,14 @@ type Snowflake_Dialect
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        type_mapping = self.get_type_mapping
+        mapping = self.get_type_mapping
         # TODO simpler distinct if distinct_expressions are all columns?
         distinct_expressions = new_key_columns.map column->
-            value_type = type_mapping.sql_type_to_value_type column.sql_type_reference.get
+            value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type
         new_context = SQL_IR_Source.for_subquery setup.subquery
             . add_extension (make_distinct_extension distinct_expressions)
         table.updated_context_and_columns new_context new_columns subquery=True
-
-    ## ---
-       private: true
-       ---
-       Returns the mapping between SQL types of this dialect and Enso
-       `Value_Type`.
-    get_type_mapping : SQL_Type_Mapping
-    get_type_mapping self = Snowflake_Type_Mapping
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Type_Mapping.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Type_Mapping.enso
@@ -11,11 +11,14 @@ from Standard.Table.Errors import Inexact_Type_Coercion
 import Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
 import Standard.Database.Internal.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
+import Standard.Database.Internal.Statement_Setter.Statement_Setter
 import Standard.Database.SQL.SQL_Type
 from Standard.Database.Errors import Unsupported_Database_Type
+from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
 polyglot java import java.sql.Types
 polyglot java import org.enso.snowflake.SnowflakeColumnFetcherFactory
+polyglot java import org.enso.snowflake.SnowflakeJDBCUtils
 
 ## ---
    private: true
@@ -169,6 +172,23 @@ type Snowflake_Type_Mapping
     is_same_type (value_type1 : Value_Type) (value_type2 : Value_Type) -> Boolean =
         # Types are considered the same by original semantics, or additionally if both of them are an integer-like type as denoted by `is_integer_type`.
         (value_type1.is_same_type value_type2) || (Snowflake_Type_Mapping.is_integer_type value_type1 && Snowflake_Type_Mapping.is_integer_type value_type2)
+
+    ## ---
+       private: true
+       ---
+       Creates a Snowflake customised Statement_Setter.
+    statement_setter =
+        custom_fill_hole stmt i type_hint value = case value of
+            _ : Date_Time ->
+                keep_offset = case type_hint of
+                    Value_Type.Date_Time with_timezone -> with_timezone
+                    _ -> True
+                SnowflakeJDBCUtils.setDateTime stmt i value keep_offset
+            _ : Time_Of_Day -> SnowflakeJDBCUtils.setTimeOfDay stmt i value
+            _ : Date        -> SnowflakeJDBCUtils.setDate stmt i value
+            # Fallback to default logic for everything else
+            _ -> fill_hole_default stmt i type_hint value
+        Statement_Setter.Value custom_fill_hole
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -60,7 +60,7 @@ type Snowflake_Connection
            Our generator always quotes identifiers, so we can rely on the case sensitivity.
            This is the same as in Postgres.
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection is_case_sensitive=True
-        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake Snowflake_Type_Mapping entity_naming_properties data_link_setup) make_new
+        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake Snowflake_Type_Mapping Snowflake_Type_Mapping.statement_setter entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -60,7 +60,7 @@ type Snowflake_Connection
            Our generator always quotes identifiers, so we can rely on the case sensitivity.
            This is the same as in Postgres.
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection is_case_sensitive=True
-        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake Snowflake_Type_Mapping Snowflake_Type_Mapping.statement_setter entity_naming_properties data_link_setup) make_new
+        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake Snowflake_Type_Mapping entity_naming_properties data_link_setup statement_setter=Snowflake_Type_Mapping.statement_setter) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -377,6 +377,12 @@ type Snowflake_Connection
     ## ---
        private: true
        ---
+       Access the Statement Setter.
+    statement_setter self = self.connection.statement_setter
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -371,6 +371,12 @@ type Snowflake_Connection
     ## ---
        private: true
        ---
+       Access the Type Mapping.
+    type_mapping self = self.connection.type_mapping
+
+    ## ---
+       private: true
+       ---
        Access the underlying JDBC connection.
     jdbc_connection self = self.connection.jdbc_connection
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -26,6 +26,7 @@ from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_co
 
 import project.Connection.Key_Pair_Credentials.Key_Pair_Credentials
 import project.Internal.Snowflake_Dialect
+import project.Internal.Snowflake_Type_Mapping.Snowflake_Type_Mapping
 
 polyglot java import org.enso.snowflake.SnowflakeCloudCredentials
 
@@ -59,7 +60,7 @@ type Snowflake_Connection
            Our generator always quotes identifiers, so we can rely on the case sensitivity.
            This is the same as in Postgres.
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection is_case_sensitive=True
-        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake entity_naming_properties data_link_setup) make_new
+        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Dialect.snowflake Snowflake_Type_Mapping entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true


### PR DESCRIPTION
### Pull Request Description

- Fix for `bat` file running on windows now ydoc integrates.
- Error logging on the `ensoRunner` to help with debugging.
- Remove `get_type_mapping` and `get_statement_setter` from dialects and move them to instances on `Connection.
- Adjusted `make_cast` and `adapt_unified_column` to take the type mapping as an argument. (To review where these should be).
- Added `type_mapping` and `statement_setter` to specialised connection types.

ToDo:
- `get_error_mapper` and `fetch_primary_key` off dialect.
- Review the `make_cast` and `adapt_unified_column` methods and decide where they belong.
- Move `needs_execute_query_for_type_inference` to type mapper.
- Move `value_type_for_upload_of_existing_column` to type mapper.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
