### PR TITLE
No need to copy and replace jvm: true, there is none anymore

### DIFF
--- a/test/Base_Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Spec.enso
@@ -17,7 +17,7 @@ add_specs suite_builder =
     if Polyglot.is_language_installed "js" then
         spec_with suite_builder "JavaScriptDate" js_date js_parse
     if Polyglot.is_language_installed "python" then
-        spec_with suite_builder "PythonDate" python_date python_parse
+        spec_with suite_builder "PythonDate" python_date python_parse pending="https://github.com/enso-org/enso/issues/8913"
     spec_with suite_builder "JavaDate" java_date java_parse
     if Polyglot.is_language_installed "js" then
         spec_with suite_builder "JavaScriptArrayWithADate" js_array_date js_parse

--- a/test/Benchmarks/src/Jvms/Execute_Generic_JDBC_Tests.enso
+++ b/test/Benchmarks/src/Jvms/Execute_Generic_JDBC_Tests.enso
@@ -34,7 +34,7 @@ collect_benches = Bench.build builder->
     options = Bench.options . set_warmup (Bench.phase_conf 1 10) . set_measure (Bench.phase_conf 2 10)
 
     exe = find_enso_bin
-    data = Data.Value exe (copy_test_prj exe "Generic_JDBC_Tests")
+    data = Data.Value exe (find_test_prj exe "Generic_JDBC_Tests")
 
     no_test_filter = "NoTestFilter"
     single_test_filter = "should.be.able.to.insert..update"
@@ -60,7 +60,7 @@ collect_benches = Bench.build builder->
         group_builder.specify "Real_Dual_JVM_Tests" <|
             data.bench_tests 3 jvm=True [ "--vm.D=polyglot.enso.classLoading=guest", real_test_filter ]
 
-private copy_test_prj bin:File name:Text -> File =
+private find_test_prj bin:File name:Text -> File =
     repo_root e =
         if e/".git" . exists then e else
             @Tail_Call repo_root e.parent
@@ -72,24 +72,7 @@ private copy_test_prj bin:File name:Text -> File =
     prj = install_dir / "test" / name
     Runtime.assert prj.is_directory "Found directory "+prj.to_text
 
-    copy s d =
-        if s.is_directory.not then s.copy_to d else
-            d.create_directory
-            s.list . map f->
-                copy f d/f.name
-
-    copy prj target
-
-    yaml = target/"package.yaml"
-    yaml_text = yaml.read_text
-    new_text = yaml_text . replace "jvm: true" ""
-    replace = new_text.write path=yaml
-    IO.println "Replacing "+replace.to_text+" with:"
-    IO.println yaml.read_text
-    IO.println "Enso project created at "+target.to_text
-
-    target
-
+    prj
 
 private find_enso_bin =
     find_prefix dir prefix =

--- a/test/Benchmarks/src/Jvms/Execute_Generic_JDBC_Tests.enso
+++ b/test/Benchmarks/src/Jvms/Execute_Generic_JDBC_Tests.enso
@@ -65,9 +65,6 @@ private find_test_prj bin:File name:Text -> File =
         if e/".git" . exists then e else
             @Tail_Call repo_root e.parent
 
-    target = File.create_temporary_file
-    target.delete
-
     install_dir = repo_root bin
     prj = install_dir / "test" / name
     Runtime.assert prj.is_directory "Found directory "+prj.to_text


### PR DESCRIPTION
### Pull Request Description

- [stdlib benchmarks](https://github.com/enso-org/enso/actions/runs/19282004870/job/55134921437#step:10:6416) are failing
   - probably because of #14263 change
   - in `test/Generic_JDBC_Tests`
- #13780 had to copy `Generic_JDBC_Tests` project
- and replace `jvm: true` in it will an empty line
- this is no longer necessary as there is no `jvm: true` line anymore - avoiding copy

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      style guides. 
- [x] Unit tests have been written where possible.
- [x] Benchmark [run successful](https://github.com/enso-org/enso/actions/runs/19293181533) again