### PR TITLE
Fix issue with Microsoft and Snowflake connection access

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/Database/Redshift/Internal/Redshift_Dialect.md
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/docs/api/Database/Redshift/Internal/Redshift_Dialect.md
@@ -8,7 +8,6 @@
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - default_table_types self -> Standard.Base.Any.Any
     - ensure_query_has_no_holes self jdbc:Standard.Database.Internal.JDBC_Connection.JDBC_Connection raw_sql:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
-    - fetch_primary_key self connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - flagged self flag:Standard.Database.Dialects.Dialect_Flag.Dialect_Flag -> Standard.Base.Data.Boolean.Boolean
     - generate_collate self collation_name:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
     - generate_expression self base_gen:Standard.Base.Any.Any expr:(Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression|Standard.Database.Internal.IR.Order_Descriptor.Order_Descriptor|Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement) for_select:Standard.Base.Data.Boolean.Boolean -> Standard.Database.SQL.SQL_Builder

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -282,15 +282,6 @@ type Redshift_Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        Connection.default_fetch_primary_key connection table_name schema_name
-
-    ## ---
-       private: true
-       ---
     value_type_for_upload_of_existing_column : DB_Column -> Value_Type
     value_type_for_upload_of_existing_column self column =
         ## TODO special behaviour for big integer columns should be added here, once we start testing this dialect again

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -3,7 +3,6 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Aggregate_Column, Value_Type
 
-import Standard.Database.Connection.Connection.Connection
 import Standard.Database.DB_Column.DB_Column
 import Standard.Database.Dialects.Dialect
 import Standard.Database.Dialects.Dialect.Temp_Table_Style

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
@@ -9,12 +9,12 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
-    - default_fetch_primary_key connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_columns self statement:Standard.Base.Any.Any statement_setter:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - get_tables_advanced self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= include_hidden:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - internal_allocate_dry_run_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - maybe_run_maintenance self -> Standard.Base.Any.Any
@@ -37,6 +37,6 @@
 - make_database_selector connection:Standard.Base.Any.Any include_any:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
 - make_schema_selector connection:Standard.Base.Any.Any include_any:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
 - make_structure_creator -> Standard.Base.Any.Any
-- make_table_name_selector connection:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- make_table_name_selector connection:Standard.Base.Any.Any add_custom:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
 - make_table_name_with_schema_selector connection:Standard.Base.Any.Any schema_black_list:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_table_types_selector connection:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Connection.md
@@ -16,7 +16,7 @@
     - fetch_columns self statement:Standard.Base.Any.Any statement_setter:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - get_tables_advanced self name_like:Standard.Base.Any.Any= database:Standard.Base.Any.Any= schema:Standard.Base.Any.Any= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= include_hidden:Standard.Base.Any.Any= -> Standard.Base.Any.Any
-    - internal_allocate_dry_run_table self table_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - internal_allocate_dry_run_table self table_name:Standard.Base.Any.Any connection:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - maybe_run_maintenance self -> Standard.Base.Any.Any
     - new jdbc_connection:Standard.Database.Internal.JDBC_Connection.JDBC_Connection dialect:Standard.Base.Any.Any type_mapping:Standard.Base.Any.Any entity_naming_properties:Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties data_link_setup:(Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup|Standard.Base.Nothing.Nothing)= try_large_update:Standard.Base.Data.Boolean.Boolean= statement_setter:Standard.Database.Internal.Statement_Setter.Statement_Setter= -> Standard.Database.Connection.Connection.Connection
     - query self query:Standard.Base.Any.Any alias:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -12,6 +12,7 @@
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -4,6 +4,7 @@
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - create url:Standard.Base.Any.Any properties:Standard.Base.Any.Any make_new:Standard.Base.Any.Any data_link_setup:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -13,6 +13,7 @@
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -5,6 +5,7 @@
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - create url:Standard.Base.Any.Any properties:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
@@ -1,7 +1,6 @@
 ## Enso Signatures 1.0
 ## module Standard.Database.DB_Table
 - type DB_Table
-    - Value internal_name:Standard.Base.Data.Text.Text connection:(Standard.Database.Connection.Connection.Connection|Standard.Base.Any.Any) internal_columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) context:Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source
     - as_subquery self -> Standard.Base.Any.Any
     - default_ordering self -> Standard.Base.Any.Any
     - dialect_name self -> Standard.Base.Data.Text.Text

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/DB_Table.md
@@ -1,6 +1,7 @@
 ## Enso Signatures 1.0
 ## module Standard.Database.DB_Table
 - type DB_Table
+    - Value internal_name:Standard.Base.Data.Text.Text connection:(Standard.Database.Connection.Connection.Connection|Standard.Base.Any.Any) internal_columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) context:Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source
     - as_subquery self -> Standard.Base.Any.Any
     - default_ordering self -> Standard.Base.Any.Any
     - dialect_name self -> Standard.Base.Data.Text.Text

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Dialects/Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Dialects/Dialect.md
@@ -6,7 +6,6 @@
     - custom_build_aggregate self base_table:Standard.Database.DB_Table.DB_Table key_columns:(Standard.Base.Data.Vector.Vector Standard.Database.Internal.IR.Internal_Column.Internal_Column) resolved_aggregates:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any) problem_builder:Standard.Table.Internal.Problem_Builder.Problem_Builder -> (Standard.Base.Data.Pair.Pair Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source Standard.Base.Any.Any)
     - default_table_types self -> Standard.Base.Any.Any
     - ensure_query_has_no_holes jdbc:Standard.Database.Internal.JDBC_Connection.JDBC_Connection raw_sql:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
-    - fetch_primary_key self connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - flagged self flag:Standard.Database.Dialects.Dialect_Flag.Dialect_Flag -> Standard.Base.Data.Boolean.Boolean
     - generate_collate self collation_name:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
     - generate_expression self base_gen:Standard.Base.Any.Any expr:(Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression|Standard.Database.Internal.IR.Order_Descriptor.Order_Descriptor|Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement) for_select:Standard.Base.Data.Boolean.Boolean -> Standard.Database.SQL.SQL_Builder

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Postgres/Postgres_Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Postgres/Postgres_Dialect.md
@@ -8,7 +8,6 @@
     - check_aggregate_support self aggregate:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - default_table_types self -> Standard.Base.Any.Any
     - ensure_query_has_no_holes self jdbc:Standard.Database.Internal.JDBC_Connection.JDBC_Connection raw_sql:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
