### PR TITLE
`Standard.Base` is closesely connected to Engine

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,10 @@ tsconfig.json
 /project/ @4e6 @jaroslavtulach @hubertp @Akirathan
 /tools/ @4e6 @jaroslavtulach @hubertp @Akirathan
 
+# Engine & Core Enso Libraries
+/distribution/lib/Standard/Base/ @jaroslavtulach
+/std-bits/base/ @jaroslavtulach
+
 # Enso Libraries
 # This section should be amended once the engine moves to /app/engine
 /distribution/lib/ @jdunkerley @hubertp @GregoryTravis @AdRiley


### PR DESCRIPTION
### Pull Request Description

- `Standard.Base` contains _builtins_ as well as other code working in close orchestration with engine
- API of `Standard.Base` is the _core API of Enso_ runtime
- reviewers of Engine code need to be notified of changes in `Standard.Base` in advance
