### PR TITLE
Document Playwright tests

### DIFF
--- a/app/electron-client/tests/README.md
+++ b/app/electron-client/tests/README.md
@@ -17,8 +17,8 @@ In order to run tests locally you have to create credentials file under
 enso> mkdir -p app/electron-client/playwright/.auth && touch app/electron-client/playwright/.auth/user.json && chmod 600 app/electron-client/playwright/.auth/user.json && echo "{\"user\": \"$ENSO_TEST_USER\",\"password\":\"$ENSO_TEST_PASS\"}" > app/electron-client/playwright/.auth/user.json
 ```
 
-The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_PASS` credentials
-should be created **before** running the test suite.
+The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_PASS` credentials should be
+created **before** running the test suite.
 
 ### Playwright
 

--- a/app/electron-client/tests/README.md
+++ b/app/electron-client/tests/README.md
@@ -1,0 +1,51 @@
+# Playwright tests
+
+The `test` directory contains a set of end-to-end integration tests written using [Playwright Test](https://playwright.dev/) framework.
+
+
+## Prerequisite
+
+Running end-to-test tests requires a locally build IDE, that should be present in `dist/ide` directory.
+
+### Test account
+In order to run tests locally you have to create credentials file under `app/electron-client/playwright/.auth/user.json`:
+
+```bash
+enso> mkdir -p app/electron-client/playwright/.auth && touch app/electron-client/playwright/.auth/user.json && chmod 600 app/electron-client/playwright/.auth/user.json && echo "{\"user\": \"$ENSO_TEST_USER\",\"password\":\"$ENSO_TEST_PASS\"}" > app/electron-client/playwright/.auth/user.json
+```
+
+The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_USER_PASS` credentials should be created **before** running the test suite.
+
+### Playwright
+
+```bash
+enso> corepack pnpm add -D playwright -w
+enso> corepack pnpm exec playwright install
+```
+
+## Running end-to-end testing
+
+```bash
+enso> corepack pnpm -r --filter enso ide-integration-test
+```
+
+will run a full suite of end-to-end tests.
+
+### Debugging
+
+Debugging is possible by adding a `--debug` flag:
+
+```bash
+enso> corepack pnpm -r --filter enso ide-integration-test --debug
+```
+
+The command will start the usual electron app but with the possibility to pause/continue and add breakpoints.
+
+
+### Selective tests
+
+It is possible to run only a specific test suite by including its name at the end of the arguments.
+
+```bash
+enso> corepack pnpm -r --filter enso ide-integration-test tests/gettingStarted.spec.ts
+```

--- a/app/electron-client/tests/README.md
+++ b/app/electron-client/tests/README.md
@@ -17,13 +17,13 @@ In order to run tests locally you have to create credentials file under
 enso> mkdir -p app/electron-client/playwright/.auth && touch app/electron-client/playwright/.auth/user.json && chmod 600 app/electron-client/playwright/.auth/user.json && echo "{\"user\": \"$ENSO_TEST_USER\",\"password\":\"$ENSO_TEST_PASS\"}" > app/electron-client/playwright/.auth/user.json
 ```
 
-The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_USER_PASS` credentials
+The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_PASS` credentials
 should be created **before** running the test suite.
 
 ### Playwright
 
 ```bash
-enso> corepack pnpm add -D playwright -w
+enso> corepack pnpm install
 enso> corepack pnpm exec playwright install
 ```
 

--- a/app/electron-client/tests/README.md
+++ b/app/electron-client/tests/README.md
@@ -1,20 +1,24 @@
 # Playwright tests
 
-The `test` directory contains a set of end-to-end integration tests written using [Playwright Test](https://playwright.dev/) framework.
-
+The `test` directory contains a set of end-to-end integration tests written
+using [Playwright Test](https://playwright.dev/) framework.
 
 ## Prerequisite
 
-Running end-to-test tests requires a locally build IDE, that should be present in `dist/ide` directory.
+Running end-to-test tests requires a locally build IDE, that should be present
+in `dist/ide` directory.
 
 ### Test account
-In order to run tests locally you have to create credentials file under `app/electron-client/playwright/.auth/user.json`:
+
+In order to run tests locally you have to create credentials file under
+`app/electron-client/playwright/.auth/user.json`:
 
 ```bash
 enso> mkdir -p app/electron-client/playwright/.auth && touch app/electron-client/playwright/.auth/user.json && chmod 600 app/electron-client/playwright/.auth/user.json && echo "{\"user\": \"$ENSO_TEST_USER\",\"password\":\"$ENSO_TEST_PASS\"}" > app/electron-client/playwright/.auth/user.json
 ```
 
-The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_USER_PASS` credentials should be created **before** running the test suite.
+The test account with `$ENSO_TEST_USER`/`$ENSO_TEST_USER_PASS` credentials
+should be created **before** running the test suite.
 
 ### Playwright
 
