### PR TITLE
Remove builtin methods with two self arguments

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsGenerate.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsGenerate.java
@@ -122,7 +122,7 @@ public final class DocsGenerate {
               }
               for (var mb : moduleBindings) {
                 if (mb instanceof Method.Explicit m) {
-                  if (m.isStaticWrapperForInstanceMethod() || m.isPrivate()) {
+                  if (m.isPrivate()) {
                     alreadyDispatched.put(m, m);
                     continue;
                   }
@@ -139,7 +139,7 @@ public final class DocsGenerate {
             }
           }
           case Method.Explicit m -> {
-            if (!m.isPrivate() && !m.isStaticWrapperForInstanceMethod()) {
+            if (!m.isPrivate()) {
               dispatch.dispatchMethod(null, m);
             }
           }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferenceSignatures.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeInferenceSignatures.java
@@ -88,9 +88,7 @@ public final class TypeInferenceSignatures implements IRPass {
             (def) ->
                 switch (def) {
                   case Method.Explicit b -> {
-                    boolean keepSelfArgument = b.isStaticWrapperForInstanceMethod();
-                    TypeRepresentation resolvedType =
-                        resolveTopLevelTypeSignature(b.body(), keepSelfArgument);
+                    TypeRepresentation resolvedType = resolveTopLevelTypeSignature(b.body());
                     if (resolvedType != null) {
                       b.passData().update(INSTANCE, new InferredType(resolvedType));
                     }
@@ -115,13 +113,8 @@ public final class TypeInferenceSignatures implements IRPass {
    * Constructs the type signature for a given method body.
    *
    * @param body the method body
-   * @param keepSelfArgument whether to keep the self argument. For regular static methods, the self
-   *     argument is synthetic and does not take part in type inference. For member methods, it is
-   *     provided implicitly when resolving the call, so again it is ignored for type inference. It
-   *     should only be kept for such static methods that are wrappers for instance methods.
    */
-  private TypeRepresentation resolveTopLevelTypeSignature(
-      Expression body, boolean keepSelfArgument) {
+  private TypeRepresentation resolveTopLevelTypeSignature(Expression body) {
     return switch (body) {
       // Combine argument types with ascribed type (if available) for a function type signature
       case Function.Lambda lambda -> {
@@ -135,21 +128,7 @@ public final class TypeInferenceSignatures implements IRPass {
         scala.collection.immutable.List<TypeRepresentation> argTypesScala =
             lambda
                 .arguments()
-                // Filter out the self argument, unless it should be kept.
-                .filter(
-                    (arg) -> {
-                      if (arg.name() instanceof Name.Self selfArg) {
-                        if (selfArg.synthetic()) {
-                          // The 'synthetic' self is always dropped.
-                          return false;
-                        } else {
-                          return keepSelfArgument;
-                        }
-                      } else {
-                        // We keep all other args.
-                        return true;
-                      }
-                    })
+                .filter((arg) -> !(arg.name() instanceof Name.Self))
                 .map(
                     (arg) -> {
                       if (arg.ascribedType().isDefined()) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/BindingSorterTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/dump/test/BindingSorterTest.java
@@ -188,7 +188,6 @@ public final class BindingSorterTest {
         .bodyReference(bodyRef)
         .isStatic(isStatic)
         .isPrivate(isPrivate)
-        .isStaticWrapperForInstanceMethod(false)
         .build();
   }
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/Function.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/Function.java
@@ -42,20 +42,6 @@ public interface Function extends Expression {
     return args + " -> " + bodyStr;
   }
 
-  static boolean computeIsStaticWrapperForInstanceMethod(IR body) {
-    if (body instanceof Function.Lambda function) {
-      var argNames = function.arguments().map(DefinitionArgument::name);
-      if (argNames.size() >= 2
-          && argNames.apply(0) instanceof Name.Self self1
-          && argNames.apply(1) instanceof Name.Self self2
-          && self1.synthetic()
-          && !self2.synthetic()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   static boolean computeIsStatic(IR body) {
     if (body instanceof Function.Lambda function) {
       var firstArgName = function.arguments().headOption().map(DefinitionArgument::name);

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/module/scope/definition/Method.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/module/scope/definition/Method.java
@@ -58,8 +58,6 @@ public interface Method extends Definition {
      * @param bodyReference the body of the method
      * @param isStatic true if this method is static, false otherwise
      * @param isPrivate true if this method is private, false otherwise
-     * @param isStaticWrapperForInstanceMethod true if this method represents a static wrapper for
-     *     instance method, false otherwise
      */
     @GenerateFields
     public Explicit(
@@ -67,7 +65,6 @@ public interface Method extends Definition {
         @IRChild Persistance.Reference<Expression> bodyReference,
         @IRField boolean isPrivate,
         @IRField boolean isStatic,
-        @IRField boolean isStaticWrapperForInstanceMethod,
         IdentifiedLocation identifiedLocation,
         MetadataStorage passData,
         DiagnosticStorage diagnostics) {
@@ -76,7 +73,6 @@ public interface Method extends Definition {
           bodyReference,
           isPrivate,
           isStatic,
-          isStaticWrapperForInstanceMethod,
           identifiedLocation,
           passData,
           diagnostics);
@@ -102,8 +98,6 @@ public interface Method extends Definition {
           .bodyReference(Persistance.Reference.of(body, false))
           .isStatic(org.enso.compiler.core.ir.Function.computeIsStatic(body))
           .isPrivate(ir.isPrivate())
-          .isStaticWrapperForInstanceMethod(
-              org.enso.compiler.core.ir.Function.computeIsStaticWrapperForInstanceMethod(body))
           .location(ir.identifiedLocation())
           .passData(ir.passData())
           .diagnostics(ir.diagnostics())

--- a/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
+++ b/engine/runtime-suggestions/src/main/scala/org/enso/compiler/suggestions/SuggestionBuilder.scala
@@ -120,7 +120,6 @@ final class SuggestionBuilder[A: IndexedSource](
 
           case m: definition.Method.Explicit
               if m.body().isInstanceOf[Function.Lambda] &&
-              !m.isStaticWrapperForInstanceMethod &&
               !m.isPrivate =>
             val typePtr       = m.methodReference().typePointer
             val methodName    = m.methodReference().methodName

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -214,13 +214,13 @@ public final class Builtins {
    *     builtin method was ever registerd
    */
   public Optional<BuiltinFunction> getBuiltinFunction(
-      String type, String methodName, EnsoLanguage language, boolean isStaticInstance) {
-    return builtins.getBuiltinFunction(type, methodName, language, isStaticInstance);
+      String type, String methodName, EnsoLanguage language) {
+    return builtins.getBuiltinFunction(type, methodName, language);
   }
 
   public Optional<BuiltinFunction> getBuiltinFunction(
       Type type, String methodName, EnsoLanguage language) {
-    return getBuiltinFunction(type.getName(), methodName, language, false);
+    return getBuiltinFunction(type.getName(), methodName, language);
   }
 
   public <T extends Builtin> T getBuiltinType(Class<T> clazz) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
@@ -117,39 +117,6 @@ final class BuiltinsRegistry {
   }
 
   /**
-   * Registers builtin methods with their corresponding Atom Constructor's owners. That way
-   * "special" builtin types have builtin methods in the scope without requiring everyone to always
-   * import full stdlib.
-   *
-   * @param scope Builtins scope
-   * @param language The language the resulting function nodes should be associated with
-   */
-  private void registerBuiltinMethods(ModuleScopeBuilder scope, EnsoLanguage language) {
-    for (Builtin builtin : builtins.values()) {
-      var type = builtin.getType();
-      Map<String, Supplier<LoadedBuiltinMethod>> methods = builtinMethodNodes.get(type.getName());
-      if (methods != null) {
-        // Register a builtin method iff it is marked as auto-register.
-        // Methods can only register under a type or, if we deal with a static method, it's
-        // eigen-type.
-        // Such builtins are available on certain types without importing the whole stdlib, e.g. Any
-        // or Number.
-        methods.forEach(
-            (key, value) -> {
-              LoadedBuiltinMethod meth = value.get();
-              Type tpe =
-                  meth.isAutoRegister ? (!meth.isStatic() ? type : type.getEigentype()) : null;
-              if (tpe != null) {
-                Optional<BuiltinFunction> fun = meth.toFunction(language, false);
-                fun.ifPresent(
-                    f -> scope.registerMethod(tpe, key, CachingSupplier.forValue(f.getFunction())));
-              }
-            });
-      }
-    }
-  }
-
-  /**
    * Returns a list of supported builtins.
    *
    * <p>Builtin types are marked via @BuiltinType annotation. The metadata file represents a single

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
@@ -89,7 +89,7 @@ final class BuiltinsRegistry {
    *     builtin method was ever registerd
    */
   final Optional<BuiltinFunction> getBuiltinFunction(
-      String type, String methodName, EnsoLanguage language, boolean isStaticInstance) {
+      String type, String methodName, EnsoLanguage language) {
     // TODO: move away from String mapping once Builtins is gone
     Map<String, Supplier<LoadedBuiltinMethod>> atomNodes = builtinMethodNodes.get(type);
     if (atomNodes == null) {
@@ -103,7 +103,7 @@ final class BuiltinsRegistry {
     if (builtin == null) {
       return Optional.empty();
     }
-    return builtin.toFunction(language, isStaticInstance);
+    return builtin.toFunction(language);
   }
 
   private static Map<String, LoadedBuiltinMethod> loadBuiltinMethodClassesEarly(
@@ -287,7 +287,7 @@ final class BuiltinsRegistry {
                   value.isAutoRegister() ? (!value.isStatic() ? type : type.getEigentype()) : null;
               if (tpe != null) {
                 Supplier<Function> supplier =
-                    () -> value.toMethod().toFunction(language, false).get().getFunction();
+                    () -> value.toMethod().toFunction(language).get().getFunction();
                 scope.registerMethod(tpe, key, supplier);
               }
             });
@@ -332,7 +332,7 @@ final class BuiltinsRegistry {
         try {
           @SuppressWarnings("unchecked")
           Class<BuiltinRootNode> clazz = (Class<BuiltinRootNode>) Class.forName(className);
-          Method meth = clazz.getMethod("makeFunction", EnsoLanguage.class, boolean.class);
+          Method meth = clazz.getMethod("makeFunction", EnsoLanguage.class);
           method = new LoadedBuiltinMethod(meth, staticMethod, autoRegister);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
           throw new CompilerError("Invalid builtin method " + className, e);
@@ -343,9 +343,9 @@ final class BuiltinsRegistry {
   }
 
   private record LoadedBuiltinMethod(Method meth, boolean isStatic, boolean isAutoRegister) {
-    Optional<BuiltinFunction> toFunction(EnsoLanguage language, boolean isStaticInstance) {
+    Optional<BuiltinFunction> toFunction(EnsoLanguage language) {
       try {
-        var f = (Function) meth.invoke(null, language, isStaticInstance);
+        var f = (Function) meth.invoke(null, language);
         if (f != null) {
           var bf = new BuiltinFunction(f, isAutoRegister);
           return Optional.of(bf);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/BuiltinsRegistry.java
@@ -234,9 +234,7 @@ final class BuiltinsRegistry {
   }
 
   /**
-   * Register builtin methods and initialize them lazily in the provided scope. This method differs
-   * from `registerBuiltinMethods` where all methods are initialized by the time they are
-   * registered..
+   * Register builtin methods and initialize them lazily in the provided scope.
    *
    * @param scope Builtins scope
    * @param language The language the resulting function nodes should be associated with
@@ -258,7 +256,7 @@ final class BuiltinsRegistry {
           if (constr != null) {
             Map<String, Supplier<LoadedBuiltinMethod>> atomNodes =
                 getOrUpdate(builtinMethodNodes, constr.getName());
-            atomNodes.put(builtinMethodName, CachingSupplier.wrap(() -> meta.toMethod()));
+            atomNodes.put(builtinMethodName, CachingSupplier.wrap(meta::toMethod));
 
             Map<String, LoadedBuiltinMetaMethod> atomNodesMeta =
                 getOrUpdate(builtinMetaMethods, constr.getName());
@@ -266,7 +264,7 @@ final class BuiltinsRegistry {
           } else {
             Map<String, Supplier<LoadedBuiltinMethod>> atomNodes =
                 getOrUpdate(builtinMethodNodes, builtinMethodOwner);
-            atomNodes.put(builtinMethodName, CachingSupplier.wrap(() -> meta.toMethod()));
+            atomNodes.put(builtinMethodName, CachingSupplier.wrap(meta::toMethod));
 
             Map<String, LoadedBuiltinMetaMethod> atomNodesMeta =
                 getOrUpdate(builtinMetaMethods, builtinMethodOwner);

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -750,14 +750,11 @@ private[runtime] class IrToTruffle(
     val methodName      = builtinNameElements(1)
     val methodOwnerName = builtinNameElements(0)
 
-    val staticWrapper = methodDef.isStaticWrapperForInstanceMethod
-
     val builtinFunction = getBuiltins
       .getBuiltinFunction(
         methodOwnerName,
         methodName,
-        language,
-        staticWrapper
+        language
       )
     builtinFunction.toScala
       .map(Some(_))
@@ -770,9 +767,7 @@ private[runtime] class IrToTruffle(
       .flatMap { l =>
         // Builtin Types Number and Integer have methods only for documentation purposes
         val number = getBuiltins.number()
-        val ok =
-          staticWrapper && (cons == number.getNumber.getEigentype || cons == number.getInteger.getEigentype) ||
-          !staticWrapper && (cons == number.getNumber             || cons == number.getInteger)
+        val ok     = cons == number.getNumber || cons == number.getInteger
         if (ok) Right(None)
         else Left(l)
       }

--- a/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/impl/MethodProcessor.java
+++ b/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/impl/MethodProcessor.java
@@ -201,22 +201,11 @@ public class MethodProcessor
       out.println("  private @Children ArgNode[] argNodes = new ArgNode[] {");
       generateArguments(methodDefinition, out);
       out.println("    };");
-      out.println("  private static final class Internals {");
-      out.println("    Internals(boolean s) {");
-      out.println("      this.staticOrInstanceMethod = s;");
-      out.println("    }");
       out.println();
-      out.println("    private final boolean staticOrInstanceMethod;");
-      out.println("  }");
-      out.println("  private final Internals internals;");
 
-      out.println(
-          "  private "
-              + methodDefinition.getClassName()
-              + "(EnsoLanguage language, boolean staticOrInstanceMethod) {");
+      out.println("  private " + methodDefinition.getClassName() + "(EnsoLanguage language) {");
       out.println("    super(language);");
       out.println("    this.bodyNode = " + methodDefinition.getConstructorExpression() + ";");
-      out.println("    this.internals = new Internals(staticOrInstanceMethod);");
       out.println("  }");
 
       out.println();
@@ -227,32 +216,13 @@ public class MethodProcessor
               : "fromBuiltinRootNode";
 
       out.println("  public static Function makeFunction(EnsoLanguage language) {");
-      out.println("    return makeFunction(language, false);");
-      out.println("  }");
-      out.println();
-      out.println(
-          "  public static Function makeFunction(EnsoLanguage language, boolean"
-              + " staticOrInstanceMethod) {");
-      out.println("    if (staticOrInstanceMethod) {");
-      out.println("      return Function." + functionBuilderMethod + "(");
-      out.print(
-          "        new " + methodDefinition.getClassName() + "(language, staticOrInstanceMethod)");
-      List<String> argsStaticInstace =
-          generateMakeFunctionArgs(true, methodDefinition.getArguments());
-      if (!argsStaticInstace.isEmpty()) {
-        out.println(",");
-      }
-      out.println(String.join(",\n", argsStaticInstace) + ");");
-      out.println("    } else {");
-      out.println("      return Function." + functionBuilderMethod + "(");
-      out.print(
-          "        new " + methodDefinition.getClassName() + "(language, staticOrInstanceMethod)");
+      out.println("    return Function." + functionBuilderMethod + "(");
+      out.print("      new " + methodDefinition.getClassName() + "(language)");
       List<String> argsInstance = generateMakeFunctionArgs(false, methodDefinition.getArguments());
       if (!argsInstance.isEmpty()) {
         out.println(",");
       }
       out.println(String.join(",\n", argsInstance) + ");");
-      out.println("    }");
       out.println("  }");
 
       out.println();
@@ -260,9 +230,6 @@ public class MethodProcessor
         out.println("  @Override");
         out.println("  public final InlineableNode createInlineableNode() {");
         out.println("    class Inlineable extends InlineableNode {");
-        out.println(
-            "      private final Internals extra = new"
-                + " Internals(internals.staticOrInstanceMethod);");
         out.println(
             "      private @Child "
                 + methodDefinition.getOriginalClassName()
@@ -272,9 +239,10 @@ public class MethodProcessor
         out.println("      private @Children ArgNode[] argNodes = new ArgNode[] {");
         generateArguments(methodDefinition, out);
         out.println("      };");
+        out.println();
         out.println("      @Override");
         out.println("      public Object call(VirtualFrame frame, Object[] args) {");
-        out.println("        return handleExecute(argNodes, frame, extra, body, args);");
+        out.println("        return handleExecute(argNodes, frame, body, args);");
         out.println("      }");
         out.println("    }");
         out.println();
@@ -290,16 +258,13 @@ public class MethodProcessor
         out.println("    var args = frame.getArguments();");
       } else {
         out.println(
-            "    return handleExecute(argNodes, frame, this.internals, bodyNode,"
-                + " frame.getArguments());");
+            "    return handleExecute(argNodes, frame, bodyNode," + " frame.getArguments());");
         out.println("  }");
         out.println(
-            "  private static Object handleExecute(ArgNode[] argNodes, VirtualFrame frame,"
-                + " Internals internals, "
+            "  private static Object handleExecute(ArgNode[] argNodes, VirtualFrame frame, "
                 + methodDefinition.getOriginalClassName()
                 + " bodyNode, Object[] args) {");
       }
-      out.println("    var prefix = internals.staticOrInstanceMethod ? 1 : 0;");
       if (methodDefinition.needsCallerInfo()) {
         out.println("    CallerInfo callerInfo = Function.ArgumentsHelper.getCallerInfo(args);");
       }
@@ -308,8 +273,7 @@ public class MethodProcessor
       List<String> callArgNames = new ArrayList<>();
       for (MethodDefinition.ArgumentDefinition arg : methodDefinition.getArguments()) {
         if (!(arg.isImplicit() || arg.isFrame() || arg.isCallerInfo() || arg.isNode())) {
-          out.println(
-              "    int arg" + arg.getPosition() + "Idx = " + arg.getPosition() + " + prefix;");
+          out.println("    int arg" + arg.getPosition() + "Idx = " + arg.getPosition() + ";");
         }
       }
       out.println("    var argCtx = new ArgContext();");
@@ -391,9 +355,7 @@ public class MethodProcessor
       out.println("  @Override");
       out.println("  protected RootNode cloneUninitialized() {");
       out.println(
-          "    return new "
-              + methodDefinition.getClassName()
-              + "(EnsoLanguage.get(this), internals.staticOrInstanceMethod);");
+          "    return new " + methodDefinition.getClassName() + "(EnsoLanguage.get(this));");
       out.println("  }");
 
       out.println();

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 
 final class PerMap {
-  private static final int serialVersionUID = 13962; // Use PR number
+  private static final int serialVersionUID = 14234; // Use PR number
   private final Map<Integer, Persistance<?>> ids = new HashMap<>();
   private final Map<Class<?>, Persistance<?>> types = new HashMap<>();
   final int versionStamp;

--- a/project/IRCaches.scala
+++ b/project/IRCaches.scala
@@ -4,10 +4,10 @@ import java.io.File
 
 object IRCaches {
 
-  /** As of 2025-09-12, on latest develop (https://github.com/enso-org/enso/commit/b1f5f661b9ad45604b6e419d79b8bcb2d2cd59e6),
-    * the total cache size is 114.91 MB.
+  /** As of 2025-11-04, on latest develop (https://github.com/enso-org/enso/actions/runs/19065973719/job/54456606143?pr=14223#step:10:3289),
+    * the total cache size is 90.49 MB.
     */
-  val EXPECTED_MAX_SIZE_MB = 130
+  val EXPECTED_MAX_SIZE_MB = 100
 
   /** Ensures that IR caches of all standard libraries
     * are within the size limit.


### PR DESCRIPTION
Follow-up of https://github.com/enso-org/enso/pull/13962

Part of https://github.com/enso-org/enso/issues/11686

### Pull Request Description

Builtin methods do not accept two self arguments. Remove boolean field from IR node. Decrease expected IR cache sizes.

### Important Notes

- Removed `isStaticWrapperForInstanceMethod` boolean field from `Method.Explicit` IR.
  - impact on cache sizes: reduction by 500 KB.
- Removed `isStaticInstance` parameter from generated builtin method code.
  - This simplifies the generated code.
  - It used to receive two self arguments. Now, it receives a single self argument.
- Reduce the expected IR cache size.
  - 7d906ef08d3afcbb35f3368498132635ffe3c75c
  - Reduce from 130MB to 100MB.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
