### PR TITLE
Bypass language server timeout in debug mode

### DIFF
--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -54,6 +54,7 @@ interface RunningProject {
 }
 
 const DEFAULT_JSONRPC_PORT = 30616
+const LANGUAGE_SERVER_STARTUP_TIMEOUT = 30000
 
 /** Implementation of Runner that uses the Enso executable. */
 export class EnsoRunner implements Runner {
@@ -238,13 +239,17 @@ export class EnsoRunner implements Runner {
           }
         })
 
-        // Timeout after 30 seconds if server doesn't start
-        setTimeout(() => {
-          if (!resolved) {
-            serverProcess.kill('SIGKILL')
-            reject(new Error('Language server startup timeout'))
-          }
-        }, 30000)
+        // Timeout if server doesn't start (skip timeout in debug mode)
+        const javaToolOptions = process.env.JAVA_TOOL_OPTIONS
+        const isDebugMode = javaToolOptions?.includes('jdwp')
+        if (!isDebugMode) {
+          setTimeout(() => {
+            if (!resolved) {
+              serverProcess.kill('SIGKILL')
+              reject(new Error('Language server startup timeout'))
+            }
+          }, LANGUAGE_SERVER_STARTUP_TIMEOUT)
+        }
       })
     })
     this.loadingProjects.set(projectId, promise)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- close #14205 

When debugging the language server, do not kill the process by timeout (the process may be waiting in the debugger)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
