### PR TITLE
Handle Ydoc shutdown correctly 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1998,7 +1998,7 @@ lazy val `ydoc-polyfill` = project
     Compile / internalModuleDependencies := Seq(
       (`syntax-rust-definition` / Compile / exportedModule).value
     ),
-    libraryDependencies ++= slf4jApi ++ Seq(
+    libraryDependencies ++= logbackTest ++ slf4jApi ++ Seq(
       "org.graalvm.truffle"  % "truffle-api"                 % graalMavenPackagesVersion % "provided",
       "org.graalvm.polyglot" % "inspect-community"           % graalMavenPackagesVersion % "runtime",
       "org.graalvm.polyglot" % "js-community"                % graalMavenPackagesVersion % "runtime",

--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
@@ -9,6 +9,7 @@ import io.helidon.webclient.websocket.WsClientProtocolConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.websocket.WsRouting;
+import io.helidon.websocket.WsCloseCodes;
 import io.helidon.websocket.WsListener;
 import io.helidon.websocket.WsSession;
 import java.io.UncheckedIOException;
@@ -46,6 +47,7 @@ final class WebSocket implements ProxyExecutable {
   private static final String NEW_WEB_SOCKET_SERVER = "new-web-socket-server";
   private static final String WEB_SOCKET_SERVER_START = "web-socket-server-start";
 
+  private static final String SOCKET_CLOSED_REASON = "Socket closed";
   private static final String WEBSOCKET_JS = "websocket.js";
 
   private final ScheduledExecutorService executor;
@@ -196,7 +198,11 @@ final class WebSocket implements ProxyExecutable {
 
         var session = connection.getSession();
         if (session != null) {
-          session.terminate();
+          try {
+            session.terminate();
+          } catch (IllegalStateException socketClosed) {
+            connection.onClose(session, WsCloseCodes.CLOSED_ABNORMALLY, SOCKET_CLOSED_REASON);
+          }
         }
 
         yield null;
@@ -210,7 +216,11 @@ final class WebSocket implements ProxyExecutable {
         var session = connection.getSession();
         if (session != null) {
           var reason = reasonArgument == null ? "Close" : reasonArgument;
-          session.close(code, reason);
+          try {
+            session.close(code, reason);
+          } catch (IllegalStateException socketClosed) {
+            connection.onClose(session, WsCloseCodes.CLOSED_ABNORMALLY, SOCKET_CLOSED_REASON);
+          }
         }
 
         yield null;

--- a/lib/java/ydoc-polyfill/src/main/resources/org/enso/ydoc/polyfill/web/websocket.js
+++ b/lib/java/ydoc-polyfill/src/main/resources/org/enso/ydoc/polyfill/web/websocket.js
@@ -229,6 +229,8 @@
         }
 
         close(code, reason) {
+            if (this.#state == WebSocket.CLOSED) return
+
             this.#state = WebSocket.CLOSING;
             if (code === undefined) {
                 jvm('web-socket-terminate', this._connection);

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
@@ -249,6 +249,7 @@ public class WebSocketTest extends ExecutorSetup {
           ws.close();
           ws.close();
           res.set(true);
+          // Notify that the client socket is closed
           lock.release();
         });
         """;
@@ -258,6 +259,7 @@ public class WebSocketTest extends ExecutorSetup {
 
     CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
 
+    // Wait until the client socket is closed
     lock.acquire();
 
     Assert.assertTrue(res.get());
@@ -274,11 +276,14 @@ public class WebSocketTest extends ExecutorSetup {
         """
         var ws = new WebSocket('ws://localhost:22334');
         ws.addEventListener('open', () => {
+          // Notify that the client socket is connected
           lock1.release();
+          // Wait until the server socket is closed
           lock2.acquire();
-          // Close WebSocket closed by the server
+          // Close the client socket (closed by the server)
           ws.close();
           res.set(true);
+          // Notify that the client socket is closed
           lock3.release();
         });
         """;
@@ -290,9 +295,13 @@ public class WebSocketTest extends ExecutorSetup {
 
     CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
 
+    // Wait for the client socket connection
     lock1.acquire();
+    // Close the server socket
     ws.stop();
+    // Notify that the server socked is closed
     lock2.release();
+    // Wait until the client socket is closed
     lock3.acquire();
 
     Assert.assertTrue(res.get());

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
@@ -48,6 +48,7 @@ public class WebSocketTest extends ExecutorSetup {
             .allowAccess(AtomicReference.class.getDeclaredMethod("set", Object.class))
             .allowAccess(
                 AtomicReferenceArray.class.getDeclaredMethod("set", int.class, Object.class))
+            .allowAccess(Semaphore.class.getDeclaredMethod("acquire"))
             .allowAccess(Semaphore.class.getDeclaredMethod("release"))
             .build();
     var contextBuilder = WebEnvironment.createContext(hostAccess);
@@ -232,6 +233,67 @@ public class WebSocketTest extends ExecutorSetup {
     CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
 
     lock.acquire();
+
+    Assert.assertTrue(res.get());
+  }
+
+  @Test
+  public void closeIdempotent() throws Exception {
+    var lock = new Semaphore(0);
+    var res = new AtomicBoolean(false);
+
+    var code =
+        """
+        var ws = new WebSocket('ws://localhost:22334');
+        ws.addEventListener('open', () => {
+          ws.close();
+          ws.close();
+          res.set(true);
+          lock.release();
+        });
+        """;
+
+    context.getBindings("js").putMember("lock", lock);
+    context.getBindings("js").putMember("res", res);
+
+    CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
+
+    lock.acquire();
+
+    Assert.assertTrue(res.get());
+  }
+
+  @Test
+  public void handleSocketClosed() throws Exception {
+    var lock1 = new Semaphore(0);
+    var lock2 = new Semaphore(0);
+    var lock3 = new Semaphore(0);
+    var res = new AtomicBoolean(false);
+
+    var code =
+        """
+        var ws = new WebSocket('ws://localhost:22334');
+        ws.addEventListener('open', () => {
+          lock1.release();
+          lock2.acquire();
+          // Close WebSocket closed by the server
+          ws.close();
+          res.set(true);
+          lock3.release();
+        });
+        """;
+
+    context.getBindings("js").putMember("lock1", lock1);
+    context.getBindings("js").putMember("lock2", lock2);
+    context.getBindings("js").putMember("lock3", lock3);
+    context.getBindings("js").putMember("res", res);
+
+    CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
+
+    lock1.acquire();
+    ws.stop();
+    lock2.release();
+    lock3.acquire();
 
     Assert.assertTrue(res.get());
   }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #14225 

Changelog:
- update: handle the case when WebSocket was closed by the server during shutdown

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
