### PR TITLE
Fix inconsistent polyglot method invocation via type

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java
@@ -477,6 +477,51 @@ public class AtomInteropTest {
   }
 
   @Test
+  public void instanceMethod_CanBeInvokedViaAtom() {
+    var atom =
+        ctxRule.evalModule(
+            """
+            type My_Type
+                Cons
+                method self = 42
+            main = My_Type.Cons
+            """);
+    assertThat(atom.hasMember("method"), is(true));
+    assertThat(atom.canInvokeMember("method"), is(true));
+    var res = atom.invokeMember("method");
+    assertThat(res.asInt(), is(42));
+  }
+
+  @Test
+  public void instanceMethod_IsMemberOfType() {
+    var type =
+        ctxRule.evalModule(
+            """
+            type My_Type
+                Cons
+                method self = 42
+            main = My_Type
+            """);
+    assertThat(type.hasMember("method"), is(true));
+    assertThat(type.canInvokeMember("method"), is(true));
+  }
+
+  @Test
+  public void instanceMethod_CanBeInvokedViaType() {
+    var atom =
+        ctxRule.evalModule(
+            """
+            type My_Type
+                Cons
+                method self = 42
+            main = My_Type.Cons
+            """);
+    var type = atom.getMetaObject();
+    var res = type.invokeMember("method", atom);
+    assertThat(res.asInt(), is(42));
+  }
+
+  @Test
   public void invokeVsReadAndExecute() throws Exception {
     var atom =
         ctxRule.evalModule(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -5,11 +5,9 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
@@ -28,10 +26,8 @@ import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeMethodNode;
-import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.ModuleScopeBuilder;
-import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -429,11 +425,8 @@ public final class Type extends EnsoObject {
         String member,
         Object[] args,
         @Cached("member") String cachedMember,
-        @Cached MethodResolverNode methodResolverNode,
-        @Cached("buildSymbol(receiver, member)") UnresolvedSymbol symbol,
-        @Cached("findMethod(receiver, symbol, methodResolverNode)") Function func,
-        @Cached("buildInvokeCallableNode(func)") InvokeCallableNode invokeCallableNode)
-        throws UnsupportedMessageException, UnsupportedTypeException, ArityException {
+        @Cached("findMethod(receiver, cachedMember)") Function func,
+        @Cached("buildInvokeCallableNode(func)") InvokeCallableNode invokeCallableNode) {
       Object[] finalArgs = args;
       if (InvokeMethodNode.shouldPrependSyntheticSelfArg(func.getSchema(), args.length)) {
         var argsWithReceiver = new Object[args.length + 1];
@@ -446,44 +439,18 @@ public final class Type extends EnsoObject {
 
     @Specialization(replaces = "doCached")
     @TruffleBoundary
-    static Object doUncached(
-        Type receiver,
-        String member,
-        Object[] args,
-        @CachedLibrary(limit = "3") InteropLibrary interop)
-        throws UnsupportedMessageException,
-            UnsupportedTypeException,
-            ArityException,
-            UnknownIdentifierException {
-      var symbol = buildSymbol(receiver, member);
-      var methodResolverNode = MethodResolverNode.getUncached();
-      var method = findMethod(receiver, symbol, methodResolverNode);
+    static Object doUncached(Type receiver, String member, Object[] args)
+        throws UnknownIdentifierException {
+      var method = findMethod(receiver, member);
       if (method == null) {
         throw UnknownIdentifierException.create(member);
       }
       var invokeCallableNode = buildInvokeCallableNode(method);
-      return doCached(
-          receiver, member, args, member, methodResolverNode, symbol, method, invokeCallableNode);
+      return doCached(receiver, member, args, member, method, invokeCallableNode);
     }
 
-    static UnresolvedSymbol buildSymbol(Type receiver, String member) {
-      return UnresolvedSymbol.build(member, receiver.getDefinitionScope());
-    }
-
-    static Function findMethod(
-        Type self, UnresolvedSymbol symbol, MethodResolverNode methodResolverNode) {
-      if (self.isBuiltin()) {
-        // Some builtin types are singletons (have no constructors) and they contain
-        // both instance (methods with self argument) and static methods on themselves.
-        // This makes sense only for builtin types. Which means that here, we try to
-        // find the method on both builtin type and its eigen type.
-        var func = InvokeMethodNode.resolveFunction(symbol, self, self, methodResolverNode);
-        if (func != null) {
-          return func;
-        }
-      }
-      return InvokeMethodNode.resolveFunction(
-          symbol, self, self.getEigentype(), methodResolverNode);
+    static Function findMethod(Type self, String methodName) {
+      return self.methods().get(methodName);
     }
 
     static InvokeCallableNode buildInvokeCallableNode(Function func) {


### PR DESCRIPTION
### Pull Request Description

Fixes inconsistency introduced in https://github.com/enso-org/enso/pull/13962 - static method invocation does not work in interop.

### Important Notes

[AtomInteropTest.instanceMethod_CanBeInvokedViaType](https://github.com/enso-org/enso/blob/824a4835fd9f7efa396f1d73c647e408653f8f12/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/AtomInteropTest.java#L520) is failing. And should not. In other words, this is what I am trying to fix in polyglot invocation:
```
type My_Type
    Cons
    method self = 42
main =
    obj = My_Type.Cons
    My_Type.method self=obj
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Fix [CurrentEnsoProject workaround](https://github.com/enso-org/enso/pull/14297/files#r2550558782) - Fixed in https://github.com/enso-org/enso/pull/14297/commits/1d7aece61be8b5bf6f3ff23e2d8ba3f645f13ce3
- [x] The documentation has been updated, if necessary.
- [x] Unit tests have been written where possible.
