### PR TITLE
OneDrive API tweaks

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -30,7 +30,7 @@ from Standard.Database.Internal.JDBC_Connection import JDBC_Connection
    The dialect for Redshift connections.
 redshift : Redshift_Dialect
 redshift =
-    Redshift_Dialect.Value Postgres_Connection.dialect.get_dialect_operations
+    Redshift_Dialect.Value Postgres_Connection.get_dialect.get_dialect_operations
 
 ## ---
    private: true
@@ -125,7 +125,7 @@ type Redshift_Dialect
           types, it should be set to `Nothing`.
     prepare_order_descriptor : Internal_Column -> Sort_Direction -> Nothing | Text_Ordering -> Order_Descriptor
     prepare_order_descriptor self internal_column sort_direction text_ordering =
-        Postgres_Connection.dialect.prepare_order_descriptor internal_column sort_direction text_ordering
+        Postgres_Connection.get_dialect.prepare_order_descriptor internal_column sort_direction text_ordering
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/Postgres_Connection.md
@@ -8,13 +8,13 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
-    - dialect -> Standard.Base.Any.Any
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_dialect -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
+++ b/distribution/lib/Standard/Database/0.0.0-dev/docs/api/Connection/SQLite_Connection.md
@@ -9,13 +9,13 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
-    - dialect -> Standard.Base.Any.Any
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_dialect -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:Standard.Database.SQL_Query.SQL_Query alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:Standard.Database.SQL_Query.SQL_Query limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Connection.enso
@@ -33,8 +33,8 @@ type Postgres_Connection
     ## ---
        private: true
        ---
-    dialect : Dialect.Dialect
-    dialect = Postgres_Dialect.postgres
+    get_dialect : Dialect.Dialect
+    get_dialect = Postgres_Dialect.postgres
 
     ## ---
        private: true
@@ -59,7 +59,7 @@ type Postgres_Connection
            Our generator is supposed to always quote identifiers
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection encoding is_case_sensitive=True
 
