### PR TITLE
Fix local docker build

### DIFF
--- a/tools/ci/docker/engine/Dockerfile
+++ b/tools/ci/docker/engine/Dockerfile
@@ -30,6 +30,8 @@ ENV ENSO_RUNTIME_DIRECTORY=/opt/enso/work
 ENV ENSO_LOG_DIRECTORY=/opt/enso/logs
 ENV ENSO_HOME=/volumes/workspace/home
 
+RUN mkdir -p /opt/enso
+RUN chown -hR ensodev:ensodev /opt/enso
 COPY --chown=ensodev:ensodev --chmod=555 bin /opt/enso/bin
 COPY --chown=ensodev:ensodev --chmod=555 --from=docker-tools docker-entrypoint.sh /opt/enso/bin/
 COPY --chown=ensodev:ensodev --chmod=554 component /opt/enso/component


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Fixes the issue when building the image locally
```
#17 ERROR: process "/bin/sh -c mkdir -m 777 /opt/enso/work" did not complete successfully: exit code: 1
------
 > [stage-0 11/14] RUN mkdir -m 777 /opt/enso/work:
0.189 mkdir: cannot create directory '/opt/enso/work': Permission denied
------
Dockerfile:55
--------------------
  53 |     USER ensodev:ensodev
  54 |     
  55 | >>> RUN mkdir -m 777 /opt/enso/work
  56 |     RUN mkdir -m 777 /opt/enso/logs
  57 |     RUN mkdir -m 777 /opt/enso/profiling
--------------------
ERROR: failed to solve: process "/bin/sh -c mkdir -m 777 /opt/enso/work" did not complete successfully: exit code: 1
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