-    - fetch_primary_key self connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - flagged self flag:Standard.Database.Dialects.Dialect_Flag.Dialect_Flag -> Standard.Base.Data.Boolean.Boolean
     - generate_collate self collation_name:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
     - generate_expression self base_gen:Standard.Base.Any.Any expr:(Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression|Standard.Database.Internal.IR.Order_Descriptor.Order_Descriptor|Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement) for_select:Standard.Base.Data.Boolean.Boolean -> Standard.Database.SQL.SQL_Builder

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQL_Type_Reference.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQL_Type_Reference.md
@@ -1,7 +1,7 @@
 ## Enso Signatures 1.0
 ## module Standard.Database.Internal.SQL_Type_Reference
 - type SQL_Type_Recipe
-    - Value connection:Standard.Database.Connection.Connection.Connection context:Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source expression:Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
+    - Value connection:Standard.Base.Any.Any context:Standard.Database.Internal.IR.SQL_IR_Source.SQL_IR_Source expression:Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
 - type SQL_Type_Reference
     - Computed_By_Database ref:(Standard.Base.Runtime.Ref.Ref Standard.Base.Any.Any)
     - Null

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQLite/SQLite_Dialect.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/SQLite/SQLite_Dialect.md
@@ -9,7 +9,6 @@
     - custom_build_aggregate self -> Standard.Base.Any.Any
     - default_table_types self -> Standard.Base.Any.Any
     - ensure_query_has_no_holes self jdbc:Standard.Database.Internal.JDBC_Connection.JDBC_Connection raw_sql:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
-    - fetch_primary_key self connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any schema_name:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - flagged self flag:Standard.Database.Dialects.Dialect_Flag.Dialect_Flag -> Standard.Base.Data.Boolean.Boolean
     - generate_collate self collation_name:Standard.Base.Data.Text.Text -> Standard.Base.Data.Text.Text
     - generate_expression self base_gen:Standard.Base.Any.Any expr:(Standard.Database.Internal.IR.SQL_IR_Expression.SQL_IR_Expression|Standard.Database.Internal.IR.Order_Descriptor.Order_Descriptor|Standard.Database.Internal.IR.SQL_IR_Statement.SQL_IR_Statement) for_select:Standard.Base.Data.Boolean.Boolean -> Standard.Database.SQL.SQL_Builder

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Upload/Operations/Create.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Internal/Upload/Operations/Create.md
@@ -1,0 +1,3 @@
+## Enso Signatures 1.0
+## module Standard.Database.Internal.Upload.Operations.Create
+- create_table_implementation connection:Standard.Base.Any.Any table_name:Standard.Base.Any.Any structure:Standard.Base.Any.Any primary_key:Standard.Base.Any.Any temporary:Standard.Base.Any.Any allow_existing:Standard.Base.Any.Any on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/SQL_Query.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/SQL_Query.md
@@ -3,12 +3,12 @@
 - type SQL_Query
     - Raw_SQL sql:Standard.Base.Data.Text.Text=
     - Table_Name name:Standard.Base.Data.Text.Text=
-    - to_db_table self connection:Standard.Database.Connection.Connection.Connection alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
+    - to_db_table self connection:Standard.Base.Any.Any alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
 - type SQL_Query_With_Schema
     - Raw_SQL sql:Standard.Base.Data.Text.Text=
     - Table_Name name:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text=
     - From that:Standard.Database.SQL_Query.SQL_Query -> Standard.Base.Any.Any
-    - to_db_table self connection:Standard.Database.Connection.Connection.Connection alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
+    - to_db_table self connection:Standard.Base.Any.Any alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
 - make_table_for_name connection:Standard.Base.Any.Any name:Standard.Base.Any.Any schema:Standard.Base.Any.Any alias:Standard.Base.Any.Any internal_temporary_keep_alive_reference:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - make_table_from_query connection:Standard.Base.Any.Any query:(Standard.Base.Data.Text.Text|Standard.Database.SQL.SQL_Statement) alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
 - Standard.Database.SQL_Query.SQL_Query.from that:Standard.Base.Data.Text.Text -> Standard.Database.SQL_Query.SQL_Query

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -534,9 +534,9 @@ type Connection
        Once all references to the table with this name are destroyed, the table
        will be marked for removal and dropped at the next maintenance.
     internal_allocate_dry_run_table : Text -> Table & DB_Table
-    internal_allocate_dry_run_table self table_name =
+    internal_allocate_dry_run_table self table_name connection =
         ref = self.hidden_table_registry.make_reference table_name
-        make_table_for_name self table_name "" table_name ref
+        make_table_for_name connection table_name "" table_name ref
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -102,7 +102,7 @@ type Connection
     close self = self.jdbc_connection.close
 
     ## ---
-       private: true
+       icon: metadata
        ---
        Returns the list of databases (or catalogs) for the connection.
     databases : Vector Text
@@ -111,7 +111,7 @@ type Connection
             Vector.from_polyglot_array <| JDBCUtils.readTextColumn metadata.getCatalogs "TABLE_CAT"
 
     ## ---
-       private: true
+       icon: metadata
        ---
        Returns the name of the current database (or catalog).
     database : Text
@@ -119,7 +119,7 @@ type Connection
         self.jdbc_connection.with_connection connection->connection.getCatalog
 
     ## ---
-       private: true
+       icon: data_input
        ---
        Returns a new Connection with the specified database set as default.
 
@@ -131,7 +131,7 @@ type Connection
             SQL_Error.throw_sql_error "Changing database is not supported."
 
     ## ---
-       private: true
+       icon: metadata
        ---
        Returns the list of schemas for the connection within the current database
        (or catalog).
@@ -141,7 +141,7 @@ type Connection
             Vector.from_polyglot_array <| JDBCUtils.readTextColumn metadata.getSchemas "TABLE_SCHEM"
 
     ## ---
-       private: true
+       icon: metadata
        ---
        Returns the name of the current schema.
     schema : Text
@@ -149,7 +149,7 @@ type Connection
         self.jdbc_connection.with_connection .getSchema
 
     ## ---
-       private: true
+       icon: data_input
        ---
        Returns a new Connection with the specified schema set as default.
 
@@ -161,7 +161,8 @@ type Connection
             SQL_Error.throw_sql_error "Changing schema is not supported."
 
     ## ---
-       private: true
+       group: Standard.Base.Metadata
+       icon: metadata
        ---
        Gets a list of the table types
     table_types : Vector Text
@@ -232,7 +233,9 @@ type Connection
         tables.at "Name" . to_vector . contains table_name
 
     ## ---
