### PR TITLE
Avoid long builder leaking internals

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigDecimalBuilder.java
@@ -39,12 +39,12 @@ final class BigDecimalBuilder extends TypedBuilder<BigDecimal> {
     return new TypedStorage<>(BigDecimalType.INSTANCE, data);
   }
 
-  static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
-    var res = new BigDecimalBuilder(longBuilder.data.length);
-    int n = longBuilder.currentSize;
+  static Builder retypeFromLongBuilder(BuilderForLong longBuilder) {
+    var res = Builder.getForBigDecimal(longBuilder.getCurrentCapacity());
+    long n = longBuilder.getCurrentSize();
     Context context = Context.getCurrent();
-    for (int i = 0; i < n; i++) {
-      res.append(BigDecimal.valueOf(longBuilder.data[i]));
+    for (long i = 0; i < n; i++) {
+      res.append(longBuilder.isNothing(i) ? null : BigDecimal.valueOf(longBuilder.getLong(i)));
       context.safepoint();
     }
     return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -84,7 +84,8 @@ final class BigIntegerBuilder extends TypedBuilder<BigInteger> {
     return this;
   }
 
-  static Builder retypeFromLongBuilder(BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
+  static Builder retypeFromLongBuilder(
+      BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
     var res = Builder.getForBigInteger(longBuilder.getCurrentCapacity(), problemAggregator);
     long n = longBuilder.getCurrentSize();
     Context context = Context.getCurrent();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BigIntegerBuilder.java
@@ -84,12 +84,12 @@ final class BigIntegerBuilder extends TypedBuilder<BigInteger> {
     return this;
   }
 
-  static Builder retypeFromLongBuilder(LongBuilder longBuilder) {
-    var res = new BigIntegerBuilder(longBuilder.data.length, longBuilder.problemAggregator);
-    int n = longBuilder.currentSize;
+  static Builder retypeFromLongBuilder(BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
+    var res = Builder.getForBigInteger(longBuilder.getCurrentCapacity(), problemAggregator);
+    long n = longBuilder.getCurrentSize();
     Context context = Context.getCurrent();
-    for (int i = 0; i < n; i++) {
-      res.append(BigInteger.valueOf(longBuilder.data[i]));
+    for (long i = 0; i < n; i++) {
+      res.append(longBuilder.isNothing(i) ? null : BigInteger.valueOf(longBuilder.getLong(i)));
       context.safepoint();
     }
     return res;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderForLong.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderForLong.java
@@ -17,18 +17,18 @@ public interface BuilderForLong extends BuilderForType<Long> {
    */
   boolean isNothing(long index);
 
-    /**
-     * Gets the long value at the given index.
-     *
-     * @param index the index to get the value from
-     * @return the long value at the index
-     */
+  /**
+   * Gets the long value at the given index.
+   *
+   * @param index the index to get the value from
+   * @return the long value at the index
+   */
   long getLong(long index);
 
-    /**
-     * Gets the current capacity of the builder.
-     *
-     * @return the current capacity
-     */
+  /**
+   * Gets the current capacity of the builder.
+   *
+   * @return the current capacity
+   */
   long getCurrentCapacity();
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderForLong.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderForLong.java
@@ -8,4 +8,27 @@ public interface BuilderForLong extends BuilderForType<Long> {
    * @param value the long to append
    */
   BuilderForLong appendLong(long value);
+
+  /**
+   * Checks whether the value at the given index is null.
+   *
+   * @param index the index to check
+   * @return true if the value at the index is null, false otherwise
+   */
+  boolean isNothing(long index);
+
+    /**
+     * Gets the long value at the given index.
+     *
+     * @param index the index to get the value from
+     * @return the long value at the index
+     */
+  long getLong(long index);
+
+    /**
+     * Gets the current capacity of the builder.
+     *
+     * @return the current capacity
+     */
+  long getCurrentCapacity();
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -19,8 +19,11 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
    * <p>The original LongBuilder becomes invalidated after this operation and should no longer be
    * used.
    */
-  static InferredDoubleBuilder retypeFromLongBuilder(BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
-    var newBuilder = new InferredDoubleBuilder(Builder.checkSize(longBuilder.getCurrentSize()), problemAggregator);
+  static InferredDoubleBuilder retypeFromLongBuilder(
+      BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
+    var newBuilder =
+        new InferredDoubleBuilder(
+            Builder.checkSize(longBuilder.getCurrentSize()), problemAggregator);
     long currentSize = longBuilder.getCurrentSize();
     Context context = Context.getCurrent();
     for (long i = 0; i < currentSize; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -9,6 +9,7 @@ import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.error.ValueTypeMismatchException;
 import org.enso.table.problems.ProblemAggregator;
+import org.graalvm.polyglot.Context;
 
 /** A double builder variant that preserves types and can be retyped to Mixed. */
 final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRetyping {
@@ -18,16 +19,18 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
    * <p>The original LongBuilder becomes invalidated after this operation and should no longer be
    * used.
    */
-  static InferredDoubleBuilder retypeFromLongBuilder(LongBuilder longBuilder) {
-    int currentSize = longBuilder.currentSize;
-    var newBuilder =
-        new InferredDoubleBuilder(longBuilder.getDataSize(), longBuilder.problemAggregator);
-
-    for (int i = 0; i < currentSize; i++) {
-      newBuilder.appendLong(longBuilder.data[i]);
+  static InferredDoubleBuilder retypeFromLongBuilder(BuilderForLong longBuilder, ProblemAggregator problemAggregator) {
+    var newBuilder = new InferredDoubleBuilder(Builder.checkSize(longBuilder.getCurrentSize()), problemAggregator);
+    long currentSize = longBuilder.getCurrentSize();
+    Context context = Context.getCurrent();
+    for (long i = 0; i < currentSize; i++) {
+      if (longBuilder.isNothing(i)) {
+        newBuilder.appendNulls(1);
+      } else {
+        newBuilder.appendLong(longBuilder.getLong(i));
+      }
+      context.safepoint();
     }
-    newBuilder.isNothing = longBuilder.isNothing;
-
     return newBuilder;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -67,9 +67,9 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
   @Override
   public Builder retypeTo(StorageType<?> type) {
     if (Objects.equals(type, BigIntegerType.INSTANCE)) {
-      return BigIntegerBuilder.retypeFromLongBuilder(this);
+      return BigIntegerBuilder.retypeFromLongBuilder(this, this.problemAggregator);
     } else if (Objects.equals(type, FloatType.FLOAT_64)) {
-      return InferredDoubleBuilder.retypeFromLongBuilder(this);
+      return InferredDoubleBuilder.retypeFromLongBuilder(this, this.problemAggregator);
     } else if (Objects.equals(type, BigDecimalType.INSTANCE)) {
       return BigDecimalBuilder.retypeFromLongBuilder(this);
     } else {
@@ -136,6 +136,29 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
     ensureSpaceToAppend();
     this.data[currentSize++] = value;
     return this;
+  }
+
+  @Override
+  public boolean isNothing(long index) {
+    if (index >= currentSize) {
+      throw new IndexOutOfBoundsException();
+    } else {
+      return isNothing.get((int) index);
+    }
+  }
+
+  @Override
+  public long getLong(long index) {
+    if (index >= currentSize) {
+      throw new IndexOutOfBoundsException();
+    } else {
+      return data[(int) index];
+    }
+  }
+
+  @Override
+  public long getCurrentCapacity() {
+    return data.length;
   }
 
   @Override


### PR DESCRIPTION
### Pull Request Description

- Alternate to #14337 
- Adds a couple of methods on BuilderForLong interface.
- Removes the assumption to copy the nothing map.
- Checkpoint check for the Double loop

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
