### PR TITLE
Testing EnsoMeta ability to load Enso types from Standard.Base

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5531,7 +5531,6 @@ lazy val `std-tests` = project
   .configs(Test)
   .settings(
     frgaalJavaCompilerSetting,
-    mockitoAgentSettings,
     commands += WithDebugCommand.withDebug,
     Test / fork := true,
     autoScalaLibrary := false,

--- a/build.sbt
+++ b/build.sbt
@@ -403,6 +403,7 @@ lazy val enso = (project in file("."))
     `std-microsoft`,
     `std-snowflake`,
     `std-table`,
+    `std-tests`,
     `std-tableau`,
     `std-saas`,
     `std-duckdb`,
@@ -5524,6 +5525,27 @@ lazy val `std-table` = project
   )
   .dependsOn(`poi-wrapper`)
   .dependsOn(`std-base` % "provided")
+
+lazy val `std-tests` = project
+  .in(file("std-bits") / "tests")
+  .configs(Test)
+  .settings(
+    frgaalJavaCompilerSetting,
+    mockitoAgentSettings,
+    commands += WithDebugCommand.withDebug,
+    Test / fork := true,
+    autoScalaLibrary := false,
+    Compile / compile / compileInputs := (Compile / compile / compileInputs)
+      .dependsOn(SPIHelpers.ensureSPIConsistency)
+      .value,
+    libraryDependencies ++= Seq(
+      "junit"          % "junit"           % junitVersion   % Test,
+      "com.github.sbt" % "junit-interface" % junitIfVersion % Test
+    )
+  )
+  .dependsOn(`std-base`)
+  .dependsOn(`std-table`)
+  .dependsOn(`test-utils`)
 
 lazy val `opencv-wrapper` = project
   .in(file("lib/java/opencv-wrapper"))

--- a/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/EnsoMetaTest.java
+++ b/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/EnsoMetaTest.java
@@ -1,0 +1,35 @@
+package org.enso.base.polyglot.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.enso.base.polyglot.EnsoMeta;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.PolyglotException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class EnsoMetaTest {
+  @ClassRule public static final ContextUtils ctx = ContextUtils.createDefault();
+
+  @BeforeClass
+  public static void importAll() {
+    ctx.eval("enso", "from Standard.Base import all");
+  }
+
+  @Test
+  public void loadErrorType() {
+    var errorType = EnsoMeta.getType("Standard.Base.Error", "Error");
+    assertTrue("Is meta object", errorType.isMetaObject());
+    var fqn = errorType.getMetaQualifiedName();
+    assertEquals("Standard.Base.Error.Error", fqn);
+    var error = errorType.invokeMember("throw", "error message");
+    assertTrue("An error was created", error.isException());
+    try {
+      throw error.throwException();
+    } catch (PolyglotException ex) {
+      assertEquals("Converted to panic with the same exception", "error message", ex.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description

- comments in #14040 indicates
- a need for `std-bits` to be tested with `@Rule ContextUtils`
- e.g. run quickly as JUnit tests
- allow access to Enso runtime while running the tests

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
