### PR TITLE
Using validity bitmap as Arrow does

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -55,6 +55,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
     if (value) {
       vals.set(size);
     }
+    validityMap.set(size, true);
     size++;
     return this;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -13,13 +13,13 @@ import org.enso.table.util.BitSets;
 /** A builder for boolean columns. */
 final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   private final BitSet vals;
-  private final BitSet isNothing;
+  private final BitSet validityMap;
   int size = 0;
 
   // ** Creates a new builder for boolean columns. Should be built via Builder.getForBoolean. */
   BoolBuilder(int capacity) {
     vals = new BitSet(capacity);
-    isNothing = new BitSet(capacity);
+    validityMap = new BitSet(capacity);
   }
 
   @Override
@@ -31,6 +31,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
         if (b) {
           vals.set(size);
         }
+        validityMap.set(size);
       } else {
         throw new ValueTypeMismatchException(getType(), o);
       }
@@ -60,7 +61,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
 
   @Override
   public BoolBuilder appendNulls(int count) {
-    isNothing.set(size, size + count);
+    validityMap.set(size, size + count, false);
     size += count;
     return this;
   }
@@ -71,7 +72,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
       // We know this is valid for a BoolStorage.
       int toCopy = (int) boolStorage.getSize();
       BitSets.copy(boolStorage.getValues(), vals, size, toCopy);
