### PR TITLE
Fix warning and error opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   with <kbd>Delete</kbd> key.
 - [Improved visuals of high components][14267]. Their contents is aligned to
   top.
+- [Warnings and Errors no longer become transparent][14388]
 
 [13685]: https://github.com/enso-org/enso/pull/13685
 [13658]: https://github.com/enso-org/enso/pull/13658
@@ -45,6 +46,7 @@
 [14270]: https://github.com/enso-org/enso/pull/14270
 [14311]: https://github.com/enso-org/enso/pull/14311
 [14267]: https://github.com/enso-org/enso/pull/14267
+[14388]: https://github.com/enso-org/enso/pull/14388
 
 #### Enso Standard Library
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -107,7 +107,6 @@ providePopoverRoot(rootNode)
 const { visibleMessage, hiddenMessage } = useNodeMessage({
   projectStore,
   graphDb: graph.db,
-  passEvents: () => outputVisible.value,
   expand: () => nodeHovered.value || selected.value,
   nodeId,
 })

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode.vue
@@ -174,7 +174,6 @@ function ensureSelected() {
   }
 }
 
-const outputVisible = computed(() => graph.nodeOutputVisible.get(nodeId.value))
 const outputHovered = computed(() => graph.nodeOutputHovered.get(nodeId.value))
 
 const scale = computed(() => navigator?.scale ?? 1)

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeMessage.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeMessage.ts
@@ -18,7 +18,6 @@ interface NodeMessageOptions {
   projectStore: ProjectStore
   graphDb: GraphDb
   expand: ToValue<boolean>
-  passEvents: ToValue<boolean>
   nodeId: ToValue<NodeId>
 }
 
@@ -27,7 +26,6 @@ export function useNodeMessage({
   projectStore,
   graphDb,
   expand,
-  passEvents,
   nodeId,
 }: NodeMessageOptions) {
   const inputExternalIds = computed(() => {
@@ -92,7 +90,6 @@ export function useNodeMessage({
     return {
       type: availableMessage.value.type,
       message: availableMessage.value.text,
-      passEvents: toValue(passEvents),
     }
   })
 

--- a/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeMessage.ts
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNode/nodeMessage.ts
@@ -22,12 +22,7 @@ interface NodeMessageOptions {
 }
 
 /** Composable managing messages (warnings, errors, etc.) associated with a node. */
-export function useNodeMessage({
-  projectStore,
-  graphDb,
-  expand,
-  nodeId,
-}: NodeMessageOptions) {
+export function useNodeMessage({ projectStore, graphDb, expand, nodeId }: NodeMessageOptions) {
   const inputExternalIds = computed(() => {
     const externalIds = new Array<ExternalId>()
     for (const inputId of graphDb.nodeDependents.reverseLookup(toValue(nodeId))) {

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeMessage.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeMessage.vue
@@ -64,10 +64,7 @@ export const colorForMessageType: Record<MessageType, string> = {
 </script>
 
 <template>
-  <div
-    class="GraphNodeMessage"
-    :style="{ '--background-color': colorForMessageType[props.type] }"
-  >
+  <div class="GraphNodeMessage" :style="{ '--background-color': colorForMessageType[props.type] }">
     <SvgIcon class="icon" :name="iconForMessageType[props.type]" />
     <div class="message" v-text="props.message"></div>
     <div class="toolbar">

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeMessage.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeMessage.vue
@@ -12,7 +12,6 @@ const { projectNames: names, module } = useCurrentProject()
 const props = defineProps<{
   message: string
   type: MessageType
-  passEvents?: boolean
 }>()
 
 function containsLibraryName(): ProjectPath | null {
@@ -67,7 +66,6 @@ export const colorForMessageType: Record<MessageType, string> = {
 <template>
   <div
     class="GraphNodeMessage"
-    :class="{ passEvents }"
     :style="{ '--background-color': colorForMessageType[props.type] }"
   >
     <SvgIcon class="icon" :name="iconForMessageType[props.type]" />
@@ -109,10 +107,6 @@ export const colorForMessageType: Record<MessageType, string> = {
   pointer-events: none;
   opacity: 1;
   transition: opacity 0.2s ease;
-
-  &.passEvents {
-    opacity: 0.5;
-  }
 }
 
 .icon {


### PR DESCRIPTION
### Pull Request Description

Warnings and Errors will no longer become transparent when the component is selected.

Fixes #14370 

Before:

https://github.com/user-attachments/assets/9ad2614d-e204-430c-bfbf-7cae99b5cb05

After:

https://github.com/user-attachments/assets/52842828-345d-4a63-948d-9e93cf124bf3


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
