### PR TITLE
Dual JVM benchmark computing mean on a table loaded by Generic_JDBC driver

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/docs/api/Bench.md
+++ b/distribution/lib/Standard/Test/0.0.0-dev/docs/api/Bench.md
@@ -20,7 +20,8 @@
     - Impl builder:Standard.Base.Any.Any
     - group self name:Standard.Base.Data.Text.Text configuration:Standard.Test.Bench.Bench_Options fn:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - type Bench_Options
-    - Impl warmup:Standard.Test.Bench.Phase_Conf measure:Standard.Test.Bench.Phase_Conf
+    - Impl warmup:Standard.Test.Bench.Phase_Conf measure:Standard.Test.Bench.Phase_Conf jvm_args:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)=
+    - set_jvm_args self args:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
     - set_measure self meas:Standard.Test.Bench.Phase_Conf -> Standard.Base.Any.Any
     - set_warmup self warm:Standard.Test.Bench.Phase_Conf -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso
@@ -33,15 +33,18 @@ type Bench_Options
     ## ---
        private: true
        ---
-    Impl (warmup:Phase_Conf) (measure:Phase_Conf)
+    Impl (warmup:Phase_Conf) (measure:Phase_Conf) (jvm_args:Text|Nothing)=Nothing
 
     ## Sets the warmup phase.
     set_warmup : Phase_Conf -> Bench_Options
-    set_warmup self (warm:Phase_Conf) = Bench_Options.Impl warm self.measure
+    set_warmup self (warm:Phase_Conf) = Bench_Options.Impl warm self.measure self.jvm_args
 
     ## Sets the measurement phase.
     set_measure : Phase_Conf -> Bench_Options
-    set_measure self (meas:Phase_Conf) = Bench_Options.Impl self.warmup meas
+    set_measure self (meas:Phase_Conf) = Bench_Options.Impl self.warmup meas self.jvm_args
+
+    ## Sets additional JVM args
+    set_jvm_args self args:Text = Bench_Options.Impl self.warmup self.measure args
 
     ## ---
        private: true
@@ -188,6 +191,8 @@ type Bench
             case should_skip bench_name of
                 False ->
                     IO.println <| "Benchmarking '" + bench_name + "' with configuration: " + c.to_text