@@ -39,12 +43,13 @@ Debugging is possible by adding a `--debug` flag:
 enso> corepack pnpm -r --filter enso ide-integration-test --debug
 ```
 
-The command will start the usual electron app but with the possibility to pause/continue and add breakpoints.
-
+The command will start the usual electron app but with the possibility to
+pause/continue and add breakpoints.
 
 ### Selective tests
 
-It is possible to run only a specific test suite by including its name at the end of the arguments.
+It is possible to run only a specific test suite by including its name at the
+end of the arguments.
 
 ```bash
 enso> corepack pnpm -r --filter enso ide-integration-test tests/gettingStarted.spec.ts

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -414,14 +414,18 @@ final class TruffleCompilerContext implements CompilerContext {
     logSerializationManager(
         Level.FINE, "Requesting serialization for module [{0}].", module.getName());
     var ir = module.getIr();
-    var dupl = ir.duplicate(true, true, true, true);
-    var duplicatedIr = compiler.updateMetadata(ir, dupl);
+    org.enso.compiler.core.ir.Module duplicatedIr;
     Source src;
     try {
+      var dupl = ir.duplicate(true, true, true, true);
+      duplicatedIr = compiler.updateMetadata(ir, dupl);
       var m = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
       src = m.getSource();
     } catch (IOException ex) {
-      logSerializationManager(Level.WARNING, "Cannot get source for " + module.getName(), ex);
+      logSerializationManager(
+          Level.WARNING,
+          "Cannot get source for " + module.getName() + " at stage " + module.getCompilationStage(),
+          ex);
       return CompletableFuture.failedFuture(ex);
     }
     var task =


### PR DESCRIPTION
Adds a simple instruction on how to run e2e integration testing.
Also made `SerializeModuleJob` a bit more resilient to internal errors that we can see occasionally in e2e runs:
```
Error: 1mpw:browser [pid=12792][out] [ERROR] [2025-11-25T00:53:24.379] [org.enso.interpreter.instrument.execution.JobExecutionEngine] Error executing SerializeModuleJob(local.NewProject1.Main) +187ms
  pw:browser [pid=12792][out] org.enso.compiler.core.CompilerError: Dataflow Analysis must have run. +1ms
  pw:browser [pid=12792][out] 	at org.enso.runtime.parser/org.enso.compiler.core.Implicits$AsMetadata.$anonfun$unsafeGetMetadata$1(Implicits.scala:124) +0ms
  pw:browser [pid=12792][out] 	at scala.library@2.13.15/scala.Option.getOrElse(Option.scala:201) +0ms
  pw:browser [pid=12792][out] 	at org.enso.runtime.parser/org.enso.compiler.core.Implicits$AsMetadata.unsafeGetMetadata(Implicits.scala:124) +0ms
  pw:browser [pid=12792][out] 	at org.enso.compiler.pass.analyse.DataflowAnalysis$.updateMetadataInDuplicate(DataflowAnalysis.scala:111) +0ms
  pw:browser [pid=12792][out] 	at org.enso.compiler.pass.PassManager.$anonfun$runMetadataUpdate$1(PassManager.scala:342) +0ms
  pw:browser [pid=12792][out] 	at scala.library@2.13.15/scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183) +0ms
  pw:browser [pid=12792][out] 	at scala.library@2.13.15/scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179) +0ms
  pw:browser [pid=12792][out] 	at scala.library@2.13.15/scala.collection.immutable.List.foldLeft(List.scala:79) +0ms
  pw:browser [pid=12792][out] 	at org.enso.compiler.pass.PassManager.runMetadataUpdate(PassManager.scala:340) +0ms
  pw:browser [pid=12792][out] 	at org.enso.compiler.Compiler.updateMetadata(Compiler.scala:1184) +0ms
  pw:browser [pid=12792][out] 	at org.enso.interpreter.runtime.TruffleCompilerContext.serializeModule(TruffleCompilerContext.java:418) +0ms
  pw:browser [pid=12792][out] 	at 
  ...
```
([src](https://github.com/enso-org/enso/actions/runs/19650805936/job/56283455629?pr=14311#step:15:441))