### PR TITLE
Add explicit named self argument to static method calls

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
@@ -132,7 +132,7 @@ type Boolean
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -140,7 +140,7 @@ type Boolean
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -148,7 +148,7 @@ type Boolean
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -156,4 +156,4 @@ type Boolean
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -536,7 +536,7 @@ type Number
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -544,7 +544,7 @@ type Number
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -552,7 +552,7 @@ type Number
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -560,7 +560,7 @@ type Number
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
 ## Float is the type of float numbers in Enso.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -221,7 +221,7 @@ type Text
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -229,7 +229,7 @@ type Text
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -237,7 +237,7 @@ type Text
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -245,4 +245,4 @@ type Text
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -950,7 +950,7 @@ type Date
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -958,7 +958,7 @@ type Date
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -966,7 +966,7 @@ type Date
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -974,7 +974,7 @@ type Date
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -1114,7 +1114,7 @@ type Date_Time
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -1122,7 +1122,7 @@ type Date_Time
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -1130,7 +1130,7 @@ type Date_Time
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -1138,7 +1138,7 @@ type Date_Time
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
@@ -373,7 +373,7 @@ type Duration
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -381,7 +381,7 @@ type Duration
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -389,7 +389,7 @@ type Duration
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -397,4 +397,4 @@ type Duration
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
@@ -199,7 +199,7 @@ type Period
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -207,7 +207,7 @@ type Period
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -215,7 +215,7 @@ type Period
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -223,7 +223,7 @@ type Period
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
     ## ---
        group: Operators

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -614,7 +614,7 @@ type Time_Of_Day
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -622,7 +622,7 @@ type Time_Of_Day
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -630,7 +630,7 @@ type Time_Of_Day
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -638,7 +638,7 @@ type Time_Of_Day
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Column_Implementation.enso
@@ -107,28 +107,28 @@ type In_Memory_Column_Implementation
         new_name = naming_helper.binary_operation_name ">=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
