### PR TITLE
Fix undeclared dependency

### DIFF
--- a/app/common/package.json
+++ b/app/common/package.json
@@ -25,7 +25,7 @@
     "@internationalized/date": "3.7.0",
     "@types/node": "catalog:",
     "is-network-error": "^1.1.0",
-    "vue": "catalog:",
+    "vue": "^3.5.13",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/app/common/package.json
+++ b/app/common/package.json
@@ -21,14 +21,12 @@
     "compile": "tsc",
     "lint": "eslint ./src --cache --max-warnings=0"
   },
-  "peerDependencies": {
-    "zod": "^3.25.49"
-  },
   "dependencies": {
     "@internationalized/date": "3.7.0",
     "@types/node": "catalog:",
     "is-network-error": "^1.1.0",
-    "vue": "*"
+    "vue": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@fast-check/vitest": "catalog:",

--- a/app/gui/package.json
+++ b/app/gui/package.json
@@ -126,7 +126,7 @@
     "y-websocket": "^1.5.4",
     "ydoc-shared": "workspace:*",
     "yjs": "^13.6.21",
-    "zod": "^3.25.49",
+    "zod": "catalog:",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/app/ydoc-server/package.json
+++ b/app/ydoc-server/package.json
@@ -29,7 +29,7 @@
     "y-protocols": "^1.0.6",
     "ydoc-shared": "workspace:*",
     "yjs": "^13.6.21",
-    "zod": "^3.25.49"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@fast-check/vitest": "catalog:",

--- a/app/ydoc-shared/package.json
+++ b/app/ydoc-shared/package.json
@@ -42,7 +42,7 @@
     "partysocket": "^1.0.3",
     "rust-ffi": "workspace:*",
     "yjs": "^13.6.21",
-    "zod": "^3.25.49"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@fast-check/vitest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
+    zod:
+      specifier: ^3.25.49
+      version: 3.25.76
 
 overrides:
   tslib: ^2.8.1
@@ -125,10 +128,10 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       vue:
-        specifier: '*'
+        specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.2)
       zod:
-        specifier: ^3.25.49
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@fast-check/vitest':
@@ -532,7 +535,7 @@ importers:
         specifier: ^13.6.21
         version: 13.6.21
       zod:
-        specifier: ^3.25.49
+        specifier: 'catalog:'
         version: 3.25.76
       zustand:
         specifier: ^4.5.5
@@ -863,7 +866,7 @@ importers:
         specifier: ^13.6.21
         version: 13.6.21
       zod:
-        specifier: ^3.25.49
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@fast-check/vitest':
@@ -961,7 +964,7 @@ importers:
         specifier: ^13.6.21
         version: 13.6.21
       zod:
-        specifier: ^3.25.49
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@fast-check/vitest':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,3 +24,4 @@ catalog:
   "@codemirror/state": ^6.5.2
   "@codemirror/view": ^6.38.2
   "@fast-check/vitest": ^0.2.1
+  zod: ^3.25.49


### PR DESCRIPTION
### Pull Request Description

app-common requires `zod`, but it was only declared as a `peerDependency`, causing nondeterministic build failures

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
