### PR TITLE
Avoid `writeUTF` random test failure because of too long string

### DIFF
--- a/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
+++ b/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
@@ -14,8 +14,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LoadClassTest {
-  private static final int MAX = 5000;
-  private static final int MIN = 1000;
+  private static final int MAX = 3000;
+  private static final int MIN = 300;
   private static final String PATH = System.getProperty("java.home");
   // set from TestCollectorFeature
   public static String MODULE_PATH;


### PR DESCRIPTION
### Pull Request Description

Avoiding following failure when `sbt os-environment/test`:
```
 java.lang.IllegalStateException: java.io.UTFDataFormatException: encoded string (18192063...00000000) too long: 77338 bytes
  at org.enso.jvm.channel.Channel.checkForException(Channel.java:373)
  at org.enso.jvm.channel.Channel.toHotSpotMessage(Channel.java:329)
  at org.enso.jvm.channel.Channel.executeImpl(Channel.java:393)
  at org.enso.jvm.channel.Channel.execute(Channel.java:241)
  at org.enso.os.environment.jni.LoadClassTest.computeFactorialViaMessages(LoadClassTest.java:70)
  at java.base@24.0.1/java.lang.reflect.Method.invoke(Method.java:565)
  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
  at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
  at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
  at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
  at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
  at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
  at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
```
this could happen when the random numbers were too close to `MAX`. With 3000 limit, the test never exceeds those 64KB of string size.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
