### PR TITLE
Do not check memory leaks in VectorSortTest.

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/VectorSortTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/VectorSortTest.java
@@ -22,7 +22,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Theories.class)
 public class VectorSortTest {
-  @ClassRule public static final ContextUtils ctxRule = ContextUtils.createDefault();
+  @ClassRule
+  public static final ContextUtils ctxRule = ContextUtils.newBuilder().assertGC(false).build();
+
   private static Value sortFunc;
   private static Value equalsFunc;
 


### PR DESCRIPTION
Closes #14277.

### Pull Request Description

Memory leak checks caused frequent transient failures in `VectorSortTest`. This PR simple disables these checks in that test.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
