### PR TITLE
Detect background libgraal compilations in `ContextUtils.close()`

### DIFF
--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/MemoryUtils.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/MemoryUtils.java
@@ -2,6 +2,8 @@ package org.enso.test.utils;
 
 import static org.junit.Assert.fail;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.ref.Reference;
 import java.util.ArrayList;
 import org.graalvm.polyglot.Context;
@@ -11,18 +13,23 @@ final class MemoryUtils {
   private MemoryUtils() {}
 
   static void assertGC(String msg, boolean expectGC, Reference<?> ref) {
+    var buffer = new StringWriter();
+    var log = new PrintWriter(buffer);
     var memory = expectGC ? new ArrayList<>() : null;
     var retry = 3;
     for (var i = 1L; ; i *= 2) {
       try {
         var size = (int) Math.min(i, Integer.MAX_VALUE / 2);
         if (i >= 64) {
-          tryHarderToGc();
+          tryHarderToGc(log);
+          flushLog(buffer);
         }
-        if (checkAndAlloc(ref, memory, size)) {
+        if (checkAndAlloc(log, ref, memory, size)) {
           break;
         }
       } catch (OutOfMemoryError err) {
+        err.printStackTrace(log);
+        flushLog(buffer);
         // launch the JVM with
         //   -XX:+HeapDumpOnOutOfMemoryError
         //   -XX:HeapDumpPath=/tmp
@@ -32,22 +39,21 @@ final class MemoryUtils {
         }
       }
     }
-    assertReference(ref, expectGC, msg, memory);
+    assertReference(buffer, ref, expectGC, msg, memory);
   }
 
   private static void assertReference(
-      Reference<?> ref, boolean expectGC, String msg, ArrayList<Object> memory) {
+      Object log, Reference<?> ref, boolean expectGC, String msg, ArrayList<Object> memory) {
     var obj = ref.get();
     if (expectGC) {
       if (obj != null) {
-        fail(msg + " ref still alive: " + obj);
+        fail(msg + " ref still alive: " + obj + "\n" + log);
       }
     } else {
       if (obj == null) {
-        fail(msg + " ref has been cleaned: " + obj);
+        fail(msg + " ref has been cleaned: " + obj + "\n" + log);
       }
     }
-    System.getLogger("assertGC").log(System.Logger.Level.TRACE, "Cannot GC {0}", memory);
   }
 
   /**
@@ -59,20 +65,53 @@ final class MemoryUtils {
    * @param toAllocate
    * @return
    */
-  private static boolean checkAndAlloc(Reference<?> ref, ArrayList<Object> memory, int toAllocate) {
+  private static boolean checkAndAlloc(
+      PrintWriter log, Reference<?> ref, ArrayList<Object> memory, int toAllocate) {
     if (ref.get() == null) {
       return true;
     }
+    log.println("System.gc()");
     System.gc();
     if (memory != null) {
+      log.println("Allocating " + toAllocate + " bytes");
       memory.add(new byte[toAllocate]);
     }
     return false;
   }
 
-  private static void tryHarderToGc() {
-    try (var ctx = Context.create()) {
-      System.getLogger("assertGC").log(System.Logger.Level.TRACE, "Creating and closing {0}", ctx);
+  private static void tryHarderToGc(PrintWriter log) {
+    for (var t : Thread.getAllStackTraces().entrySet()) {
+      var threadName = t.getKey().getName();
+      if (threadName.contains("TruffleCompilerThread")) {
+        var foundCompilation = false;
+        for (var frame : t.getValue()) {
+          if ("com.oracle.truffle.runtime.CompilationTask".equals(frame.getClassName())) {
+            foundCompilation = true;
+          }
+        }
+        if (foundCompilation) {
+          log.println("Found running compiler thread: " + threadName);
+          for (var frame : t.getValue()) {
+            log.println("  at " + frame);
+          }
+          try {
+            log.println("Sleeping");
+            Thread.sleep(1000);
+            log.println("Slept 1s, trying again.");
+            return;
+          } catch (InterruptedException ex) {
+            ex.printStackTrace(log);
+          }
+        }
+      }
     }
+    try (var ctx = Context.create()) {
+      log.println("Creating and closing " + ctx);
+    }
+  }
+
+  private static void flushLog(StringWriter buffer) {
+    System.err.println(buffer);
+    buffer.getBuffer().setLength(0);
   }
 }


### PR DESCRIPTION
### Pull Request Description

- to address #14293
- as analyzed in the [November 17 Summary](https://github.com/enso-org/enso/issues/14293#issuecomment-3540267080)
- let's detect [background libgraal compilations](https://github.com/enso-org/enso/issues/14293#issuecomment-3533283116) and wait until they are over
- collect a log of `assertGC` progress to provide some insight into the garbage collecting process for further analysis

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
