### PR TITLE
Add new high level `bulk_load` API to Snowflake Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [Add Text_Column.proper and Rename Case.Title->Case.Proper.][14184]
 - [Snowflake stage support for reading and writing files.][14210]
 - [Snowflake file format and copy into support.][14221]
+- [Snowflake bulk load API.][14230]
 
 [13769]: https://github.com/enso-org/enso/pull/13769
 [14026]: https://github.com/enso-org/enso/pull/14026
@@ -55,6 +56,7 @@
 [14184]: https://github.com/enso-org/enso/pull/14184
 [14210]: https://github.com/enso-org/enso/pull/14210
 [14221]: https://github.com/enso-org/enso/pull/14221
+[14230]: https://github.com/enso-org/enso/pull/14230
 
 #### Enso Language & Runtime
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Errors.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Errors.md
@@ -7,6 +7,7 @@
     - error_message self -> Standard.Base.Data.Text.Text
     - payload self -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Data.Text.Text
+    - to_js_object self -> Standard.Base.Data.Json.JS_Object
 - type Stage_Not_Found
     - Error name:Standard.Base.Data.Text.Text
     - to_display_text self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -2,12 +2,14 @@
 ## module Standard.Snowflake.Snowflake_Connection
 - type Snowflake_Connection
     - base_connection self -> Standard.Base.Any.Any
+    - bulk_load self table:Standard.Table.Table.Table= table_name:Standard.Base.Data.Text.Text= drop_if_exists:Standard.Base.Data.Boolean.Boolean= temporary:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - close self -> Standard.Base.Any.Any
     - copy_into_table self table_name:Standard.Base.Data.Text.Text= stage:Standard.Snowflake.Identifier.Identifier= file_name:Standard.Base.Data.Text.Text= format:Standard.Snowflake.File_Format.Snowflake_File_Format= match_names_insensitively:Standard.Base.Data.Boolean.Boolean= truncate_first:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - create_literal_table self source:Standard.Table.Table.Table alias:Standard.Base.Data.Text.Text -> (Standard.Table.Table.Table&Standard.Database.DB_Table.DB_Table)
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
+    - default_formatter self -> Standard.Table.Data_Formatter.Data_Formatter
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Errors.enso
@@ -18,6 +18,13 @@ type Snowflake_Error
     to_display_text self -> Text =
         "Snowflake_Error: " + self.message
 
+    ## ---
+       private: true
+       ---
+    to_js_object self -> JS_Object =
+        values = [["type", "Snowflake_Error"], ["Constructor", "Unexpected_Result"], ["message", self.message], ["payload", self.internal_payload.to_js_object]]
+        JS_Object.from_pairs values
+
 ## An error when a stage was not found in the database or not accessible.
 type Stage_Not_Found
     ## ---
@@ -27,7 +34,7 @@ type Stage_Not_Found
 
        ## Arguments
         - `name`: The name of the stage that was not found.
-    Error (name:Text)
+    Error name:Text
 
     ## ---
        private: true
@@ -52,7 +59,7 @@ type File_Format_Not_Found
 
        ## Arguments
         - `name`: The name of the file format that was not found.
-    Error (name:Text)
+    Error name:Text
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
@@ -61,7 +61,7 @@ type Snowflake_File_Format
         map_ident identifier =
             opt = identifier.to_option
             Option opt.label ("(..Saved " + opt.value + ")")
-        identifiers = [Option "<Default>" ..NONE]
+        identifiers = [Option "<Default>" "..NONE"]
             + connection.file_format_names.map map_ident
             + [Option "<CSV>" "..CSV", Option "<JSON>" "..JSON", Option "<AVRO>" "..AVRO", Option "<ORC>" "..ORC", Option "<PARQUET>" "..PARQUET", Option "<XML>" "..XML"]
         Single_Choice display=..Always values=identifiers

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -11,7 +11,8 @@ from Standard.Base.Metadata.Widget import File_Browse, Folder_Browse, Single_Cho
 from Standard.Base.Visualization.Table_Viz_Data import Table_Viz_Data, Table_Viz_Header
 
 import Standard.Table.Rows_To_Read.Rows_To_Read
-from Standard.Table import Table
+import Standard.Table.In_Memory_Table.In_Memory_Table
+from Standard.Table import Table, Data_Formatter
 
 import Standard.Database.Column_Description.Column_Description
 import Standard.Database.Connection.Connection.Connection
@@ -637,7 +638,7 @@ type Snowflake_Connection
                         _ -> Error.throw (Snowflake_Error.Unexpected_Result "Uploading to stage reported multiple uploaded files." result)
 
     ## ---
-       icon: trash2
+       icon: trash
        ---
        Remove one or more file(s) from a stage
 
@@ -758,6 +759,71 @@ type Snowflake_Connection
             Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot copy data. Press the Write button ▶ to perform the operation." panic=False <|
                 if truncate_first then self.truncate_table table_name
                 self.execute_query query Rows_To_Read.All_Rows write_operation=True
