### PR TITLE
Add `Upload heapdump` step to all JVM tests jobs

### DIFF
--- a/.github/workflows/engine-checks-nightly.yml
+++ b/.github/workflows/engine-checks-nightly.yml
@@ -372,6 +372,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, linux, amd64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1
         with:
@@ -447,6 +457,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, macos, aarch64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1
         with:
@@ -521,6 +541,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, windows, amd64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1
         with:
@@ -594,6 +624,16 @@ jobs:
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, linux, amd64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1

--- a/.github/workflows/engine-checks.yml
+++ b/.github/workflows/engine-checks.yml
@@ -255,6 +255,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, linux, amd64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1
         with:
@@ -328,6 +338,16 @@ jobs:
       - run: ./run backend test jvm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        name: Upload Heap Dumps
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: Heap dumps (JVM Tests, windows, amd64)
+          path: |-
+            test/**/*.hprof
+            engine/**/*.hprof
+          retention-days: 3
       - if: (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Engine Test Reporter
         uses: dorny/test-reporter@v1

--- a/build_tools/build/src/ci_gen/job.rs
+++ b/build_tools/build/src/ci_gen/job.rs
@@ -240,6 +240,8 @@ impl JobArchetype for JvmTests {
         let graal_edition = self.graal_edition;
         let engine_launcher = self.engine_launcher;
         let job_name = format!("JVM Tests ({graal_edition})");
+        let heapdump_artifact_name =
+            format!("Heap dumps ({}, {}, {})", "JVM Tests", target.0, target.1);
         let mut job = RunStepsBuilder::new("backend test jvm")
             .customize(move |step| {
                 let cleanup_engine_distribution =
@@ -248,12 +250,15 @@ impl JobArchetype for JvmTests {
                 let download_engine_distribution =
                     step::download_engine_distribution(target, engine_launcher, graal_edition);
 
+                let upload_hprof_step = step::heapdump_upload(heapdump_artifact_name);
+
                 vec![
                     cleanup_engine_distribution,
                     download_engine_distribution,
                     step::check_engine_distribution(),
                     step::unpack_engine_distribution(),
                     step,
+                    upload_hprof_step,
                     step::engine_test_reporter(target, graal_edition),
                 ]
             })


### PR DESCRIPTION
### Pull Request Description

In #13981 "Upload Heapdump" step was introduced to every "Standard Library Tests" job. This PR adds this step also into every "JVM Tests" job.

### Important Notes
Note that before https://www.github.com/enso-org/enso/pull/14219/files#r2495228404, there were no `.hprof` files in the JVM tests.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
