### PR TITLE
Always build ydoc-server .so when shouldBuildNativeImage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6507,6 +6507,7 @@ lazy val buildEngineDistributionNoIndex =
 buildEngineDistributionNoIndex := Def.taskIf {
   createEnginePackageNoIndex.value
   if (shouldBuildNativeImage.value) {
+    (`ydoc-server` / buildNativeImage).value
     (`engine-runner` / buildNativeImage).value
     (`engine-runner` / checkNativeImageSize).value
   }


### PR DESCRIPTION
### Pull Request Description

- Add on to #14232
- and #14245 
- need to build `org-enso-ydoc-server.so` file when building `enso` binary executable 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Tests will pass
