### PR TITLE
Fail benchmarks on error

### DIFF
--- a/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.results.BenchmarkResult;
@@ -29,6 +30,9 @@ public class BenchmarksRunner {
     if (args.length == 0) {
       args = new String[] {"--jvmArgsPrepend=-Dbench.all=true"};
     }
+    var old = Stream.of(args);
+    var add = Stream.of("--foe=true");
+    args = Stream.concat(old, add).toArray(String[]::new);
     CommandLineOptions cmdOpts = null;
     try {
       cmdOpts = new CommandLineOptions(args);

--- a/test/Benchmarks/src/Table/Internal/Multi_Value_Key.enso
+++ b/test/Benchmarks/src/Table/Internal/Multi_Value_Key.enso
@@ -74,7 +74,7 @@ collect_benches = Bench.build builder->
             key_columns = table.columns
             directions = Vector.fill key_columns.length False
             make_key row_ix = Ordered_Multi_Value_Key.from_row key_columns directions row_ix
-            compare_keys key1 key2 = key1 < key2
+            compare_keys key1 key2 = Comparable.< self=key1 that=key2
             compare_ordered_keys make_key table compare_keys
 
         group_builder.specify "Primitive_Enso" <|


### PR DESCRIPTION
### Pull Request Description

Simple fix for #13901. Tell JMH to _fail on error_ via `--foe` flag. A failing benchmark will _turn everything down_. However the idea is: if things are completely down, the like-a-hood of someone noticing is higher than if there is one small benchmark failing among hundreds of others (like in 10283fe28b). Hence let's fail abruptly and force people to investigate what's wrong.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- [x] Unit tests have been written where possible.
- [x] [Engine benchmarks](https://github.com/enso-org/enso/actions/runs/19071625603) executed
- [x] Standard Libraries benchmarks executed
   -  [first run](https://github.com/enso-org/enso/actions/runs/19071630167) detected a failing benchmark (that's success of this PR!)
   - fixed in 10283fe28b and scheduling [second run](https://github.com/enso-org/enso/actions/runs/19098038059) is **green**!
