### PR TITLE
Restore telemetry format of xls_format

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -133,12 +133,12 @@ type Excel_Format
             Excel_Format.Workbook _ _ ->
                 result = Excel_Workbook.new file format
                 result.if_not_error <|
-                    Telemetry.log "File_Format.read" "Read file: format={}, output={}, sheet_count={}, xls_format={}" ["Excel_Format", "Excel_Workbook", result.sheet_count, format.to_text]
+                    Telemetry.log "File_Format.read" "Read file: format={}, output={}, sheet_count={}, xls_format={}, file_type={}" ["Excel_Format", "Excel_Workbook", result.sheet_count, format==Excel_File_Format.XLS, format.to_text]
                     result
             _ ->
                 result = Excel_Reader.read_file file (as_section self) on_problems format
                 result.if_not_error <|
-                    Telemetry.log "File_Format.read" "Read file: format={}, output={}, row_count={}, column_count={}, xls_format={}" ["Excel_Format", "Table", result.row_count, result.column_count, format.to_text]
+                    Telemetry.log "File_Format.read" "Read file: format={}, output={}, row_count={}, column_count={}, xls_format={}, file_type={}" ["Excel_Format", "Table", result.row_count, result.column_count, format==Excel_File_Format.XLS, format.to_text]
                     result
 
     ## ---

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -284,7 +284,7 @@ type Excel_Workbook
                 _ : Integer -> ExcelReader.readSheetByIndex self.java_file query java_headers skip_rows java_limit self.internal_xl_format.to_java java_problem_aggregator
         result = limit.attach_warning (from_java_table java_table)
         result.if_not_error <|
-            Telemetry.log "Excel_Workbook.read" "Read sheet: format={}, output={}, row_count={}, column_count={}, xls_format={}" ["Excel_Format", "Table", result.row_count, result.column_count, self.internal_xl_format.to_text]
+            Telemetry.log "Excel_Workbook.read" "Read sheet: format={}, output={}, row_count={}, column_count={}, xls_format={}, file_format={}" ["Excel_Format", "Table", result.row_count, result.column_count, self.internal_xl_format==Excel_File_Format.XLS, self.internal_xl_format.to_text]
             result
 
     ## ---


### PR DESCRIPTION
### Pull Request Description

- The change to XLS/XLSX/XLSB causes errors in telemetry.
- This should fix that.
<img width="486" height="259" alt="image" src="https://github.com/user-attachments/assets/fffb5dbe-1437-4120-91be-adadf39782c8" />

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