-        Postgres_Connection.Value (Connection.new jdbc_connection Postgres_Connection.dialect Postgres_Type_Mapping entity_naming_properties data_link_setup) make_new
+        Postgres_Connection.Value (Connection.new jdbc_connection Postgres_Connection.get_dialect Postgres_Type_Mapping entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Connection.enso
@@ -32,8 +32,8 @@ type SQLite_Connection
     ## ---
        private: true
        ---
-    dialect : Dialect.Dialect
-    dialect = SQLite_Dialect.sqlite
+    get_dialect : Dialect.Dialect
+    get_dialect = SQLite_Dialect.sqlite
 
     ## ---
        private: true
@@ -47,7 +47,7 @@ type SQLite_Connection
     create url properties =
         types_record = JDBCDriverTypes.create "Postgres"
         jdbc_connection = JDBC_Connection.create types_record url properties
-        SQLite_Connection.Value (Connection.new jdbc_connection SQLite_Connection.dialect SQLite_Type_Mapping SQLite_Entity_Naming_Properties.new)
+        SQLite_Connection.Value (Connection.new jdbc_connection SQLite_Connection.get_dialect SQLite_Type_Mapping SQLite_Entity_Naming_Properties.new)
 
     ## ---
        private: true

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/docs/api/DuckDB_Connection.md
@@ -8,13 +8,13 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
-    - dialect -> Standard.Base.Any.Any
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_dialect -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:(Standard.Database.SQL_Query.SQL_Query_With_Schema|Standard.Database.SQL_Query.SQL_Query) alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:(Standard.Database.SQL_Query.SQL_Query_With_Schema|Standard.Database.SQL_Query.SQL_Query) limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/DuckDB_Connection.enso
@@ -30,8 +30,8 @@ type DuckDB_Connection
     ## ---
        private: true
        ---
-    dialect : Dialect
-    dialect = DuckDB_Dialect.duckdb
+    get_dialect : Dialect
+    get_dialect = DuckDB_Dialect.duckdb
 
     ## ---
        private: true
@@ -49,7 +49,7 @@ type DuckDB_Connection
         jdbc_connection = JDBC_Connection.create types_record url properties schema=schema
 
         ## For initial work using DuckDB, we will use the Postgres dialect.
-        DuckDB_Connection.Value (Connection.new jdbc_connection DuckDB_Connection.dialect DuckDB_Type_Mapping DuckDB_Entity_Naming_Properties.new) make_new
+        DuckDB_Connection.Value (Connection.new jdbc_connection DuckDB_Connection.get_dialect DuckDB_Type_Mapping DuckDB_Entity_Naming_Properties.new) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Dialect.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Dialect.enso
@@ -40,7 +40,7 @@ import Standard.Database.SQL.SQL_Type
    The dialect of DuckDB built on top of PostgreSQL dialect.
 duckdb : DuckDB_Dialect
 duckdb =
-    parent = Postgres_Connection.dialect
+    parent = Postgres_Connection.get_dialect
     with_overrides = parent.get_dialect_operations.extend_with duckdb_overrides
     DuckDB_Dialect.Value parent with_overrides
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/OneDrive.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/OneDrive.md
@@ -1,5 +1,8 @@
 ## Enso Signatures 1.0
 ## module Standard.Microsoft.OneDrive
+- type OneDrive
+    - new path:Standard.Base.Data.Text.Text= credential:(Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret)= -> Standard.Microsoft.OneDrive.OneDrive_File
+    - root credential:(Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret)= -> Standard.Microsoft.OneDrive.OneDrive_File
 - type OneDrive_File
     - is_directory self -> Standard.Base.Data.Boolean.Boolean
     - list self name_filter:Standard.Base.Data.Text.Text= recursive:Standard.Base.Data.Boolean.Boolean= -> (Standard.Base.Data.Vector.Vector Standard.Microsoft.OneDrive.OneDrive_File)
@@ -7,4 +10,7 @@
     - path self -> Standard.Base.Data.Text.Text
     - read self format:Standard.Base.Any.Any= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any!Standard.Base.Errors.Illegal_Argument.Illegal_Argument
     - root credential:Standard.Microsoft.Microsoft365_Credential.Microsoft365_Credential -> Standard.Base.Any.Any
+    - to_display_text self -> Standard.Base.Any.Any
+    - to_text self -> Standard.Base.Any.Any
+    - uri self -> Standard.Base.Any.Any
     - with_input_stream self open_options:Standard.Base.Data.Vector.Vector action:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/docs/api/SQLServer_Connection.md
@@ -8,13 +8,13 @@
     - create_table self table_name:Standard.Base.Data.Text.Text structure:(Standard.Base.Any.Any|Standard.Table.Table.Table) primary_key:(Standard.Base.Any.Any|Standard.Base.Nothing.Nothing)= temporary:Standard.Base.Data.Boolean.Boolean= allow_existing:Standard.Base.Data.Boolean.Boolean= on_problems:Standard.Base.Errors.Problem_Behavior.Problem_Behavior= -> Standard.Base.Any.Any
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
-    - dialect -> Standard.Base.Any.Any
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - execute_query self query:Standard.Base.Any.Any limit:Standard.Table.Rows_To_Read.Rows_To_Read= write_operation:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
     - execute_update self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - fetch_primary_key self table_name:Standard.Base.Data.Text.Text schema_name:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_dialect -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - query self query:(Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query|Standard.Database.SQL_Query.SQL_Query) alias:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - read self query:(Standard.Microsoft.Connection.SQLServer_Query.SQLServer_Query|Standard.Database.SQL_Query.SQL_Query) limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/Services.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/Services.enso
@@ -5,7 +5,7 @@ import Standard.Base.System.File.File_System_SPI
 import Standard.Database.Connection.Database.Database_Connection_Details_SPI
 
 import project.Connection.SQLServer_Details.SQLServer_Details
-import project.OneDrive.OneDrive_File
+import project.OneDrive.OneDrive
 import project.SQLServer_Data_Link.SQLServer_Data_Link
 
 type Impl
@@ -20,4 +20,4 @@ Database_Connection_Details_SPI.from (that:Impl) =
 
 File_System_SPI.from (that:Impl) =
     _ = that
-    File_System_SPI.new "onedrive" OneDrive_File
+    File_System_SPI.new "onedrive" OneDrive

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Main.enso
@@ -6,4 +6,4 @@ export project.Connection.SQLServer_Details.SQLServer_Details
 
 export project.Microsoft365_Credential.Microsoft365_Credential
 
-export project.OneDrive.OneDrive_File
+export project.OneDrive.OneDrive

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
@@ -9,6 +9,34 @@ import project.Internal.Graph.Graph
 import project.Internal.OneDrive_Path.OneDrive_Path
 import project.Microsoft365_Credential.Microsoft365_Credential
 
+type OneDrive
+    ## ---
+        icon: cloud
+        ---
+
+        Returns the root directory of the user's OneDrive.
+
+        ## Arguments
+        - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+    root (credential : File | Enso_Secret = _default_credential) -> OneDrive_File =
+        ms_cred = Microsoft365_Credential.initialize credential
+        OneDrive_File.root ms_cred
+
+    ## ---
+        icon: cloud
+        ---
+
+        Returns the root directory of the user's OneDrive.
+
+        ## Arguments
+        - `path`: A path to a file or folder in OneDrive.
+        - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+    new path:Text="" (credential : File | Enso_Secret = _default_credential) -> OneDrive_File =
+        used_path = (if (path.starts_with "onedrive://" ..Insensitive) then path.drop (..First 11) else path) . trim ..Left '/'
+        parts = if used_path == "" then [] else used_path.replace "\" "/" . split "/"
+        ms_cred = Microsoft365_Credential.initialize credential
+        OneDrive_File.Value ms_cred (OneDrive_Path.Value parts)
+
 type OneDrive_File
     private Value (credential : Microsoft365_Credential) (onedrive_path : OneDrive_Path)
 
@@ -139,6 +167,29 @@ type OneDrive_File
         entry = Graph.fetch_json self.credential Graph.base_url+frag
         entry.contains_key "folder"
 
+    ## ---
+       group: Standard.Base.Metadata
+       icon: metadata
+       ---
+       Returns the URI of this file The URI is in the form
+       `onedrive://bucket/path/to/file`.
+    uri : Text
+    uri self = "onedrive:/"+self.onedrive_path.to_text
+
+    ## ---
+       private: true
+       ---
+       Return the absolute path of this OneDrive_File.
+    to_text : Text
+    to_text self = self.uri
+
+    ## ---
+       private: true
+       ---
+       Convert to a display representation of this OneDrive_File.
+    to_display_text : Text
+    to_display_text self = "OneDrive_File {" + self.to_text + "}"
+
 private _check_directory file:OneDrive_File ~action =
     if file.is_directory then action else
         Error.throw <| Illegal_Argument.Error "The OneDrive_File must represent a folder: "+file.onedrive_path.path.to_text
@@ -146,3 +197,8 @@ private _check_directory file:OneDrive_File ~action =
 private _check_not_directory file:OneDrive_File ~action =
     if file.is_directory.not then action else
         Error.throw <| Illegal_Argument.Error "The OneDrive_File must represent a file, not a folder: "+file.onedrive_path.path.to_text
+
+private _default_credential =
+    test = Enso_Secret.get "Microsoft365" Enso_File.home
+    if test.is_error.not then test else
+        Error.throw (Illegal_Argument.Error "Default credentials not found - log in as new credential in cloud home called Microsoft365.")

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
@@ -11,24 +11,26 @@ import project.Microsoft365_Credential.Microsoft365_Credential
 
 type OneDrive
     ## ---
-        icon: cloud
-        ---
-        Returns the root directory of the user's OneDrive.
+       icon: cloud
+       ---
+       Returns the root directory of the user's OneDrive.
 
-        ## Arguments
-        - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+       ## Arguments
+       - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+    root : File | Enso_Secret -> OneDrive_File
     root (credential : File | Enso_Secret = _default_credential) -> OneDrive_File =
         ms_cred = Microsoft365_Credential.initialize credential
         OneDrive_File.root ms_cred
 
     ## ---
-        icon: cloud
-        ---
-        Return a list of a directory of the user's OneDrive.
+       icon: cloud
+       ---
+       Return a list of a directory of the user's OneDrive.
 
-        ## Arguments
-        - `path`: A path to a file or folder in OneDrive.
-        - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+       ## Arguments
+       - `path`: A path to a file or folder in OneDrive.
+       - `credential`: A Cloud secret or a file containing Microsoft365 credentials.
+    new : Text -> File | Enso_Secret -> OneDrive_File
     new path:Text="" (credential : File | Enso_Secret = _default_credential) -> OneDrive_File =
         used_path = (if (path.starts_with "onedrive://" ..Insensitive) then path.drop (..First 11) else path) . trim ..Left '/'
         parts = if used_path == "" then [] else used_path.replace "\" "/" . split "/"
@@ -39,10 +41,10 @@ type OneDrive_File
     private Value (credential : Microsoft365_Credential) (onedrive_path : OneDrive_Path)
 
     ## ---
-        icon: cloud
-        ---
+       icon: cloud
+       ---
 
-        Returns the root directory of the user's OneDrive.
+       Returns the root directory of the user's OneDrive.
     root (credential : Microsoft365_Credential) =
         OneDrive_File.Value credential (OneDrive_Path.Value [])
 
@@ -87,10 +89,10 @@ type OneDrive_File
        it returns exceptionally).
 
        ## Arguments