-       private: true
+       aliases: [import, load, open, read, sql]
+       group: Standard.Base.Input
+       icon: data_input
        ---
        Set up a query returning a Table object, which can be used to work with
        data within the database or load it into memory.
@@ -566,14 +569,21 @@ type Connection
                     data_link_setup -> data_link_setup.save_as_data_link path on_existing_file
 
     ## ---
-       private: true
+       icon: metadata
        ---
-       Default implementation relying on DatabaseMetaData for fetching primary key.
-    default_fetch_primary_key connection table_name schema_name =
-        connection.jdbc_connection.with_metadata metadata->
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        self.jdbc_connection.with_metadata metadata->
             used_schema = if schema_name == "" then Nothing else schema_name
             rs = metadata.getPrimaryKeys Nothing used_schema table_name
-            tm = connection.type_mapping
+            tm = self.type_mapping
             keys_table = result_set_to_table rs tm.sql_type_to_value_type tm.column_fetcher_factory
             # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
             selected = keys_table.select_columns ["COLUMN_NAME", "KEY_SEQ"] case_sensitivity=Case_Sensitivity.Insensitive reorder=True
@@ -608,11 +618,11 @@ make_schema_selector connection include_any:Boolean=False =
 ## ---
    private: true
    ---
-make_table_name_selector : Connection -> Widget
-make_table_name_selector connection =
+make_table_name_selector : Connection -> Boolean -> Widget
+make_table_name_selector connection add_custom:Boolean=True =
     tables_to_display = connection.tables.at "Name" . to_vector
     table_name_values = tables_to_display.map t-> Option t t.pretty