-            Comparable.>= a b
+            Comparable.>= self=a that=b
         _call_comparator this_column other new_name (Comparators.greaterThanEq this_column.java_column (_java_other other)) fallback
 
     less_than_eq (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<=" this_column other
         fallback problem_builder a b =
             _ = problem_builder
-            Comparable.<= a b
+            Comparable.<= self=a that=b
         _call_comparator this_column other new_name (Comparators.lessThanEq this_column.java_column (_java_other other)) fallback
 
     greater_than (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name ">" this_column other
         fallback problem_builder a b =
             _ = problem_builder
-            Comparable.> a b
+            Comparable.> self=a that=b
         _call_comparator this_column other new_name (Comparators.greaterThan this_column.java_column (_java_other other)) fallback
 
     less_than (this_column : Column & In_Memory_Column) (other : Column | Any) = Value_Type.expect_comparable this_column other <| Incomparable_Values.handle_errors <|
         new_name = naming_helper.binary_operation_name "<" this_column other
         fallback problem_builder a b =
             _ = problem_builder
-            Comparable.< a b
+            Comparable.< self=a that=b
         _call_comparator this_column other new_name (Comparators.lessThan this_column.java_column (_java_other other)) fallback
 
     between (this_column : Column & In_Memory_Column) (lower : Column | Any) (upper : Column | Any) = Value_Type.expect_comparable this_column lower <| Value_Type.expect_comparable this_column upper <|

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Value_Type_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Value_Type_Helpers.enso
@@ -114,7 +114,7 @@ reconcile_types current:Value_Type new:Value_Type -> Value_Type =
    returned.
 max_size a b =
     if a.is_nothing || b.is_nothing then Nothing else
-        if Comparable.< a b then b else a
+        if Comparable.< self=a that=b then b else a
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
@@ -48,7 +48,7 @@ type Bits
       icon: operators
       ---
       Checks if `self` is greater than `that`.
-    > self that = Comparable.> self that
+    > self that = Comparable.> self=self that
 
     ## ---
        aliases: [greater than or equal]
@@ -56,7 +56,7 @@ type Bits
        icon: operators
        ---
        Checks if `self` is greater than or equal to `that`.
-    >= self that = Comparable.>= self that
+    >= self that = Comparable.>= self=self that
 
     ## ---
        aliases: [less than]
@@ -64,7 +64,7 @@ type Bits
        icon: operators
        ---
        Checks if `self` is less than `that`.
-    < self that = Comparable.< self that
+    < self that = Comparable.< self=self that
 
     ## ---
        aliases: [less than or equal]
@@ -72,7 +72,7 @@ type Bits
        icon: operators
        ---
        Checks if `self` is less than or equal to `that`.
-    <= self that = Comparable.<= self that
+    <= self that = Comparable.<= self=self that
 
 ## ---
    private: true

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -413,8 +413,8 @@ public class SignatureTest {
                     Ctor x
 
                 normal_call = (My_Type.Value 42).f 10
-                static_call = My_Type.f (My_Type.Value 23) 100
-                invalid_static_call = My_Type.f (Other_Type.Ctor 11) 1000
+                static_call = My_Type.f self=(My_Type.Value 23) 100
+                invalid_static_call = My_Type.f self=(Other_Type.Ctor 11) 1000
                 """,
                 uri.getAuthority())
             .uri(uri)
@@ -631,9 +631,9 @@ public class SignatureTest {
 
                 My_Type.from (that : Convertible_Type) = My_Type.Value that.x+1
 
-                static_my_type = My_Type.f (My_Type.Value 23) 1000
-                static_convertible = My_Type.f (Convertible_Type.A 23) 1000
-                static_inconvertible = My_Type.f (Inconvertible_Type.B 23) 1000
+                static_my_type = My_Type.f self=(My_Type.Value 23) 1000
+                static_convertible = My_Type.f self=(Convertible_Type.A 23) 1000
+                static_inconvertible = My_Type.f self=(Inconvertible_Type.B 23) 1000
                 """,
                 uri.getAuthority())
             .uri(uri)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2342,8 +2342,8 @@ class RuntimeServerTest
 
     val metadata = new Metadata("import Standard.Base.Data.Numbers\n\n")
     val id_x1_1  = metadata.addItem(30, 14, "aa")
-    val id_x1_2  = metadata.addItem(49, 10, "ab")
-    val id_x1    = metadata.addItem(69, 6, "ac")
+    val id_x1_2  = metadata.addItem(56, 10, "ab")
+    val id_x1    = metadata.addItem(76, 6, "ac")
 
     val code =
       """main =

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2724,14 +2724,14 @@ class RuntimeServerTest
 
     val metadata = new Metadata
     val id_x     = metadata.addItem(52, 25, "aa")
-    val id_y     = metadata.addItem(86, 16, "ab")
+    val id_y     = metadata.addItem(86, 21, "ab")
 
     val code =
       """import Standard.Base.Data.Time.Date
         |
         |main =
         |    x = Date.new_builtin 1970 1 1
-        |    y = Date.Date.year x
+        |    y = Date.Date.year self=x
         |    y
         |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2335,7 +2335,10 @@ class RuntimeServerTest
     )
   }
 
