### PR TITLE
Fix HTTP_Error Viz

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/HTTP_Error.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/HTTP_Error.enso
@@ -2,8 +2,8 @@ import project.Data.Text.Text
 import project.Error.Error
 import project.Network.HTTP.HTTP_Status_Code.HTTP_Status_Code
 import project.Network.URI.URI
-import project.Nothing.Nothing
 import project.Panic.Panic
+from project.Nothing import all
 
 polyglot java import java.io.IOException
 

--- a/test/Base_Tests/src/Network/Http_Spec.enso
+++ b/test/Base_Tests/src/Network/Http_Spec.enso
@@ -76,6 +76,8 @@ add_specs suite_builder =
                 r.should_fail_with HTTP_Error
                 r.catch.should_be_a HTTP_Error.Status_Error
                 r.catch.status_code.code . should_equal 302
+                r.catch.uri . should_equal (URI.from (base_url_with_slash+"test_redirect"))
+                r.catch.to_display_text . should_contain "status 302"
 
         group_builder.specify "should create HTTP client with proxy setting" <|
             proxy_setting = Proxy.Address "example.com" 80


### PR DESCRIPTION
### Pull Request Description

Before:

<img width="1003" height="371" alt="image" src="https://github.com/user-attachments/assets/905f14e9-fa42-45f0-ad66-1dab423dddb9" />

After:

<img width="1404" height="556" alt="image" src="https://github.com/user-attachments/assets/16af91d3-f39e-458f-9c8d-6eacdbcb6c29" />

But... The new test passes with or without the code change, so isn't really a test at all

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
