### PR TITLE
Snowflake Stage Operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [Add Text_Column.upper and Text_Column.lower.][14179]
 - [Microsoft 365 OAuth support.][14135]
 - [Add Text_Column.proper and Rename Case.Title->Case.Proper.][14184]
+- [Snowflake stage support for reading and writing files.][14210]
 
 [13769]: https://github.com/enso-org/enso/pull/13769
 [14026]: https://github.com/enso-org/enso/pull/14026
@@ -51,6 +52,7 @@
 [14157]: https://github.com/enso-org/enso/pull/14157
 [14179]: https://github.com/enso-org/enso/pull/14179
 [14184]: https://github.com/enso-org/enso/pull/14184
+[14210]: https://github.com/enso-org/enso/pull/14210
 
 #### Enso Language & Runtime
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error.enso
@@ -208,7 +208,7 @@ type Error
     is_error self = True
 
     ## ---
-       private: true
+       icon: warning
        advanced: true
        ---
        Returns the provided `other` value, unless `self` is an error.
@@ -340,7 +340,7 @@ Any.map_error self ~f =
 Any.is_error self -> Boolean = False
 
 ## ---
-   private: true
+   icon: warning
    advanced: true
    ---
    Returns the provided `other` value, unless `self` is an error.

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -1,5 +1,10 @@
 ## Enso Signatures 1.0
 ## module Standard.Snowflake.Snowflake_Connection
+- type Identifier
+    - Name name:Standard.Base.Data.Text.Text=
+    - Name_And_Schema name:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text=
+    - to_identifier self -> Standard.Base.Any.Any
+    - to_option self -> Standard.Base.Any.Any
 - type Snowflake_Connection
     - base_connection self -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
@@ -13,15 +18,22 @@
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_from_stage self stage:Standard.Snowflake.Snowflake_Connection.Identifier= path:Standard.Base.Data.Text.Text= directory:Standard.Base.Any.Any= pattern:Standard.Base.Data.Text.Text= ~if_not_found:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
+    - list_stage_objects self stage:Standard.Snowflake.Snowflake_Connection.Identifier= path:Standard.Base.Data.Text.Text= limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any
+    - put_to_stage self file:Standard.Base.Any.Any stage:Standard.Snowflake.Snowflake_Connection.Identifier= path:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any
+    - remove_from_stage self stage:Standard.Snowflake.Snowflake_Connection.Identifier= path:Standard.Base.Data.Text.Text= pattern:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - save_as_data_link self path:Standard.Base.Enso_Cloud.Enso_File.Enso_File on_existing_file:Standard.Base.System.File.Existing_File_Behavior.Existing_File_Behavior= -> Standard.Base.Any.Any
     - schema self -> Standard.Base.Any.Any
     - schemas self -> Standard.Base.Any.Any
     - set_database self database:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_schema self schema:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - set_warehouse self warehouse:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - stage_names self -> Standard.Base.Any.Any
+    - stage_properties self stage:Standard.Snowflake.Snowflake_Connection.Identifier= -> Standard.Base.Any.Any
+    - stages self schema:Standard.Base.Data.Text.Text= pattern:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - statement_setter self -> Standard.Base.Any.Any
     - table_types self -> Standard.Base.Any.Any
     - tables self name_like:Standard.Base.Data.Text.Text= database:Standard.Base.Data.Text.Text= schema:Standard.Base.Data.Text.Text= types:Standard.Base.Any.Any= all_fields:Standard.Base.Any.Any= -> Standard.Base.Any.Any
@@ -30,4 +42,9 @@
     - type_mapping self -> Standard.Base.Any.Any
     - warehouse self -> Standard.Base.Any.Any
     - warehouses self -> Standard.Base.Any.Any
