### PR TITLE
Fix application config overriding in native image

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/config/ApplicationConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/config/ApplicationConfig.scala
@@ -11,7 +11,8 @@ object ApplicationConfig {
   private val ConfigFilename  = "application.conf"
   private val ConfigNamespace = "language-server"
 
-  def load(): ApplicationConfig = {
+  /** Load the configuration from the config file. */
+  private def loadConfig(): ApplicationConfig = {
     val contextClassLoader = Thread.currentThread().getContextClassLoader
     try {
       Thread.currentThread().setContextClassLoader(getClass.getClassLoader)
@@ -21,6 +22,26 @@ object ApplicationConfig {
         .at(ConfigNamespace)
         .loadOrThrow[ApplicationConfig]
     } finally Thread.currentThread().setContextClassLoader(contextClassLoader)
+  }
+
+  /** Override the configuration with environment variables.
+    *
+    * This is a workaround for the issue that the standard config overloading
+    * does not work in the native image.
+    */
+  private def overrideConfig(config: ApplicationConfig): ApplicationConfig = {
+    val ydocHostname =
+      sys.env.getOrElse("LANGUAGE_SERVER_YDOC_HOSTNAME", config.ydoc.hostname)
+    val ydocPort = sys.env
+      .get("LANGUAGE_SERVER_YDOC_PORT")
+      .map(_.toInt)
+      .getOrElse(config.ydoc.port)
+
+    config.copy(ydoc = YdocConfig(hostname = ydocHostname, port = ydocPort))
+  }
+
+  def load(): ApplicationConfig = {
+    overrideConfig(loadConfig())
   }
 
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

Tested manually

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

A quick fix for the issue with application config overriding with environment variables in native image.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
