### PR TITLE
Fix for flakiness of fix of flakiness.

### DIFF
--- a/app/electron-client/tests/electronTest.ts
+++ b/app/electron-client/tests/electronTest.ts
@@ -131,10 +131,10 @@ export async function createNewProject(page: Page) {
  */
 export async function closeWelcome(page: Page) {
   const welcomeProjectTab = page.getByRole('tab', { name: 'Getting Started with Enso' })
-  const loadingIndicator = page.locator('.LoadingSpinner')
+  const loadingIndicator = welcomeProjectTab.locator('.LoadingSpinner')
   await Promise.race([
     welcomeProjectTab
-      .waitFor({ state: 'visible' })
+      .waitFor({ state: 'visible', timeout: 0 })
       .then(() => loadingIndicator.waitFor({ state: 'hidden' })),
     page.waitForTimeout(3000),
   ])

--- a/app/gui/integration-test/pm-openrpc.json
+++ b/app/gui/integration-test/pm-openrpc.json
@@ -36,6 +36,13 @@
                 "port": { "type": "number" }
               }
             },
+            "languageServerYdocAddress": {
+              "type": "object",
+              "properties": {
+                "host": { "type": "string" },
+                "port": { "type": "number" }
+              }
+            },
             "projectName": { "type": "string" },
             "projectNormalizedName": { "type": "string" },
             "projectNamespace": { "type": "string" }

--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -124,6 +124,7 @@ export class EnsoRunner implements Runner {
     while (this.loadingProjects.size > 0) {
       await this.loadingProjects.values().next().value
     }
+    await this.waitForYDocPort()
     const promise = this.findServerPorts(DEFAULT_JSONRPC_PORT).then(([jsonPort, binaryPort]) => {
       const rootId = crypto.randomUUID()
       const args: string[] = [
@@ -437,6 +438,15 @@ export class EnsoRunner implements Runner {
         resolve(ports as [number, number])
       })
     })
+  }
+
+  // TODO[ao]: A quick patch for delayed ydoc processed closing; sometimes the port is still busy
+  // after closing project and when opening another. This may result in errors.
+  // Should be fixed properly by
+  private async waitForYDocPort() {
+    return await portfinder
+      .getPortPromise({ startPort: 5976, stopPort: 5976 })
+      .catch(() => new Promise((resolve) => setTimeout(resolve, 4000)))
   }
 }
 

