### PR TITLE
Python date tests seem to work on GraalVM 25.0.1

### DIFF
--- a/test/Base_Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Spec.enso
@@ -17,7 +17,7 @@ add_specs suite_builder =
     if Polyglot.is_language_installed "js" then
         spec_with suite_builder "JavaScriptDate" js_date js_parse
     if Polyglot.is_language_installed "python" then
-        spec_with suite_builder "PythonDate" python_date python_parse pending="https://github.com/enso-org/enso/issues/8913"
+        spec_with suite_builder "PythonDate" python_date python_parse
     spec_with suite_builder "JavaDate" java_date java_parse
     if Polyglot.is_language_installed "js" then
         spec_with suite_builder "JavaScriptArrayWithADate" js_array_date js_parse


### PR DESCRIPTION
### Pull Request Description

- upgrade to GraalVM 25.0.1 seems to improve behavior of Python interop
- enabling pending test
- fixes #8632
- fixes #8913

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the Enso styleguides
- [x] Fifty unit tests enabled - [see PythonDate & co.](https://github.com/enso-org/enso/actions/runs/19260530157/job/55149822213?pr=14276#step:14:1060)