### PR TITLE
Fix code editor failure when project is not loaded yet

### DIFF
--- a/app/gui/src/project-view/components/CodeEditor/CodeEditorImpl.vue
+++ b/app/gui/src/project-view/components/CodeEditor/CodeEditorImpl.vue
@@ -41,7 +41,7 @@ const { editorView, setExtraExtensions } = useCodeMirror(editorRoot, {
     foldGutter(),
     lintGutter(),
     highlightSelectionMatches(),
-    ensoSyntax(toRef(module.value, 'root')),
+    () => (module.value.root ? ensoSyntax(toRef(module.value, 'root')) : []),
     ensoHoverTooltip(graph, vueHost),
     () => (editorRoot.value ? highlightStyle(editorRoot.value.highlightClasses) : []),
   ],


### PR DESCRIPTION
### Pull Request Description

I noticed that opening code editor _quickly_ (when the project is not loaded yet) can cause [this](https://github.com/enso-org/enso/blob/e085ab746757d350dd1ccaa81c359f435073fe47/app/gui/src/project-view/components/CodeEditor/ensoSyntax.ts#L141) assertion failure in EnsoParser extension.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
