### PR TITLE
Encapsulate access to LongBuilder.data field

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
@@ -40,11 +40,11 @@ final class BigDecimalBuilder extends TypedBuilder<BigDecimal> {
   }
 
   static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
-    var res = new BigDecimalBuilder(longBuilder.data.length);
-    int n = longBuilder.currentSize;
+    var res = new BigDecimalBuilder(longBuilder.dataCapacity());
+    int n = longBuilder.dataCurrentSize();
     Context context = Context.getCurrent();
     for (int i = 0; i < n; i++) {
-      res.append(BigDecimal.valueOf(longBuilder.data[i]));
+      res.append(BigDecimal.valueOf(longBuilder.data(i)));
       context.safepoint();
     }
     return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -85,11 +85,11 @@ final class BigIntegerBuilder extends TypedBuilder<BigInteger> {
   }
 
   static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
-    var res = new BigIntegerBuilder(longBuilder.data.length, longBuilder.problemAggregator);
-    int n = longBuilder.currentSize;
+    var res = new BigIntegerBuilder(longBuilder.dataCapacity(), longBuilder.problemAggregator);
+    int n = longBuilder.dataCurrentSize();
     Context context = Context.getCurrent();
     for (int i = 0; i < n; i++) {
-      res.append(BigInteger.valueOf(longBuilder.data[i]));
+      res.append(BigInteger.valueOf(longBuilder.data(i)));
       context.safepoint();
     }
     return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -24,7 +24,7 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
         new InferredDoubleBuilder(longBuilder.getDataSize(), longBuilder.problemAggregator);
 
     for (int i = 0; i < currentSize; i++) {
-      newBuilder.appendLong(longBuilder.data[i]);
+      newBuilder.appendLong(longBuilder.data(i));
     }
     newBuilder.isNothing = longBuilder.isNothing;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -17,8 +17,8 @@ import org.enso.table.util.BitSets;
 
 /** A builder for integer columns. */
 class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping {
-  protected final ProblemAggregator problemAggregator;
-  protected long[] data;
+  final ProblemAggregator problemAggregator;
+  private long[] data;
 
   protected LongBuilder(int initialSize, ProblemAggregator problemAggregator) {
     this.data = new long[initialSize];
@@ -163,5 +163,17 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
   @Override
   public ColumnStorage<Long> seal() {
     return new LongStorage(data, currentSize, isNothing, getType());
+  }
+
+  final int dataCapacity() {
+    return data.length;
+  }
+
+  final int dataCurrentSize() {
+    return currentSize;
+  }
+
+  final long data(int index) {
+    return data[index];
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -10,8 +10,8 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
   // TODO [RW] at some point we will want to add separate storage classes for byte, short and int,
   // for more compact storage and more efficient handling of smaller integers; for now we will be
   // handling this just by checking the bounds
-  final long[] data;
-  final BitSet isNothing;
+  private final long[] data;
+  private final BitSet isNothing;
 
   /**
    * @param data the underlying data


### PR DESCRIPTION
### Pull Request Description

- work on #14309
- shows the need for replacing `long[] data` field with some other type
- however there are other places in the code referencing the field
- this PR encapsulates it, so it is easier to refactor the type of the field later

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] All Unit tests continue to pass
- [ ] [Benchmarks results](https://github.com/enso-org/enso/actions/runs/19592107590) remain the same