### PR TITLE
Improved `OtherJvmClassLoader` API to simplify direct class loading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2220,6 +2220,9 @@ lazy val `engine-common` = project
   .enablePlugins(JPMSPlugin)
   .settings(
     frgaalJavaCompilerSetting,
+    publishLocalSetting,
+    autoScalaLibrary := false,
+    crossPaths := false,
     Test / fork := true,
     commands += WithDebugCommand.withDebug,
     Test / envVars ++= distributionEnvironmentOverrides,
@@ -4358,7 +4361,9 @@ lazy val `jvm-channel` =
     .enablePlugins(JPMSPlugin)
     .settings(
       customFrgaalJavaCompilerSettings(targetJdk = "24"),
+      publishLocalSetting,
       autoScalaLibrary := false,
+      crossPaths := false,
       (Test / fork) := true,
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= Seq(
@@ -4393,7 +4398,9 @@ lazy val `jvm-interop` =
       inConfig(Compile)(
         Seq(fork := true, javaOptions ++= Seq("-ea:org.enso.jvm..."))
       ),
+      publishLocalSetting,
       autoScalaLibrary := false,
+      crossPaths := false,
       (Test / fork) := true,
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= Seq(

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
@@ -412,12 +412,20 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
         // read length
         len = buffer.getLong();
         // read address
-        var overflowSegment = MemorySegment.ofAddress(buffer.getLong()).reinterpret(len);
-        buffer = overflowSegment.asByteBuffer();
+        var addr = buffer.getLong();
+        if (ImageInfo.inImageRuntimeCode()) {
+          var overflowPtr = WordFactory.pointer(addr);
+          buffer =
+              CTypeConversion.asByteBuffer(overflowPtr, Math.toIntExact(len))
+                  .order(ByteOrder.BIG_ENDIAN);
+        } else {
+          var overflowSegment = MemorySegment.ofAddress(addr).reinterpret(len);
+          buffer = overflowSegment.asByteBuffer();
+        }
       }
       assert len >= 0;
       buffer.position(0);
-      buffer.limit((int) len);
+      buffer.limit(Math.toIntExact(len));
       var result = pool.read(buffer);
       return result.get(replyType);
     } catch (IOException ex) {

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
@@ -20,17 +20,32 @@ import org.enso.jvm.channel.JVM;
 import org.enso.jvm.interop.impl.OtherJvmMessage;
 import org.enso.jvm.interop.impl.OtherJvmPool;
 import org.enso.jvm.interop.impl.OtherJvmResult;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 /**
- * Class responsible for loading Java classes from <em>other JVM</em> connected via a {@link
- * Channel}.
+ * Responsible for loading Java classes from <em>other JVM</em> connected via a {@link Channel}.
+ * Provides basic methods for direct configuration, but also exposes its functionality with {@link
+ * TruffleObject} messages.
  */
 @ExportLibrary(InteropLibrary.class)
-public final class OtherJvmClassLoader implements TruffleObject {
+public final class OtherJvmClassLoader implements TruffleObject, AutoCloseable {
   private final Channel<OtherJvmPool> channel;
+  private Context ctx;
 
   private OtherJvmClassLoader(Channel<OtherJvmPool> ch) {
     this.channel = ch;
+  }
+
+  /**
+   * Creates instance of the class loader.
+   *
+   * @param jvm the "other" JVM to load classes from (can be {@code null} to mock the system inside
+   *     of the existing JVM)
+   * @return new instance of the class loader from the provided JVM
+   */
+  public static OtherJvmClassLoader create(JVM jvm) {
+    return createImpl(jvm, null, null);
   }
 
   /**
@@ -52,12 +67,63 @@ public final class OtherJvmClassLoader implements TruffleObject {
       TruffleContext ctx)
       throws IOException, URISyntaxException {
     var jvm = otherJvm ? initializeJvm(mainModule) : null;
+    return createImpl(jvm, ctx, language);
+  }
+
+  /**
+   * Adds provided directory to the classpath.
+   *
+   * @param dir directory to add to classpath
+   */
+  public final void addPath(File dir) {
+    addPath(dir.getAbsolutePath());
+  }
+
+  /**
+   * Loads a class as a value.
+   *
+   * @param fqn fully qualified name of class to load
+   * @return
+   */
+  public final Value loadClass(String fqn) {
+    try {
+      var rawClass = loadRawClass(fqn);
+      if (ctx == null) {
+        ctx = Context.create("hosted");
+      }
+      return ctx.asValue(rawClass);
+    } catch (ClassNotFoundException ex) {
+      throw new IllegalArgumentException(ex);
+    }
+  }
+
+  /** Closes the loader. Closes associated channel and/or context. */
+  @Override
+  public final void close() {
+    try {
+      channel.close();
+    } catch (AbstractTruffleException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new org.enso.jvm.interop.impl.OtherJvmException(ex);
+    }
+    if (ctx != null) {
+      ctx.close();
+    }
+  }
+
+  private static OtherJvmClassLoader createImpl(
+      JVM jvm, TruffleContext ctx, Class<? extends TruffleLanguage> language) {
     var ch = Channel.create(jvm, OtherJvmPool.class);
     var pool = ch.getConfig();
     if (ctx != null) {
       pool.onEnterLeave(language, ctx::enter, ctx::leave);
     }
     return new OtherJvmClassLoader(ch);
+  }
+
+  private void addPath(String path) {
+    channel.execute(Void.class, new OtherJvmMessage.AddToClassPath(path));
   }
 
   @ExportMessage
@@ -83,7 +149,7 @@ public final class OtherJvmClassLoader implements TruffleObject {
   @ExportMessage
   final TruffleObject readMember(String name) throws UnknownIdentifierException {
     try {
-      return loadClass(name);
+      return loadRawClass(name);
     } catch (ClassNotFoundException ex) {
       throw UnknownIdentifierException.create(name, ex);
     }
@@ -96,7 +162,7 @@ public final class OtherJvmClassLoader implements TruffleObject {
     switch (name) {
       case "addPath" -> {
         var path = InteropLibrary.getUncached().asString(args[0]);
-        channel.execute(Void.class, new OtherJvmMessage.AddToClassPath(path));
+        addPath(path);
       }
       case "findLibraries" -> {
         if (args[0] instanceof TruffleObject obj) {
@@ -106,13 +172,7 @@ public final class OtherJvmClassLoader implements TruffleObject {
         }
       }
       case "close" -> {
-        try {
-          channel.close();
-        } catch (AbstractTruffleException ex) {
-          throw ex;
-        } catch (Exception ex) {
-          throw new org.enso.jvm.interop.impl.OtherJvmException(ex);
-        }
+        close();
       }
       default -> throw UnknownIdentifierException.create(name);
     }
@@ -120,7 +180,7 @@ public final class OtherJvmClassLoader implements TruffleObject {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private final TruffleObject loadClass(String name) throws ClassNotFoundException {
+  private final TruffleObject loadRawClass(String name) throws ClassNotFoundException {
     var result = channel.execute(OtherJvmResult.class, new OtherJvmMessage.LoadClass(name));
     return result.value(null);
   }

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
@@ -102,14 +102,17 @@ public final class OtherJvmClassLoader implements TruffleObject, AutoCloseable {
   @Override
   public final void close() {
     try {
-      channel.close();
+      try {
+        channel.close();
+      } finally {
+        if (ctx != null) {
+          ctx.close();
+        }
+      }
     } catch (AbstractTruffleException ex) {
       throw ex;
     } catch (Exception ex) {
       throw new org.enso.jvm.interop.impl.OtherJvmException(ex);
-    }
-    if (ctx != null) {
-      ctx.close();
     }
   }
 

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
@@ -90,9 +90,7 @@ public final class OtherJvmClassLoader implements TruffleObject, AutoCloseable {
     try {
       var rawClass = loadRawClass(fqn);
       if (ctx == null) {
-        ctx = Context.newBuilder("hosted")
-            .allowHostAccess(HostAccess.ALL)
-            .build();
+        ctx = Context.newBuilder("hosted").allowHostAccess(HostAccess.ALL).build();
       }
       return ctx.asValue(rawClass);
     } catch (ClassNotFoundException ex) {

--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/api/OtherJvmClassLoader.java
@@ -21,6 +21,7 @@ import org.enso.jvm.interop.impl.OtherJvmMessage;
 import org.enso.jvm.interop.impl.OtherJvmPool;
 import org.enso.jvm.interop.impl.OtherJvmResult;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.Value;
 
 /**
@@ -89,7 +90,9 @@ public final class OtherJvmClassLoader implements TruffleObject, AutoCloseable {
     try {
       var rawClass = loadRawClass(fqn);
       if (ctx == null) {
-        ctx = Context.create("hosted");
+        ctx = Context.newBuilder("hosted")
+            .allowHostAccess(HostAccess.ALL)
+            .build();
       }
       return ctx.asValue(rawClass);
     } catch (ClassNotFoundException ex) {

--- a/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
+++ b/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
@@ -14,11 +14,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LoadClassTest {
-  // TBD: Make the number bigger again
-  //   - which currently exceeds the maximum size of a message
-  //   - so fix it
-  private static final int MAX = 5; // 5000;
-  private static final int MIN = 1; // 1000;
+  private static final int MAX = 5000;
+  private static final int MIN = 1000;
   private static final String PATH = System.getProperty("java.home");
   // set from TestCollectorFeature
   public static String MODULE_PATH;

--- a/lib/java/ydoc-server-registration/src/main/java/org/enso/ydoc/server/registration/YdocServerImpl.java
+++ b/lib/java/ydoc-server-registration/src/main/java/org/enso/ydoc/server/registration/YdocServerImpl.java
@@ -7,7 +7,6 @@ import org.enso.jvm.interop.api.OtherJvmClassLoader;
 import org.enso.runner.common.WrongOption;
 import org.enso.runner.common.YdocServerApi;
 import org.graalvm.nativeimage.ImageInfo;
-import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.proxy.ProxyArray;
 
 public final class YdocServerImpl extends YdocServerApi {
@@ -20,9 +19,7 @@ public final class YdocServerImpl extends YdocServerApi {
     //   return launch(hostname, port);
     // but in the other JVM
     var isAot = ImageInfo.inImageRuntimeCode();
-    var ctx = Context.create("hosted");
-    var rawLoader = OtherJvmClassLoader.create("org.enso.ydoc.server", null, isAot, null);
-    var loader = ctx.asValue(rawLoader);
+    var loader = OtherJvmClassLoader.create("org.enso.ydoc.server", null, isAot, null);
     if (isAot) {
       // in AOT mode the org.enso.ydoc.server is the main module loaded
       // to the JVM's boot layer - e.g. its classes are available
@@ -38,16 +35,13 @@ public final class YdocServerImpl extends YdocServerApi {
                   .toURI());
       var ydocServerJar = new File(myJar.getParentFile(), "ydoc-server.jar");
       assert ydocServerJar.exists() : "Found " + ydocServerJar;
-      loader.invokeMember("addPath", ydocServerJar.getPath());
+      loader.addPath(ydocServerJar);
     }
     var fqn = "org.enso.ydoc.server.Main";
-    var impl = loader.getMember(fqn);
+    var impl = loader.loadClass(fqn);
     assert impl != null;
     var arr = ProxyArray.fromArray(hostname, "" + port);
     impl.invokeMember("main", arr);
-    return () -> {
-      loader.invokeMember("close");
-      ctx.close();
-    };
+    return loader;
   }
 }


### PR DESCRIPTION
### Pull Request Description

With these changes I am able to `sbt publishM2` and then use this _dual JVM_ mode in a separate Maven project.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
