### PR TITLE
Fix inheriting stdio on Windows

### DIFF
--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -166,6 +166,7 @@ export class EnsoRunner implements Runner {
             detached: false,
             cwd,
             stdio: ['pipe', 'inherit', 'inherit'],
+            windowsHide: true,
           })
 
           let resolved = false

--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -161,12 +161,7 @@ export class EnsoRunner implements Runner {
           const cmd = this.ensoPath.endsWith('.bat') ? 'cmd.exe' : this.ensoPath
           const cmdArgs = this.ensoPath.endsWith('.bat') ? ['/c', this.ensoPath, ...args] : args
           const cwd = path.dirname(projectPath)
-          const serverProcess = childProcess.spawn(cmd, cmdArgs, {
-            env,
-            detached: false,
-            cwd,
-            stdio: ['pipe', 'inherit', 'inherit'],
-          })
+          const serverProcess = childProcess.spawn(cmd, cmdArgs, { env, detached: false, cwd })
 
           let resolved = false
 
@@ -209,6 +204,15 @@ export class EnsoRunner implements Runner {
 
           // Start health check after initial delay
           setTimeout(startHealthCheck, 250)
+
+          // stdio buffers should be consumed before they reach their capacity
+          // and the process hangs
+          serverProcess.stdout.on('data', (data) => {
+            console.log(data.toString())
+          })
+          serverProcess.stderr.on('data', (data) => {
+            console.error(data.toString())
+          })
 
           serverProcess.on('error', (error) => {
             console.error(error.toString())

--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -161,7 +161,12 @@ export class EnsoRunner implements Runner {
           const cmd = this.ensoPath.endsWith('.bat') ? 'cmd.exe' : this.ensoPath
           const cmdArgs = this.ensoPath.endsWith('.bat') ? ['/c', this.ensoPath, ...args] : args
           const cwd = path.dirname(projectPath)
-          const serverProcess = childProcess.spawn(cmd, cmdArgs, { env, detached: false, cwd })
+          const serverProcess = childProcess.spawn(cmd, cmdArgs, {
+            env,
+            detached: false,
+            cwd,
+            stdio: ['pipe', 'inherit', 'inherit'],
+          })
 
           let resolved = false
 
@@ -204,15 +209,6 @@ export class EnsoRunner implements Runner {
 
           // Start health check after initial delay
           setTimeout(startHealthCheck, 250)
-
-          // stdio buffers should be consumed before they reach their capacity
-          // and the process hangs
-          serverProcess.stdout.on('data', (data) => {
-            console.log(data.toString())
-          })
-          serverProcess.stderr.on('data', (data) => {
-            console.error(data.toString())
-          })
 
           serverProcess.on('error', (error) => {
             console.error(error.toString())


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- followup #14317

Inheriting stdio on Windows causes terminal window to open :exploding_head: 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
