### PR TITLE
Update enso runner environment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4228,6 +4228,8 @@ lazy val `engine-runner` = project
               "net.snowflake.client",
               "com.sun.jna",
               "com.tableau.hyperapi",
+              "com.typesafe.config.impl.ConfigImpl$EnvVariablesHolder",
+              "com.typesafe.config.impl.ConfigImpl$SystemPropertiesHolder",
               // See https://github.com/HarrDevY/native-register-bouncy-castle
               "org.bouncycastle.jcajce.provider.drbg.DRBG$Default",
               "org.bouncycastle.jcajce.provider.drbg.DRBG$NonceAndIV",

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/config/ApplicationConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/config/ApplicationConfig.scala
@@ -12,7 +12,7 @@ object ApplicationConfig {
   private val ConfigNamespace = "language-server"
 
   /** Load the configuration from the config file. */
-  private def loadConfig(): ApplicationConfig = {
+  def load(): ApplicationConfig = {
     val contextClassLoader = Thread.currentThread().getContextClassLoader
     try {
       Thread.currentThread().setContextClassLoader(getClass.getClassLoader)
@@ -22,26 +22,6 @@ object ApplicationConfig {
         .at(ConfigNamespace)
         .loadOrThrow[ApplicationConfig]
     } finally Thread.currentThread().setContextClassLoader(contextClassLoader)
-  }
-
-  /** Override the configuration with environment variables.
-    *
-    * This is a workaround for the issue that the standard config overloading
-    * does not work in the native image.
-    */
-  private def overrideConfig(config: ApplicationConfig): ApplicationConfig = {
-    val ydocHostname =
-      sys.env.getOrElse("LANGUAGE_SERVER_YDOC_HOSTNAME", config.ydoc.hostname)
-    val ydocPort = sys.env
-      .get("LANGUAGE_SERVER_YDOC_PORT")
-      .map(_.toInt)
-      .getOrElse(config.ydoc.port)
-
-    config.copy(ydoc = YdocConfig(hostname = ydocHostname, port = ydocPort))
-  }
-
-  def load(): ApplicationConfig = {
-    overrideConfig(loadConfig())
   }
 
 }

--- a/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
+++ b/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
@@ -19,6 +19,10 @@ public abstract class LanguageServerApi {
   public static final String SKIP_GRAALVM_UPDATER = "skip-graalvm-updater";
   public static final String NO_LOG_MASKING_OPTION = "no-log-masking";
 
+  public static final String ENSO_CLOUD_PROJECT_ID_ENV_NAME = "ENSO_CLOUD_PROJECT_ID";
+  public static final String ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME =
+      "ENSO_CLOUD_PROJECT_SESSION_ID";
+
   public static void launchLanguageServer(CommandLine line, ProfilingConfig config, Level logLevel)
       throws WrongOption {
     var loader = LanguageServerApi.class.getClassLoader();

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1672,11 +1672,17 @@ public class Main {
     }
     if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_ID_OPTION)) {
       MDC.put("projectId", line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_ID_OPTION));
+    } else if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME) != null) {
+      MDC.put("projectId", System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME));
     }
     if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION)) {
       MDC.put(
           "projectSessionId",
           line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION));
+    } else if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME) != null) {
+      MDC.put(
+          "projectSessionId",
+          System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME));
     }
     MDC.put("projectLocalId", projectId);
     RunnerLogging.setup(connectionUri, logLevel, logMasking[0]);


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- close #14285 

Changelog:
- fix: language server config overloading with environment variables (fixes setting of cloud environment)
- fix: CLOUD_PROJECT env vars setting

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