-        - `open_options`: A vector of `File_Access` objects determining how to
-          open the stream. These options set the access properties of the stream.
-        - `action`: A function that operates on the input stream and returns some
-          value. The value is returned from this method.
+       - `open_options`: A vector of `File_Access` objects determining how to
+         open the stream. These options set the access properties of the stream.
+       - `action`: A function that operates on the input stream and returns some
+         value. The value is returned from this method.
     with_input_stream : Vector File_Access -> (Input_Stream -> Any ! File_Error) -> Any ! Illegal_Argument
     with_input_stream self (open_options : Vector) action =
         _check_not_directory self <|
@@ -120,7 +122,6 @@ type OneDrive_File
 
        ## Errors
         - Throws `Illegal_Argument` if called on a folder.
-    @format File_Format.default_widget
     @format File_Format.default_widget
     read : File_Format -> Problem_Behavior -> Any ! Illegal_Argument
     read self format=Auto_Detect (on_problems : Problem_Behavior = ..Report_Warning) -> Any ! Illegal_Argument =

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/OneDrive.enso
@@ -13,7 +13,6 @@ type OneDrive
     ## ---
         icon: cloud
         ---
-
         Returns the root directory of the user's OneDrive.
 
         ## Arguments
@@ -25,8 +24,7 @@ type OneDrive
     ## ---
         icon: cloud
         ---
