### PR TITLE
OneDrive fix for NI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,9 +41,11 @@ tsconfig.json
 /app/ydoc-server-nodejs/ @Frizi @farmaazon @vitvakatu @kazcw @AdRiley
 /app/ydoc-server-polyglot/ @Frizi @farmaazon @vitvakatu @kazcw @AdRiley
 /app/ydoc-shared/ @Frizi @farmaazon @vitvakatu @kazcw @AdRiley
+
 # The data-link schema is owned by the libraries team
 /app/gui/src/dashboard/data/datalinkSchema.json @jdunkerley @GregoryTravis @AdRiley
 /app/gui/src/dashboard/data/__tests__ @jdunkerley @GregoryTravis @AdRiley @PabloBuchu @indiv0 @somebody1234
+/app/gui/src/dashboard/data/serviceCredentials @jdunkerley @GregoryTravis @AdRiley @PabloBuchu @indiv0 @somebody1234
 
 # Engine (old)
 # This section should be removed once the engine moves to /app/engine

--- a/app/gui/src/dashboard/data/serviceCredentials/MS365CredentialsForm.tsx
+++ b/app/gui/src/dashboard/data/serviceCredentials/MS365CredentialsForm.tsx
@@ -37,7 +37,7 @@ export function MS365CredentialsForm(props: CredentialFormProps) {
     >
       {(form) => (
         <>
-          <Input form={form} name="name" label={getText('name')} />
+          <Input form={form} name="name" label={getText('name')} defaultValue="Microsoft365" />
           <Checkbox.Group form={form} name="scopes" label={getText('ms365CredentialScopes')}>
             <Checkbox value="User.Read">{getText('ms365CredentialUserReadScope')}</Checkbox>
             <Checkbox value="Files.Read">{getText('ms365CredentialFilesReadScope')}</Checkbox>

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/Graph.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/Graph.enso
@@ -2,6 +2,7 @@ private
 
 from Standard.Base import all
 
+polyglot java import org.enso.base.enso_cloud.ExternalLibraryCredentialHelper.AccessToken
 polyglot java import org.enso.base.enso_cloud.ExternalLibraryCredentialHelper.CredentialReference
 polyglot java import org.enso.microsoft.ms365.MS365Service
 


### PR DESCRIPTION
### Pull Request Description

- Let Libs own the OAuth credential forms
- Fix for M365 issue in NI (missing a polyglot import).
- Add a default name for M365.
 
<img width="478" height="380" alt="image" src="https://github.com/user-attachments/assets/2f993011-f1cd-4acb-a539-f04e7dbadc33" />


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