+                    if c.jvm_args != Nothing then
+                        IO.println <| "Ignoring JVM arguments "+c.jvm_args
                     Bench.measure bench_name c.warmup c.measure (s.code 0)
                 True ->
                     IO.println <| "Skipping '" + bench_name + "' benchmark"

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchConfig.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchConfig.java
@@ -8,4 +8,6 @@ public interface BenchConfig {
   PhaseConfig warmup();
 
   PhaseConfig measure();
+
+  String jvm_args();
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
@@ -249,7 +249,11 @@ public final class SpecCollector {
     out.println(" */");
     out.println("@BenchmarkMode(Mode.AverageTime)");
     out.println("@OutputTimeUnit(TimeUnit.MILLISECONDS)");
-    out.println("@Fork(1)");
+    if (group.configuration().jvm_args() instanceof String args) {
+      out.println("@Fork(value=1, jvmArgsAppend=\"" + args + "\")");
+    } else {
+      out.println("@Fork(1)");
+    }
     out.println(getWarmupAnnotationForGroup(group));
     out.println(getMeasureAnnotationForGroup(group));
     out.println("@State(Scope.Benchmark)");

--- a/test/Benchmarks/src/Main.enso
+++ b/test/Benchmarks/src/Main.enso
@@ -17,6 +17,7 @@ import project.Sieve
 import project.Jvms.Execute_Generic_JDBC_Tests
 import project.Startup.Startup
 import project.Statistics.Count_Min_Max
+import project.Statistics.Generic_JDBC_Mean
 import project.Sum
 import project.Table.Add_Row_Number
 import project.Table.Aggregate
@@ -66,6 +67,7 @@ all_benchmarks =
 
         # Statistics
         builder.append Count_Min_Max.collect_benches
+        builder.append Generic_JDBC_Mean.collect_benches
 
         # Table
         builder.append Aggregate.collect_benches

--- a/test/Benchmarks/src/Statistics/Generic_JDBC_Mean.enso
+++ b/test/Benchmarks/src/Statistics/Generic_JDBC_Mean.enso
@@ -6,7 +6,7 @@ from Standard.Generic_JDBC import Generic_JDBC_Connection
 from Standard.Test import Bench
 
 options = Bench.options . set_warmup (Bench.phase_conf 3 5) . set_measure (Bench.phase_conf 1 5)
-
+dual_jvm_options = options . set_jvm_args "-Dpolyglot.enso.classLoading=Standard.Generic_JDBC:guest,hosted"
 
 
 type Seq
@@ -41,7 +41,11 @@ type Seq
 collect_benches = Bench.build builder->
     million = Seq.create 10 10000
 
-    builder.group "Generic_JDBC" options group_builder->
+    builder.group "Single_JVM_Generic_JDBC" options group_builder->
+        group_builder.specify "mean" <|
+            million.column . compute ..Mean
+
+    builder.group "Dual_JVM_Generic_JDBC" dual_jvm_options group_builder->
         group_builder.specify "mean" <|
             million.column . compute ..Mean
 

--- a/test/Benchmarks/src/Statistics/Generic_JDBC_Mean.enso
+++ b/test/Benchmarks/src/Statistics/Generic_JDBC_Mean.enso
@@ -1,0 +1,48 @@
+private
+
+from Standard.Base import all
+from Standard.Table import Column
+from Standard.Generic_JDBC import Generic_JDBC_Connection
+from Standard.Test import Bench
+
+options = Bench.options . set_warmup (Bench.phase_conf 3 5) . set_measure (Bench.phase_conf 1 5)
+
+
+
+type Seq
+    private Value ~column
+
+    create times count =
+        Seq.Value (Seq.generate times count)
+
+    private insert_numbers conn arr =
+        values = (arr.map \n->'('+n.to_text+')') . join ','
+        conn.execute 'INSERT INTO seq VALUES '+values
+        Nothing
+
+    private generate times count -> Column =
+        dir = Meta.Enso_Project.enso_project.data
+        db = dir.create_directory / "seq.db"
+        if db.exists then
+            db.delete
+
+        jdbc = Generic_JDBC_Connection.connect 'jdbc:sqlite:'+db.to_text
+        jdbc.execute 'CREATE TABLE seq (number INTEGER)'
+        0.up_to times-1 . map t->
+            numbers = 1.up_to count . map (+ t*count)
+            Seq.insert_numbers jdbc numbers
+
+        t = jdbc.read (..Table_Name 'seq') ..All_Rows
+        c = t:Column
+        m = c . compute ..Mean
+        Runtime.assert (m == 45000) "Properly computed mean, was: "+m.to_text
+        c
+
+collect_benches = Bench.build builder->
+    million = Seq.create 10 10000
+
+    builder.group "Generic_JDBC" options group_builder->
+        group_builder.specify "mean" <|
+            million.column . compute ..Mean
+
+main = collect_benches . run_main


### PR DESCRIPTION
### Pull Request Description

- _dual JVM_ benchmark to track progress of #13851 
- `Column` is loaded by `Standard.Generic_JDBC` module, but the mean is computed by `Standard.Table`
- that (in _dual JVM mode_) means the `Column` data are **crossing the boundary**

### Important Notes

- with c35aa2e14e8a6fc535ba83f11c72741f60e4d9d1 we can run both tests at the same time:
```
sbt:enso> std-benchmarks/benchOnly JDBC.mean
[info] Benchmark                     Mode  Cnt    Score   Error  Units
[info] Dual_JVM_Generic_JDBC.mean    avgt       544,708          ms/op
[info] Single_JVM_Generic_JDBC.mean  avgt        32,655          ms/op
```
- e.g. **20x** slower for now
   - #14309 will make it faster

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] [Benchmark is executed](https://github.com/enso-org/enso/actions/runs/19696163586) in single as well as _dual JVM mode_ during our CI run
