### PR TITLE
Re-enabling CurriedFunctionBenchmarks

### DIFF
--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
@@ -1,0 +1,112 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.logging.Level;
+import org.enso.common.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.io.IOAccess;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class CurriedFunctionBenchmarks {
+  private Value fn;
+  private Value avg;
+
+  @Setup
+  public void initializeBenchmark(BenchmarkParams params) throws Exception {
+    var ctx =
+        Context.newBuilder()
+            .allowExperimentalOptions(true)
+            .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
+            .logHandler(System.err)
+            .allowIO(IOAccess.ALL)
+            .allowAllAccess(true)
+            .option(
+                "enso.languageHomeOverride",
+                Paths.get("../../distribution/component").toFile().getAbsolutePath())
+            .build();
+
+    var benchmarkName = SrcUtil.findName(params);
+    var code =
+        """
+        from Standard.Base import all
+
+        avg fn len =
+            sum acc i = if i == len then acc else
+                @Tail_Call sum (acc + fn i) i+1
+            (sum 0 0) / len
+
+        type Holder
+            three_times x = 3 * x
+
+        callback_curried =
+            h = Holder
+            h.three_times
+
+        callback_lambda =
+            h = Holder
+            (x -> h.three_times x)
+        """;
+
+    var module = ctx.eval(SrcUtil.source(benchmarkName, code));
+
+    Function<String, Value> getMethod = (name) -> module.invokeMember("eval_expression", name);
+    switch (benchmarkName) {
+      case "averageLambda":
+        {
+          this.fn = getMethod.apply("callback_lambda");
+          break;
+        }
+      case "averageCurried":
+        {
+          this.fn = getMethod.apply("callback_curried");
+          break;
+        }
+      default:
+        throw new IllegalStateException("Unexpected benchmark: " + params.getBenchmark());
+    }
+    this.avg = getMethod.apply("avg");
+  }
+
+  @Benchmark
+  public void averageLambda(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void averageCurried(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  private void performBenchmark(Blackhole hole) throws AssertionError {
+    var average = avg.execute(fn, 10000);
+    if (!average.fitsInDouble()) {
+      throw new AssertionError("Shall be a double: " + average);
+    }
+    var result = (long) average.asDouble();
+    boolean isResultCorrect = result == 14998;
+    if (!isResultCorrect) {
+      throw new AssertionError("Expecting reasonable average but was " + result + "\n" + fn);
+    }
+    hole.consume(result);
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Fixes #8321 by adding `@Tail_Call` annotation and avoiding `StackOverflowError`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] [Benchmarks execute](https://github.com/enso-org/enso/actions/runs/19072809109) fine - yes, [they do](https://github.com/enso-org/enso/actions/runs/19072809109/job/54480006006#step:10:2609)