-    values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
+    values = table_name_values + (if add_custom then [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""'] else [])
     Single_Choice display=Display.Always values=values
 
 ## ---

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -382,6 +382,20 @@ type Postgres_Connection
         self.base_connection.save_as_data_link path on_existing_file
 
     ## ---
+       icon: metadata
+       ---
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        self.base_connection.fetch_primary_key table_name schema_name
+
+    ## ---
        private: true
        ---
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -181,7 +181,8 @@ type Postgres_Connection
           not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
     query : SQL_Query -> Text -> Table & DB_Table ! Table_Not_Found
-    query self query:SQL_Query alias="" = self.connection.query query alias
+    query self query:SQL_Query alias="" =
+        query.to_db_table self alias
 
     ## ---
        aliases: [import, load, open, query, sql]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -9,6 +9,7 @@ from Standard.Table import Table
 
 import project.Column_Description.Column_Description
 import project.Connection.Connection.Connection
+import project.DB_Table as DB_Table_Module
 import project.DB_Table.DB_Table
 import project.Dialects.Dialect
 import project.Internal.Common.Connections_Helpers
@@ -259,6 +260,21 @@ type Postgres_Connection
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a `DB_Table` that is not backed by an existing table in the
+       Database, but is created in a query by constructing a `VALUES` expression.
+       We limit these tables to at most 256 cells to avoid creating too large
+       queries. If you need a larger table, create a temporary table instead.
+       Note that the types of columns in the created table will depend on how the
+       Database interprets the provided values and may not reflect the types of
+       the source table. If you need more sophisticated type mapping mechanism,
+       use `create_table` instead.
+    create_literal_table self (source : Table) (alias : Text) -> Table & DB_Table =
+        DB_Table_Module.make_literal_table self (source.columns.map .to_vector) source.column_names alias
 
     ## ---
        advanced: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -23,6 +23,7 @@ from project.Connection.Connection import make_schema_selector, make_structure_c
 from project.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from project.Internal.Postgres.Helpers import get_encoding_name, parse_postgres_encoding
 from project.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
+from project.Internal.Upload.Operations.Create import create_table_implementation
 
 type Postgres_Connection
     ## ---
@@ -259,7 +260,7 @@ type Postgres_Connection
     @structure make_structure_creator
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
-        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+        create_table_implementation self table_name structure primary_key temporary allow_existing on_problems
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -9,6 +9,7 @@ from Standard.Table import Table
 
 import project.Column_Description.Column_Description
 import project.Connection.Connection.Connection
+import project.DB_Table as DB_Table_Module
 import project.DB_Table.DB_Table
 import project.Dialects.Dialect
 import project.Internal.Common.Connections_Helpers
@@ -246,6 +247,21 @@ type SQLite_Connection
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a `DB_Table` that is not backed by an existing table in the
+       Database, but is created in a query by constructing a `VALUES` expression.
+       We limit these tables to at most 256 cells to avoid creating too large
+       queries. If you need a larger table, create a temporary table instead.
+       Note that the types of columns in the created table will depend on how the
+       Database interprets the provided values and may not reflect the types of
+       the source table. If you need more sophisticated type mapping mechanism,
+       use `create_table` instead.
+    create_literal_table self (source : Table) (alias : Text) -> Table & DB_Table =
+        DB_Table_Module.make_literal_table self (source.columns.map .to_vector) source.column_names alias
 
     ## ---
        advanced: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -15,6 +15,7 @@ import project.Internal.Common.Connections_Helpers
 import project.Internal.JDBC_Connection
 import project.Internal.SQLite.SQLite_Entity_Naming_Properties
 import project.Internal.SQLite.SQLite_Type_Mapping.SQLite_Type_Mapping
+import project.SQL.SQL_Builder
 import project.SQL.SQL_Statement
 import project.SQL_Query.SQL_Query
 from project.Connection.Connection import make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
@@ -357,6 +358,28 @@ type SQLite_Connection
        on the 'subclasses'.
     base_connection : Connection
     base_connection self = self.connection
+
+    ## ---
+       icon: metadata
+       ---
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        _ = schema_name
+        wrapped_name = self.dialect.wrap_identifier table_name
+        query = SQL_Builder.code "pragma table_info(" ++ wrapped_name ++ ")"
+        info_table = self.connection.read_statement query.build
+        ## The `pk` field is non-zero if the columns is part of the primary key.
+           The column value indicates the position in the key.
+           See: https://www.sqlite.org/pragma.html#pragma_table_info
+        v = info_table.filter "pk" (>0) . sort "pk" . at "name" . to_vector
+        if v.is_empty then Nothing else v
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -168,7 +168,8 @@ type SQLite_Connection
           not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
     query : SQL_Query -> Text -> Table & DB_Table ! Table_Not_Found
-    query self query:SQL_Query alias="" = self.connection.query query alias
+    query self query:SQL_Query alias="" =
+        query.to_db_table self alias
 
     ## ---
        aliases: [import, load, open, query, sql]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -22,6 +22,7 @@ import project.SQL_Query.SQL_Query
 from project.Connection.Connection import make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
 from project.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from project.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
+from project.Internal.Upload.Operations.Create import create_table_implementation
 
 type SQLite_Connection
     ## ---
@@ -246,7 +247,7 @@ type SQLite_Connection
     @structure make_structure_creator
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
-        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+        create_table_implementation self table_name structure primary_key temporary allow_existing on_problems
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -152,7 +152,7 @@ type DB_Table
             # The primary key may not be valid anymore after grouping!
             is_primary_key_still_valid = self.context.groups.is_empty
             if is_primary_key_still_valid.not then Nothing else
-                result = self.connection.dialect.fetch_primary_key self.connection table_name schema_name
+                result = self.connection.fetch_primary_key table_name schema_name
                 result.catch Any _->Nothing
         # If the key is a result of a join, union or a subquery then it has no notion of primary key.
         _ -> Nothing

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -63,7 +63,7 @@ type DB_Table
         - `connection`: The connection with which the table is associated.
         - `internal_columns`: The internal representation of the table columns.
         - `context`: The context associated with this table.
-    private Value internal_name:Text connection:(Connection | Any) (internal_columns:(Vector Internal_Column)) context:SQL_IR_Source
+    Value internal_name:Text connection:(Connection | Any) (internal_columns:(Vector Internal_Column)) context:SQL_IR_Source
 
     ## The internal constructor used to construct a DB_Table instance.
        It can perform some additional operations, like refining the type, so it

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -63,7 +63,7 @@ type DB_Table
         - `connection`: The connection with which the table is associated.
         - `internal_columns`: The internal representation of the table columns.
         - `context`: The context associated with this table.
-    Value internal_name:Text connection:(Connection | Any) (internal_columns:(Vector Internal_Column)) context:SQL_IR_Source
+    private Value internal_name:Text connection:(Connection | Any) (internal_columns:(Vector Internal_Column)) context:SQL_IR_Source
 
     ## The internal constructor used to construct a DB_Table instance.
        It can perform some additional operations, like refining the type, so it

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -241,16 +241,6 @@ type Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        _ = [connection, table_name, schema_name]
-        Unimplemented.throw "This is an interface only."
-
-    ## ---
-       private: true
-       ---
        Prepares metadata for an operation taking a date/time period and checks if
        the given period is supported.
     prepare_metadata_for_period : Date_Period | Time_Period -> Value_Type -> Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialects/Dialect.enso
@@ -5,7 +5,6 @@ import Standard.Base.Errors.Unimplemented.Unimplemented
 import Standard.Table.Internal.Problem_Builder.Problem_Builder
 from Standard.Table import Aggregate_Column, Table, Value_Type
 
-import project.Connection.Connection.Connection
 import project.DB_Column.DB_Column
 import project.DB_Table.DB_Table
 import project.Dialects.Dialect_Flag.Dialect_Flag

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Data_Link_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Data_Link_Helpers.enso
@@ -25,7 +25,7 @@ data_link_connection_parameters (source : Data_Link_Source_Metadata) -> Connecti
    private: true
    ---
 save_table_as_data_link table destination on_existing_file:Existing_File_Behavior =
-    data_link_setup = table.connection.data_link_setup.if_nothing <|
+    data_link_setup = table.connection.base_connection.data_link_setup.if_nothing <|
         Error.throw (Illegal_Argument.Error "Saving a Table as data link is currently not supported in this backend.")
 
     # For a trivial query we return the table name.
@@ -73,7 +73,7 @@ private _find_referred_temporary_tables connection context -> Nothing | Vector T
             return_nothing_if_empty encountered_temporary_tables
         # For CREATE TEMPORARY we query `getTables` and try to check table Type
         Temp_Table_Style.Temporary_Table ->
-            table_info = connection.get_tables_advanced include_hidden=True
+            table_info = connection.base_connection.get_tables_advanced include_hidden=True
             # If types are unknown, we cannot tell anything.
             if table_info.column_names.contains "Type" . not then Nothing else
                 encountered_table_info = table_info.join (Table.new [["Name", encountered_table_names]]) join_kind=..Inner on="Name"

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -412,7 +412,7 @@ type DB_Table_Implementation
         if this_table.internal_columns.is_empty then Error.throw (Illegal_Argument.Error "Cannot create a table with no columns.") else
             sql = this_table.to_sql
             column_types = this_table.internal_columns.map .sql_type_reference
-            table = this_table.connection.read_statement sql column_types last_row_only=True
+            table = this_table.connection.base_connection.read_statement sql column_types last_row_only=True
             table.rows.first
 
     sort (this_table : Table & DB_Table) (columns : Vector Sort_Column | Sort_Column) text_ordering:Text_Ordering error_on_missing_columns:Boolean on_problems:Problem_Behavior =
@@ -640,7 +640,7 @@ type DB_Table_Implementation
         new_ctx = SQL_IR_Source.for_subquery setup.subquery
         query = SQL_IR_Statement.Select [[column_name, expr]] new_ctx
         sql = this_table.connection.dialect.generate_sql query
-        table = this_table.connection.read_statement sql
+        table = this_table.connection.base_connection.read_statement sql
         table.at column_name . at 0
 
     default_max_rows = Rows_To_Read.First_With_Warning 1000
@@ -654,7 +654,7 @@ type DB_Table_Implementation
 
             sql = preprocessed.to_sql
             column_types = preprocessed.internal_columns.map .sql_type_reference
-            materialized_table = this_table.connection.read_statement sql column_types . catch SQL_Error sql_error->
+            materialized_table = this_table.connection.base_connection.read_statement sql column_types . catch SQL_Error sql_error->
                 Error.throw (this_table.connection.dialect.get_error_mapper.transform_custom_errors sql_error)
 
             warnings_builder = Builder.new
@@ -684,7 +684,7 @@ type DB_Table_Implementation
                 [column.name, SQL_IR_Expression.Operation "COUNT" [column.expression]]
             query = SQL_IR_Statement.Select new_columns new_ctx
             this_table.connection.dialect.generate_sql query
-        count_table = this_table.connection.read_statement count_query
+        count_table = this_table.connection.base_connection.read_statement count_query
         counts = if cols.is_empty then [] else count_table.columns.map c-> c.at 0
         mapping = this_table.connection.type_mapping
         types = cols.map col->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -9,7 +9,6 @@ from Standard.Table import Aggregate_Column, Column, Table, Value_Type
 from Standard.Table.Aggregate_Column.Aggregate_Column import all
 from Standard.Table.Errors import Inexact_Type_Coercion
 
-import project.Connection.Connection.Connection
 import project.DB_Column.DB_Column
 import project.DB_Table.DB_Table
 import project.Dialects.Dialect

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -21,6 +21,7 @@ import project.Internal.Base_Generator
 import project.Internal.Common.Database_Distinct_Helper
 import project.Internal.Common.Database_Join_Helper
 import project.Internal.Error_Mapper.Error_Mapper
+import project.Internal.Internals_Access
 import project.Internal.IR.Internal_Column.Internal_Column
 import project.Internal.IR.Nulls_Order.Nulls_Order
 import project.Internal.IR.Operation_Metadata.Date_Period_Metadata
@@ -152,14 +153,15 @@ type Postgres_Dialect
        Prepares a distinct operation.
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
-        table_name_deduplicator = table.connection.base_connection.table_naming_helper.create_unique_name_strategy
+        table_connection = Internals_Access.get_connection table
+        table_name_deduplicator = table_connection.base_connection.table_naming_helper.create_unique_name_strategy
         table_name_deduplicator.mark_used table.name
         inner_table_alias = table_name_deduplicator.make_unique table.name+"_inner"
         setup = table.context.as_subquery inner_table_alias [table.internal_columns]
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = table.connection.type_mapping
+        mapping = table_connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -357,15 +357,6 @@ type Postgres_Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        Connection.default_fetch_primary_key connection table_name schema_name
-
-    ## ---
-       private: true
-       ---
        Prepares metadata for an operation taking a date/time period and checks if
        the given period is supported.
     prepare_metadata_for_period : Date_Period | Time_Period -> Value_Type -> Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
@@ -107,7 +107,7 @@ type SQL_Type_Recipe
        private: true
        ---
        A recipe for computing the SQL type.
-    Value connection:Connection context:SQL_IR_Source expression:SQL_IR_Expression
+    Value connection context:SQL_IR_Source expression:SQL_IR_Expression
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQL_Type_Reference.enso
@@ -122,7 +122,7 @@ get_or_compute (ref : Ref (SQL_Type_Recipe | SQL_Type)) -> SQL_Type =
         SQL_Type_Recipe.Value connection context expression ->
             statement = connection.dialect.prepare_fetch_types_query expression context
             statement_setter = connection.statement_setter
-            columns = connection.fetch_columns statement statement_setter
+            columns = connection.base_connection.fetch_columns statement statement_setter
             only_column = columns.first
             computed_type = only_column.second
             ref.put computed_type

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -367,25 +367,6 @@ type SQLite_Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-       Custom handling is required, because the default DatabaseMetaData
-       implementation does not correctly handle temporary tables.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        _ = schema_name
-        wrapped_name = self.wrap_identifier table_name
-        query = SQL_Builder.code "pragma table_info(" ++ wrapped_name ++ ")"
-        info_table = connection.read_statement query.build
-        ## The `pk` field is non-zero if the columns is part of the primary key.
-           The column value indicates the position in the key.
-           See: https://www.sqlite.org/pragma.html#pragma_table_info
-        v = info_table.filter "pk" (>0) . sort "pk" . at "name" . to_vector
-        if v.is_empty then Nothing else v
-
-    ## ---
-       private: true
-       ---
        Prepares metadata for an operation taking a date/time period and checks if
        the given period is supported.
     prepare_metadata_for_period : Date_Period | Time_Period -> Value_Type -> Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -22,6 +22,7 @@ import project.Internal.Common.Database_Distinct_Helper
 import project.Internal.Common.Database_Join_Helper
 import project.Internal.Common.Row_Number_Helpers
 import project.Internal.Error_Mapper.Error_Mapper
+import project.Internal.Internals_Access
 import project.Internal.IR.Internal_Column.Internal_Column
 import project.Internal.IR.Order_Descriptor.Order_Descriptor
 import project.Internal.IR.SQL_IR_Expression.SQL_IR_Expression
@@ -162,14 +163,15 @@ type SQLite_Dialect
        Prepares a distinct operation.
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
-        table_name_deduplicator = table.connection.base_connection.table_naming_helper.create_unique_name_strategy
+        table_connection = Internals_Access.get_connection table
+        table_name_deduplicator = table_connection.base_connection.table_naming_helper.create_unique_name_strategy
         table_name_deduplicator.mark_used table.name
         inner_table_alias = table_name_deduplicator.make_unique table.name+"_inner"
         setup = table.context.as_subquery inner_table_alias [table.internal_columns]
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = table.connection.type_mapping
+        mapping = table_connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -7,7 +7,6 @@ import Standard.Table.Internal.Problem_Builder.Problem_Builder
 from Standard.Table import Aggregate_Column, Table, Value_Type
 from Standard.Table.Aggregate_Column.Aggregate_Column import all
 
-import project.Connection.Connection.Connection
 import project.DB_Column.DB_Column
 import project.DB_Table.DB_Table
 import project.Dialects.Dialect

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Create.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Create.enso
@@ -1,5 +1,3 @@
-private
-
 from Standard.Base import all
 import Standard.Base.Errors.Common.Dry_Run_Operation
 import Standard.Base.Runtime.Context

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Create.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Create.enso
@@ -47,7 +47,7 @@ create_table_implementation connection table_name structure primary_key temporar
                 case created_table_name.is_error of
                     False ->
                         if dry_run.not then connection.query (..Table_Name created_table_name) else
-                            created_table = connection.base_connection.internal_allocate_dry_run_table created_table_name
+                            created_table = connection.base_connection.internal_allocate_dry_run_table created_table_name connection
                             warning = Dry_Run_Operation.Warning "Only a dry run of `create_table` has occurred, creating a temporary table ("+created_table_name.pretty+").  Press the Write button ▶ to create the actual one."
                             Warning.attach warning created_table
                     True ->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Select_Into.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Select_Into.enso
@@ -39,7 +39,7 @@ select_into_table_implementation source_table connection table_name primary_key 
                                     . catch Table_Already_Exists _->
                                         # Another dry-run table was created in the meantime - we restart to now DROP it and try again.
                                         create_dry_run_table Nothing
-                            temporary_table = connection.base_connection.internal_allocate_dry_run_table table.name
+                            temporary_table = connection.base_connection.internal_allocate_dry_run_table table.name connection
                             warning = Dry_Run_Operation.Warning "Only a dry run of `select_into_database_table` was performed - a temporary table ("+tmp_table_name+") was created, containing a sample of the data.  Press the Write button ▶ to write to the actual table."
                             Warning.attach warning temporary_table
                         create_dry_run_table Nothing

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
@@ -3,7 +3,6 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Table
 
-import project.Connection.Connection.Connection
 import project.DB_Table as DB_Table_Module
 import project.DB_Table.DB_Table
 import project.Errors.Table_Not_Found

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
@@ -25,7 +25,7 @@ type SQL_Query
     ## ---
        private: true
        ---
-    to_db_table self connection:Connection alias:Text = alias.if_not_error <| case self of
+    to_db_table self connection alias:Text = alias.if_not_error <| case self of
         SQL_Query.Table_Name name ->
             table_naming_helper = connection.base_connection.table_naming_helper
             table_naming_helper.verify_table_name name <|
@@ -45,7 +45,7 @@ type SQL_Query_With_Schema
     ## ---
        private: true
        ---
-    to_db_table self connection:Connection alias:Text = alias.if_not_error <| case self of
+    to_db_table self connection alias:Text = alias.if_not_error <| case self of
         SQL_Query_With_Schema.Table_Name name schema ->
             table_naming_helper = connection.base_connection.table_naming_helper
             table_naming_helper.verify_table_name name <|
@@ -104,7 +104,7 @@ make_table_from_query connection query:Text|SQL_Statement alias:Text -> Table & 
     columns = connection.base_connection.fetch_columns query statement_setter
     name = if alias == "" then (UUID.randomUUID.to_text) else alias
     ctx = SQL_IR_Source.for_query query name
-    r = DB_Table_Module.make_table connection.base_connection name columns ctx on_problems=Problem_Behavior.Report_Error
+    r = DB_Table_Module.make_table connection name columns ctx on_problems=Problem_Behavior.Report_Error
 
     ## Any problems are treated as errors - e.g. if the query
        contains clashing column names, it may very likely lead to

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
@@ -4,6 +4,7 @@
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - create url:Standard.Base.Any.Any properties:Standard.Base.Any.Any make_new:Standard.Base.Any.Any schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
@@ -12,6 +12,7 @@
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:(Standard.Database.SQL_Query.SQL_Query_With_Schema|Standard.Database.SQL_Query.SQL_Query) alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:(Standard.Database.SQL_Query.SQL_Query_With_Schema|Standard.Database.SQL_Query.SQL_Query) limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -201,7 +201,7 @@ type DuckDB_Connection
             SQL_Query.Table_Name name -> SQL_Query_With_Schema.Table_Name name ""
             SQL_Query.Raw_SQL sql -> SQL_Query_With_Schema.Raw_SQL sql
             _ : SQL_Query_With_Schema -> query
-        self.connection.query used_query alias
+        used_query.to_db_table self alias
 
     ## ---
        aliases: [import, load, open, query, sql]

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -8,6 +8,7 @@ import Standard.Table.Rows_To_Read.Rows_To_Read
 from Standard.Table import Table
 
 from Standard.Database import Column_Description, DB_Table, SQL_Query, SQL_Query_With_Schema
+import Standard.Database.DB_Table as DB_Table_Module
 import Standard.Database.Connection.Connection.Connection
 import Standard.Database.Dialects.Dialect
 import Standard.Database.Internal.JDBC_Connection
@@ -278,6 +279,21 @@ type DuckDB_Connection
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a `DB_Table` that is not backed by an existing table in the
+       Database, but is created in a query by constructing a `VALUES` expression.
+       We limit these tables to at most 256 cells to avoid creating too large
+       queries. If you need a larger table, create a temporary table instead.
+       Note that the types of columns in the created table will depend on how the
+       Database interprets the provided values and may not reflect the types of
+       the source table. If you need more sophisticated type mapping mechanism,
+       use `create_table` instead.
+    create_literal_table self (source : Table) (alias : Text) -> Table & DB_Table =
+        DB_Table_Module.make_literal_table self (source.columns.map .to_vector) source.column_names alias
 
     ## ---
        advanced: true

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -17,6 +17,7 @@ import Standard.Database.SQL.SQL_Statement
 from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_name_with_schema_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
+from Standard.Database.Internal.Upload.Operations.Create import create_table_implementation
 
 import project.Internal.DuckDB_Entity_Naming_Properties
 
@@ -278,7 +279,7 @@ type DuckDB_Connection
     @structure make_structure_creator
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
-        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+        create_table_implementation self table_name structure primary_key temporary allow_existing on_problems
 
     ## ---
        private: true

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -393,6 +393,20 @@ type DuckDB_Connection
     base_connection self = self.connection
 
     ## ---
+       icon: metadata
+       ---
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        self.base_connection.fetch_primary_key table_name schema_name
+
+    ## ---
        private: true
        ---
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -13,7 +13,7 @@ import Standard.Database.Dialects.Dialect
 import Standard.Database.Internal.JDBC_Connection
 import Standard.Database.Internal.Postgres.Postgres_Type_Mapping.Postgres_Type_Mapping
 import Standard.Database.SQL.SQL_Statement
-from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_with_schema_selector, make_table_types_selector
+from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_name_with_schema_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/Connection/SQLServer_Query.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/Connection/SQLServer_Query.md
@@ -4,5 +4,5 @@
     - Raw_SQL sql:Standard.Base.Data.Text.Text=
     - Table_Name name:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text=
     - From that:Standard.Database.SQL_Query.SQL_Query -> Standard.Base.Any.Any
-    - to_db_table self connection:Standard.Database.Connection.Connection.Connection alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
+    - to_db_table self connection:Standard.Base.Any.Any alias:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
 - Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query.from that:Standard.Base.Data.Text.Text -> Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -12,6 +12,7 @@
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:(Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query|Standard.Database.SQL_Query.SQL_Query) alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:(Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query|Standard.Database.SQL_Query.SQL_Query) limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -4,6 +4,7 @@
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - create url:Standard.Base.Any.Any properties:Standard.Base.Any.Any make_new:Standard.Base.Any.Any data_link_setup:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Query.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Query.enso
@@ -15,7 +15,7 @@ type SQLServer_Query
     ## ---
        private: true
        ---
-    to_db_table self connection:Connection alias:Text = alias.if_not_error <| case self of
+    to_db_table self connection alias:Text = alias.if_not_error <| case self of
         SQLServer_Query.Table_Name name schema ->
             table_naming_helper = connection.base_connection.table_naming_helper
             table_naming_helper.verify_table_name name <|

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Query.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Query.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Database.Connection.Connection.Connection
 import Standard.Database.SQL_Query.SQL_Query
 from Standard.Database.Internal.JDBC_Connection import handle_sql_errors
 from Standard.Database.SQL_Query import make_table_for_name, make_table_from_query

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -165,14 +165,15 @@ type SQLServer_Dialect
        Prepares a distinct operation.
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
-        table_name_deduplicator = table.connection.base_connection.table_naming_helper.create_unique_name_strategy
+        table_connection = Internals_Access.get_connection table
+        table_name_deduplicator = table_connection.base_connection.table_naming_helper.create_unique_name_strategy
         table_name_deduplicator.mark_used table.name
         inner_table_alias = table_name_deduplicator.make_unique table.name+"_inner"
         setup = table.context.as_subquery inner_table_alias [table.internal_columns]
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = table.connection.type_mapping
+        mapping = table_connection.type_mapping
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get
             Database_Distinct_Helper.make_distinct_expression case_sensitivity problem_builder column value_type

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -378,15 +378,6 @@ type SQLServer_Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        Connection.default_fetch_primary_key connection table_name schema_name
-
-    ## ---
-       private: true
-       ---
        Prepares metadata for an operation taking a date/time period and checks if
        the given period is supported.
     prepare_metadata_for_period : Date_Period | Time_Period -> Value_Type -> Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -408,6 +408,20 @@ type SQLServer_Connection
         self.base_connection.save_as_data_link path on_existing_file
 
     ## ---
+       icon: metadata
+       ---
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        self.base_connection.fetch_primary_key table_name schema_name
+
+    ## ---
        private: true
        ---
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -10,6 +10,7 @@ from Standard.Table import Table
 
 import Standard.Database.Column_Description.Column_Description
 import Standard.Database.Connection.Connection.Connection
+import Standard.Database.DB_Table as DB_Table_Module
 import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Internal.Common.Connections_Helpers
 import Standard.Database.Internal.Common.Encoding_Limited_Naming_Properties.Encoding_Limited_Naming_Properties
@@ -284,6 +285,21 @@ type SQLServer_Connection
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a `DB_Table` that is not backed by an existing table in the
+       Database, but is created in a query by constructing a `VALUES` expression.
+       We limit these tables to at most 256 cells to avoid creating too large
+       queries. If you need a larger table, create a temporary table instead.
+       Note that the types of columns in the created table will depend on how the
+       Database interprets the provided values and may not reflect the types of
+       the source table. If you need more sophisticated type mapping mechanism,
+       use `create_table` instead.
+    create_literal_table self (source : Table) (alias : Text) -> Table & DB_Table =
+        DB_Table_Module.make_literal_table self (source.columns.map .to_vector) source.column_names alias
 
     ## ---
        advanced: true

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -18,7 +18,7 @@ import Standard.Database.Internal.Data_Link_Setup.Data_Link_Setup
 import Standard.Database.Internal.JDBC_Connection
 import Standard.Database.SQL.SQL_Statement
 import Standard.Database.SQL_Query.SQL_Query
-from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_with_schema_selector, make_table_types_selector
+from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_name_with_schema_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -207,7 +207,7 @@ type SQLServer_Connection
             SQL_Query.Table_Name name -> SQLServer_Query.Table_Name name ""
             SQL_Query.Raw_SQL sql -> SQLServer_Query.Raw_SQL sql
             _ : SQLServer_Query -> query
-        self.connection.query used_query alias
+        used_query.to_db_table self alias
 
     ## ---
        aliases: [import, load, open, query, sql]

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -22,6 +22,7 @@ import Standard.Database.SQL_Query.SQL_Query
 from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_name_with_schema_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
+from Standard.Database.Internal.Upload.Operations.Create import create_table_implementation
 
 import project.Connection.SQLServer_Query.SQLServer_Query
 import project.Internal.SQLServer_Dialect
@@ -284,7 +285,7 @@ type SQLServer_Connection
     @structure make_structure_creator
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
-        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+        create_table_implementation self table_name structure primary_key temporary allow_existing on_problems
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -11,6 +11,7 @@
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -3,6 +3,7 @@
 - type Snowflake_Connection
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
+    - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -339,15 +339,6 @@ type Snowflake_Dialect
     ## ---
        private: true
        ---
-       The dialect-dependent strategy to get the Primary Key for a given table.
-       Returns `Nothing` if the key is not defined.
-    fetch_primary_key : Connection -> Text -> Text -> Vector Text ! Nothing
-    fetch_primary_key self connection table_name schema_name =
-        Connection.default_fetch_primary_key connection table_name schema_name
-
-    ## ---
-       private: true
-       ---
        Prepares metadata for an operation taking a date/time period and checks if
        the given period is supported.
     prepare_metadata_for_period : Date_Period | Time_Period -> Value_Type -> Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -11,7 +11,6 @@ from Standard.Table import Aggregate_Column, Column, Table, Value_Type
 from Standard.Table.Aggregate_Column.Aggregate_Column import all
 from Standard.Table.Errors import Inexact_Type_Coercion
 
-import Standard.Database.Connection.Connection.Connection
 import Standard.Database.DB_Column.DB_Column
 import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Dialects.Dialect

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -163,14 +163,15 @@ type Snowflake_Dialect
        Prepares a distinct operation.
     prepare_distinct : DB_Table -> Vector -> Case_Sensitivity -> Problem_Builder -> Table & DB_Table
     prepare_distinct self table key_columns case_sensitivity problem_builder =
-        table_name_deduplicator = (Internals_Access.get_connection table).base_connection.table_naming_helper.create_unique_name_strategy
+        table_connection = Internals_Access.get_connection table
+        table_name_deduplicator = table_connection.base_connection.table_naming_helper.create_unique_name_strategy
         table_name_deduplicator.mark_used table.name
         inner_table_alias = table_name_deduplicator.make_unique table.name+"_inner"
         setup = (Internals_Access.get_context table).as_subquery inner_table_alias [Internals_Access.internal_columns table]
         new_columns = setup.new_columns.first
         column_mapping = Dictionary.from_vector <| new_columns.map c-> [c.name, c]
         new_key_columns = key_columns.map c-> column_mapping.at c.name
-        mapping = table.connection.type_mapping
+        mapping = table_connection.type_mapping
         # TODO simpler distinct if distinct_expressions are all columns?
         distinct_expressions = new_key_columns.map column->
             value_type = mapping.sql_type_to_value_type column.sql_type_reference.get

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -24,6 +24,7 @@ import Standard.Database.SQL_Query.SQL_Query
 from Standard.Database.Connection.Connection import make_database_selector, make_schema_selector, make_structure_creator, make_table_name_selector, make_table_types_selector
 from Standard.Database.Errors import SQL_Error, Table_Already_Exists, Table_Not_Found
 from Standard.Database.Internal.Upload.Helpers.Default_Arguments import first_column_name_in_structure
+from Standard.Database.Internal.Upload.Operations.Create import create_table_implementation
 
 import project.Connection.Key_Pair_Credentials.Key_Pair_Credentials
 import project.Internal.Snowflake_Dialect
@@ -306,7 +307,7 @@ type Snowflake_Connection
     @structure make_structure_creator
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
-        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+        create_table_implementation self table_name structure primary_key temporary allow_existing on_problems
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -429,6 +429,20 @@ type Snowflake_Connection
         self.base_connection.save_as_data_link path on_existing_file
 
     ## ---
+       icon: metadata
+       ---
+       Get the Primary Key for a given table.
+       Returns `Nothing` if the key is not defined.
+
+       ## Arguments
+       - `table_name`: the name of the table to get the primary key for.
+       - `schema_name`: optionally, the schema name where the table is located.
+    @table_name make_table_name_selector add_custom=False
+    fetch_primary_key : Text -> Text -> Vector Text ! Nothing
+    fetch_primary_key self table_name:Text schema_name:Text="" =
+        self.base_connection.fetch_primary_key table_name schema_name
+
+    ## ---
        private: true
        ---
        Converts this value to a JSON serializable object.

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -228,7 +228,8 @@ type Snowflake_Connection
           not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
     query : SQL_Query -> Text -> Table & DB_Table ! Table_Not_Found
-    query self query:SQL_Query alias="" = self.connection.query query alias
+    query self query:SQL_Query alias="" =
+        query.to_db_table self alias
 
     ## ---
        aliases: [import, load, open, query, sql]

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -13,6 +13,7 @@ from Standard.Table import Table
 import Standard.Database.Column_Description.Column_Description
 import Standard.Database.Connection.Connection.Connection
 import Standard.Database.Connection.Credentials.Credentials
+import Standard.Database.DB_Table as DB_Table_Module
 import Standard.Database.DB_Table.DB_Table
 import Standard.Database.Internal.Common.Connections_Helpers
 import Standard.Database.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Properties
@@ -306,6 +307,21 @@ type Snowflake_Connection
     create_table : Text  -> Vector Column_Description | Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Table & DB_Table ! Table_Already_Exists
     create_table self (table_name : Text) (structure : Vector Column_Description | Table) (primary_key : (Vector Text | Nothing) = [first_column_name_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = ..Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a `DB_Table` that is not backed by an existing table in the
+       Database, but is created in a query by constructing a `VALUES` expression.
+       We limit these tables to at most 256 cells to avoid creating too large
+       queries. If you need a larger table, create a temporary table instead.
+       Note that the types of columns in the created table will depend on how the
+       Database interprets the provided values and may not reflect the types of
+       the source table. If you need more sophisticated type mapping mechanism,
+       use `create_table` instead.
+    create_literal_table self (source : Table) (alias : Text) -> Table & DB_Table =
+        DB_Table_Module.make_literal_table self (source.columns.map .to_vector) source.column_names alias
 
     ## ---
        advanced: true

--- a/test/AWS_Tests/src/Redshift_Spec.enso
+++ b/test/AWS_Tests/src/Redshift_Spec.enso
@@ -71,7 +71,7 @@ add_database_specs suite_builder create_connection_fn =
         in_mem_table = Table.new columns
         in_mem_table.select_into_database_table (connection.if_nothing default_connection.get) name primary_key=Nothing temporary=True
     light_table_builder columns =
-        default_connection.get.base_connection.create_literal_table (Table.new columns) "literal_table"
+        default_connection.get.create_literal_table (Table.new columns) "literal_table"
     materialize = .read
 
     common_selection = Common_Table_Operations.Main.Test_Selection.Config run_advanced_edge_case_tests_by_default=False

--- a/test/Microsoft_Tests/src/SQLServer_Spec.enso
+++ b/test/Microsoft_Tests/src/SQLServer_Spec.enso
@@ -185,7 +185,7 @@ add_sqlserver_specs suite_builder create_connection_fn =
     light_table_builder columns = table_builder columns
     
     ## TODO need to be able to type_hint the nulls for this to work 
-       light_table_builder columns = default_connection.get.base_connection.create_literal_table (Table.new columns) "literal_table"
+       light_table_builder columns = default_connection.get.create_literal_table (Table.new columns) "literal_table"
        https://github.com/enso-org/enso/issues/11487
 
     materialize = .read

--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -530,7 +530,7 @@ add_snowflake_specs suite_builder create_connection_fn db_name =
         in_mem_table = Table.new columns
         in_mem_table.select_into_database_table (connection.if_nothing default_connection.get) name primary_key=Nothing temporary=True
     light_table_builder columns =
-        default_connection.get.base_connection.create_literal_table (Table.new columns) "literal_table"
+        default_connection.get.create_literal_table (Table.new columns) "literal_table"
     materialize = .read
 
     common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=supported_replace_params run_advanced_edge_case_tests_by_default=False

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -717,7 +717,7 @@ add_postgres_specs suite_builder create_connection_fn db_name =
         in_mem_table = Table.new columns
         in_mem_table.select_into_database_table (connection.if_nothing default_connection.get) name primary_key=Nothing temporary=True
     light_table_builder columns =
-        default_connection.get.base_connection.create_literal_table (Table.new columns) "literal_table"
+        default_connection.get.create_literal_table (Table.new columns) "literal_table"
 
     materialize = .read
 

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -331,7 +331,7 @@ sqlite_spec suite_builder prefix create_connection_func persistent_connector =
         in_mem_table = Table.new columns
         in_mem_table.select_into_database_table (connection.if_nothing default_connection.get) name primary_key=Nothing
     light_table_builder columns =
-        default_connection.get.base_connection.create_literal_table (Table.new columns) "literal_table"
+        default_connection.get.create_literal_table (Table.new columns) "literal_table"
 
     materialize = .read
 


### PR DESCRIPTION
### Pull Request Description

- Snowflake and Microsoft were trying to access the connection of a `DB_Table`. 
  - Fixed to now use `Internal_Access`.
  - Also amended all other dialects to use this, so they can all be moved out of `Database` later.
- Moved `fetch_primary_key` to Connection and made public.
- `connection` within `DB_Table` and `DB_Column` is now the type-specific connection.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
