### PR TITLE
Debugger does not evaluate methods when inspecting fields

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/BuiltinsFallbackScope.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/BuiltinsFallbackScope.java
@@ -23,7 +23,8 @@ public final class BuiltinsFallbackScope {
     var scopeBuilder =
         new StaticModuleScope.Builder(QualifiedName.fromString("Standard.Builtins.Main"));
     scopeBuilder.registerMethod(TypeScopeReference.ANY, ConstantsNames.TO_TEXT, BuiltinTypes.TEXT);
-    scopeBuilder.registerMethod(TypeScopeReference.ANY, "to_display_text", BuiltinTypes.TEXT);
+    scopeBuilder.registerMethod(
+        TypeScopeReference.ANY, ConstantsNames.TO_DISPLAY_TEXT, BuiltinTypes.TEXT);
     scopeBuilder.registerMethod(TypeScopeReference.ANY, "pretty", BuiltinTypes.TEXT);
 
     var any = new TypeRepresentation.TopType();

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/BuiltinsFallbackScope.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/scope/BuiltinsFallbackScope.java
@@ -1,5 +1,6 @@
 package org.enso.compiler.pass.analyse.types.scope;
 
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.compiler.pass.analyse.types.BuiltinTypes;
 import org.enso.compiler.pass.analyse.types.TypeRepresentation;
 import org.enso.pkg.QualifiedName;
@@ -21,7 +22,7 @@ public final class BuiltinsFallbackScope {
   private static StaticModuleScope constructFallbackScope() {
     var scopeBuilder =
         new StaticModuleScope.Builder(QualifiedName.fromString("Standard.Builtins.Main"));
-    scopeBuilder.registerMethod(TypeScopeReference.ANY, "to_text", BuiltinTypes.TEXT);
+    scopeBuilder.registerMethod(TypeScopeReference.ANY, ConstantsNames.TO_TEXT, BuiltinTypes.TEXT);
     scopeBuilder.registerMethod(TypeScopeReference.ANY, "to_display_text", BuiltinTypes.TEXT);
     scopeBuilder.registerMethod(TypeScopeReference.ANY, "pretty", BuiltinTypes.TEXT);
 

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames;
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.compiler.suggestions.SimpleUpdate;
 import org.enso.interpreter.instrument.Endpoint;
 import org.enso.interpreter.instrument.ExpressionExecutionState;
@@ -628,8 +629,8 @@ public final class ExecutionService {
       // contrary to what is
       // expected from the documentation, throw an `UnsupportedMessageException`.
       // Instead it will crash with some internal assertion deep inside runtime. Hence the check.
-      if (iop.isMemberInvocable(payload, "to_display_text")) {
-        return iop.asString(iop.invokeMember(payload, "to_display_text"));
+      if (iop.isMemberInvocable(payload, ConstantsNames.TO_DISPLAY_TEXT)) {
+        return iop.asString(iop.invokeMember(payload, ConstantsNames.TO_DISPLAY_TEXT));
       } else throw UnsupportedMessageException.create();
     } catch (UnsupportedMessageException
         | ArityException

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
@@ -660,6 +660,52 @@ public class DebuggingEnsoTest {
   }
 
   @Test
+  public void debuggerDoesNotEvaluateMethods() {
+    var fooFunc =
+        createEnsoMethod(
+            """
+            from Standard.Base import IO
+
+            type My_Type
+                Cons
+
+                method self =
+                    IO.println "Method evaluated"
+                    42
+
+            foo x =
+                obj = My_Type.Cons
+                obj
+            """,
+            "foo");
+    try (DebuggerSession session =
+        debugger.startSession(
+            (SuspendedEvent event) -> {
+              switch (event.getSourceSection().getCharacters().toString().strip()) {
+                case "obj" -> {
+                  DebugScope scope = event.getTopStackFrame().getScope();
+                  DebugValue objValue = scope.getDeclaredValue("obj");
+                  assertThat(objValue.isReadable(), is(true));
+                  assertThat(objValue.isInternal(), is(false));
+                  assertThat(objValue.hasReadSideEffects(), is(false));
+
+                  var methodProp = objValue.getProperty("method");
+                  assertThat(methodProp.canExecute(), is(true));
+                  assertThat("It is a method, not a number", methodProp.isNumber(), is(false));
+                  assertThat(
+                      "Method should not be evaluated when accessed as a debug property",
+                      out.toString(),
+                      not(containsString("Method evaluated")));
+                }
+              }
+              event.getSession().suspendNextExecution();
+            })) {
+      session.suspendNextExecution();
+      fooFunc.execute(0);
+    }
+  }
+
+  @Test
   public void testAtomFieldAreReadable_MultipleConstructors() {
     var fooFunc =
         createEnsoMethod(

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MethodResolutionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MethodResolutionTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.interpreter.Constants.Names;
 import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -44,7 +45,8 @@ public final class MethodResolutionTest {
             main = My_Type
             """);
     var myType = unwrapType(myTypeVal);
-    var symbol = UnresolvedSymbol.build("to_display_text", myType.getDefinitionScope());
+    var symbol =
+        UnresolvedSymbol.build(ConstantsNames.TO_DISPLAY_TEXT, myType.getDefinitionScope());
     var func = methodResolverNode.executeResolution(myType, symbol);
     assertThat("to_display_text method is found", func, is(notNullValue()));
     assertSingleSelfArgument(func);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/InvokeBuiltinMethodViaInteropTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/builtins/InvokeBuiltinMethodViaInteropTest.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import org.enso.interpreter.Constants;
 import org.enso.test.utils.ContextUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -78,8 +79,8 @@ public class InvokeBuiltinMethodViaInteropTest {
     var vec = ctxRule.evalModule(code);
     var vecType = vec.getMetaObject();
     assertThat(vecType, is(notNullValue()));
-    assertThat(vecType.hasMember("to_text"), is(true));
-    var res = vecType.invokeMember("to_text", new Object[] {vec});
+    assertThat(vecType.hasMember(Constants.Names.TO_TEXT), is(true));
+    var res = vecType.invokeMember(Constants.Names.TO_TEXT, new Object[] {vec});
     assertThat("to_text method can be invoked", res, is(notNullValue()));
     assertThat("to_text method returns correct result", res.isString(), is(true));
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames.Module;
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Value;
@@ -98,7 +99,7 @@ public final class MethodInvocationOnTypeConsistencyTest {
                 }),
             new TestArgs(
                 new EnsoInvokeArgs("Any.to_text my_type_atom"),
-                new InteropInvokeArgs(anyType, "to_text", List.of(myTypeAtom)),
+                new InteropInvokeArgs(anyType, ConstantsNames.TO_TEXT, List.of(myTypeAtom)),
                 (res, msg) -> {
                   assertThat(msg, res.asString(), containsString("Cons 1"));
                 }),

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/MethodInvocationOnTypeConsistencyTest.java
@@ -93,7 +93,7 @@ public final class MethodInvocationOnTypeConsistencyTest {
         List.of(
             new TestArgs(
                 new EnsoInvokeArgs("Any.to_display_text My_Type"),
-                new InteropInvokeArgs(anyType, "to_display_text", List.of(myType)),
+                new InteropInvokeArgs(anyType, ConstantsNames.TO_DISPLAY_TEXT, List.of(myType)),
                 (res, msg) -> {
                   assertThat(msg, res.asString(), is("My_Type"));
                 }),
@@ -105,7 +105,7 @@ public final class MethodInvocationOnTypeConsistencyTest {
                 }),
             new TestArgs(
                 new EnsoInvokeArgs("My_Type.to_display_text"),
-                new InteropInvokeArgs(myType, "to_display_text", List.of()),
+                new InteropInvokeArgs(myType, ConstantsNames.TO_DISPLAY_TEXT, List.of()),
                 (res, msg) -> {
                   assertThat(msg, res.asString(), is("My_Type"));
                 }),

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
@@ -103,7 +103,7 @@ public class TypeMembersTest {
     assertEquals(
         "all members",
         Set.of(
-            "to_display_text",
+            ConstantsNames.TO_DISPLAY_TEXT,
             "message",
             ConstantsNames.TO_TEXT,
             "==",
@@ -174,7 +174,7 @@ public class TypeMembersTest {
 
             main = My_Type
             """);
-    var displayTextRes = myType.invokeMember("to_display_text");
+    var displayTextRes = myType.invokeMember(ConstantsNames.TO_DISPLAY_TEXT);
     assertThat("Has correct result type", displayTextRes.isString(), is(true));
     assertThat("Has correct result value", displayTextRes.asString(), is("My_Type"));
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/interop/TypeMembersTest.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
@@ -101,7 +102,13 @@ public class TypeMembersTest {
     var compileError = module.invokeMember("eval_expression", "v");
     assertEquals(
         "all members",
-        Set.of("to_display_text", "message", "to_text", "==", "catch_primitive", "pretty"),
+        Set.of(
+            "to_display_text",
+            "message",
+            ConstantsNames.TO_TEXT,
+            "==",
+            "catch_primitive",
+            "pretty"),
         compileError.getMemberKeys());
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRecomputeTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRecomputeTest.scala
@@ -2,6 +2,7 @@ package org.enso.interpreter.test.instrument
 
 import org.apache.commons.io.output.TeeOutputStream
 import org.enso.common.{LanguageInfo, MethodNames, RuntimeOptions}
+import org.enso.compiler.core.ConstantsNames
 import org.enso.interpreter.runtime.EnsoContext
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
@@ -1299,7 +1300,7 @@ class RuntimeRecomputeTest
           Api.MethodPointer(
             "Standard.Base.Any",
             "Standard.Base.Any.Any",
-            "to_text"
+            ConstantsNames.TO_TEXT
           ),
           Vector()
         )
@@ -1312,7 +1313,7 @@ class RuntimeRecomputeTest
           Api.MethodPointer(
             "Standard.Base.Any",
             "Standard.Base.Any.Any",
-            "to_text"
+            ConstantsNames.TO_TEXT
           ),
           Vector()
         )
@@ -1385,7 +1386,7 @@ class RuntimeRecomputeTest
             Api.MethodPointer(
               "Standard.Base.Any",
               "Standard.Base.Any.Any",
-              "to_text"
+              ConstantsNames.TO_TEXT
             ),
             Vector()
           )
@@ -1402,7 +1403,7 @@ class RuntimeRecomputeTest
             Api.MethodPointer(
               "Standard.Base.Any",
               "Standard.Base.Any.Any",
-              "to_text"
+              ConstantsNames.TO_TEXT
             ),
             Vector()
           )
@@ -1458,7 +1459,7 @@ class RuntimeRecomputeTest
             Api.MethodPointer(
               "Standard.Base.Any",
               "Standard.Base.Any.Any",
-              "to_text"
+              ConstantsNames.TO_TEXT
             ),
             Vector()
           )

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
@@ -1,8 +1,8 @@
 package org.enso.compiler.core;
 
 public interface ConstantsNames {
-  public static final String SELF_ARGUMENT = "self";
-  public static final String SELF_TYPE_ARGUMENT = "Self";
-  public static final String THAT_ARGUMENT = "that";
-  public static final String FROM_MEMBER = "from";
+  String SELF_ARGUMENT = "self";
+  String SELF_TYPE_ARGUMENT = "Self";
+  String THAT_ARGUMENT = "that";
+  String FROM_MEMBER = "from";
 }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
@@ -6,4 +6,5 @@ public interface ConstantsNames {
   String THAT_ARGUMENT = "that";
   String FROM_MEMBER = "from";
   String TO_TEXT = "to_text";
+  String TO_DISPLAY_TEXT = "to_display_text";
 }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ConstantsNames.java
@@ -5,4 +5,5 @@ public interface ConstantsNames {
   String SELF_TYPE_ARGUMENT = "Self";
   String THAT_ARGUMENT = "that";
   String FROM_MEMBER = "from";
+  String TO_TEXT = "to_text";
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/ErrorToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/ErrorToTextNode.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -11,7 +12,10 @@ import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
 
-@BuiltinMethod(type = "Error", name = "to_text", description = "Convert an error to text.")
+@BuiltinMethod(
+    type = "Error",
+    name = Constants.Names.TO_TEXT,
+    description = "Convert an error to text.")
 public abstract class ErrorToTextNode extends Node {
   private static final int DISPATCH_CACHE = 3;
   private @Child InteropLibrary displays =

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidConversionTargetToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidConversionTargetToDisplayTextNode.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
 import org.enso.interpreter.runtime.data.atom.Atom;
@@ -13,7 +14,7 @@ import org.enso.interpreter.runtime.data.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Invalid_Conversion_Target", name = "to_display_text")
+@BuiltinMethod(type = "Invalid_Conversion_Target", name = ConstantsNames.TO_DISPLAY_TEXT)
 public abstract class InvalidConversionTargetToDisplayTextNode extends Node {
   static InvalidConversionTargetToDisplayTextNode build() {
     return InvalidConversionTargetToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
@@ -83,6 +84,6 @@ public abstract class PrintErrNode extends Node {
   static UnresolvedSymbol buildToTextSymbol(Node where) {
     var mod = Builtins.get(where).getModule();
     var scope = mod.getScope();
-    return UnresolvedSymbol.build("to_text", scope);
+    return UnresolvedSymbol.build(Constants.Names.TO_TEXT, scope);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
@@ -102,7 +103,7 @@ public abstract class PrintlnNode extends Node {
   static UnresolvedSymbol buildToTextSymbol(Node where) {
     var mod = Builtins.get(where).getModule();
     var scope = mod.getScope();
-    return UnresolvedSymbol.build("to_text", scope);
+    return UnresolvedSymbol.build(Constants.Names.TO_TEXT, scope);
   }
 
   @NeverDefault

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToDisplayTextNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -19,7 +20,7 @@ import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.polyglot.common_utils.Core_Text_Utils;
 
-@BuiltinMethod(type = "Any", name = "to_display_text")
+@BuiltinMethod(type = "Any", name = Constants.Names.TO_DISPLAY_TEXT)
 public abstract class AnyToDisplayTextNode extends Node {
   static AnyToDisplayTextNode build() {
     return AnyToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
@@ -16,7 +17,10 @@ import org.enso.interpreter.runtime.data.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Any", name = "to_text", description = "Generic text conversion.")
+@BuiltinMethod(
+    type = "Any",
+    name = Constants.Names.TO_TEXT,
+    description = "Generic text conversion.")
 @GenerateUncached
 public abstract class AnyToTextNode extends Node {
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -401,7 +403,7 @@ public abstract class Atom extends EnsoObject {
     Object result = null;
     String msg;
     try {
-      result = atoms.invokeMember(this, "to_text");
+      result = atoms.invokeMember(this, Constants.Names.TO_TEXT);
       if (warnings.hasWarnings(result)) {
         result = warnings.removeWarnings(result);
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -281,7 +281,6 @@ public abstract class Atom extends EnsoObject {
    * @param member An identifier of a field or method.
    * @return Value of the field or function.
    * @throws UnknownIdentifierException If an unknown field/method is requested.
-   * @throws UnsupportedMessageException If the requested member is not readable.
    */
   @ExportMessage
   @ExplodeLoop
@@ -289,7 +288,7 @@ public abstract class Atom extends EnsoObject {
       String member,
       @CachedLibrary(limit = "3") StructsLibrary structs,
       @Cached InteropApplicationNode preApplySelf)
-      throws UnknownIdentifierException, UnsupportedMessageException {
+      throws UnknownIdentifierException {
     if (!isMemberReadable(member)) {
       throw UnknownIdentifierException.create(member);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -310,7 +309,7 @@ public abstract class Atom extends EnsoObject {
   }
 
   @TruffleBoundary
-  private Function findMethod(String methodName) {
+  Function findMethod(String methodName) {
     var matchedMethod =
         getInstanceMethods().stream()
             .filter(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/DebugAtomWrapper.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/DebugAtomWrapper.java
@@ -1,11 +1,13 @@
 package org.enso.interpreter.runtime.data.atom;
 
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import org.enso.compiler.core.ConstantsNames;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.runtime.data.EnsoObject;
 
@@ -50,10 +52,17 @@ public final class DebugAtomWrapper extends EnsoObject {
    */
   @ExportMessage
   @ExplodeLoop
-  Object readMember(String member, @CachedLibrary(limit = "3") StructsLibrary structsLib)
+  Object readMember(
+      String member,
+      @CachedLibrary(limit = "3") StructsLibrary structsLib,
+      @Cached InteropApplicationNode appNode)
       throws UnknownIdentifierException {
-    // TODO: to_text and to_display_text are exceptions - they should always be
-    //  evaluated when the atom is inspected.
+    // Special fallback behavior for `to_text` and `to_display_text` methods -
+    // they should always be evaluated.
+    if (member.equals(ConstantsNames.TO_TEXT) || member.equals(ConstantsNames.TO_DISPLAY_TEXT)) {
+      return atom.readMember(member, structsLib, appNode);
+    }
+
     var ctor = atom.getConstructor();
     for (var i = 0; i < ctor.getArity(); i++) {
       var fieldName = ctor.getFields()[i].getName();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/DebugAtomWrapper.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/DebugAtomWrapper.java
@@ -1,0 +1,77 @@
+package org.enso.interpreter.runtime.data.atom;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import org.enso.interpreter.node.callable.InteropApplicationNode;
+import org.enso.interpreter.runtime.data.EnsoObject;
+
+/**
+ * Wrapper for {@link Atom} that is meant to be used by inspector and the debugger. This wrapper
+ * changes the behavior of some atom interop messages to be more debugger-friendly. For example, it
+ * does not invoke parameter-less instance methods when inspecting the atom. Note that from the
+ * engine and language perspective, there is no difference between a field and parameter-less
+ * instance method.
+ */
+@ExportLibrary(value = InteropLibrary.class, delegateTo = "atom")
+public final class DebugAtomWrapper extends EnsoObject {
+  final Atom atom;
+
+  private DebugAtomWrapper(Atom atom) {
+    this.atom = atom;
+  }
+
+  public static DebugAtomWrapper wrap(Atom atom) {
+    assert atom != null;
+    return new DebugAtomWrapper(atom);
+  }
+
+  @ExportMessage
+  boolean hasMembers() {
+    return atom.hasMembers();
+  }
+
+  @ExportMessage
+  boolean isMemberReadable(String member) {
+    return atom.isMemberReadable(member);
+  }
+
+  @ExportMessage
+  Object getMembers(boolean includeInternal) {
+    return atom.getMembers(includeInternal);
+  }
+
+  /**
+   * Inspired by {@link Atom#readMember(String, StructsLibrary, InteropApplicationNode)}, but does
+   * not preapply {@code self} argument if the member is an instance method.
+   */
+  @ExportMessage
+  @ExplodeLoop
+  Object readMember(String member, @CachedLibrary(limit = "3") StructsLibrary structsLib)
+      throws UnknownIdentifierException {
+    // TODO: to_text and to_display_text are exceptions - they should always be
+    //  evaluated when the atom is inspected.
+    var ctor = atom.getConstructor();
+    for (var i = 0; i < ctor.getArity(); i++) {
+      var fieldName = ctor.getFields()[i].getName();
+      if (fieldName.equals(member)) {
+        return structsLib.getField(atom, i);
+      }
+    }
+    var method = atom.findMethod(member);
+    if (method != null) {
+      return method;
+    } else {
+      throw UnknownIdentifierException.create(member);
+    }
+  }
+
+  @ExportMessage
+  @Override
+  public Object toDisplayString(boolean allowSideEffects) {
+    return atom.toDisplayString(allowSideEffects);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToTextNode.java
@@ -9,12 +9,13 @@ import com.oracle.truffle.api.interop.StopIterationException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
 
 @BuiltinMethod(
     type = "Dictionary",
-    name = "to_text",
+    name = Constants.Names.TO_TEXT,
     description =
         """
         Returns text representation of this hash map

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.BaseNode.TailStatus;
 import org.enso.interpreter.node.callable.IndirectInvokeMethodNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
@@ -158,7 +159,7 @@ public final class PanicException extends AbstractTruffleException {
   static UnresolvedSymbol toDisplayText(EnsoContext ctx, IndirectInvokeMethodNode payloads)
       throws UnsupportedMessageException {
     var scope = ctx.getBuiltins().panic().getDefinitionScope();
-    return UnresolvedSymbol.build("to_display_text", scope);
+    return UnresolvedSymbol.build(Constants.Names.TO_DISPLAY_TEXT, scope);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
@@ -21,6 +21,8 @@ import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.EnsoObject;
+import org.enso.interpreter.runtime.data.atom.Atom;
+import org.enso.interpreter.runtime.data.atom.DebugAtomWrapper;
 import org.enso.interpreter.runtime.error.DataflowError;
 
 /**
@@ -186,6 +188,9 @@ public class DebugLocalScope extends EnsoObject {
     }
     FramePointer framePtr = allBindings.get(member);
     var value = getValue(frame, framePtr);
+    if (value instanceof Atom atom) {
+      return DebugAtomWrapper.wrap(atom);
+    }
     if (value != null) {
       var ensoLang = EnsoLanguage.get(interop);
       var ensoCtx = EnsoContext.get(interop);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/WithWarnings.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.library.Message;
 import com.oracle.truffle.api.library.ReflectionLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.InteropMethodCallNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -194,7 +195,7 @@ public final class WithWarnings extends EnsoObject {
     var warns = Warning.fromMapToArray(warnsMap);
     var ctx = EnsoContext.get(where);
     var scopeOfAny = ctx.getBuiltins().any().getDefinitionScope();
-    var toText = UnresolvedSymbol.build("to_text", scopeOfAny);
+    var toText = UnresolvedSymbol.build(Constants.Names.TO_TEXT, scopeOfAny);
     var node = InteropMethodCallNode.getUncached();
     var state = State.create(ctx);
     var text = Text.empty();


### PR DESCRIPTION
Fixes #14360

### Pull Request Description

parameter-less instance methods are not called by the inspector, except for `to_text` and `to_display_text`:
<img width="729" height="373" alt="obrazek" src="https://github.com/user-attachments/assets/ecb0a8bb-2dc9-4fb5-bc3f-c4b86541ec19" />

Previously, inspection of `obj` would trigger "Calling My_Type.method" to be printed in the Console.

### Important Notes

- Also extract "to_text" and "to_display_text" constants from the codebase.
- Interop behavior of `Atom` is unchanged.
- Introduced special [DebugAtomWrapper](https://github.com/enso-org/enso/blob/2c94a2560417d10e0454250edc539200e29ce856/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/DebugAtomWrapper.java) so that an `Atom` is treated specially in the inspector/debugger.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
