### PR TITLE
Minor fixes for asset versions panel

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1107,6 +1107,7 @@ export interface InviteUserRequestBody {
 export interface ListInvitationsResponseBody {
   readonly invitations: readonly Invitation[]
   readonly availableLicenses: number
+  readonly maxLicenses: number
 }
 
 /** Invitation to join an organization. */
@@ -1766,7 +1767,11 @@ export abstract class Backend {
   /** Restore an arbitrary asset from the trash. */
   abstract undoDeleteAsset(assetId: AssetId, parentDirectoryId: DirectoryId | null): Promise<void>
   /** Copy an arbitrary asset to another directory. */
-  abstract copyAsset(assetId: AssetId, parentDirectoryId: DirectoryId): Promise<CopyAssetResponse>
+  abstract copyAsset(
+    assetId: AssetId,
+    parentDirectoryId: DirectoryId,
+    versionId?: S3ObjectVersionId,
+  ): Promise<CopyAssetResponse>
   /** Create a project for the current user. */
   abstract createProject(body: CreateProjectRequestBody): Promise<CreatedProject>
   /** Close a project. */

--- a/app/common/src/services/RemoteBackend.ts
+++ b/app/common/src/services/RemoteBackend.ts
@@ -540,10 +540,11 @@ export class RemoteBackend extends backend.Backend {
   override async copyAsset(
     assetId: backend.AssetId,
     parentDirectoryId: backend.DirectoryId,
+    versionId?: backend.S3ObjectVersionId,
   ): Promise<backend.CopyAssetResponse> {
     const response = await this.post<backend.CopyAssetResponse>(
       remoteBackendPaths.copyAssetPath(assetId),
-      { parentDirectoryId },
+      { parentDirectoryId, versionId },
     )
 
     if (!response.ok) {

--- a/app/gui/integration-test/mock/cloudApi.ts
+++ b/app/gui/integration-test/mock/cloudApi.ts
@@ -919,6 +919,7 @@ export async function mockCloudApi(page: Page) {
       return {
         invitations: [],
         availableLicenses: totalSeats - usersMap.size,
+        maxLicenses: totalSeats,
       }
     })
     await post(paths.INVITE_USER_PATH, async (route) => {

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersion.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersion.tsx
@@ -24,6 +24,7 @@ export interface Version extends backendService.S3ObjectVersion {
 /** Options for duplicating an asset. */
 export interface DuplicateOptions {
   readonly start?: boolean
+  readonly versionId?: backendService.S3ObjectVersionId
 }
 
 /** Props for a {@link AssetVersion}. */
@@ -116,12 +117,18 @@ export function AssetVersion(props: AssetVersionProps) {
               </Menu.Item>
             )}
 
-            <Menu.Item onAction={doDuplicate} icon="duplicate">
+            <Menu.Item
+              onAction={() => doDuplicate({ versionId: version.versionId })}
+              icon="duplicate"
+            >
               {getText('duplicateThisVersion')}
             </Menu.Item>
 
             {isProject && (
-              <Menu.Item onAction={() => doDuplicate({ start: true })} icon="copy">
+              <Menu.Item
+                onAction={() => doDuplicate({ start: true, versionId: version.versionId })}
+                icon="copy"
+              >
                 {getText('duplicateAndOpen')}
               </Menu.Item>
             )}
@@ -166,7 +173,7 @@ interface VersionDialogProps {
   readonly backend: Backend
   readonly item: backendService.ProjectAsset
   readonly doRestore?: (() => Promise<void> | void) | undefined
-  readonly doDuplicate?: (() => Promise<void> | void) | undefined
+  readonly doDuplicate?: ((options?: DuplicateOptions) => Promise<void> | void) | undefined
 }
 
 /** Displays a dialog that allows the user to compare two versions of an asset. */
@@ -207,7 +214,7 @@ function VersionDialog(props: VersionDialogProps) {
               loaderPosition="icon"
               icon="duplicate"
               onPress={async () => {
-                await doDuplicate()
+                await doDuplicate({ versionId: version.versionId })
               }}
             >
               {getText('duplicateThisVersion')}

--- a/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersions.tsx
+++ b/app/gui/src/dashboard/layouts/AssetPanel/components/AssetVersions.tsx
@@ -1,7 +1,7 @@
 /** @file A list of previous versions of an asset. */
 import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Result } from '#/components/Result'
-import { copyAssetsMutationOptions } from '#/hooks/backendBatchedHooks'
+import { backendMutationOptions } from '#/hooks/backendHooks'
 import { useEventCallback } from '#/hooks/eventCallbackHooks'
 import { useToastAndLog } from '#/hooks/toastAndLogHooks'
 import { useBackends, useText } from '$/providers/react'
@@ -102,13 +102,17 @@ function AssetVersionsInternal(props: AssetVersionsInternalProps) {
     meta: { invalidates: [queryOptions.queryKey], awaitInvalidates: true },
   })
 
-  const duplicateProjectMutation = useMutation(copyAssetsMutationOptions(backend))
+  const duplicateProjectMutation = useMutation(backendMutationOptions(backend, 'copyAsset'))
 
   const doDuplicate = useEventCallback(async (options?: DuplicateOptions) => {
-    const newItem = await duplicateProjectMutation.mutateAsync([[item.id], item.parentId])
-    const newAsset = newItem[0]?.asset
+    const newItem = await duplicateProjectMutation.mutateAsync([
+      item.id,
+      item.parentId,
+      options?.versionId,
+    ])
+    const newAsset = newItem.asset
 
-    if (options?.start === true && newAsset != null && item.type === AssetType.project) {
+    if (options?.start === true && item.type === AssetType.project) {
       // This is SAFE because we know that the the new asset is a Project,
       // because we can't create a duplicate with a different type.
       /* eslint-disable-next-line no-restricted-syntax */

--- a/app/gui/src/dashboard/layouts/Settings/MembersSettingsSection.tsx
+++ b/app/gui/src/dashboard/layouts/Settings/MembersSettingsSection.tsx
@@ -36,7 +36,7 @@ export default function MembersSettingsSection() {
   const feature = getFeature('inviteUser')
 
   const seatsLeft = isUnderPaywall ? invitations.availableLicenses : null
-  const seatsTotal = feature.meta.maxSeats
+  const seatsTotal = isUnderPaywall ? invitations.maxLicenses : feature.meta.maxSeats
   const isAdmin = user.isOrganizationAdmin
 
   return (


### PR DESCRIPTION
…of licenses

### Pull Request Description

1. Adds support for `versionId` to copy endpoint when trying to `Restore from version`
2. Duplicates now respects choose asset / project version
3. Fix `Duplicate & run`. 
4. Remove hardocded max number of licenses on members page.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