--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -38,6 +38,7 @@ export interface LanguageServerSockets {
   readonly secureJsonSocket?: Socket
   readonly binarySocket: Socket
   readonly secureBinarySocket?: Socket
+  readonly ydocSocket: Socket
 }
 
 export interface Socket {
@@ -124,135 +125,140 @@ export class EnsoRunner implements Runner {
     while (this.loadingProjects.size > 0) {
       await this.loadingProjects.values().next().value
     }
-    await this.waitForYDocPort()
-    const promise = this.findServerPorts(DEFAULT_JSONRPC_PORT).then(([jsonPort, binaryPort]) => {
-      const rootId = crypto.randomUUID()
-      const args: string[] = [
-        '--server',
-        '--root-id',
-        rootId,
-        '--project-id',
-        projectId,
-        '--path',
-        projectPath,
-        '--interface',
-        '127.0.0.1',
-        '--rpc-port',
-        jsonPort.toString(),
-        '--data-port',
-        binaryPort.toString(),
-      ]
+    const promise = this.findServerPorts(DEFAULT_JSONRPC_PORT).then(
+      ([jsonPort, binaryPort, ydocPort]) => {
+        const rootId = crypto.randomUUID()
+        const args: string[] = [
+          '--server',
+          '--root-id',
+          rootId,
+          '--project-id',
+          projectId,
+          '--path',
+          projectPath,
+          '--interface',
+          '127.0.0.1',
+          '--rpc-port',
+          jsonPort.toString(),
+          '--data-port',
+          binaryPort.toString(),
+        ]
 
-      // Add extra arguments if provided
-      if (extraArgs) {
-        args.push(...extraArgs)
-      }
-
-      const env = { ...process.env }
-      if (extraEnv) {
-        for (const [key, value] of extraEnv) {
-          env[key] = value
+        // Add extra arguments if provided
+        if (extraArgs) {
+          args.push(...extraArgs)
         }
-      }
 
-      return new Promise<LanguageServerSockets>((resolve, reject) => {
-        const cmd = this.ensoPath.endsWith('.bat') ? 'cmd.exe' : this.ensoPath
-        const cmdArgs = this.ensoPath.endsWith('.bat') ? ['/c', this.ensoPath, ...args] : args
-        const cwd = path.dirname(projectPath)
-        const serverProcess = childProcess.spawn(cmd, cmdArgs, { env, detached: false, cwd })
-
-        let stderr = ''
-        let resolved = false
-
-        // Health check function
-        const checkServerHealth = async (): Promise<boolean> => {
-          try {
-            const response = await fetch(`http://127.0.0.1:${jsonPort}/_health`)
-            return response.ok
-          } catch {
-            return false
+        const env = { ...process.env }
+        env['LANGUAGE_SERVER_YDOC_PORT'] = ydocPort.toString()
+        if (extraEnv) {
+          for (const [key, value] of extraEnv) {
+            env[key] = value
           }
         }
 
-        // Start polling for server readiness after initial delay
-        const startHealthCheck = () => {
-          const pollInterval = setInterval(async () => {
-            if (resolved) {
-              clearInterval(pollInterval)
-              return
-            }
+        return new Promise<LanguageServerSockets>((resolve, reject) => {
+          const cmd = this.ensoPath.endsWith('.bat') ? 'cmd.exe' : this.ensoPath
+          const cmdArgs = this.ensoPath.endsWith('.bat') ? ['/c', this.ensoPath, ...args] : args
+          const cwd = path.dirname(projectPath)
+          const serverProcess = childProcess.spawn(cmd, cmdArgs, { env, detached: false, cwd })
 
-            const isReady = await checkServerHealth()
-            if (isReady) {
-              clearInterval(pollInterval)
-              resolved = true
-              const sockets: LanguageServerSockets = {
-                jsonSocket: { host: '127.0.0.1', port: jsonPort },
-                binarySocket: { host: '127.0.0.1', port: binaryPort },
+          let stderr = ''
+          let resolved = false
+
+          // Health check function
+          const checkServerHealth = async (): Promise<boolean> => {
+            try {
+              const response = await fetch(`http://127.0.0.1:${jsonPort}/_health`)
+              return response.ok
+            } catch {
+              return false
+            }
+          }
+
+          // Start polling for server readiness after initial delay
+          const startHealthCheck = () => {
+            const pollInterval = setInterval(async () => {
+              if (resolved) {
+                clearInterval(pollInterval)
+                return
               }
-              this.runningProjects.set(projectId, {
-                process: serverProcess,
-                sockets: sockets,
-                shutdownHooks: new Map(),
-              })
-              resolve(sockets)
-            }
-          }, 250) // Poll every 250ms
-        }
 
-        // Start health check after initial delay
-        setTimeout(startHealthCheck, 250)
-
-        serverProcess.stderr.on('data', (data) => {
-          const dataStr = data.toString()
-          console.error(dataStr)
-          stderr += dataStr
-        })
-
-        serverProcess.on('error', (error) => {
-          console.error(error.toString())
-          if (!resolved) {
-            reject(new Error(`Failed to start language server: ${error.message}`))
-          }
-        })
-
-        serverProcess.on('close', async (code) => {
-          // Execute shutdown hooks if the process exits unexpectedly
-          const runningProject = this.runningProjects.get(projectId)
-          if (runningProject && runningProject.shutdownHooks) {
-            for (const [hookType, hook] of runningProject.shutdownHooks) {
-              try {
-                runningProject.shutdownHooks.delete(hookType)
-                await hook()
-              } catch (error) {
-                console.error(
-                  `Error executing shutdown hook '${hookType}' for project ${projectId}:`,
-                  error,
-                )
+              const isReady = await checkServerHealth()
+              if (isReady) {
+                clearInterval(pollInterval)
+                resolved = true
+                const sockets: LanguageServerSockets = {
+                  jsonSocket: { host: '127.0.0.1', port: jsonPort },
+                  binarySocket: { host: '127.0.0.1', port: binaryPort },
+                  ydocSocket: { host: '127.0.0.1', port: ydocPort },
+                }
+                this.runningProjects.set(projectId, {
+                  process: serverProcess,
+                  sockets: sockets,
+                  shutdownHooks: new Map(),
+                })
+                resolve(sockets)
               }
-            }
+            }, 250) // Poll every 250ms
           }
 
-          // Remove from running projects when it closes
-          this.runningProjects.delete(projectId)
-          if (!resolved) {
-            reject(new Error(`Language server process exited with code ${code}. stderr: ${stderr}`))
-          }
-        })
+          // Start health check after initial delay
+          setTimeout(startHealthCheck, 250)
 
-        // Timeout if server doesn't start (skip timeout in debug mode)
-        const javaToolOptions = process.env.JAVA_TOOL_OPTIONS
-        const isDebugMode = javaToolOptions?.includes('jdwp')
-        if (!isDebugMode) {
-          setTimeout(() => {
+          serverProcess.stderr.on('data', (data) => {
+            const dataStr = data.toString()
+            console.error(dataStr)
+            stderr += dataStr
+          })
+
+          serverProcess.on('error', (error) => {
+            console.error(error.toString())
             if (!resolved) {
-              serverProcess.kill('SIGKILL')
-              reject(new Error('Language server startup timeout'))
+              reject(new Error(`Failed to start language server: ${error.message}`))
             }
-          }, LANGUAGE_SERVER_STARTUP_TIMEOUT)
-        }
-      })
-    })
+          })
+
+          serverProcess.on('close', async (code) => {
+            // Execute shutdown hooks if the process exits unexpectedly
+            const runningProject = this.runningProjects.get(projectId)
+            if (runningProject && runningProject.shutdownHooks) {
+              for (const [hookType, hook] of runningProject.shutdownHooks) {
+                try {
+                  runningProject.shutdownHooks.delete(hookType)
+                  await hook()
+                } catch (error) {
+                  console.error(
+                    `Error executing shutdown hook '${hookType}' for project ${projectId}:`,
+                    error,
+                  )
+                }
+              }
+            }
+
+            // Remove from running projects when it closes
+            this.runningProjects.delete(projectId)
+            if (!resolved) {
+              reject(
+                new Error(`Language server process exited with code ${code}. stderr: ${stderr}`),
+              )
+            }
+          })
+
+          // Timeout if server doesn't start (skip timeout in debug mode)
+          const javaToolOptions = process.env.JAVA_TOOL_OPTIONS
+          const isDebugMode = javaToolOptions?.includes('jdwp')
+          if (!isDebugMode) {
+            setTimeout(() => {
+              if (!resolved) {
+                serverProcess.kill('SIGKILL')
+                reject(new Error('Language server startup timeout'))
+              }
+            }, LANGUAGE_SERVER_STARTUP_TIMEOUT)
+          }
+        })
+      },
+    )
     this.loadingProjects.set(projectId, promise)
     promise.finally(() => this.loadingProjects.delete(projectId))
     return promise
@@ -426,27 +432,18 @@ export class EnsoRunner implements Runner {
   }
 
   /** Finds an available port starting from the given port number. */
-  private async findServerPorts(startPort: number): Promise<[number, number]> {
+  private async findServerPorts(startPort: number): Promise<[number, number, number]> {
     return new Promise((resolve, reject) => {
-      portfinder.getPorts(2, { port: startPort }, (err, ports) => {
+      portfinder.getPorts(3, { port: startPort }, (err, ports) => {
         if (err) {
           reject(new Error(`Failed to find ports: ${err}`))
         }
-        if (ports.length < 2) {
+        if (ports.length < 3) {
           reject(new Error(`Failed to find all ports: ${ports}`))
         }
-        resolve(ports as [number, number])
+        resolve(ports as [number, number, number])
       })
     })
-  }
-
-  // TODO[ao]: A quick patch for delayed ydoc processed closing; sometimes the port is still busy
-  // after closing project and when opening another. This may result in errors.
-  // Should be fixed properly by
-  private async waitForYDocPort() {
-    return await portfinder
-      .getPortPromise({ startPort: 5976, stopPort: 5976 })
-      .catch(() => new Promise((resolve) => setTimeout(resolve, 4000)))
   }
 }
 

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -54,6 +54,7 @@ export interface CreateProject {
 export interface OpenProject {
   readonly languageServerJsonAddress: Socket
   readonly languageServerBinaryAddress: Socket
+  readonly languageServerYdocAddress: Socket
   readonly projectName: string
   readonly projectNormalizedName: string
   readonly projectNamespace: string
@@ -185,6 +186,7 @@ export class ProjectService {
     return {
       languageServerJsonAddress: sockets.jsonSocket,
       languageServerBinaryAddress: sockets.binarySocket,
+      languageServerYdocAddress: sockets.ydocSocket,
       projectName: project.name,
       projectNormalizedName: nameValidation.normalizedName(project.name),
       projectNamespace: project.namespace,


### PR DESCRIPTION
### Pull Request Description

There is a small fix in package testing, and make Project Manager scan for available ports for ydoc server, actually allowing more than one project opened at once.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