+- Standard.Snowflake.Snowflake_Connection.Stage_Not_Found.to_display_text self -> Standard.Base.Any.Any
+- Standard.Snowflake.Snowflake_Connection.Identifier.from that:Standard.Base.Data.Text.Text -> Standard.Snowflake.Snowflake_Connection.Identifier
+- type Stage_Not_Found
+    - Error name:Standard.Base.Data.Text.Text
+    - to_display_text self -> Standard.Base.Any.Any
 - Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data.from that:Standard.Snowflake.Snowflake_Connection.Snowflake_Connection -> Standard.Base.Visualization.Table_Viz_Data.Table_Viz_Data

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -471,11 +471,9 @@ type Snowflake_Connection
     ## ---
        icon: folder
        ---
-       Returns the list of stages for the connection.
+       Returns the list of stages for the current database.
 
        ## Arguments
-        - `database`: The database name to search in (default is current).
-          Use an asterisk (`*`) to search in all databases.
         - `schema`: The schema name to search in (defaults to current). If an
           asterisk (`*`) is provided, all schemas are searched.
         - `pattern`: The stage name pattern to search for. Supports SQL
@@ -496,6 +494,33 @@ type Snowflake_Connection
     stage_names : Vector
     stage_names self =
         self.connection.read_text_column "show stages in database" "name"
+
+    ## ---
+       icon: metadata
+       ---
+       Reads the values specified for the properties in a stage (file format,
+       copy, and location), as well as the default values for each property.
+
+       ## Arguments
+        - `stage_name`: The name of the stage to read the properties from.
+    stage_properties : Text -> Table ! Table_Not_Found
+    stage_properties self stage_name:Text =
+        query = 'DESC STAGE "' + (stage_name.replace '"' '""') + '"'
+        self.execute_query query write_operation=False
+
+    ## ---
+       icon: folder
+       ---
+       List all the objects in a stage.
+
+       ## Arguments
+        - `stage_name`: The name of the stage to read the properties from.
+    @stage_name (self-> Single_Choice display=..Always values=(["~"] + self.stage_names).map d-> Option d d.pretty)
+    list_stage_objects : Text -> Text -> Table ! Table_Not_Found
+    list_stage_objects self stage_name:Text="~" prefix:Text="" =
+        query = if stage_name == '~' then 'LIST \'@~' else 'LIST \'@"' + (stage_name.replace '"' '""') + '"'
+            + if prefix == "'" then "" else '/' + (prefix.replace "'" "''") + "'"
+        self.execute_query query write_operation=False
 
 private auth_jdbc_properties credentials = case credentials of
     Credentials.Username_And_Password username password ->

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -528,7 +528,8 @@ type Snowflake_Connection
     @stage make_stage_selector
     list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Table_Not_Found
     list_stage_objects self stage:Identifier="~" prefix:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
-        query = "LIST '@" + stage.to_identifier + if prefix == "" then "'" else '/' + (prefix.replace "'" "''") + "'"
+        stage_and_path = stage.to_identifier + if prefix == "" then "" else '/' + prefix
+        query = "LIST '@" + (stage_and_path.replace "'" "''") + "'"
         self.execute_query query limit write_operation=False
 
 ## Snowflake Identifier - with optional schema.

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
+import Standard.Base.Errors.Common.Not_Found
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.File_Type
 import Standard.Base.Runtime.Context as Execution_Context