-      BitSets.copy(boolStorage.getIsNothingMap(), isNothing, size, toCopy);
+      BitSets.copy(boolStorage.getValidityMap(), validityMap, size, toCopy);
       size += toCopy;
     } else if (storage instanceof ColumnBooleanStorage columnBooleanStorage) {
       for (long i = 0; i < columnBooleanStorage.getSize(); i++) {
@@ -90,7 +91,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
 
   @Override
   public ColumnStorage<Boolean> seal() {
-    return new BoolStorage(vals, isNothing, size, false);
+    return new BoolStorage(vals, validityMap, size, false);
   }
 
   @Override
@@ -101,7 +102,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   @Override
   public void copyDataTo(Object[] items) {
     for (int i = 0; i < size; i++) {
-      if (isNothing.get(i)) {
+      if (validityMap.get(i)) {
         items[i] = null;
       } else {
         items[i] = vals.get(i);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -103,7 +103,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
   @Override
   public void copyDataTo(Object[] items) {
     for (int i = 0; i < size; i++) {
-      if (validityMap.get(i)) {
+      if (!validityMap.get(i)) {
         items[i] = null;
       } else {
         items[i] = vals.get(i);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BoolBuilder.java
@@ -73,7 +73,7 @@ final class BoolBuilder implements BuilderForBoolean, BuilderWithRetyping {
       // We know this is valid for a BoolStorage.
       int toCopy = (int) boolStorage.getSize();
       BitSets.copy(boolStorage.getValues(), vals, size, toCopy);
-      BitSets.copy(boolStorage.getValidityMap(), validityMap, size, toCopy);
+      boolStorage.getValidityMap().copyTo(validityMap, size, toCopy);
       size += toCopy;
     } else if (storage instanceof ColumnBooleanStorage columnBooleanStorage) {
       for (long i = 0; i < columnBooleanStorage.getSize(); i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -54,8 +54,12 @@ public interface Builder {
     // Create a single storage item based on the type of the item.
     return switch (item) {
       case null -> new NullBuilder().appendNulls(checkSize(size)).seal();
-      case Boolean booleanValue ->
-          new BoolStorage(new BitSet(), new BitSet(), checkSize(size), booleanValue);
+      case Boolean booleanValue -> {
+        var s = checkSize(size);
+        var validity = new BitSet();
+        validity.set(0, s, true);
+        yield new BoolStorage(new BitSet(), validity, s, booleanValue);
+      }
       default -> {
         var storageType = StorageType.forBoxedItem(item, PreciseTypeOptions.DEFAULT);
         var builder = Builder.getForType(storageType, size, BlackholeProblemAggregator.INSTANCE);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -16,8 +16,8 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 
 /** A builder for floating point columns. */
-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble permits
-    InferredDoubleBuilder {
+sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
+    permits InferredDoubleBuilder {
   protected final PrecisionLossAggregator precisionLossAggregator;
   protected double[] data;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -80,7 +80,7 @@ sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
     }
 
     ensureSpaceToAppend();
-    validityMap.set(currentSize, true);
+    setValid(currentSize);
     data[currentSize++] = value;
     return this;
   }
@@ -92,7 +92,7 @@ sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
         int n = (int) doubleStorage.getSize();
         ensureFreeSpaceFor(n);
         System.arraycopy(doubleStorage.getData(), 0, data, currentSize, n);
-        doubleStorage.getValidityMap().copyTo(validityMap, currentSize, n);
+        appendValidityMap(doubleStorage.getValidityMap(), n);
         currentSize += n;
       } else {
         var doubleStorage = floatType.asTypedStorage(storage);
@@ -151,7 +151,7 @@ sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
   @Override
   public DoubleBuilder appendDouble(double value) {
     ensureSpaceToAppend();
-    validityMap.set(currentSize, true);
+    setValid(currentSize);
     data[currentSize++] = value;
     return this;
   }
@@ -169,7 +169,7 @@ sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
 
   @Override
   public ColumnStorage<Double> seal() {
-    return new DoubleStorage(data, currentSize, validityMap);
+    return new DoubleStorage(data, currentSize, validityMap());
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -16,7 +16,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 
 /** A builder for floating point columns. */
-class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
+non-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
   protected final PrecisionLossAggregator precisionLossAggregator;
   protected double[] data;
 
@@ -91,7 +91,7 @@ class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
         int n = (int) doubleStorage.getSize();
         ensureFreeSpaceFor(n);
         System.arraycopy(doubleStorage.getData(), 0, data, currentSize, n);
-        BitSets.copy(doubleStorage.getIsNothingMap(), isNothing, currentSize, n);
+        BitSets.copy(doubleStorage.getValidityMap(), validityMap, currentSize, n);
         currentSize += n;
       } else {
         var doubleStorage = floatType.asTypedStorage(storage);
@@ -165,7 +165,7 @@ class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
 
   @Override
   public ColumnStorage<Double> seal() {
-    return new DoubleStorage(data, currentSize, isNothing);
+    return new DoubleStorage(data, currentSize, validityMap);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -80,6 +80,7 @@ non-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDoubl
     }
 
     ensureSpaceToAppend();
+    validityMap.set(currentSize, true);
     data[currentSize++] = value;
     return this;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -147,8 +147,10 @@ non-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDoubl
    *
    * @param value the double to append
    */
+  @Override
   public DoubleBuilder appendDouble(double value) {
     ensureSpaceToAppend();
+    validityMap.set(currentSize, true);
     data[currentSize++] = value;
     return this;
   }
@@ -158,6 +160,7 @@ non-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDoubl
    *
    * <p>It ensures that any loss of precision is reported.
    */
+  @Override
   public DoubleBuilder appendLong(long value) {
     appendDouble(convertLongToDouble(value));
     return this;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -16,7 +16,8 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 
 /** A builder for floating point columns. */
-non-sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble {
+sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble permits
+    InferredDoubleBuilder {
   protected final PrecisionLossAggregator precisionLossAggregator;
   protected double[] data;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -13,7 +13,6 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.error.ValueTypeMismatchException;
 import org.enso.table.problems.ProblemAggregator;
-import org.enso.table.util.BitSets;
 
 /** A builder for floating point columns. */
 sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
@@ -93,7 +92,7 @@ sealed class DoubleBuilder extends NumericBuilder implements BuilderForDouble
         int n = (int) doubleStorage.getSize();
         ensureFreeSpaceFor(n);
         System.arraycopy(doubleStorage.getData(), 0, data, currentSize, n);
-        BitSets.copy(doubleStorage.getValidityMap(), validityMap, currentSize, n);
+        doubleStorage.getValidityMap().copyTo(validityMap, currentSize, n);
         currentSize += n;
       } else {
         var doubleStorage = floatType.asTypedStorage(storage);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -66,7 +66,7 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
   public void copyDataTo(Object[] items) {
     int rawN = rawData == null ? 0 : rawData.length;
     for (int i = 0; i < currentSize; i++) {
-      if (isNothing.get(i)) {
+      if (!validityMap.get(i)) {
         items[i] = null;
       } else {
         if (isLongCompactedAsDouble.get(i)) {
@@ -160,7 +160,7 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
     if (type instanceof BigDecimalType) {
       Builder res = Builder.getForBigDecimal(data.length);
       for (int i = 0; i < currentSize; i++) {
-        if (isNothing.get(i)) {
+        if (!validityMap.get(i)) {
           res.appendNulls(1);
         } else {
           BigDecimal bigDecimal = BigDecimal.valueOf(data[i]);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredDoubleBuilder.java
@@ -66,7 +66,7 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
   public void copyDataTo(Object[] items) {
     int rawN = rawData == null ? 0 : rawData.length;
     for (int i = 0; i < currentSize; i++) {
-      if (!validityMap.get(i)) {
+      if (!isValid(i)) {
         items[i] = null;
       } else {
         if (isLongCompactedAsDouble.get(i)) {
@@ -160,7 +160,7 @@ final class InferredDoubleBuilder extends DoubleBuilder implements BuilderWithRe
     if (type instanceof BigDecimalType) {
       Builder res = Builder.getForBigDecimal(data.length);
       for (int i = 0; i < currentSize; i++) {
-        if (!validityMap.get(i)) {
+        if (!isValid(i)) {
           res.appendNulls(1);
         } else {
           BigDecimal bigDecimal = BigDecimal.valueOf(data[i]);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -16,7 +16,7 @@ import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.BitSets;
 
 /** A builder for integer columns. */
-class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping {
+non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping {
   protected final ProblemAggregator problemAggregator;
   protected long[] data;
 
@@ -49,7 +49,7 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
   @Override
   public void copyDataTo(Object[] items) {
     for (int i = 0; i < currentSize; i++) {
-      if (isNothing.get(i)) {
+      if (!validityMap.get(i)) {
         items[i] = null;
       } else {
         items[i] = data[i];
@@ -96,7 +96,7 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
           int n = (int) longStorage.getSize();
           ensureFreeSpaceFor(n);
           System.arraycopy(longStorage.getData(), 0, data, currentSize, n);
-          BitSets.copy(longStorage.getIsNothingMap(), isNothing, currentSize, n);
+          BitSets.copy(longStorage.getValidityMap(), validityMap, currentSize, n);
           currentSize += n;
         } else {
           // No conversions needed, but we need to iterate over the items.
@@ -143,7 +143,7 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
     if (index >= currentSize) {
       throw new IndexOutOfBoundsException();
     } else {
-      return isNothing.get((int) index);
+      return !validityMap.get((int) index);
     }
   }
 
@@ -185,6 +185,6 @@ class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithR
 
   @Override
   public ColumnStorage<Long> seal() {
-    return new LongStorage(data, currentSize, isNothing, getType());
+    return new LongStorage(data, currentSize, validityMap, getType());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -13,7 +13,6 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.error.ValueTypeMismatchException;
 import org.enso.table.problems.ProblemAggregator;
-import org.enso.table.util.BitSets;
 
 /** A builder for integer columns. */
 non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping {
@@ -96,7 +95,7 @@ non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, B
           int n = (int) longStorage.getSize();
           ensureFreeSpaceFor(n);
           System.arraycopy(longStorage.getData(), 0, data, currentSize, n);
-          BitSets.copy(longStorage.getValidityMap(), validityMap, currentSize, n);
+          longStorage.getValidityMap().copyTo(validityMap, currentSize, n);
           currentSize += n;
         } else {
           // No conversions needed, but we need to iterate over the items.

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -13,7 +13,6 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.error.ValueTypeMismatchException;
 import org.enso.table.problems.ProblemAggregator;
-import org.enso.table.util.ImmutableBitSet;
 
 /** A builder for integer columns. */
 sealed class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping
@@ -50,7 +49,7 @@ sealed class LongBuilder extends NumericBuilder implements BuilderForLong, Build
   @Override
   public void copyDataTo(Object[] items) {
     for (int i = 0; i < currentSize; i++) {
-      if (!validityMap.get(i)) {
+      if (!isValid(i)) {
         items[i] = null;
       } else {
         items[i] = data[i];
@@ -97,7 +96,7 @@ sealed class LongBuilder extends NumericBuilder implements BuilderForLong, Build
           int n = (int) longStorage.getSize();
           ensureFreeSpaceFor(n);
           System.arraycopy(longStorage.getData(), 0, data, currentSize, n);
-          longStorage.getValidityMap().copyTo(validityMap, currentSize, n);
+          appendValidityMap(longStorage.getValidityMap(), n);
           currentSize += n;
         } else {
           // No conversions needed, but we need to iterate over the items.
@@ -135,7 +134,7 @@ sealed class LongBuilder extends NumericBuilder implements BuilderForLong, Build
    */
   public LongBuilder appendLong(long value) {
     ensureSpaceToAppend();
-    this.validityMap.set(currentSize, true);
+    this.setValid(currentSize);
     this.data[currentSize++] = value;
     return this;
   }
@@ -145,7 +144,7 @@ sealed class LongBuilder extends NumericBuilder implements BuilderForLong, Build
     if (index >= currentSize) {
       throw new IndexOutOfBoundsException();
     } else {
-      return !validityMap.get((int) index);
+      return !isValid((int) index);
     }
   }
 
@@ -187,7 +186,6 @@ sealed class LongBuilder extends NumericBuilder implements BuilderForLong, Build
 
   @Override
   public ColumnStorage<Long> seal() {
-    return new LongStorage(
-        data, currentSize, new ImmutableBitSet(validityMap, currentSize), getType());
+    return new LongStorage(data, currentSize, validityMap(), getType());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -13,9 +13,11 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.error.ValueTypeMismatchException;
 import org.enso.table.problems.ProblemAggregator;
+import org.enso.table.util.ImmutableBitSet;
 
 /** A builder for integer columns. */
-non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping {
+sealed class LongBuilder extends NumericBuilder implements BuilderForLong, BuilderWithRetyping
+    permits BoundCheckedIntegerBuilder {
   protected final ProblemAggregator problemAggregator;
   protected long[] data;
 
@@ -185,6 +187,7 @@ non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, B
 
   @Override
   public ColumnStorage<Long> seal() {
-    return new LongStorage(data, currentSize, validityMap, getType());
+    return new LongStorage(
+        data, currentSize, new ImmutableBitSet(validityMap, currentSize), getType());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -134,6 +134,7 @@ non-sealed class LongBuilder extends NumericBuilder implements BuilderForLong, B
    */
   public LongBuilder appendLong(long value) {
     ensureSpaceToAppend();
+    this.validityMap.set(currentSize, true);
     this.data[currentSize++] = value;
     return this;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -3,17 +3,17 @@ package org.enso.table.data.column.builder;
 import java.util.BitSet;
 
 /** A common base for numeric builders. */
-abstract class NumericBuilder implements Builder {
-  protected BitSet isNothing;
-  protected int currentSize;
+abstract sealed class NumericBuilder implements Builder permits DoubleBuilder, LongBuilder {
+  BitSet validityMap;
+  int currentSize;
 
   protected NumericBuilder() {
-    this.isNothing = new BitSet();
+    this.validityMap = new BitSet();
     this.currentSize = 0;
   }
 
   protected void doAppendNulls(int count) {
-    isNothing.set(currentSize, currentSize + count);
+    validityMap.set(currentSize, currentSize + count, false);
     currentSize += count;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -1,20 +1,50 @@
 package org.enso.table.data.column.builder;
 
 import java.util.BitSet;
+import org.enso.table.util.ImmutableBitSet;
 
 /** A common base for numeric builders. */
 abstract sealed class NumericBuilder implements Builder permits DoubleBuilder, LongBuilder {
-  BitSet validityMap;
+  private BitSet validityMap;
   int currentSize;
 
-  protected NumericBuilder() {
-    this.validityMap = new BitSet();
-    this.currentSize = 0;
+  protected NumericBuilder() {}
+
+  private BitSet getValidityMap() {
+    if (validityMap == null) {
+      validityMap = new BitSet();
+      validityMap.set(0, currentSize);
+    }
+    return validityMap;
   }
 
-  protected void doAppendNulls(int count) {
-    validityMap.set(currentSize, currentSize + count, false);
+  protected final void doAppendNulls(int count) {
+    getValidityMap().set(currentSize, currentSize + count, false);
     currentSize += count;
+  }
+
+  protected final boolean isValid(int i) {
+    return validityMap == null || validityMap.get(i);
+  }
+
+  protected final void setValid(int i) {
+    if (validityMap != null) {
+      validityMap.set(i);
+    }
+  }
+
+  protected final ImmutableBitSet validityMap() {
+    if (validityMap == null) {
+      return ImmutableBitSet.allTrue(currentSize);
+    } else {
+      return new ImmutableBitSet(validityMap, currentSize);
+    }
+  }
+
+  protected final void appendValidityMap(ImmutableBitSet validity, int n) {
+    if (validity.cardinality() < n || validityMap != null) {
+      validity.copyTo(getValidityMap(), currentSize, n);
+    }
   }
 
   @Override
@@ -22,7 +52,7 @@ abstract sealed class NumericBuilder implements Builder permits DoubleBuilder, L
     return currentSize;
   }
 
-  protected void ensureFreeSpaceFor(int additionalSize) {
+  protected final void ensureFreeSpaceFor(int additionalSize) {
     if (currentSize + additionalSize > getDataSize()) {
       resize(currentSize + additionalSize);
     }
@@ -35,7 +65,7 @@ abstract sealed class NumericBuilder implements Builder permits DoubleBuilder, L
    * appends. It tries to keep the invariant that after calling `grow` the array has at least one
    * free slot.
    */
-  protected void ensureSpaceToAppend() {
+  protected final void ensureSpaceToAppend() {
     int dataLength = getDataSize();
 
     // Check current size. If there is space, we don't need to grow.

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
@@ -265,8 +265,8 @@ public final class IsInOperation {
 
     // If had both true and false, then return all true when not nothing
     if (flags.hadTrue && flags.hadFalse) {
-      var isNothing = makeIsNothingMap(boolStorage, checkedSize);
-      return new BoolStorage(new BitSet(), isNothing, checkedSize, true);
+      var validityMap = makeValidityMap(boolStorage, checkedSize);
+      return new BoolStorage(new BitSet(), validityMap, checkedSize, true);
     }
 
     // Only have one of true or false
@@ -313,18 +313,18 @@ public final class IsInOperation {
     }
   }
 
-  private static BitSet makeIsNothingMap(ColumnStorage<?> storage, int size) {
+  private static BitSet makeValidityMap(ColumnStorage<?> storage, int size) {
     if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
       return withNothingMap.getValidityMap();
     }
 
-    BitSet isNothingMap = new BitSet(size);
+    BitSet validityMap = new BitSet(size);
     for (int i = 0; i < size; i++) {
-      if (storage.isNothing(i)) {
-        isNothingMap.set(i);
+      if (!storage.isNothing(i)) {
+        validityMap.set(i);
       }
     }
-    return isNothingMap;
+    return validityMap;
   }
 
   private static BitSet or(BitSet left, BitSet right, int sizeIsIgnored) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
@@ -28,6 +28,7 @@ import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.MapOperationProblemAggregator;
+import org.enso.table.util.ImmutableBitSet;
 
 /**
  * The IsInOperation class provides a way to check if a value is in a set of values. It checks if
@@ -296,7 +297,7 @@ public final class IsInOperation {
   private static ColumnStorage<?> applyBoolStorage(
       boolean keepValue, BoolStorage boolStorage, int checkedSize) {
     BitSet values = boolStorage.getValues();
-    BitSet isNothing = (BitSet) boolStorage.getValidityMap().clone();
+    BitSet isNothing = boolStorage.getValidityMap().cloneBitSet();
     isNothing.flip(0, Math.toIntExact(boolStorage.getSize()));
 
     if (keepValue) {
@@ -316,7 +317,7 @@ public final class IsInOperation {
     }
   }
 
-  private static BitSet makeValidityMap(ColumnStorage<?> storage, int size) {
+  private static ImmutableBitSet makeValidityMap(ColumnStorage<?> storage, int size) {
     if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
       return withNothingMap.getValidityMap();
     }
@@ -327,7 +328,7 @@ public final class IsInOperation {
         validityMap.set(i);
       }
     }
-    return validityMap;
+    return new ImmutableBitSet(validityMap, size);
   }
 
   private static BitSet or(BitSet left, BitSet right, int sizeIsIgnored) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
@@ -14,7 +14,7 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnBooleanStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.ColumnStorageWithInferredStorage;
-import org.enso.table.data.column.storage.ColumnStorageWithNothingMap;
+import org.enso.table.data.column.storage.ColumnStorageWithValidityMap;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.BigIntegerType;
@@ -296,22 +296,26 @@ public final class IsInOperation {
   private static ColumnStorage<?> applyBoolStorage(
       boolean keepValue, BoolStorage boolStorage, int checkedSize) {
     BitSet values = boolStorage.getValues();
-    BitSet isNothing = boolStorage.getIsNothingMap();
+    BitSet validityMap = boolStorage.getValidityMap();
 
     if (keepValue) {
-      var newIsNothing =
-          boolStorage.isNegated() ? or(isNothing, values) : orNot(isNothing, values, checkedSize);
-      return new BoolStorage(values, newIsNothing, checkedSize, boolStorage.isNegated());
+      var newValidity =
+          boolStorage.isNegated()
+              ? orNot(validityMap, values, checkedSize)
+              : or(validityMap, values, checkedSize);
+      return new BoolStorage(values, newValidity, checkedSize, boolStorage.isNegated());
     } else {
-      var newIsNothing =
-          boolStorage.isNegated() ? orNot(isNothing, values, checkedSize) : or(isNothing, values);
-      return new BoolStorage(values, newIsNothing, checkedSize, !boolStorage.isNegated());
+      var newValidity =
+          boolStorage.isNegated()
+              ? or(validityMap, values, checkedSize)
+              : orNot(validityMap, values, checkedSize);
+      return new BoolStorage(values, newValidity, checkedSize, !boolStorage.isNegated());
     }
   }
 
   private static BitSet makeIsNothingMap(ColumnStorage<?> storage, int size) {
-    if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
-      return withNothingMap.getIsNothingMap();
+    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
+      return withNothingMap.getValidityMap();
     }
 
     BitSet isNothingMap = new BitSet(size);
@@ -323,7 +327,7 @@ public final class IsInOperation {
     return isNothingMap;
   }
 
-  private static BitSet or(BitSet left, BitSet right) {
+  private static BitSet or(BitSet left, BitSet right, int sizeIsIgnored) {
     BitSet result = (BitSet) left.clone();
     result.or(right);
     return result;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/IsInOperation.java
@@ -296,20 +296,23 @@ public final class IsInOperation {
   private static ColumnStorage<?> applyBoolStorage(
       boolean keepValue, BoolStorage boolStorage, int checkedSize) {
     BitSet values = boolStorage.getValues();
-    BitSet validityMap = boolStorage.getValidityMap();
+    BitSet isNothing = (BitSet) boolStorage.getValidityMap().clone();
+    isNothing.flip(0, Math.toIntExact(boolStorage.getSize()));
 
     if (keepValue) {
-      var newValidity =
+      var newIsNothing =
           boolStorage.isNegated()
-              ? orNot(validityMap, values, checkedSize)
-              : or(validityMap, values, checkedSize);
-      return new BoolStorage(values, newValidity, checkedSize, boolStorage.isNegated());
+              ? or(isNothing, values, checkedSize)
+              : orNot(isNothing, values, checkedSize);
+      newIsNothing.flip(0, checkedSize);
+      return new BoolStorage(values, newIsNothing, checkedSize, boolStorage.isNegated());
     } else {
-      var newValidity =
+      var newIsNothing =
           boolStorage.isNegated()
-              ? or(validityMap, values, checkedSize)
-              : orNot(validityMap, values, checkedSize);
-      return new BoolStorage(values, newValidity, checkedSize, !boolStorage.isNegated());
+              ? orNot(isNothing, values, checkedSize)
+              : or(isNothing, values, checkedSize);
+      newIsNothing.flip(0, checkedSize);
+      return new BoolStorage(values, newIsNothing, checkedSize, !boolStorage.isNegated());
     }
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
@@ -100,9 +100,9 @@ public class FillMissingOperation implements BinaryOperation {
     public static BoolStorage fillMissingBoolStorage(BoolStorage storage, boolean fillValue) {
       final var newValues = (BitSet) storage.getValues().clone();
       if (fillValue != storage.isNegated()) {
-        newValues.or(storage.getIsNothingMap());
+        newValues.andNot(storage.getValidityMap());
       } else {
-        newValues.andNot(storage.getIsNothingMap());
+        newValues.or(storage.getValidityMap());
       }
       return new BoolStorage(newValues, new BitSet(), (int) storage.getSize(), storage.isNegated());
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
@@ -18,6 +18,7 @@ import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.MapOperationProblemAggregator;
+import org.enso.table.util.ImmutableBitSet;
 
 public class FillMissingOperation implements BinaryOperation {
   public static FillMissingOperation create(Column column, StorageType<?> resultType) {
@@ -98,18 +99,17 @@ public class FillMissingOperation implements BinaryOperation {
 
   public static class BooleanFillMissingOperation extends FillMissingOperation {
     public static BoolStorage fillMissingBoolStorage(BoolStorage storage, boolean fillValue) {
-      var s = (int) storage.getSize();
+      var size = (int) storage.getSize();
       var newValues = (BitSet) storage.getValues().clone();
       var isNothingMap = storage.getValidityMap().cloneBitSet();
-      isNothingMap.flip(0, s);
+      isNothingMap.flip(0, size);
       if (fillValue != storage.isNegated()) {
         newValues.or(isNothingMap);
       } else {
         newValues.andNot(isNothingMap);
       }
-      var validity = new BitSet();
-      validity.set(0, s, true);
-      return new BoolStorage(newValues, validity, s, storage.isNegated());
+      var validity = ImmutableBitSet.allTrue(size);
+      return new BoolStorage(newValues, validity, size, storage.isNegated());
     }
 
     public BooleanFillMissingOperation(StorageType<?> resultType) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
@@ -100,7 +100,7 @@ public class FillMissingOperation implements BinaryOperation {
     public static BoolStorage fillMissingBoolStorage(BoolStorage storage, boolean fillValue) {
       var s = (int) storage.getSize();
       var newValues = (BitSet) storage.getValues().clone();
-      var isNothingMap = (BitSet) storage.getValidityMap().clone();
+      var isNothingMap = storage.getValidityMap().cloneBitSet();
       isNothingMap.flip(0, s);
       if (fillValue != storage.isNegated()) {
         newValues.or(isNothingMap);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/FillMissingOperation.java
@@ -98,13 +98,18 @@ public class FillMissingOperation implements BinaryOperation {
 
   public static class BooleanFillMissingOperation extends FillMissingOperation {
     public static BoolStorage fillMissingBoolStorage(BoolStorage storage, boolean fillValue) {
-      final var newValues = (BitSet) storage.getValues().clone();
+      var s = (int) storage.getSize();
+      var newValues = (BitSet) storage.getValues().clone();
+      var isNothingMap = (BitSet) storage.getValidityMap().clone();
+      isNothingMap.flip(0, s);
       if (fillValue != storage.isNegated()) {
-        newValues.andNot(storage.getValidityMap());
+        newValues.or(isNothingMap);
       } else {
-        newValues.or(storage.getValidityMap());
+        newValues.andNot(isNothingMap);
       }
-      return new BoolStorage(newValues, new BitSet(), (int) storage.getSize(), storage.isNegated());
+      var validity = new BitSet();
+      validity.set(0, s, true);
+      return new BoolStorage(newValues, validity, s, storage.isNegated());
     }
 
     public BooleanFillMissingOperation(StorageType<?> resultType) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
@@ -86,10 +86,14 @@ public final class LogicalOperations {
         var newMissing = new BitSet(size);
         newMissing.flip(0, size);
         newMissing.xor(values);
+        newMissing.flip(0, size);
         return new BoolStorage(values, newMissing, size, true);
       } else {
-        var newValidity = left.getValidityMap().get(0, size);
-        newValidity.and(values);
+        var newMissing = left.getValidityMap().get(0, size);
+        newMissing.flip(0, size);
+        newMissing.or(values);
+        var newValidity = newMissing;
+        newValidity.flip(0, size);
         return new BoolStorage(new BitSet(), newValidity, size, false);
       }
     }
@@ -209,13 +213,10 @@ public final class LogicalOperations {
       BitSet values = left.getValues();
       if (left.isNegated()) {
         var newValidity = left.getValidityMap().get(0, size);
-        newValidity.and(values);
+        newValidity.andNot(values);
         return new BoolStorage(new BitSet(), newValidity, size, true);
       } else {
-        var newMissing = new BitSet(size);
-        newMissing.flip(0, size);
-        newMissing.xor(values);
-        return new BoolStorage(values, newMissing, size, false);
+        return new BoolStorage(values, values, size, false);
       }
     }
 
@@ -260,15 +261,15 @@ public final class LogicalOperations {
       if (size > rightSize) {
         validity.set(rightSize, size, false);
       }
-      int current = validity.nextSetBit(0);
-      while (current != -1) {
+      int current = validity.nextClearBit(0);
+      while (current < size) {
         Boolean a = left.getItemBoxed(current);
         Boolean b = (current < rightSize) ? right.getItemBoxed(current) : null;
         if (a == Boolean.TRUE || b == Boolean.TRUE) {
-          validity.clear(current);
+          validity.set(current);
           out.set(current, !negated);
         }
-        current = validity.nextSetBit(current + 1);
+        current = validity.nextClearBit(current + 1);
       }
 
       return new BoolStorage(out, validity, size, negated);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
@@ -9,7 +9,6 @@ import org.enso.table.data.column.storage.ColumnBooleanStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.table.problems.MapOperationProblemAggregator;
-import org.enso.table.util.BitSets;
 
 /**
  * This class contains logical operations that can be applied to columns.
@@ -89,7 +88,7 @@ public final class LogicalOperations {
         newMissing.flip(0, size);
         return new BoolStorage(values, newMissing, size, true);
       } else {
-        var newMissing = left.getValidityMap().get(0, size);
+        var newMissing = left.getValidityMap().cloneBitSet().get(0, size);
         newMissing.flip(0, size);
         newMissing.or(values);
         var newValidity = newMissing;
@@ -133,8 +132,8 @@ public final class LogicalOperations {
         negated = false;
       }
 
-      BitSet newValidity = BitSets.makeDuplicate(left.getValidityMap());
-      newValidity.and(right.getValidityMap());
+      var newValidity = left.getValidityMap().cloneBitSet();
+      right.getValidityMap().applyAndTo(newValidity);
       if (size > rightSize) {
         newValidity.set(rightSize, size, false);
       }
@@ -212,7 +211,7 @@ public final class LogicalOperations {
       int size = (int) left.getSize();
       BitSet values = left.getValues();
       if (left.isNegated()) {
-        var newValidity = left.getValidityMap().get(0, size);
+        var newValidity = left.getValidityMap().cloneBitSet();
         newValidity.andNot(values);
         return new BoolStorage(new BitSet(), newValidity, size, true);
       } else {
@@ -256,8 +255,8 @@ public final class LogicalOperations {
         negated = false;
       }
 
-      BitSet validity = BitSets.makeDuplicate(left.getValidityMap());
-      validity.and(right.getValidityMap());
+      var validity = left.getValidityMap().cloneBitSet();
+      right.getValidityMap().applyAndTo(validity);
       if (size > rightSize) {
         validity.set(rightSize, size, false);
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
@@ -134,15 +134,15 @@ public final class LogicalOperations {
       if (size > rightSize) {
         newValidity.set(rightSize, size, false);
       }
-      int current = newValidity.nextSetBit(0);
-      while (current != -1) {
+      var current = newValidity.nextClearBit(0);
+      while (current < size) {
         Boolean a = left.getItemBoxed(current);
         Boolean b = (current < rightSize) ? right.getItemBoxed(current) : null;
         if (a == Boolean.FALSE || b == Boolean.FALSE) {
-          newValidity.clear(current);
+          newValidity.set(current);
           out.set(current, negated);
         }
-        current = newValidity.nextSetBit(current + 1);
+        current = newValidity.nextClearBit(current + 1);
       }
 
       return new BoolStorage(out, newValidity, size, negated);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/binary/LogicalOperations.java
@@ -88,9 +88,9 @@ public final class LogicalOperations {
         newMissing.xor(values);
         return new BoolStorage(values, newMissing, size, true);
       } else {
-        var newMissing = left.getIsNothingMap().get(0, size);
-        newMissing.or(values);
-        return new BoolStorage(new BitSet(), newMissing, size, false);
+        var newValidity = left.getValidityMap().get(0, size);
+        newValidity.and(values);
+        return new BoolStorage(new BitSet(), newValidity, size, false);
       }
     }
 
@@ -129,23 +129,23 @@ public final class LogicalOperations {
         negated = false;
       }
 
-      BitSet isNothing = BitSets.makeDuplicate(left.getIsNothingMap());
-      isNothing.or(right.getIsNothingMap());
+      BitSet newValidity = BitSets.makeDuplicate(left.getValidityMap());
+      newValidity.and(right.getValidityMap());
       if (size > rightSize) {
-        isNothing.set(rightSize, size);
+        newValidity.set(rightSize, size, false);
       }
-      int current = isNothing.nextSetBit(0);
+      int current = newValidity.nextSetBit(0);
       while (current != -1) {
         Boolean a = left.getItemBoxed(current);
         Boolean b = (current < rightSize) ? right.getItemBoxed(current) : null;
         if (a == Boolean.FALSE || b == Boolean.FALSE) {
-          isNothing.clear(current);
+          newValidity.clear(current);
           out.set(current, negated);
         }
-        current = isNothing.nextSetBit(current + 1);
+        current = newValidity.nextSetBit(current + 1);
       }
 
-      return new BoolStorage(out, isNothing, size, negated);
+      return new BoolStorage(out, newValidity, size, negated);
     }
   }
 
@@ -208,9 +208,9 @@ public final class LogicalOperations {
       int size = (int) left.getSize();
       BitSet values = left.getValues();
       if (left.isNegated()) {
-        var newMissing = left.getIsNothingMap().get(0, size);
-        newMissing.or(values);
-        return new BoolStorage(new BitSet(), newMissing, size, true);
+        var newValidity = left.getValidityMap().get(0, size);
+        newValidity.and(values);
+        return new BoolStorage(new BitSet(), newValidity, size, true);
       } else {
         var newMissing = new BitSet(size);
         newMissing.flip(0, size);
@@ -255,23 +255,23 @@ public final class LogicalOperations {
         negated = false;
       }
 
-      BitSet isNothing = BitSets.makeDuplicate(left.getIsNothingMap());
-      isNothing.or(right.getIsNothingMap());
+      BitSet validity = BitSets.makeDuplicate(left.getValidityMap());
+      validity.and(right.getValidityMap());
       if (size > rightSize) {
-        isNothing.set(rightSize, size);
+        validity.set(rightSize, size, false);
       }
-      int current = isNothing.nextSetBit(0);
+      int current = validity.nextSetBit(0);
       while (current != -1) {
         Boolean a = left.getItemBoxed(current);
         Boolean b = (current < rightSize) ? right.getItemBoxed(current) : null;
         if (a == Boolean.TRUE || b == Boolean.TRUE) {
-          isNothing.clear(current);
+          validity.clear(current);
           out.set(current, !negated);
         }
-        current = isNothing.nextSetBit(current + 1);
+        current = validity.nextSetBit(current + 1);
       }
 
-      return new BoolStorage(out, isNothing, size, negated);
+      return new BoolStorage(out, validity, size, negated);
     }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/comparators/BooleanComparators.java
@@ -63,7 +63,7 @@ final class BooleanComparators {
           return rightBoolean
               ? NotOperation.applySpecializedBoolStorage(left)
               : new BoolStorage(
-                  new BitSet(), left.getIsNothingMap(), Builder.checkSize(left.getSize()), false);
+                  new BitSet(), left.getValidityMap(), Builder.checkSize(left.getSize()), false);
         }
       };
 
@@ -83,7 +83,7 @@ final class BooleanComparators {
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean
               ? new BoolStorage(
-                  new BitSet(), left.getIsNothingMap(), Builder.checkSize(left.getSize()), true)
+                  new BitSet(), left.getValidityMap(), Builder.checkSize(left.getSize()), true)
               : NotOperation.applySpecializedBoolStorage(left);
         }
       };
@@ -104,7 +104,7 @@ final class BooleanComparators {
             MapOperationProblemAggregator problemAggregator) {
           return rightBoolean
               ? new BoolStorage(
-                  new BitSet(), left.getIsNothingMap(), Builder.checkSize(left.getSize()), false)
+                  new BitSet(), left.getValidityMap(), Builder.checkSize(left.getSize()), false)
               : left;
         }
       };
@@ -126,7 +126,7 @@ final class BooleanComparators {
           return rightBoolean
               ? left
               : new BoolStorage(
-                  new BitSet(), left.getIsNothingMap(), Builder.checkSize(left.getSize()), true);
+                  new BitSet(), left.getValidityMap(), Builder.checkSize(left.getSize()), true);
         }
       };
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
@@ -44,8 +44,8 @@ public class CountNothing {
 
   /** Returns true if any value in the storage is Nothing. */
   public static boolean anyNothing(ColumnStorage<?> storage) {
-    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
-      return !withNothingMap.getValidityMap().isEmpty();
+    if (storage instanceof ColumnStorageWithValidityMap withValidityMap) {
+      return withValidityMap.getValidityMap().isEmpty() && storage.getSize() > 0;
     }
 
     return StorageIterators.forEachOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
@@ -61,7 +61,7 @@ public class CountNothing {
 
     if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
       var cardinality = withNothingMap.getValidityMap().cardinality();
-      return cardinality == storage.getSize();
+      return cardinality == 0;
     }
 
     boolean hasSomething =

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
@@ -30,8 +30,10 @@ public class CountNothing {
 
   /** Counts the number of Nothing values in the given storage. */
   public static long apply(ColumnStorage<?> storage) {
-    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
-      return withNothingMap.getValidityMap().cardinality();
+    if (storage instanceof ColumnStorageWithValidityMap withValidityMap) {
+      var validityMap = withValidityMap.getValidityMap();
+      var numberOfValidEntries = validityMap.cardinality();
+      return storage.getSize() - numberOfValidEntries;
     }
 
     var accumulator = new Accumulator();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
@@ -2,7 +2,7 @@ package org.enso.table.data.column.operation.unary;
 
 import org.enso.table.data.column.operation.StorageIterators;
 import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.ColumnStorageWithNothingMap;
+import org.enso.table.data.column.storage.ColumnStorageWithValidityMap;
 import org.enso.table.data.column.storage.type.NullType;
 import org.enso.table.data.table.Column;
 
@@ -30,8 +30,8 @@ public class CountNothing {
 
   /** Counts the number of Nothing values in the given storage. */
   public static long apply(ColumnStorage<?> storage) {
-    if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
-      return withNothingMap.getIsNothingMap().cardinality();
+    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
+      return withNothingMap.getValidityMap().cardinality();
     }
 
     var accumulator = new Accumulator();
@@ -42,8 +42,8 @@ public class CountNothing {
 
   /** Returns true if any value in the storage is Nothing. */
   public static boolean anyNothing(ColumnStorage<?> storage) {
-    if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
-      return !withNothingMap.getIsNothingMap().isEmpty();
+    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
+      return !withNothingMap.getValidityMap().isEmpty();
     }
 
     return StorageIterators.forEachOverStorage(
@@ -57,8 +57,8 @@ public class CountNothing {
       return true;
     }
 
-    if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
-      var cardinality = withNothingMap.getIsNothingMap().cardinality();
+    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
+      var cardinality = withNothingMap.getValidityMap().cardinality();
       return cardinality == storage.getSize();
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/CountNothing.java
@@ -45,7 +45,7 @@ public class CountNothing {
   /** Returns true if any value in the storage is Nothing. */
   public static boolean anyNothing(ColumnStorage<?> storage) {
     if (storage instanceof ColumnStorageWithValidityMap withValidityMap) {
-      return withValidityMap.getValidityMap().isEmpty() && storage.getSize() > 0;
+      return withValidityMap.getValidityMap().cardinality() < storage.getSize();
     }
 
     return StorageIterators.forEachOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/DoubleIsOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/DoubleIsOperation.java
@@ -8,7 +8,7 @@ import org.enso.table.data.column.operation.UnaryOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnDoubleStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.ColumnStorageWithNothingMap;
+import org.enso.table.data.column.storage.ColumnStorageWithValidityMap;
 import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.IntegerType;
@@ -61,9 +61,9 @@ public class DoubleIsOperation implements UnaryOperation {
       ColumnStorage<?> storage, MapOperationProblemAggregator problemAggregator) {
     // For Finite
     if (isAllFinite(storage.getType())) {
-      if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
+      if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
         return new BoolStorage(
-            new BitSet(), withNothingMap.getIsNothingMap(), (int) storage.getSize(), finiteValue);
+            new BitSet(), withNothingMap.getValidityMap(), (int) storage.getSize(), finiteValue);
       }
 
       return StorageIterators.mapOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
@@ -28,9 +28,11 @@ public class IsNothingOperation implements UnaryOperation {
   @Override
   public ColumnStorage<?> apply(
       ColumnStorage<?> storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
-      return new BoolStorage(
-          withNothingMap.getValidityMap(), new BitSet(), (int) storage.getSize(), false);
+    if (storage instanceof ColumnStorageWithValidityMap validityMap) {
+      var allValidity = new BitSet();
+      var s = (int) storage.getSize();
+      allValidity.set(0, s);
+      return new BoolStorage(validityMap.getValidityMap(), allValidity, s, true);
     }
 
     return StorageIterators.buildOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
@@ -6,7 +6,7 @@ import org.enso.table.data.column.operation.StorageIterators;
 import org.enso.table.data.column.operation.UnaryOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
-import org.enso.table.data.column.storage.ColumnStorageWithNothingMap;
+import org.enso.table.data.column.storage.ColumnStorageWithValidityMap;
 import org.enso.table.data.table.problems.MapOperationProblemAggregator;
 
 public class IsNothingOperation implements UnaryOperation {
@@ -28,9 +28,9 @@ public class IsNothingOperation implements UnaryOperation {
   @Override
   public ColumnStorage<?> apply(
       ColumnStorage<?> storage, MapOperationProblemAggregator problemAggregator) {
-    if (storage instanceof ColumnStorageWithNothingMap withNothingMap) {
+    if (storage instanceof ColumnStorageWithValidityMap withNothingMap) {
       return new BoolStorage(
-          withNothingMap.getIsNothingMap(), new BitSet(), (int) storage.getSize(), false);
+          withNothingMap.getValidityMap(), new BitSet(), (int) storage.getSize(), false);
     }
 
     return StorageIterators.buildOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/IsNothingOperation.java
@@ -1,6 +1,5 @@
 package org.enso.table.data.column.operation.unary;
 
-import java.util.BitSet;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.operation.StorageIterators;
 import org.enso.table.data.column.operation.UnaryOperation;
@@ -8,6 +7,7 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.ColumnStorageWithValidityMap;
 import org.enso.table.data.table.problems.MapOperationProblemAggregator;
+import org.enso.table.util.ImmutableBitSet;
 
 public class IsNothingOperation implements UnaryOperation {
   public static final String NAME = "is_nothing";
@@ -29,10 +29,9 @@ public class IsNothingOperation implements UnaryOperation {
   public ColumnStorage<?> apply(
       ColumnStorage<?> storage, MapOperationProblemAggregator problemAggregator) {
     if (storage instanceof ColumnStorageWithValidityMap validityMap) {
-      var allValidity = new BitSet();
-      var s = (int) storage.getSize();
-      allValidity.set(0, s);
-      return new BoolStorage(validityMap.getValidityMap(), allValidity, s, true);
+      var size = (int) storage.getSize();
+      var allValidity = ImmutableBitSet.allTrue(size);
+      return new BoolStorage(validityMap.getValidityMap().cloneBitSet(), allValidity, size, true);
     }
 
     return StorageIterators.buildOverStorage(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/NotOperation.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/unary/NotOperation.java
@@ -62,7 +62,7 @@ public class NotOperation implements UnaryOperation {
   public static ColumnBooleanStorage applySpecializedBoolStorage(BoolStorage boolStorage) {
     return new BoolStorage(
         boolStorage.getValues(),
-        boolStorage.getIsNothingMap(),
+        boolStorage.getValidityMap(),
         (int) boolStorage.getSize(),
         !boolStorage.isNegated());
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -7,16 +7,17 @@ import org.enso.table.data.column.storage.type.BooleanType;
 
 /** A boolean column storage. */
 public final class BoolStorage extends Storage<Boolean>
-    implements ColumnBooleanStorage, ColumnStorageWithNothingMap {
+    implements ColumnBooleanStorage, ColumnStorageWithValidityMap {
   private final BitSet values;
-  private final BitSet isNothing;
+  private final BitSet validityMap;
   private final int size;
   private final boolean negated;
 
-  public BoolStorage(BitSet values, BitSet isNothing, int size, boolean negated) {
+  public BoolStorage(BitSet values, BitSet validityMap, int size, boolean negated) {
     super(BooleanType.INSTANCE);
+    if (true) throw new IllegalArgumentException("validity");
     this.values = values;
-    this.isNothing = isNothing;
+    this.validityMap = validityMap;
     this.size = size;
     this.negated = negated;
   }
@@ -45,7 +46,7 @@ public final class BoolStorage extends Storage<Boolean>
     if (idx < 0 || idx >= getSize()) {
       throw new IndexOutOfBoundsException(idx);
     }
-    return isNothing.get((int) idx);
+    return validityMap.get((int) idx);
   }
 
   public boolean isNegated() {
@@ -57,8 +58,8 @@ public final class BoolStorage extends Storage<Boolean>
   }
 
   @Override
-  public BitSet getIsNothingMap() {
-    return isNothing;
+  public BitSet getValidityMap() {
+    return validityMap;
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -15,7 +15,6 @@ public final class BoolStorage extends Storage<Boolean>
 
   public BoolStorage(BitSet values, BitSet validityMap, int size, boolean negated) {
     super(BooleanType.INSTANCE);
-    if (true) throw new IllegalArgumentException("validity");
     this.values = values;
     this.validityMap = validityMap;
     this.size = size;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -45,7 +45,7 @@ public final class BoolStorage extends Storage<Boolean>
     if (idx < 0 || idx >= getSize()) {
       throw new IndexOutOfBoundsException(idx);
     }
-    return validityMap.get((int) idx);
+    return !validityMap.get((int) idx);
   }
 
   public boolean isNegated() {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -4,16 +4,21 @@ import java.util.BitSet;
 import java.util.NoSuchElementException;
 import org.enso.table.data.column.storage.iterators.ColumnBooleanStorageIterator;
 import org.enso.table.data.column.storage.type.BooleanType;
+import org.enso.table.util.ImmutableBitSet;
 
 /** A boolean column storage. */
 public final class BoolStorage extends Storage<Boolean>
     implements ColumnBooleanStorage, ColumnStorageWithValidityMap {
   private final BitSet values;
-  private final BitSet validityMap;
+  private final ImmutableBitSet validityMap;
   private final int size;
   private final boolean negated;
 
   public BoolStorage(BitSet values, BitSet validityMap, int size, boolean negated) {
+    this(values, new ImmutableBitSet(validityMap, size), size, negated);
+  }
+
+  public BoolStorage(BitSet values, ImmutableBitSet validityMap, int size, boolean negated) {
     super(BooleanType.INSTANCE);
     this.values = values;
     this.validityMap = validityMap;
@@ -57,7 +62,7 @@ public final class BoolStorage extends Storage<Boolean>
   }
 
   @Override
-  public BitSet getValidityMap() {
+  public ImmutableBitSet getValidityMap() {
     return validityMap;
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithNothingMap.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithNothingMap.java
@@ -1,8 +1,0 @@
-package org.enso.table.data.column.storage;
-
-import java.util.BitSet;
-
-public interface ColumnStorageWithNothingMap {
-  /** Gets the isNothing map for the storage. */
-  BitSet getIsNothingMap();
-}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
@@ -4,7 +4,7 @@ import java.util.BitSet;
 
 public interface ColumnStorageWithValidityMap {
   /**
-   * Gets the isNothing map for the storage.
+   * Gets the validity map for the storage.
    *
    * @return bit set with {@code false} at null indexes and {@code true} at non-null indexes
    */

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
@@ -1,0 +1,12 @@
+package org.enso.table.data.column.storage;
+
+import java.util.BitSet;
+
+public interface ColumnStorageWithValidityMap {
+  /**
+   * Gets the isNothing map for the storage.
+   *
+   * @return bit set with {@code false} at null indexes and {@code true} at non-null indexes
+   */
+  BitSet getValidityMap();
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ColumnStorageWithValidityMap.java
@@ -1,6 +1,6 @@
 package org.enso.table.data.column.storage;
 
-import java.util.BitSet;
+import org.enso.table.util.ImmutableBitSet;
 
 public interface ColumnStorageWithValidityMap {
   /**
@@ -8,5 +8,5 @@ public interface ColumnStorageWithValidityMap {
    *
    * @return bit set with {@code false} at null indexes and {@code true} at non-null indexes
    */
-  BitSet getValidityMap();
+  ImmutableBitSet getValidityMap();
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ComputedLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ComputedLongStorage.java
@@ -9,9 +9,7 @@ import org.enso.table.data.column.storage.type.IntegerType;
  * <p>This storage assumes that _all_ values are present.
  */
 public abstract class ComputedLongStorage extends AbstractLongStorage
-    implements ColumnStorageWithNothingMap {
-  private static final BitSet EMPTY = new BitSet();
-
+    implements ColumnStorageWithValidityMap {
   protected abstract long computeItem(long idx);
 
   protected ComputedLongStorage(int size) {
@@ -35,8 +33,11 @@ public abstract class ComputedLongStorage extends AbstractLongStorage
   }
 
   @Override
-  public BitSet getIsNothingMap() {
-    return EMPTY;
+  public BitSet getValidityMap() {
+    var size = Math.toIntExact(getSize());
+    var set = new BitSet(size);
+    set.flip(0, size);
+    return set;
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ComputedLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ComputedLongStorage.java
@@ -1,7 +1,7 @@
 package org.enso.table.data.column.storage;
 
-import java.util.BitSet;
 import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.util.ImmutableBitSet;
 
 /**
  * Implements a storage that computes the ith stored value using some function.
@@ -33,11 +33,9 @@ public abstract class ComputedLongStorage extends AbstractLongStorage
   }
 
   @Override
-  public BitSet getValidityMap() {
+  public ImmutableBitSet getValidityMap() {
     var size = Math.toIntExact(getSize());
-    var set = new BitSet(size);
-    set.flip(0, size);
-    return set;
+    return ImmutableBitSet.allTrue(size);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
@@ -1,6 +1,5 @@
 package org.enso.table.data.column.storage;
 
-import java.util.BitSet;
 import java.util.NoSuchElementException;
 import org.enso.table.data.column.storage.iterators.ColumnDoubleStorageIterator;
 import org.enso.table.data.column.storage.type.FloatType;
@@ -10,7 +9,7 @@ import org.enso.table.util.ImmutableBitSet;
 public final class DoubleStorage extends Storage<Double>
     implements ColumnDoubleStorage, ColumnStorageWithValidityMap {
   private final double[] data;
-  private final BitSet validityMap;
+  private final ImmutableBitSet validityMap;
   private final int size;
 
   /**
@@ -19,7 +18,7 @@ public final class DoubleStorage extends Storage<Double>
    * @param validityMap a bit set denoting at index {@code i} whether there is a real value at that
    *     index.
    */
-  public DoubleStorage(double[] data, int size, BitSet validityMap) {
+  public DoubleStorage(double[] data, int size, ImmutableBitSet validityMap) {
     super(FloatType.FLOAT_64);
     this.data = data;
     this.validityMap = validityMap;
@@ -43,7 +42,7 @@ public final class DoubleStorage extends Storage<Double>
 
   @Override
   public ImmutableBitSet getValidityMap() {
-    return new ImmutableBitSet(validityMap, size);
+    return validityMap;
   }
 
   @Override
@@ -74,11 +73,11 @@ public final class DoubleStorage extends Storage<Double>
 
   private static class DoubleStorageIterator implements ColumnDoubleStorageIterator {
     private final double[] data;
-    private final BitSet validityMap;
+    private final ImmutableBitSet validityMap;
     private final int size;
     private int index = -1;
 
-    public DoubleStorageIterator(double[] data, BitSet validityMap, int size) {
+    public DoubleStorageIterator(double[] data, ImmutableBitSet validityMap, int size) {
       this.data = data;
       this.validityMap = validityMap;
       this.size = size;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.NoSuchElementException;
 import org.enso.table.data.column.storage.iterators.ColumnDoubleStorageIterator;
 import org.enso.table.data.column.storage.type.FloatType;
+import org.enso.table.util.ImmutableBitSet;
 
 /** A column containing floating point numbers. */
 public final class DoubleStorage extends Storage<Double>
@@ -41,8 +42,8 @@ public final class DoubleStorage extends Storage<Double>
   }
 
   @Override
-  public BitSet getValidityMap() {
-    return validityMap;
+  public ImmutableBitSet getValidityMap() {
+    return new ImmutableBitSet(validityMap, size);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
@@ -7,21 +7,21 @@ import org.enso.table.data.column.storage.type.FloatType;
 
 /** A column containing floating point numbers. */
 public final class DoubleStorage extends Storage<Double>
-    implements ColumnDoubleStorage, ColumnStorageWithNothingMap {
-  final double[] data;
-  final BitSet isNothing;
+    implements ColumnDoubleStorage, ColumnStorageWithValidityMap {
+  private final double[] data;
+  private final BitSet validityMap;
   private final int size;
 
   /**
    * @param data the underlying data
    * @param size the number of items stored
-   * @param isNothing a bit set denoting at index {@code i} whether the value at index {@code i} is
-   *     Nothing.
+   * @param validityMap a bit set denoting at index {@code i} whether there is a real value at that
+   *     index.
    */
-  public DoubleStorage(double[] data, int size, BitSet isNothing) {
+  public DoubleStorage(double[] data, int size, BitSet validityMap) {
     super(FloatType.FLOAT_64);
     this.data = data;
-    this.isNothing = isNothing;
+    this.validityMap = validityMap;
     this.size = size;
   }
 
@@ -41,8 +41,8 @@ public final class DoubleStorage extends Storage<Double>
   }
 
   @Override
-  public BitSet getIsNothingMap() {
-    return isNothing;
+  public BitSet getValidityMap() {
+    return validityMap;
   }
 
   @Override
@@ -58,7 +58,7 @@ public final class DoubleStorage extends Storage<Double>
     if (idx < 0 || idx >= getSize()) {
       throw new IndexOutOfBoundsException(idx);
     }
-    return isNothing.get((int) idx);
+    return !validityMap.get((int) idx);
   }
 
   /** Allow access to the underlying data array for copying. */
@@ -68,24 +68,24 @@ public final class DoubleStorage extends Storage<Double>
 
   @Override
   public ColumnDoubleStorageIterator iteratorWithIndex() {
-    return new DoubleStorageIterator(data, isNothing, (int) getSize());
+    return new DoubleStorageIterator(data, validityMap, (int) getSize());
   }
 
   private static class DoubleStorageIterator implements ColumnDoubleStorageIterator {
     private final double[] data;
-    private final BitSet isNothing;
+    private final BitSet validityMap;
     private final int size;
     private int index = -1;
 
-    public DoubleStorageIterator(double[] data, BitSet isNothing, int size) {
+    public DoubleStorageIterator(double[] data, BitSet validityMap, int size) {
       this.data = data;
-      this.isNothing = isNothing;
+      this.validityMap = validityMap;
       this.size = size;
     }
 
     @Override
     public Double getItemBoxed() {
-      return isNothing.get(index) ? null : data[index];
+      return !validityMap.get(index) ? null : data[index];
     }
 
     @Override
@@ -95,7 +95,7 @@ public final class DoubleStorage extends Storage<Double>
 
     @Override
     public boolean isNothing() {
-      return isNothing.get(index);
+      return !validityMap.get(index);
     }
 
     @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -68,19 +68,19 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
 
   private static class LongStorageIterator implements ColumnLongStorageIterator {
     private final long[] data;
-    private final BitSet isNothing;
+    private final BitSet validityMap;
     private final int size;
     private int index = -1;
 
-    public LongStorageIterator(long[] data, BitSet isNothing, int size) {
+    public LongStorageIterator(long[] data, BitSet validityMap, int size) {
       this.data = data;
-      this.isNothing = isNothing;
+      this.validityMap = validityMap;
       this.size = size;
     }
 
     @Override
     public Long getItemBoxed() {
-      return isNothing.get(index) ? null : data[index];
+      return !validityMap.get(index) ? null : data[index];
     }
 
     @Override
@@ -90,7 +90,7 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
 
     @Override
     public boolean isNothing() {
-      return isNothing.get(index);
+      return !validityMap.get(index);
     }
 
     @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -41,7 +41,7 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
     if (idx < 0 || idx >= getSize()) {
       throw new IndexOutOfBoundsException(idx);
     }
-    return validityMap.get(Math.toIntExact(idx));
+    return !validityMap.get(Math.toIntExact(idx));
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -6,28 +6,29 @@ import org.enso.table.data.column.storage.iterators.ColumnLongStorageIterator;
 import org.enso.table.data.column.storage.type.IntegerType;
 
 /** A column storing 64-bit integers. */
-public final class LongStorage extends AbstractLongStorage implements ColumnStorageWithNothingMap {
+public final class LongStorage extends AbstractLongStorage implements ColumnStorageWithValidityMap {
   // TODO [RW] at some point we will want to add separate storage classes for byte, short and int,
   // for more compact storage and more efficient handling of smaller integers; for now we will be
   // handling this just by checking the bounds
-  final long[] data;
-  final BitSet isNothing;
+  private final long[] data;
+  private final BitSet validityMap;
 
   /**
    * @param data the underlying data
    * @param size the number of items stored
-   * @param isNothing a bit set denoting at index {@code i} whether or not the value at index {@code
-   *     i} is missing.
+   * @param validityMap a bit set denoting at index {@code i} whether or not the real value is
+   *     present.
    * @param type the type specifying the bit-width of integers that are allowed in this storage
    */
-  public LongStorage(long[] data, int size, BitSet isNothing, IntegerType type) {
+  public LongStorage(long[] data, int size, BitSet validityMap, IntegerType type) {
     super(size, type);
     this.data = data;
-    this.isNothing = isNothing;
+    this.validityMap = validityMap;
   }
 
   public LongStorage(long[] data, IntegerType type) {
     this(data, data.length, new BitSet(), type);
+    validityMap.set(0, data.length, true);
   }
 
   @Override
@@ -40,19 +41,19 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
     if (idx < 0 || idx >= getSize()) {
       throw new IndexOutOfBoundsException(idx);
     }
-    return isNothing.get(Math.toIntExact(idx));
+    return validityMap.get(Math.toIntExact(idx));
   }
 
   @Override
-  public BitSet getIsNothingMap() {
-    return isNothing;
+  public BitSet getValidityMap() {
+    return validityMap;
   }
 
   /** Widening to a bigger type can be done without copying the data. */
   @Override
   public LongStorage widen(IntegerType widerType) {
     assert widerType.fits(getType());
-    return new LongStorage(data, (int) getSize(), getIsNothingMap(), widerType);
+    return new LongStorage(data, (int) getSize(), validityMap, widerType);
   }
 
   /** Allow access to the underlying data array for copying. */
@@ -62,7 +63,7 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
 
   @Override
   public ColumnLongStorageIterator iteratorWithIndex() {
-    return new LongStorageIterator(data, isNothing, (int) getSize());
+    return new LongStorageIterator(data, validityMap, (int) getSize());
   }
 
   private static class LongStorageIterator implements ColumnLongStorageIterator {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -1,6 +1,5 @@
 package org.enso.table.data.column.storage;
 
-import java.util.BitSet;
 import java.util.NoSuchElementException;
 import org.enso.table.data.column.storage.iterators.ColumnLongStorageIterator;
 import org.enso.table.data.column.storage.type.IntegerType;
@@ -12,7 +11,7 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
   // for more compact storage and more efficient handling of smaller integers; for now we will be
   // handling this just by checking the bounds
   private final long[] data;
-  private final BitSet validityMap;
+  private final ImmutableBitSet validityMap;
 
   /**
    * @param data the underlying data
@@ -21,15 +20,16 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
    *     present.
    * @param type the type specifying the bit-width of integers that are allowed in this storage
    */
-  public LongStorage(long[] data, int size, BitSet validityMap, IntegerType type) {
+  public LongStorage(long[] data, int size, ImmutableBitSet validityMap, IntegerType type) {
     super(size, type);
     this.data = data;
     this.validityMap = validityMap;
   }
 
   public LongStorage(long[] data, IntegerType type) {
-    this(data, data.length, new BitSet(), type);
-    validityMap.set(0, data.length, true);
+    super(data.length, type);
+    this.data = data;
+    this.validityMap = ImmutableBitSet.allTrue(data.length);
   }
 
   @Override
@@ -47,8 +47,7 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
 
   @Override
   public ImmutableBitSet getValidityMap() {
-    var size = Math.toIntExact(getSize());
-    return new ImmutableBitSet(validityMap, size);
+    return validityMap;
   }
 
   /** Widening to a bigger type can be done without copying the data. */
@@ -70,11 +69,11 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
 
   private static class LongStorageIterator implements ColumnLongStorageIterator {
     private final long[] data;
-    private final BitSet validityMap;
+    private final ImmutableBitSet validityMap;
     private final int size;
     private int index = -1;
 
-    public LongStorageIterator(long[] data, BitSet validityMap, int size) {
+    public LongStorageIterator(long[] data, ImmutableBitSet validityMap, int size) {
       this.data = data;
       this.validityMap = validityMap;
       this.size = size;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.NoSuchElementException;
 import org.enso.table.data.column.storage.iterators.ColumnLongStorageIterator;
 import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.util.ImmutableBitSet;
 
 /** A column storing 64-bit integers. */
 public final class LongStorage extends AbstractLongStorage implements ColumnStorageWithValidityMap {
@@ -45,8 +46,9 @@ public final class LongStorage extends AbstractLongStorage implements ColumnStor
   }
 
   @Override
-  public BitSet getValidityMap() {
-    return validityMap;
+  public ImmutableBitSet getValidityMap() {
+    var size = Math.toIntExact(getSize());
+    return new ImmutableBitSet(validityMap, size);
   }
 
   /** Widening to a bigger type can be done without copying the data. */

--- a/std-bits/table/src/main/java/org/enso/table/util/BitSets.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/BitSets.java
@@ -3,7 +3,9 @@ package org.enso.table.util;
 import java.util.BitSet;
 import org.graalvm.polyglot.Context;
 
-public class BitSets {
+public final class BitSets {
+  private BitSets() {}
+
   /**
    * An utility to copy a part of one bitset onto another, with a possible destination offset.
    *
@@ -25,11 +27,5 @@ public class BitSets {
 
       context.safepoint();
     }
-  }
-
-  public static BitSet makeDuplicate(BitSet source) {
-    BitSet result = new BitSet();
-    result.or(source);
-    return result;
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/util/ImmutableBitSet.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/ImmutableBitSet.java
@@ -6,17 +6,29 @@ import java.util.BitSet;
  * A wrapper around BitSet that implements boolean operations conveniently. Unlike BitSet,
  * ImmutableBitSet takes a size parameter, which allows .not to be implemented.
  */
-public class ImmutableBitSet {
-  private BitSet bitSet;
-  private int size;
+public final class ImmutableBitSet {
+  private final BitSet bitSet;
+  private final int size;
 
   public ImmutableBitSet(BitSet bitSet, int size) {
     this.bitSet = bitSet;
     this.size = size;
   }
 
-  public BitSet toBitSet() {
-    return bitSet;
+  public int cardinality() {
+    return bitSet.cardinality();
+  }
+
+  public boolean get(int i) {
+    return bitSet.get(i);
+  }
+
+  public void applyAndTo(BitSet other) {
+    other.and(bitSet);
+  }
+
+  public void copyTo(BitSet copyTo, int at, int length) {
+    BitSets.copy(bitSet, copyTo, at, length);
   }
 
   public ImmutableBitSet and(ImmutableBitSet other) {
@@ -57,7 +69,6 @@ public class ImmutableBitSet {
   public ImmutableBitSet notAndNot(ImmutableBitSet other) {
     assert size == other.size;
     BitSet result = (BitSet) bitSet.clone();
-    result.flip(0, size);
     result.andNot(other.bitSet);
     return new ImmutableBitSet(result, size);
   }
@@ -79,5 +90,9 @@ public class ImmutableBitSet {
 
   public static ImmutableBitSet allTrue(int size) {
     return new ImmutableBitSet(new BitSet(), size).not();
+  }
+
+  public BitSet cloneBitSet() {
+    return (BitSet) bitSet.clone();
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/util/ImmutableBitSet.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/ImmutableBitSet.java
@@ -1,5 +1,7 @@
 package org.enso.table.util;
 
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.util.BitSet;
 
 /**
@@ -16,17 +18,30 @@ public final class ImmutableBitSet {
   }
 
   public int cardinality() {
-    return bitSet.cardinality();
+    return Math.min(size, bitSet.cardinality());
   }
 
   public boolean get(int i) {
-    return bitSet.get(i);
+    return i < size && bitSet.get(i);
   }
 
+  /**
+   * Modifies {@code other} by applying "and" operation with bits in this immutable set to it.
+   *
+   * @param other bitset to modify
+   */
   public void applyAndTo(BitSet other) {
     other.and(bitSet);
   }
 
+  /**
+   * Modifies {@code copyTo} bitset by appending bits of this immutable bitset to it at {@code at}
+   * position
+   *
+   * @param copyTo bitset to modify
+   * @param at position to append bits to
+   * @param length number of bits to copy
+   */
   public void copyTo(BitSet copyTo, int at, int length) {
     BitSets.copy(bitSet, copyTo, at, length);
   }
@@ -88,10 +103,26 @@ public final class ImmutableBitSet {
     return new ImmutableBitSet(new BitSet(), size);
   }
 
+  private static Reference<BitSet> ALL = new WeakReference<>(null);
+
   public static ImmutableBitSet allTrue(int size) {
-    return new ImmutableBitSet(new BitSet(), size).not();
+    var shared = ALL.get();
+    if (shared == null) {
+      shared = new BitSet();
+      ALL = new WeakReference<>(shared);
+    }
+    if (shared.length() < size) {
+      // fill with true
+      shared.set(shared.length(), size);
+    }
+    return new ImmutableBitSet(shared, size);
   }
 
+  /**
+   * Writable copy of the bitset.
+   *
+   * @return bitset to further modify
+   */
   public BitSet cloneBitSet() {
     return (BitSet) bitSet.clone();
   }

--- a/std-bits/table/src/test/java/org/enso/table/util/ImmutableBitSetTest.java
+++ b/std-bits/table/src/test/java/org/enso/table/util/ImmutableBitSetTest.java
@@ -1,0 +1,26 @@
+package org.enso.table.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class ImmutableBitSetTest {
+  @Test
+  public void allTrueCardinality() {
+    var five = ImmutableBitSet.allTrue(5);
+    assertEquals(5, five.cardinality());
+    var ten = ImmutableBitSet.allTrue(10);
+    assertEquals(10, ten.cardinality());
+
+    var million = ImmutableBitSet.allTrue(1_000_000);
+    assertEquals(1_000_000, million.cardinality());
+
+    var two = ImmutableBitSet.allTrue(2);
+    assertEquals(2, two.cardinality());
+
+    assertEquals(5, five.cardinality());
+    assertEquals(10, ten.cardinality());
+    assertEquals(1_000_000, million.cardinality());
+    assertEquals(2, two.cardinality());
+  }
+}

--- a/std-bits/tests/src/test/java/org/enso/table/data/column/operation/unary/CountNothingTest.java
+++ b/std-bits/tests/src/test/java/org/enso/table/data/column/operation/unary/CountNothingTest.java
@@ -1,0 +1,62 @@
+package org.enso.table.data.column.operation.unary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.enso.table.data.column.builder.Builder;
+import org.enso.test.utils.ContextUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class CountNothingTest {
+  @ClassRule public static final ContextUtils ctx = ContextUtils.createDefault();
+
+  @Test
+  public void checkPlainStorageOne() {
+    var storage = Builder.getObjectBuilder(3).append("Hi").append(5).append(null).seal();
+    assertEquals(1, CountNothing.apply(storage));
+    assertTrue(CountNothing.anyNothing(storage));
+    assertFalse(CountNothing.allNothing(storage));
+  }
+
+  @Test
+  public void checkBoolStorageOne() {
+    var storage = Builder.getForBoolean(3).append(true).append(false).appendNulls(1).seal();
+    assertEquals(1, CountNothing.apply(storage));
+    assertTrue(CountNothing.anyNothing(storage));
+    assertFalse(CountNothing.allNothing(storage));
+  }
+
+  @Test
+  public void checkPlainStorageNone() {
+    var storage = Builder.getObjectBuilder(3).append("Hi").append(5).append(3.14).seal();
+    assertEquals(0, CountNothing.apply(storage));
+    assertFalse(CountNothing.anyNothing(storage));
+    assertFalse(CountNothing.allNothing(storage));
+  }
+
+  @Test
+  public void checkBoolStorageNone() {
+    var storage = Builder.getForBoolean(3).append(true).append(false).append(false).seal();
+    assertEquals(0, CountNothing.apply(storage));
+    assertFalse(CountNothing.anyNothing(storage));
+    assertFalse(CountNothing.allNothing(storage));
+  }
+
+  @Test
+  public void checkPlainStorageAll() {
+    var storage = Builder.getObjectBuilder(3).appendNulls(3).seal();
+    assertEquals(3, CountNothing.apply(storage));
+    assertTrue(CountNothing.anyNothing(storage));
+    assertTrue(CountNothing.allNothing(storage));
+  }
+
+  @Test
+  public void checkBoolStorageAll() {
+    var storage = Builder.getForBoolean(3).appendNulls(3).seal();
+    assertEquals(3, CountNothing.apply(storage));
+    assertTrue(CountNothing.anyNothing(storage));
+    assertTrue(CountNothing.allNothing(storage));
+  }
+}

--- a/std-bits/tests/src/test/java/org/enso/table/data/column/operation/unary/IsNothingOperationTest.java
+++ b/std-bits/tests/src/test/java/org/enso/table/data/column/operation/unary/IsNothingOperationTest.java
@@ -1,0 +1,50 @@
+package org.enso.table.data.column.operation.unary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.test.utils.ContextUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class IsNothingOperationTest {
+  @ClassRule public static final ContextUtils ctx = ContextUtils.createDefault();
+
+  @Test
+  public void checkPlainStorage() {
+    var storage = Builder.getObjectBuilder(3).append("Hi").append(5).append(null).seal();
+    var result = IsNothingOperation.INSTANCE.apply(storage, null);
+    assertEquals(3, result.getSize());
+    assertEquals(false, result.getItemBoxed(0));
+    assertEquals(false, result.getItemBoxed(1));
+    assertEquals(true, result.getItemBoxed(2));
+  }
+
+  @Test
+  public void checkBoolStorage() {
+    checkBoolStorage(false);
+  }
+
+  @Test
+  public void checkBoolStorageNegated() {
+    checkBoolStorage(true);
+  }
+
+  private void checkBoolStorage(boolean negate) {
+    var storage = Builder.getForBoolean(3).append(true).append(false).appendNulls(1).seal();
+    if (negate) {
+      if (storage instanceof BoolStorage bs) {
+        storage = new BoolStorage(bs.getValues(), bs.getValidityMap(), (int) bs.getSize(), true);
+      } else {
+        fail("Expecting bool storage: " + storage);
+      }
+    }
+    var result = IsNothingOperation.INSTANCE.apply(storage, null);
+    assertEquals(3, result.getSize());
+    assertEquals(false, result.getItemBoxed(0));
+    assertEquals(false, result.getItemBoxed(1));
+    assertEquals(true, result.getItemBoxed(2));
+  }
+}

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -977,8 +977,10 @@ add_column_operation_specs suite_builder setup =
 
         group_builder.specify "should support is_blank" <|
             t = build_sorted_table [["X", [1.5, 2, Number.nan, Nothing]], ["Y", [1, Nothing, 3, 4]]]
-            t.at "X" . is_blank treat_nans_as_blank=True . to_vector . should_equal [False, False, True, True]
-            t.at "Y" . is_blank treat_nans_as_blank=True . to_vector . should_equal [False, True, False, False]
+            x = t.at "X" . is_blank treat_nans_as_blank=True
+            x . to_vector . should_equal [False, False, True, True]
+            y = t.at "Y" . is_blank treat_nans_as_blank=True
+            y . to_vector . should_equal [False, True, False, False]
 
         group_builder.specify "division should be aligned with the Enso arithmetic" <|
             a = [1, 5, 10, 100]

--- a/test/Table_Tests/src/In_Memory/Bool_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Bool_Spec.enso
@@ -75,8 +75,11 @@ add_specs suite_builder = suite_builder.group "[In-Memory] Boolean Column operat
 
                 [True, False, Nothing].each scalar-> Test.with_clue "([X] "+op_name+" "+scalar.to_text+"): " <|
                     got_2 = op x_col scalar
-                    expected_2 = xs.map x-> enso_op x scalar
-                    got_2.to_vector . should_equal expected_2
+                    vec_2 = got_2.to_vector
+                    expected_2 =
+                        xs.map x->
+                            enso_op x scalar
+                    vec_2 . should_equal expected_2
 
     group_builder.specify "min/max" <| with_transformed_columns x_col-> y_col->
         enso_min x y = if x.is_nothing then y else if y.is_nothing then x else if x < y then x else y


### PR DESCRIPTION
### Pull Request Description

- to align our column storage data with Arrow as #13851 requires
- to address the _isNothing vs. validity clash_
- let's use `getValidityMap` throughout our storages

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests will pass before integration
- [x] Benchmarks to verify speed is on par with previous `isNothing` behavior
    - [stdlib first run](https://github.com/enso-org/enso/actions/runs/19867807758) - showed some slowdown
    - [stdlib second run](https://github.com/enso-org/enso/actions/runs/19905507565) with shared `allTrue` and 0c07d60