-
-        Returns the root directory of the user's OneDrive.
+        Return a list of a directory of the user's OneDrive.
 
         ## Arguments
         - `path`: A path to a file or folder in OneDrive.

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/SQLServer_Connection.enso
@@ -36,8 +36,8 @@ type SQLServer_Connection
     ## ---
        private: true
        ---
-    dialect : Dialect
-    dialect = SQLServer_Dialect.sqlserver
+    get_dialect : Dialect
+    get_dialect = SQLServer_Dialect.sqlserver
 
     ## ---
        private: true
@@ -58,7 +58,7 @@ type SQLServer_Connection
         ## jdbc reports table name length limit as 128, but it actually seems to be 116 for temp tables so we override it
         limited = Encoding_Limited_Naming_Properties.Instance Encoding.utf_8 limit=116 is_case_sensitive=True
         modified_entity_naming_properties = Entity_Naming_Properties.Value for_table_names=limited for_column_names=jdbc_entity_naming_properties.for_column_names for_generated_column_names=jdbc_entity_naming_properties.for_generated_column_names
-        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Connection.dialect SQLServer_Type_Mapping modified_entity_naming_properties data_link_setup) make_new
+        SQLServer_Connection.Value (Connection.new jdbc_connection SQLServer_Connection.get_dialect SQLServer_Type_Mapping modified_entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Snowflake_Connection.md
@@ -10,7 +10,6 @@
     - database self -> Standard.Base.Any.Any
     - databases self -> Standard.Base.Any.Any
     - default_formatter self -> Standard.Table.Data_Formatter.Data_Formatter
-    - dialect -> Standard.Base.Any.Any
     - dialect self -> Standard.Base.Any.Any
     - drop_table self table_name:Standard.Base.Any.Any if_exists:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - execute self query:Standard.Base.Any.Any -> Standard.Base.Any.Any
@@ -20,6 +19,7 @@
     - file_format_names self -> Standard.Base.Any.Any
     - file_format_properties self file_format:Standard.Snowflake.Identifier.Identifier= -> Standard.Base.Any.Any
     - file_formats self schema:Standard.Base.Data.Text.Text= pattern:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
+    - get_dialect -> Standard.Base.Any.Any
     - get_from_stage self stage:Standard.Snowflake.Identifier.Identifier= path:Standard.Base.Data.Text.Text= directory:Standard.Base.Any.Any= pattern:Standard.Base.Data.Text.Text= ~if_not_found:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - jdbc_connection self -> Standard.Base.Any.Any
     - list_stage_objects self stage:Standard.Snowflake.Identifier.Identifier= path:Standard.Base.Data.Text.Text= limit:Standard.Table.Rows_To_Read.Rows_To_Read= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Snowflake_Connection.enso
@@ -48,8 +48,8 @@ type Snowflake_Connection
     ## ---
        private: true
        ---
-    dialect : Dialect
-    dialect = Snowflake_Dialect.snowflake
+    get_dialect : Dialect
+    get_dialect = Snowflake_Dialect.snowflake
 
     ## ---
        private: true
@@ -80,7 +80,7 @@ type Snowflake_Connection
            Our generator always quotes identifiers, so we can rely on the case sensitivity.
            This is the same as in Postgres.
         entity_naming_properties = Entity_Naming_Properties.from_jdbc_connection jdbc_connection is_case_sensitive=True
-        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Connection.dialect Snowflake_Type_Mapping entity_naming_properties data_link_setup) make_new
+        Snowflake_Connection.Value (Connection.new jdbc_connection Snowflake_Connection.get_dialect Snowflake_Type_Mapping entity_naming_properties data_link_setup) make_new
 
     ## ---
        private: true

