### PR TITLE
Refactoring to encapsulate `InvokeMethodNode`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ApplicationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ApplicationNode.java
@@ -17,7 +17,7 @@ import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
  * those arguments into the correct positional order for the callable being called.
  */
 @NodeInfo(shortName = "App", description = "Executes function")
-public class ApplicationNode extends ExpressionNode {
+public final class ApplicationNode extends ExpressionNode {
   private @Children ExpressionNode[] argExpressions;
 
   @Child private InvokeCallableNode invokeCallableNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -8,14 +8,11 @@ import com.oracle.truffle.api.nodes.Node;
 import java.util.UUID;
 import org.enso.compiler.core.ConstantsNames;
 import org.enso.interpreter.node.BaseNode;
-import org.enso.interpreter.node.MethodRootNode;
 import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
-import org.enso.interpreter.runtime.callable.function.FunctionSchema;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
@@ -23,7 +20,7 @@ import org.enso.interpreter.runtime.state.State;
 import org.enso.interpreter.runtime.warning.WarningsLibrary;
 
 /** */
-public abstract class InvokeMethodNode extends BaseNode {
+abstract class InvokeMethodNode extends BaseNode {
   protected static final int CACHE_SIZE = 10;
   protected final int argumentCount;
   protected final boolean onBoundary;
@@ -98,45 +95,6 @@ public abstract class InvokeMethodNode extends BaseNode {
       UnresolvedSymbol symbol, Object self, Type selfTpe, MethodResolverNode methodResolverNode) {
     Function function = methodResolverNode.executeResolution(selfTpe, symbol);
     return function;
-  }
-
-  /**
-   * Returns true if synthetic Self argument should be prepended to the arguments passed to the
-   * function.
-   *
-   * <p>Static method calls on Any are resolved to `Any.type.method`. Such methods take one
-   * additional self argument (with Any.type) as opposed to static method calls resolved on any
-   * other types.
-   *
-   * @param resolvedFunctionSchema Schema of the function that was resolved to be invoked.
-   * @param argumentCount Count of the arguments passed to the function.
-   * @return True if synthetic self argument should be prepended to the arguments.
-   */
-  public static boolean shouldPrependSyntheticSelfArg(
-      FunctionSchema resolvedFunctionSchema, int argumentCount) {
-    var resolvedFuncArgCount = resolvedFunctionSchema.getArgumentsCount();
-    long argsWithDefaultValCount = 0;
-    for (var argDef : resolvedFunctionSchema.getArgumentInfos()) {
-      if (argDef.hasDefaultValue()) {
-        argsWithDefaultValCount++;
-      }
-    }
-    boolean shouldPrependSyntheticSelfArg =
-        resolvedFuncArgCount - argsWithDefaultValCount == argumentCount + 1;
-    return shouldPrependSyntheticSelfArg;
-  }
-
-  private static boolean typeCanOverride(MethodRootNode node, EnsoContext ctx) {
-    Type methodOwnerType = node.getType();
-    Builtins builtins = ctx.getBuiltins();
-    Type any = builtins.any();
-    Type warning = builtins.warning();
-    Type panic = builtins.panic();
-    return methodOwnerType.isEigenType()
-        && builtins.nothing() != methodOwnerType
-        && any.getEigentype() != methodOwnerType
-        && panic.getEigentype() != methodOwnerType
-        && warning.getEigentype() != methodOwnerType;
   }
 
   static PanicException methodNotFound(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/SequenceLiteralNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/SequenceLiteralNode.java
@@ -8,7 +8,7 @@ import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.error.PanicSentinel;
 
 @NodeInfo(shortName = "[]", description = "Creates a vector from given expressions.")
-public class SequenceLiteralNode extends ExpressionNode {
+public final class SequenceLiteralNode extends ExpressionNode {
   private @Children ExpressionNode[] items;
 
   private SequenceLiteralNode(ExpressionNode[] items) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/FunctionSchema.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/FunctionSchema.java
@@ -232,6 +232,30 @@ public final class FunctionSchema {
     return isFullyApplied;
   }
 
+  /**
+   * Returns true if synthetic Self argument should be prepended to the arguments passed to the
+   * function. The {@code this} represents schema of the function resolved to be invoked.
+   *
+   * <p>Static method calls on Any are resolved to `Any.type.method`. Such methods take one
+   * additional self argument (with Any.type) as opposed to static method calls resolved on any
+   * other types.
+   *
+   * @param argumentCount Count of the arguments passed to the function.
+   * @return True if synthetic self argument should be prepended to the arguments.
+   */
+  public boolean shouldPrependSyntheticSelfArg(int argumentCount) {
+    var resolvedFuncArgCount = getArgumentsCount();
+    long argsWithDefaultValCount = 0;
+    for (var argDef : getArgumentInfos()) {
+      if (argDef.hasDefaultValue()) {
+        argsWithDefaultValCount++;
+      }
+    }
+    boolean shouldPrependSyntheticSelfArg =
+        resolvedFuncArgCount - argsWithDefaultValCount == argumentCount + 1;
+    return shouldPrependSyntheticSelfArg;
+  }
+
   public static final class Builder {
     private boolean isProjectPrivate = false;
     private Annotation[] annotations = new Annotation[0];

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -25,7 +25,6 @@ import org.enso.interpreter.node.ConstantNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMode;
-import org.enso.interpreter.node.callable.InvokeMethodNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.ModuleScopeBuilder;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
@@ -428,7 +427,7 @@ public final class Type extends EnsoObject {
         @Cached("findMethod(receiver, cachedMember)") Function func,
         @Cached("buildInvokeCallableNode(func)") InvokeCallableNode invokeCallableNode) {
       Object[] finalArgs = args;
-      if (InvokeMethodNode.shouldPrependSyntheticSelfArg(func.getSchema(), args.length)) {
+      if (func.getSchema().shouldPrependSyntheticSelfArg(args.length)) {
         var argsWithReceiver = new Object[args.length + 1];
         argsWithReceiver[0] = receiver;
         System.arraycopy(args, 0, argsWithReceiver, 1, args.length);


### PR DESCRIPTION
### Pull Request Description

- distinguishing what nodes are "re-usable" from whole `engine/runtime` project
- from nodes that are just an implementation detail is hard for me
- making classes _package private_ is the simplest indicator that they shouldn't be referenced from `IrToTruffle` for example
- this PR provides one such refactoring, making `InvokeMethodNode` & subclasses _package private_

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to behave
