### PR TITLE
Remove native access warning when using shell launcher

### DIFF
--- a/distribution/bin/enso
+++ b/distribution/bin/enso
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 COMP_PATH=$(dirname "$0")/../component
 JAVA_OPTS="--enable-native-access=org.graalvm.truffle --sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED"
-exec java --module-path "$COMP_PATH" "$JAVA_OPTS" -m org.enso.runner/org.enso.runner.Main "$@"
+exec java --module-path "$COMP_PATH" $JAVA_OPTS -m org.enso.runner/org.enso.runner.Main "$@"
 exit


### PR DESCRIPTION
### Pull Request Description

Fixes the annoying warning:
```
WARNING: Unknown module: org.graalvm.truffle --sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED specified to --enable-native-access
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.oracle.truffle.polyglot.JDKSupport in module org.graalvm.truffle (file:/Users/pavel/dev/enso/built-distribution/enso-engine-0.0.0-dev-macos-aarch64/enso-0.0.0-dev/bin/../component/truffle-api-25.0.1.jar)
WARNING: Use --enable-native-access=org.graalvm.truffle to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.oracle.truffle.runtime.hotspot.HotSpotTruffleRuntime (file:/Users/pavel/dev/enso/built-distribution/enso-engine-0.0.0-dev-macos-aarch64/enso-0.0.0-dev/bin/../component/truffle-runtime-25.0.1.jar)
WARNING: Please consider reporting this to the maintainers of class com.oracle.truffle.runtime.hotspot.HotSpotTruffleRuntime
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```
when launching enso via shell launcher. The problem was in shell quoting - the `JAVA_OPTS` shell variable is a single string and it should be passed unquoted to the `java` program in order for the java program to correctly parse the arguments.

On this PR, I no longer see any of the aforementioned warnings.
