### PR TITLE
Ignore MacOS' auxilary directories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5047,10 +5047,12 @@ lazy val downloader = (project in file("lib/scala/downloader"))
     ),
     Compile / internalModuleDependencies := Seq(
       (`cli` / Compile / exportedModule).value,
+      (`engine-common` / Compile / exportedModule).value,
       (`scala-libs-wrapper` / Compile / exportedModule).value
     )
   )
   .dependsOn(cli)
+  .dependsOn(`engine-common`)
   .dependsOn(`http-test-helper` % "test->test")
   .dependsOn(testkit % Test)
 

--- a/lib/scala/downloader/src/main/java/module-info.java
+++ b/lib/scala/downloader/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module org.enso.downloader {
   requires org.apache.commons.io;
 
   requires org.enso.cli;
+  requires org.enso.engine.common;
   // For com.typesafe.scalalogging.Logger
   requires org.enso.scala.wrapper;
 

--- a/lib/scala/downloader/src/main/scala/org/enso/downloader/archive/Archive.scala
+++ b/lib/scala/downloader/src/main/scala/org/enso/downloader/archive/Archive.scala
@@ -125,11 +125,20 @@ object Archive {
     }
 
     iterateArchive(archivePath, format) { entry =>
-      val destinationPath =
-        destinationDirectory.resolve(rewritePath(entry.relativePath))
-      entry.extractTo(destinationPath)
-      true
+      if (ignoreEntry(entry.relativePath)) true
+      else {
+        val destinationPath =
+          destinationDirectory.resolve(rewritePath(entry.relativePath))
+        entry.extractTo(destinationPath)
+        true
+      }
     }
+  }
+
+  // Some entries are created automatically by the underlying OS and should be ingored
+  private def ignoreEntry(path: Path): Boolean = {
+    org.enso.common.Platform.getOperatingSystem().isMacOs() && path
+      .startsWith("._")
   }
 
   /** Iterates over entries of the archive at `archivePath`.


### PR DESCRIPTION
### Pull Request Description

It appears that on some MacOS CI runners some indexing is turned on, which means that OS creates automatically hidden directories. This messes up with our expectations. This change adds an exception for MacOS to simply ignore `._` prefixed directories during unpacking in `Archive.scala`.

Simpler version of #14340 which tried to fix dependencies as well but instead opened a can of worms.
Closes #14294.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