+
+    ## ---
+       private: true
+       icon: convert
+       ---
+       Pre-configured data formatter for Snowflake connections.
+       Allows writing CSVs in the format for loading to Snowflake.
+    default_formatter self -> Data_Formatter =
+        _ = self
+        Data_Formatter.Value datetime_formats=['yyyy-MM-dd HH:mm:ss.f']
+
+    ## ---
+       icon: data_upload
+       ---
+       Upload a Table to a new table in the database in the current schema.
+
+       ## Arguments:
+       - `table`: The input table to upload.
+       - `table_name`: The name of the table to create.
+       - `drop_if_exists`: If set to `True`, will drop the existing table if it
+          exists. Defaults to `False` - in which case an error is raised if the table
+          already exists.
+       - `temporary`: If set to `True`, the created table will be temporary.
+          Defaults to `False`.
+
+       ## Returns
+       A `DB_Table` representing the created table.
+    bulk_load : Table -> Text -> Boolean -> Boolean -> Table & DB_Table ! Table_Already_Exists
+    bulk_load self table:Table=(Missing_Argument.throw "table") table_name:Text=(Missing_Argument.throw "table_name") drop_if_exists:Boolean=False temporary:Boolean=False = case table of
+        _ : DB_Table ->
+            Error.throw (Illegal_Argument.Error "Cannot bulk load from a DB_Table, use `read` to materialize or use `select_into_database_table` if on same server.")
+        _ : In_Memory_Table ->
+            ## Check for illegal column types
+            removed = table.remove_columns [(..By_Type ..Null), (..By_Type ..Mixed), (..By_Type ..Unsupported_Data_Type), (..By_Type ..Binary)]
+            if removed.column_count != table.column_count then Error.throw (Illegal_Argument.Error "The table contains columns with unsupported types (Null, Mixed, Binary, or Unsupported_Data_Type) that cannot be uploaded to Snowflake. Please remove or convert these columns before uploading.")
+
+            ## Verify known schema
+            if self.schema == '*' then Error.throw (Illegal_Argument.Error "Cannot bulk load data when the connection schema is set to '*'. Please set a specific schema.")
+
+            ## Check if table exists
+            exists = self.query (..Table_Name table_name) . is_error . not
+            if exists && drop_if_exists.not then Error.throw (Table_Already_Exists.Error table_name)
+
+            Execution_Context.Output.if_enabled disabled_message="As writing is disabled, cannot load data. Press the Write button ▶ to perform the operation." panic=False <|
+                ## Create temporary file
+                temp_file = File.create_temporary_file "snowflake_bulk_load" ".csv"
+                table.write temp_file (..Delimited value_formatter=self.default_formatter)
+
+                ## Drop existing table if needed and then create new table
+                if exists then self.drop_table table_name if_exists=True
+                created_table = self.create_table table_name table temporary=temporary
+
+                ## Assuming we managed to create the table, proceed with upload
+                created_table.if_not_error <|
+                    ## Upload to the stage
+                    put_result = self.put_to_stage temp_file (..Name "~") overwrite=True
+                    put_result.if_not_error <|
+                        ## Copy into the table
+                        copy_result = self.copy_into_table table_name (..Name "~") put_result ..CSV
+
+                        ## Remove file regardless of copy_result
+                        self.remove_from_stage (..Name "~") put_result
+
+                        ## Return the copy result if an error or the created table
+                        copy_result.if_not_error created_table
 
 private make_stage_selector connection include_home:Boolean=True =
     stages = (if include_home then [Option "~" "..Name '~'"] else [])

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
@@ -243,21 +243,21 @@ type Data_Formatter
        ---
     make_date_parser self = self.wrap_base_parser <|
         Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-            DateParser.new (self.date_formats.map on_problems=No_Wrap.Value .get_java_formatter_for_parsing)
+            DateParser.new (self.date_formats.map on_problems=No_Wrap.Value d-> (d:Date_Time_Formatter).get_java_formatter_for_parsing)
 
     ## ---
        private: true
        ---
     make_date_time_parser self = self.wrap_base_parser <|
         Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-            DateTimeParser.new (self.datetime_formats.map on_problems=No_Wrap.Value  .get_java_formatter_for_parsing)
+            DateTimeParser.new (self.datetime_formats.map on_problems=No_Wrap.Value d-> (d:Date_Time_Formatter).get_java_formatter_for_parsing)
 
     ## ---
        private: true
        ---
     make_time_of_day_parser self = self.wrap_base_parser <|
         Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-            TimeOfDayParser.new (self.time_formats.map on_problems=No_Wrap.Value .get_java_formatter_for_parsing)
+            TimeOfDayParser.new (self.time_formats.map on_problems=No_Wrap.Value d-> (d:Date_Time_Formatter).get_java_formatter_for_parsing)
 
     ## ---
        private: true
@@ -324,7 +324,7 @@ type Data_Formatter
     make_date_formatter self =
         if self.date_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting dates requires at least one entry in the `date_formats` parameter") else
             Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-                DateFormatter.new self.date_formats.first.underlying
+                DateFormatter.new ((self.date_formats.first):Date_Time_Formatter).underlying
 
     ## ---
        private: true
@@ -332,7 +332,7 @@ type Data_Formatter
     make_time_of_day_formatter self =
         if self.time_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting times requires at least one entry in the `time_formats` parameter") else
             Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-                TimeFormatter.new self.time_formats.first.underlying
+                TimeFormatter.new ((self.time_formats.first):Date_Time_Formatter).underlying
 
     ## ---
        private: true
@@ -340,7 +340,7 @@ type Data_Formatter
     make_date_time_formatter self =
         if self.datetime_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting date-times requires at least one entry in the `datetime_formats` parameter") else
             Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
-                DateTimeFormatter.new self.datetime_formats.first.underlying
+                DateTimeFormatter.new ((self.datetime_formats.first):Date_Time_Formatter).underlying
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -3248,7 +3248,6 @@ type Table
         self.implementation.row_count self.underlying
 
     ## ---
-       private: true
        icon: data_input
        ---
        Returns a materialized dataframe containing rows of this table.


### PR DESCRIPTION
### Pull Request Description

- Add `bulk_load` to the `Snowflake_Connection`.
- Minor bug fixes for Snowflake bulk functions.
- `Table.read` is now public for in-memory as well.
- Bug fix for `Data_Formatter`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