-  it should "send method pointer updates of partially applied atom methods called with static notation" in {
+  /** Lambda instrumentation is currently not supported.
+    * Note that the expression `T.func1 self=_` creates a lambda Function.
+    */
+  ignore should "send method pointer updates of partially applied atom methods called with static notation" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()
     val moduleName = "Enso_Test.Test.Main"

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2341,14 +2341,14 @@ class RuntimeServerTest
     val moduleName = "Enso_Test.Test.Main"
 
     val metadata = new Metadata("import Standard.Base.Data.Numbers\n\n")
-    val id_x1_1  = metadata.addItem(30, 7, "aa")
+    val id_x1_1  = metadata.addItem(30, 14, "aa")
     val id_x1_2  = metadata.addItem(49, 10, "ab")
     val id_x1    = metadata.addItem(69, 6, "ac")
 
     val code =
       """main =
         |    a = T.A
-        |    x1_1 = T.func1
+        |    x1_1 = T.func1 self=_
         |    x1_2 = x1_1 a y=2
         |    x1 = x1_2 1
         |    x1

--- a/test/Base_Internal_Tests/src/Comparator_Spec.enso
+++ b/test/Base_Internal_Tests/src/Comparator_Spec.enso
@@ -39,10 +39,10 @@ type Attach_Warning
     Value (n : Integer)
     Value2 (n : Integer)
 
-    > self that = Comparable.> self that
-    >= self that = Comparable.>= self that
-    < self that = Comparable.< self that
-    <= self that = Comparable.<= self that
+    > self that = Comparable.> self=self that
+    >= self that = Comparable.>= self=self that
+    < self that = Comparable.< self=self that
+    <= self that = Comparable.<= self=self that
 
 type Attach_Warning_Comparator
     compare (x : Attach_Warning) (y : Attach_Warning) =

--- a/test/Base_Tests/src/Semantic/Error_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Error_Spec.enso
@@ -92,8 +92,8 @@ add_specs suite_builder =
 
         group_builder.specify "should implement to_text" <|
             Error.throw Nothing . to_text . should_equal "(Error: Nothing)"
-            Error.to_text Error . should_equal "Error"
-            case (Error.to_text) of
+            Error.to_text self=Error . should_equal "Error"
+            case (Error.to_text self=_) of
                 _ : Function -> Nothing
                 _ -> Test.fail "Expected the expression to be of Function type"
 

--- a/test/Base_Tests/src/Semantic/Private_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Private_Spec.enso
@@ -87,13 +87,13 @@ add_specs spec_builder =
         group_builder.specify "cannot call private static method from different project" <|
             obj = Public_Type.create 42
             Test.expect_panic Private_Access <|
-                Public_Type.priv_method obj
+                Public_Type.priv_method self=obj
 
         group_builder.specify "cannot call private method from a lambda method" <|
             obj = Public_Type.create 42
             Test.expect_panic Private_Access <|
                 Public_Type.in_ctx <|
-                    Public_Type.priv_method obj
+                    Public_Type.priv_method self=obj
 
         group_builder.specify "cannot call private static method that was directly imported" <|
             Test.expect_panic Private_Access <|

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -239,25 +239,25 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
     group_builder.specify "should allow to remove warnings, by type" <|
         warned = Warning.attach 1 <| Warning.attach "Alpha" <| Warning.attach Nothing <| Warning.attach (Unimplemented.Error "An Error Here") "foo"
 
-        no_int = warned.remove_warnings warning_type=Integer . first
+        no_int = Warning.remove_warnings warned warning_type=Integer . first
         Warning.get_all no_int . map .value . should_equal ["Alpha", Nothing, (Unimplemented.Error "An Error Here")]
 
-        no_text = warned.remove_warnings Text
+        no_text = Warning.remove_warnings warned Text
         Warning.get_all no_text . map .value . should_equal [1, Nothing, (Unimplemented.Error "An Error Here")]
 
-        no_nothing = warned.remove_warnings Nothing
+        no_nothing = Warning.remove_warnings warned Nothing
         Warning.get_all no_nothing . map .value . should_equal [1, "Alpha", (Unimplemented.Error "An Error Here")]
 
-        no_error = warned.remove_warnings Unimplemented
+        no_error = Warning.remove_warnings warned Unimplemented
         Warning.get_all no_error . map .value . should_equal [1, "Alpha", Nothing]
 
-    group_builder.specify "should allow raising warnings as errors, by type" <|
+    group_builder.specify "XX should allow raising warnings as errors, by type" <|
         warned = Warning.attach 1 <| Warning.attach "Alpha" <| Warning.attach Nothing <| Warning.attach (Unimplemented.Error "An Error Here") "foo"
 
-        warned.throw_on_warning . should_fail_with Integer
-        warned.throw_on_warning warning_type=Text . should_fail_with Text
-        warned.throw_on_warning warning_type=Nothing . should_fail_with Nothing
-        warned.throw_on_warning warning_type=Unimplemented . should_fail_with Unimplemented
+        Warning.throw_on_warning warned . should_fail_with Integer
+        Warning.throw_on_warning warned warning_type=Text . should_fail_with Text
+        Warning.throw_on_warning warned warning_type=Nothing . should_fail_with Nothing
+        Warning.throw_on_warning warned warning_type=Unimplemented . should_fail_with Unimplemented
 
     group_builder.specify "should allow to map the warnings, selectively" <|
         x = Warning.attach "foo" 1


### PR DESCRIPTION
This PR was split from #13962.

### Pull Request Description

All the [static method invocations](https://github.com/enso-org/enso/blob/55c635407f1271e3820183a19e294709846e0fb1/docs/types/dynamic-dispatch.md#L280) now have named `self` argument.

### Important Notes

- Contains only relevant changes to `*.enso` sourcdes.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