@@ -560,7 +561,10 @@ type Snowflake_Connection
                 stage_and_path = identifier + if path == "" then "" else '/' + path
                 file_uri = "'file://" + (directory.path.replace "\" "/" . replace "'" "''") + "'"
                 query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
-                self.execute_query query write_operation=True
+                table = self.execute_query query write_operation=True
+                table.if_not_error <|
+                    if table.row_count > 0 then table else
+                        Error.throw Not_Found
 
     ## ---
        icon: trash2

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -5,7 +5,7 @@ import Standard.Base.Metadata.File_Type
 import Standard.Base.Runtime.Context as Execution_Context
 from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import File_Browse, Single_Choice, Text_Input
+from Standard.Base.Metadata.Widget import File_Browse, Folder_Browse, Single_Choice, Text_Input
 from Standard.Base.Visualization.Table_Viz_Data import Table_Viz_Data, Table_Viz_Header
 
 import Standard.Table.Rows_To_Read.Rows_To_Read

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -532,6 +532,7 @@ type Snowflake_Connection
        - `stage`: The name (and optionally schema) of the stage to read the
           properties from.
        - `path`: The path (or prefix) to the files to list.
+       - `limit`: The maximum number of rows to read.
     @stage make_stage_selector
     list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Stage_Not_Found
     list_stage_objects self stage:Identifier="~" path:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
@@ -545,6 +546,7 @@ type Snowflake_Connection
        icon: data_download
        ---
        Download one or more files from a stage to a local folder.
+       This will overwrite existing files.
 
        ## Arguments
        - `stage`: The name (and optionally schema) of the stage to read the
@@ -561,10 +563,11 @@ type Snowflake_Connection
                 stage_and_path = identifier + if path == "" then "" else '/' + path
                 file_uri = "'file://" + (directory.path.replace "\" "/" . replace "'" "''") + "'"
                 query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
-                table = self.execute_query query write_operation=True
+                table = self.execute_query query Rows_To_Read.All_Rows write_operation=True
                 table.if_not_error <|
-                    if table.row_count > 0 then table else
-                        Error.throw Not_Found
+                    if table.row_count == 0 then Error.throw Not_Found else
+                        names = table.at "file" . to_vector
+                        names.map n-> directory / n
 
     ## ---
        icon: trash2

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -515,10 +515,12 @@ type Snowflake_Connection
        ## Returns
        A table containing the properties of the stage.
     @stage make_stage_selector include_home=False
-    stage_properties : Identifier -> Table ! Table_Not_Found
+    stage_properties : Identifier -> Table ! Stage_Not_Found
     stage_properties self stage:Identifier=(Missing_Argument.throw "stage") =
-        query = 'DESC STAGE ' + stage.to_identifier
-        self.execute_query query write_operation=False
+        identifier = stage.to_identifier
+        Stage_Not_Found.rethrow identifier <|
+            query = 'DESC STAGE ' + identifier
+            self.execute_query query write_operation=False
 
     ## ---
        icon: folder
@@ -530,11 +532,13 @@ type Snowflake_Connection
           properties from.
        - `path`: The path (or prefix) to the files to list.
     @stage make_stage_selector
-    list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Table_Not_Found
+    list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Stage_Not_Found
     list_stage_objects self stage:Identifier="~" path:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
-        stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
-        query = "LIST '@" + (stage_and_path.replace "'" "''") + "'"
-        self.execute_query query limit write_operation=False
+        identifier = stage.to_identifier
+        Stage_Not_Found.rethrow identifier <|
+            stage_and_path = identifier + if path == "" then "" else '/' + path
+            query = "LIST '@" + (stage_and_path.replace "'" "''") + "'"
+            self.execute_query query limit write_operation=False
 
     ## ---
        icon: data_download
@@ -548,13 +552,15 @@ type Snowflake_Connection
        - `directory`: The local folder to save the files to.
     @stage make_stage_selector
     @directory (Folder_Browse display=..Always)
-    get_from_stage : Identifier -> Text -> File -> Text -> Table
+    get_from_stage : Identifier -> Text -> File -> Text -> Table ! Stage_Not_Found
     get_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text=(Missing_Argument.throw "path") directory:File=(Missing_Argument.throw "directory") pattern:Text="" =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
-            stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
-            file_uri = "'file://" + (directory.path.replace "\" "/" . replace "'" "''") + "'"
-            query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
-            self.execute_query query write_operation=True
+            identifier = stage.to_identifier
+            Stage_Not_Found.rethrow identifier <|
+                stage_and_path = identifier + if path == "" then "" else '/' + path
+                file_uri = "'file://" + (directory.path.replace "\" "/" . replace "'" "''") + "'"
+                query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
+                self.execute_query query write_operation=True
 
     ## ---
        icon: trash2
@@ -567,12 +573,14 @@ type Snowflake_Connection
        - `path`: The path (or prefix) to the files to remove.
        - `pattern`: Optional regex pattern to match names against.
     @stage make_stage_selector
-    remove_from_stage : Identifier -> Text -> Text -> Table
+    remove_from_stage : Identifier -> Text -> Text -> Table ! Stage_Not_Found
     remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text="" =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
-            stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
-            query = "REMOVE '@" + (stage_and_path.replace "'" "''") + "'" + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
-            self.execute_query query write_operation=True
+            identifier = stage.to_identifier
+            Stage_Not_Found.rethrow identifier <|
+                stage_and_path = identifier + if path == "" then "" else '/' + path
+                query = "REMOVE '@" + (stage_and_path.replace "'" "''") + "'" + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
+                self.execute_query query write_operation=True
 
 ## Snowflake Identifier - with optional schema.
 type Identifier
@@ -598,6 +606,31 @@ type Identifier
         Identifier.Name_And_Schema n s -> Option s+"."+n "(..Name_And_Schema "+n.pretty+" "+s.pretty+")"
 
 Identifier.from (that:Text) = Identifier.Name that
+
+type Stage_Not_Found
+    ## ---
+       private: true
+       ---
+       Indicates that a stage was not found in the database.
+
+       ## Arguments
+        - `name`: The name of the stage that was not found.
+    Error (name:Text)
+
+    ## ---
+       private: true
+       ---
+       Pretty print the stage not found error.
+    to_display_text : Text
+    to_display_text self = "Stage " + self.name + " was not found in the database."
+
+    private rethrow identifier ~action =
+        result = action
+        result.catch SQL_Error error->
+            java_message = error.java_exception.getMessage
+            if (java_message.match ".*Stage .* does not exist or not authorized.") == False then Error.throw result else
+                Error.throw (Stage_Not_Found.Error identifier)
+
 
 private make_stage_selector connection include_home:Boolean=True =
     stages = (if include_home then [Option "~" "..Name '~'"] else [])
@@ -641,4 +674,3 @@ Table_Viz_Data.from (that:Snowflake_Connection) =
         schemas = tables.at "Schema" . to_vector
         (Table_Viz_Data.GenericGrid [Table_Viz_Header.Link "Schema" "Schema" "set_schema {{@Schema}}", Table_Viz_Header.Label "Name", Table_Viz_Header.Label "Type", Table_Viz_Header.Label "Description"] [schemas, names, types, descriptions])
       _ -> (Table_Viz_Data.GenericGrid [Table_Viz_Header.Link "Name" "Name" "query {{@Name}}", Table_Viz_Header.Label "Type", Table_Viz_Header.Label "Description"] [names, types, descriptions])
-

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -508,7 +508,8 @@ type Snowflake_Connection
        copy, and location), as well as the default values for each property.
 
        ## Arguments
-       - `stage`: The name (and schema) of the stage to read the properties from.
+       - `stage`: The name (and optionally schema) of the stage to read the
+          properties from.
 
        ## Returns
        A table containing the properties of the stage.
@@ -524,13 +525,32 @@ type Snowflake_Connection
        List all the objects in a stage.
 
        ## Arguments
-        - `stage_name`: The name of the stage to read the properties from.
+       - `stage`: The name (and optionally schema) of the stage to read the
+          properties from.
+       - `path`: The path (or prefix) to the files to list.
     @stage make_stage_selector
     list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Table_Not_Found
-    list_stage_objects self stage:Identifier="~" prefix:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
-        stage_and_path = stage.to_identifier + if prefix == "" then "" else '/' + prefix
+    list_stage_objects self stage:Identifier="~" path:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
+        stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
         query = "LIST '@" + (stage_and_path.replace "'" "''") + "'"
         self.execute_query query limit write_operation=False
+
+    ## ---
+       icon: trash2
+       ---
+       Remove a file from a stage
+
+       ## Arguments
+       - `stage`: The name (and optionally schema) of the stage to read the
+          properties from.
+       - `path`: The path (or prefix) to the files to remove.
+       - `pattern`: Optional regex pattern to match names against.
+    remove_from_stage : Identifier -> Text -> Text -> Integer
+    remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") pattern:Text="" =
+        Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
+            stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
+            query = "REMOVE '@" + (stage_and_path.replace "'" "''") + "'" + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
+            self.execute_query query write_operation=True
 
 ## Snowflake Identifier - with optional schema.
 type Identifier

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -490,10 +490,16 @@ type Snowflake_Connection
        private: true
        icon: metadata
        ---
-       Gets a list of stage names for current
+       Gets a list of stage names for current database.
     stage_names : Vector
     stage_names self =
-        self.connection.read_text_column "show stages in database" "name"
+        case self.schema of
+            "*" ->
+                self.execute_query "show stages in database" write_operation=False . rows
+                    . map r-> Identifier.Name_And_Schema (r.get "name") (r.get "schema_name")
+            _ ->
+                self.connection.read_text_column "show stages in schema" "name"
+                    . map n-> Identifier.Name n
 
     ## ---
        icon: metadata
@@ -502,10 +508,14 @@ type Snowflake_Connection
        copy, and location), as well as the default values for each property.
 
        ## Arguments
-        - `stage_name`: The name of the stage to read the properties from.
-    stage_properties : Text -> Table ! Table_Not_Found
-    stage_properties self stage_name:Text =
-        query = 'DESC STAGE "' + (stage_name.replace '"' '""') + '"'
+       - `stage`: The name (and schema) of the stage to read the properties from.
+
+       ## Returns
+       A table containing the properties of the stage.
+    @stage make_stage_selector include_home=False
+    stage_properties : Identifier -> Table ! Table_Not_Found
+    stage_properties self stage:Identifier=(Missing_Argument.throw "stage") =
+        query = 'DESC STAGE ' + stage.to_identifier
         self.execute_query query write_operation=False
 
     ## ---
@@ -515,12 +525,42 @@ type Snowflake_Connection
 
        ## Arguments
         - `stage_name`: The name of the stage to read the properties from.
-    @stage_name (self-> Single_Choice display=..Always values=(["~"] + self.stage_names).map d-> Option d d.pretty)
-    list_stage_objects : Text -> Text -> Table ! Table_Not_Found
-    list_stage_objects self stage_name:Text="~" prefix:Text="" =
-        query = if stage_name == '~' then 'LIST \'@~' else 'LIST \'@"' + (stage_name.replace '"' '""') + '"'
-            + if prefix == "'" then "" else '/' + (prefix.replace "'" "''") + "'"
-        self.execute_query query write_operation=False
+    @stage make_stage_selector
+    list_stage_objects : Identifier -> Text -> Rows_To_Read -> Table ! Table_Not_Found
+    list_stage_objects self stage:Identifier="~" prefix:Text="" (limit : Rows_To_Read = ..First_With_Warning 1000) =
+        query = "LIST '@" + stage.to_identifier + if prefix == "" then "'" else '/' + (prefix.replace "'" "''") + "'"
+        self.execute_query query limit write_operation=False
+
+## Snowflake Identifier - with optional schema.
+type Identifier
+    ## An object in the current schema with specified name.
+    Name name:Text=(Missing_Argument.throw "name")
+
+    ## An object with specified schema and name.
+    Name_And_Schema name:Text=(Missing_Argument.throw "name") schema:Text=(Missing_Argument.throw "schema")
+
+    ## ---
+       private: true
+       ---
+    to_identifier self = case self of
+        Identifier.Name '~' -> '~'
+        Identifier.Name n -> '"' + (n.replace '"' '""') + '"'
+        Identifier.Name_And_Schema n s -> '"' + (s.replace '"' '""') + '"."' + (n.replace '"' '""') + '"'
+
+    ## ---
+       private: true
+       ---
+    to_option self = case self of
+        Identifier.Name n -> Option n "(..Name "+n.pretty+")"
+        Identifier.Name_And_Schema n s -> Option s+"."+n "(..Name_And_Schema "+n.pretty+" "+s.pretty+")"
+
+Identifier.from (that:Text) = Identifier.Name that
+
+private make_stage_selector connection include_home:Boolean=True =
+    stages = (if include_home then [Option "~" "..Name '~'"] else [])
+        + connection.stage_names.map .to_option
+        + [Option "<Name>" "..Name", Option "<Name and Schema>" "..Name_And_Schema"]
+    Single_Choice display=..Always values=stages
 
 private auth_jdbc_properties credentials = case credentials of
     Credentials.Username_And_Password username password ->

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -468,6 +468,35 @@ type Snowflake_Connection
     to_js_object self =
         JS_Object.from_pairs <| [["type", "Snowflake_Connection"], ["links", self.connection.tables.at "Name" . to_vector]]
 
+    ## ---
+       icon: folder
+       ---
+       Returns the list of stages for the connection.
+
+       ## Arguments
+        - `database`: The database name to search in (default is current).
+          Use an asterisk (`*`) to search in all databases.
+        - `schema`: The schema name to search in (defaults to current). If an
+          asterisk (`*`) is provided, all schemas are searched.
+        - `pattern`: The stage name pattern to search for. Supports SQL
+          wildcards (`%`, `_`). Defaults to `""` which means all stages are
+          selected.
+    stages : Text -> Text -> Table
+    stages self schema:Text=self.schema pattern:Text='' =
+        parsed_schema = if schema == "*" then "" else
+            if schema == "" then " IN SCHEMA" +self.schema else ' IN SCHEMA "' + (schema.replace '"' '""') + '"'
+        query = "SHOW STAGES" + (if pattern.trim != "" then " LIKE '" + (pattern.replace "'" "''") + "'" else "") + " IN DATABASE" + parsed_schema
+        self.execute_query query write_operation=False . select_columns ["name", "database_name", "schema_name", "type", "cloud", "url", "created_on", "comment"] reorder=True error_on_missing_columns=False on_problems=..Ignore
+
+    ## ---
+       private: true
+       icon: metadata
+       ---
+       Gets a list of stage names for current
+    stage_names : Vector
+    stage_names self =
+        self.connection.read_text_column "show stages in database" "name"
+
 private auth_jdbc_properties credentials = case credentials of
     Credentials.Username_And_Password username password ->
         [Pair.new 'user' username, Pair.new 'password' password]

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -546,7 +546,7 @@ type Snowflake_Connection
        - `path`: The path (or prefix) to the files to remove.
        - `pattern`: Optional regex pattern to match names against.
     remove_from_stage : Identifier -> Text -> Text -> Integer
-    remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") pattern:Text="" =
+    remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text="" =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
             stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
             query = "REMOVE '@" + (stage_and_path.replace "'" "''") + "'" + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -537,6 +537,26 @@ type Snowflake_Connection
         self.execute_query query limit write_operation=False
 
     ## ---
+       icon: data_download
+       ---
+       Download one or more files from a stage to a local folder.
+
+       ## Arguments
+       - `stage`: The name (and optionally schema) of the stage to read the
+          properties from.
+       - `path`: The path (or prefix) to the files to list.
+       - `directory`: The local folder to save the files to.
+    @stage make_stage_selector
+    @directory (Folder_Browse display=..Always)
+    get_from_stage : Identifier -> Text -> File -> Text -> Table
+    get_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text=(Missing_Argument.throw "path") directory:File=(Missing_Argument.throw "directory") pattern:Text="" =
+        Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
+            stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path
+            file_uri = "'file://" + (directory.path.replace "\" "/" . replace "'" "''") + "'"
+            query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
+            self.execute_query query write_operation=True
+
+    ## ---
        icon: trash2
        ---
        Remove a file from a stage
@@ -547,7 +567,7 @@ type Snowflake_Connection
        - `path`: The path (or prefix) to the files to remove.
        - `pattern`: Optional regex pattern to match names against.
     @stage make_stage_selector
-    remove_from_stage : Identifier -> Text -> Text -> Integer
+    remove_from_stage : Identifier -> Text -> Text -> Table
     remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text="" =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
             stage_and_path = stage.to_identifier + if path == "" then "" else '/' + path

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.File_Type
+import Standard.Base.Runtime.Context as Execution_Context
 from Standard.Base.Enso_Cloud.Enso_Secret import as_credential_reference
 from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import File_Browse, Single_Choice, Text_Input
@@ -545,6 +546,7 @@ type Snowflake_Connection
           properties from.
        - `path`: The path (or prefix) to the files to remove.
        - `pattern`: Optional regex pattern to match names against.
+    @stage make_stage_selector
     remove_from_stage : Identifier -> Text -> Text -> Integer
     remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text="" =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value
 import Standard.Base.Errors.Common.Not_Found
+import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.File_Type
 import Standard.Base.Runtime.Context as Execution_Context
@@ -481,6 +482,9 @@ type Snowflake_Connection
         - `pattern`: The stage name pattern to search for. Supports SQL
           wildcards (`%`, `_`). Defaults to `""` which means all stages are
           selected.
+
+       ## Returns
+       A table containing the list of stages.
     stages : Text -> Text -> Table
     stages self schema:Text=self.schema pattern:Text='' =
         parsed_schema = if schema == "*" then "" else
@@ -546,18 +550,27 @@ type Snowflake_Connection
        icon: data_download
        ---
        Download one or more files from a stage to a local folder.
-       This will overwrite existing files.
+       This will overwrite existing files. It will attempt to create the
+       directory if it does not exist.
 
        ## Arguments
        - `stage`: The name (and optionally schema) of the stage to read the
           properties from.
        - `path`: The path (or prefix) to the files to list.
        - `directory`: The local folder to save the files to.
+       - `pattern`: Optional regex pattern to match names against.
+       - `if_not_found`: what to return if no files are found. Defaults to
+          raising a `Not_Found` error.
+
+       ## Returns
+       A vector of files that were downloaded or if none were found, the
+       value specified by `if_not_found`.
     @stage make_stage_selector
     @directory (Folder_Browse display=..Always)
-    get_from_stage : Identifier -> Text -> File -> Text -> Table ! Stage_Not_Found
-    get_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text=(Missing_Argument.throw "path") directory:File=(Missing_Argument.throw "directory") pattern:Text="" =
-        Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
+    get_from_stage : Identifier -> Text -> File -> Text -> Any -> Table ! Stage_Not_Found
+    get_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text=(Missing_Argument.throw "path") directory=(Missing_Argument.throw "directory") pattern:Text="" ~if_not_found=(Error.throw Not_Found) =
+        if directory.is_a File == False then Error.throw (Illegal_Argument.Error "Only local folders are supported for downloading from Snowflake stages.")
+        Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot download from stage. Press the Write button ▶ to perform the operation." panic=False <|
             identifier = stage.to_identifier
             Stage_Not_Found.rethrow identifier <|
                 stage_and_path = identifier + if path == "" then "" else '/' + path
@@ -565,9 +578,43 @@ type Snowflake_Connection
                 query = "GET '@" + (stage_and_path.replace "'" "''") + "' " + file_uri + (if pattern=="" then "" else "pattern='" + (pattern.replace "'" "''") + "'")
                 table = self.execute_query query Rows_To_Read.All_Rows write_operation=True
                 table.if_not_error <|
-                    if table.row_count == 0 then Error.throw Not_Found else
+                    if table.row_count == 0 then if_not_found else
                         names = table.at "file" . to_vector
                         names.map n-> directory / n
+
+    ## ---
+       icon: data_upload
+       ---
+       Upload a file to a stage to a local drive.
+       This will overwrite existing files.
+
+       ## Arguments
+       - `file`: The local file to upload.
+       - `stage`: The name (and optionally schema) of the stage to read the
+          properties from.
+       - `path`: The path (or prefix) to the files to list.
+    @stage make_stage_selector
+    put_to_stage : File -> Identifier -> Text -> Table ! Stage_Not_Found
+    put_to_stage self file stage:Identifier=(Missing_Argument.throw "stage") path:Text="" =
+        Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot upload to stage. Press the Write button ▶ to perform the operation." panic=False <|
+            if file.exists == False then Error.throw (File_Error.Not_Found file)
+            if file.is_directory then Error.throw (Illegal_Argument.Error "Uploading directories is not supported. Please provide a file.")
+
+            ## Need to copy the file locally first if cloud-based.
+            used_file = case file of
+                _ : File -> file
+                _ ->
+                    file_extension = file.extension
+                    file_name = file.name.drop (..Last file_extension.length)
+                    temp_file = File.create_temporary_file file_name file_extension
+                    file.copy_to temp_file
+
+            identifier = stage.to_identifier
+            Stage_Not_Found.rethrow identifier <|
+                stage_and_path = identifier + if path == "" then "" else '/' + path
+                file_uri = "'file://" + (used_file.path.replace "\" "/" . replace "'" "''") + "'"
+                query = "PUT " + file_uri + " '@" + (stage_and_path.replace "'" "''") + "'"
+                self.execute_query query write_operation=True
 
     ## ---
        icon: trash2
@@ -580,8 +627,8 @@ type Snowflake_Connection
        - `path`: The path (or prefix) to the files to remove.
        - `pattern`: Optional regex pattern to match names against.
     @stage make_stage_selector
-    remove_from_stage : Identifier -> Text -> Text -> Table ! Stage_Not_Found
-    remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text="" =
+    remove_from_stage : Identifier -> Text -> Text -> Boolean -> Table ! Stage_Not_Found
+    remove_from_stage self stage:Identifier=(Missing_Argument.throw "stage") path:Text="" pattern:Text=""  =
         Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot remove the target. Press the Write button ▶ to perform the operation." panic=False <|
             identifier = stage.to_identifier
             Stage_Not_Found.rethrow identifier <|

--- a/std-bits/microsoft/src/main/java/org/enso/microsoft/azure/AzureBlobStorage.java
+++ b/std-bits/microsoft/src/main/java/org/enso/microsoft/azure/AzureBlobStorage.java
@@ -83,7 +83,7 @@ public final class AzureBlobStorage {
       throw new IllegalArgumentException("Blob does not exist: " + blobName);
     }
 
-    var tempFile = Files.createTempFile("enso-blob-", blobName.replaceAll("[^A-Za-z0-9_]", "_"));
+    var tempFile = Files.createTempFile("enso-blob-", blobName.replaceAll("[^A-Za-z0-9_.]", "_"));
     blob.downloadToFile(tempFile.toString(), true);
     LOGGER.trace("Downloaded blob to: {}", tempFile);
     return tempFile.toString();


### PR DESCRIPTION
### Pull Request Description

- List stages (`stages`).
- Read stage properties (`stage_properties`).
- List objects in a stage (`list_stage_objects`).
- Remove 1 or more from a stage (`remove_from_stage`).
- Download one or more files from the stage (`get_from_stage`).
- Upload a file to a stage (`put_to_stage`).

New type `Identifier` for a name and optionally a schema. Support for converting to an `Option` and creating an escaped identifier.

`if_not_error` is no longer private allowing for control flow.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
