### PR TITLE
Resolve Proxy StorageType by type and size

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.List;
@@ -34,14 +35,24 @@ public class Mean extends KnownTypeAggregator {
   private static StorageType<?> resultTypeFromInput(ColumnStorage<?> inputStorage) {
     var resolvedStorage = ColumnStorageWithInferredStorage.resolveStorage(inputStorage);
     var inputType = resolvedStorage.getType();
+    return resultTypeFromInputType(inputType);
+  }
+
+  private static StorageType<?> resultTypeFromInputType(StorageType<?> inputType)
+      throws IllegalStateException {
     return switch (inputType) {
       case FloatType floatType -> FloatType.FLOAT_64;
       case IntegerType integerType -> FloatType.FLOAT_64;
       case BigIntegerType bigIntegerType -> BigDecimalType.INSTANCE;
       case BigDecimalType bigDecimalType -> BigDecimalType.INSTANCE;
       case NullType nullType -> nullType;
-      default ->
-          throw new IllegalStateException("Unexpected input type for Mean aggregate: " + inputType);
+      default -> {
+        if (Proxy.isProxyClass(inputType.getClass())) {
+          var fresh = StorageType.fromTypeCharAndSize(inputType.typeChar(), inputType.size());
+          yield resultTypeFromInputType(fresh);
+        }
+        throw new IllegalStateException("Unexpected input type for Mean aggregate: " + inputType);
+      }
     };
   }
 


### PR DESCRIPTION
### Pull Request Description

- During investigation of #13851 
- a missing conversion was found leading to an exception

 ```

Execution finished with an error: Unexpected input type for Mean aggregate: org.enso.table.data.column.storage.type.IntegerType@11cbfa7b
        at <java> org.enso.table.aggregations.Mean.resultTypeFromInput(Mean.java:44)
        at <java> org.enso.table.aggregations.Mean.<init>(Mean.java:29)
        at <enso> case_branch(Aggregate_Column_Helper.enso:256:24-79)
        at <enso> Aggregate_Column_Helper.java_aggregator(Aggregate_Column_Helper.enso:245-276)
        at <enso> In_Memory_Table_Implementation.aggregate.java_key_columns.new_columns(In_Memory_Table_Implementation.enso:206:67-122)
```
- caused by a column from the other JVM being send to `Mean` in the first JVM

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [ ] Unit tests provided