--- a/test/DuckDB_Tests/src/DuckDB_Spec.enso
+++ b/test/DuckDB_Tests/src/DuckDB_Spec.enso
@@ -43,7 +43,7 @@ duckdb_spec suite_builder prefix create_connection_func =
 
     materialize = .read
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=DuckDB_Connection.dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=DuckDB_Connection.get_dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False
     agg_in_memory_table = ((Project_Description.new enso_dev.Table_Tests).data / "data.csv") . read
 

--- a/test/Microsoft_Tests/src/SQLServer_Spec.enso
+++ b/test/Microsoft_Tests/src/SQLServer_Spec.enso
@@ -180,7 +180,7 @@ add_sqlserver_specs suite_builder create_connection_fn =
 
     materialize = .read
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=SQLServer_Connection.dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=SQLServer_Connection.get_dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config advanced_stats=False text_shortest_longest=False first_last=False first_last_row_order=False aggregation_problems=False multi_distinct=False first_last_multi_order=False first_last_ignore_nothing=False text_concat=False
     agg_in_memory_table = ((Project_Description.new enso_dev.Table_Tests).data / "data.csv") . read
 

--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -533,7 +533,7 @@ add_snowflake_specs suite_builder create_connection_fn db_name =
         default_connection.get.create_literal_table (Table.new columns) "literal_table"
     materialize = .read
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=Snowflake_Connection.dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=False
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=Snowflake_Connection.get_dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=False
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False text_concat=False
     agg_in_memory_table = ((Project_Description.new enso_dev.Table_Tests).data / "data.csv") . read
 

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -720,7 +720,7 @@ add_postgres_specs suite_builder create_connection_fn db_name =
 
     materialize = .read
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=Postgres_Connection.dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=Postgres_Connection.get_dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
 

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -334,7 +334,7 @@ sqlite_spec suite_builder prefix create_connection_func persistent_connector =
 
     materialize = .read
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=SQLite_Connection.dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supported_replace_params=SQLite_Connection.get_dialect.get_supported_replace_params run_advanced_edge_case_tests_by_default=True
 
     ## For now `advanced_stats`, `text_shortest_longest` and
        `multi_distinct` remain disabled, because SQLite does not provide the

--- a/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
@@ -125,7 +125,7 @@ add_specs suite_builder =
             r1.to_display_text . should_contain "do not support Date/time types"
 
         group_builder.specify "should be able to infer types for all supported operations" <|
-            internal_mapping = SQLite_Connection.dialect.get_dialect_operations.operations_dict
+            internal_mapping = SQLite_Connection.get_dialect.get_dialect_operations.operations_dict
             operation_type_mapping = SQLite_Type_Mapping.operations_dict
 
             operation_type_mapping.keys.sort . should_equal internal_mapping.keys.sort


### PR DESCRIPTION
### Pull Request Description

- Read credentials from `enso://~/Microsoft365` automatically.
- Add new `OneDrive` entry point.
- Add `uri`, `to_text` and `to_display_text` to `OneDrive_File`.
- Fix for connection having static and instance method called `dialect` (static now called `get_dialect`).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
