### PR TITLE
Support cloud files in email send

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Data_Link_Helpers.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Enso_Cloud/Data_Link_Helpers.md
@@ -3,7 +3,7 @@
 - type Data_Link_Source_Metadata
     - Cloud_Asset id:Standard.Base.Data.Text.Text
     - Unknown
-- as_file path:Standard.Base.Any.Any action:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- as_file path:Standard.Base.Any.Any action:Standard.Base.Any.Any delete_on_return:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Any.Any
 - data_link_content_type -> Standard.Base.Any.Any
 - data_link_encoding -> Standard.Base.Any.Any
 - data_link_extension -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/Email/Email_Attachment.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/Email/Email_Attachment.md
@@ -1,6 +1,9 @@
 ## Enso Signatures 1.0
 ## module Standard.Base.Network.Email.Email_Attachment
 - type Email_Attachment
-    - File file:Standard.Base.System.File.File= name:Standard.Base.Data.Text.Text=
+    - File file:(Standard.Base.Data.Text.Text|Standard.Base.Network.URI.URI|Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_File.Enso_File)= name:Standard.Base.Data.Text.Text=
     - default_widget display:Standard.Base.Metadata.Display= -> Standard.Base.Metadata.Widget
 - Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.System.File.File -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
+- Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Network.URI.URI -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
+- Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Data.Text.Text -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
+- Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Enso_Cloud.Enso_File.Enso_File -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/Email/Email_Attachment.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/Email/Email_Attachment.md
@@ -1,9 +1,8 @@
 ## Enso Signatures 1.0
 ## module Standard.Base.Network.Email.Email_Attachment
 - type Email_Attachment
-    - File file:(Standard.Base.Data.Text.Text|Standard.Base.Network.URI.URI|Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_File.Enso_File)= name:Standard.Base.Data.Text.Text=
+    - File file:(Standard.Base.Data.Text.Text|Standard.Base.Network.URI.URI|Standard.Base.System.File.File|Standard.Base.System.File.Generic.File_Like.File_Like)= name:Standard.Base.Data.Text.Text=
     - default_widget display:Standard.Base.Metadata.Display= -> Standard.Base.Metadata.Widget
 - Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.System.File.File -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
 - Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Network.URI.URI -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
 - Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Data.Text.Text -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment
-- Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from that:Standard.Base.Enso_Cloud.Enso_File.Enso_File -> Standard.Base.Network.Email.Email_Attachment.Email_Attachment

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Data_Link_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Data_Link_Helpers.enso
@@ -36,7 +36,7 @@ import project.System.File_Format.File_Format
 import project.System.File_Format.File_Format_SPI
 import project.System.Input_Stream.Input_Stream
 import project.System.Output_Stream.Output_Stream
-from project.Data.Boolean import False, True
+from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
 from project.Enso_Cloud.Data_Link_Capabilities import Data_Link_With_Input_Stream, Data_Link_With_Output_Stream, File_Like_Data_Link, Writable_Data_Link
 from project.Enso_Cloud.Public_Utils import get_required_field
@@ -296,7 +296,7 @@ is_regular_file file ~check_file_directly =
     - `path`: The path to the resource. Can be a `Text`, `File`, `URI`, or
       other file-like object.
     - `action`: A function that takes a `File` and performs an action with it.
-as_file path action = case path of
+as_file path action delete_on_return:Boolean=True = case path of
     _ : Text ->
         resolved = URI.parse_if_http path . if_nothing <| File.new path
         as_file resolved action
@@ -310,7 +310,7 @@ as_file path action = case path of
         ## Fetch the resource and save it to a temporary file
         ## Best guess filename
         response = HTTP.fetch path method=..Get headers=[] cache_policy=..Default
-        handle_response_as_file response path action
+        handle_response_as_file response path action delete_on_return
     _ ->
         ## Something that is file like
         file_like = File.new path
@@ -319,9 +319,10 @@ as_file path action = case path of
             name_ext = split_file_name file_like.name
             temp_file = File.create_temporary_file name_ext.first name_ext.second
             written_file = Context.Output.with_enabled <| file_like.copy_to temp_file replace_existing=True
-            Managed_Resource.bracket written_file cleanup_tmp_file (f-> as_file f action)
+            if delete_on_return.not then action written_file else
+                Managed_Resource.bracket written_file cleanup_tmp_file (f-> as_file f action)
 
-private handle_response_as_file response path action =
+private handle_response_as_file response path action delete_on_return:Boolean =
     case Data_Link.is_data_link_from_metadata response.body.metadata of
         True ->
             ## Data link, interpret it
@@ -329,10 +330,10 @@ private handle_response_as_file response path action =
             case data_link of
                 _ : HTTP_Fetch_Data_Link ->
                     inner_response = HTTP.new.request data_link.request
-                    handle_response_as_file inner_response data_link.request.uri action
+                    handle_response_as_file inner_response data_link.request.uri action delete_on_return
                 _ ->
                     target_file = File_Like_Data_Link.find data_link
-                    as_file target_file.as_file action
+                    as_file target_file.as_file action delete_on_return
         False ->
             ## Not a data link, save to temporary file
             uri_path = path.path.split '/' . last
@@ -340,7 +341,8 @@ private handle_response_as_file response path action =
             temp_file = File.create_temporary_file name_ext.first name_ext.second
             written_file = Context.Output.with_enabled <|
                 response.write temp_file ..Overwrite
-            Managed_Resource.bracket written_file cleanup_tmp_file (f-> as_file f action)
+            if delete_on_return.not then as_file written_file action False else
+               Managed_Resource.bracket written_file cleanup_tmp_file (f-> as_file f action True)
 
 private cleanup_tmp_file file =
     Context.Output.with_enabled <|

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Data_Link_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Data_Link_Helpers.enso
@@ -299,13 +299,13 @@ is_regular_file file ~check_file_directly =
 as_file path action delete_on_return:Boolean=True = case path of
     _ : Text ->
         resolved = URI.parse_if_http path . if_nothing <| File.new path
-        as_file resolved action
+        as_file resolved action delete_on_return
     _ : File ->
         ## Need to see if a data link otherwise return the file
         if path.exists.not then Error.throw (File_Error.Not_Found path)
         if path.is_directory then Error.throw (Illegal_Argument.Error "Cannot use a directory, pass a file.")
         if path.is_data_link.not then action path else
-            as_file (interpret_data_link_target_as_file path) action
+            as_file (interpret_data_link_target_as_file path) action delete_on_return
     _ : URI ->
         ## Fetch the resource and save it to a temporary file
         ## Best guess filename

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
@@ -15,7 +15,7 @@ import project.Network.Email.Email_Provider.Email_Provider
 import project.Network.Email.Email_Send_Response.Send_Response
 import project.Runtime.Context
 import project.Warning.Warning
-from project.Data.Boolean import False, True
+from project.Data.Boolean import False
 from project.Error import all
 from project.Metadata.Widget import Text_Input, Vector_Editor, Single_Choice
 from project.Nothing import all

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
@@ -1,6 +1,7 @@
 import project.Data.Text.Text
 import project.Data.Vector.No_Wrap
 import project.Data.Vector.Vector
+import project.Enso_Cloud.Data_Link_Helpers
 import project.Errors.Common.Dry_Run_Operation
 import project.Errors.Common.Missing_Argument
 import project.Errors.Illegal_Argument.Illegal_Argument
@@ -66,7 +67,10 @@ type Email
         resolved_provider = Email_Provider.resolve provider
         if resolved_provider.is_nothing then Error.throw (Illegal_Argument.Error "Could not resolve email provider.")
 
-        email = Email.Message from resolved_to resolved_cc resolved_bcc subject body resolved_attachments
+        resolved_attachements_to_local_files = resolved_attachments.map a->
+            Data_Link_Helpers.as_file a.file local_file->(Email_Attachment.File file=local_file name=a.name)
+
+        email = Email.Message from resolved_to resolved_cc resolved_bcc subject body resolved_attachements_to_local_files
         _send_email_with_provider email resolved_provider
 
     ## ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
@@ -15,6 +15,7 @@ import project.Network.Email.Email_Provider.Email_Provider
 import project.Network.Email.Email_Send_Response.Send_Response
 import project.Runtime.Context
 import project.Warning.Warning
+from project.Data.Boolean import False, True
 from project.Error import all
 from project.Metadata.Widget import Text_Input, Vector_Editor, Single_Choice
 from project.Nothing import all
@@ -68,7 +69,7 @@ type Email
         if resolved_provider.is_nothing then Error.throw (Illegal_Argument.Error "Could not resolve email provider.")
 
         resolved_attachements_to_local_files = resolved_attachments.map a->
-            Data_Link_Helpers.as_file a.file local_file->(Email_Attachment.File file=local_file name=a.name)
+            Data_Link_Helpers.as_file a.file local_file->(Email_Attachment.File file=local_file name=a.name) delete_on_return=False
 
         email = Email.Message from resolved_to resolved_cc resolved_bcc subject body resolved_attachements_to_local_files
         _send_email_with_provider email resolved_provider

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email.enso
@@ -69,7 +69,7 @@ type Email
         if resolved_provider.is_nothing then Error.throw (Illegal_Argument.Error "Could not resolve email provider.")
 
         resolved_attachements_to_local_files = resolved_attachments.map a->
-            Data_Link_Helpers.as_file a.file local_file->(Email_Attachment.File file=local_file name=a.name) delete_on_return=False
+            Email_Attachment.File (Data_Link_Helpers.as_file a.file f->f delete_on_return=False) a.name
 
         email = Email.Message from resolved_to resolved_cc resolved_bcc subject body resolved_attachements_to_local_files
         _send_email_with_provider email resolved_provider

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
@@ -23,3 +23,13 @@ type Email_Attachment
    private: true
    ---
 Email_Attachment.from (that:File) = Email_Attachment.File that
+
+## ---
+   private: true
+   ---
+Email_Attachment.from (that:URI) = Email_Attachment.File that
+
+## ---
+   private: true
+   ---
+Email_Attachment.from (that:Text) = Email_Attachment.File that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
@@ -2,14 +2,16 @@ import project.Data.Text.Text
 import project.Errors.Common.Missing_Argument
 import project.Metadata.Display
 import project.Metadata.Widget
+import project.Network.URI.URI
 import project.System.File.File
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Text_Input, Vector_Editor, Single_Choice
+import project.Enso_Cloud.Enso_File.Enso_File
 
 ## The attachment of an email.
 type Email_Attachment
     ## A file attachment.
-    File file:File=(Missing_Argument.throw "file") name:Text=""
+    File file:Text|URI|File=(Missing_Argument.throw "file") name:Text=""
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
@@ -11,7 +11,7 @@ import project.Enso_Cloud.Enso_File.Enso_File
 ## The attachment of an email.
 type Email_Attachment
     ## A file attachment.
-    File file:Text|URI|File=(Missing_Argument.throw "file") name:Text=""
+    File file:Text|URI|File|Enso_File=(Missing_Argument.throw "file") name:Text=""
 
     ## ---
        private: true
@@ -33,3 +33,8 @@ Email_Attachment.from (that:URI) = Email_Attachment.File that
    private: true
    ---
 Email_Attachment.from (that:Text) = Email_Attachment.File that
+
+## ---
+   private: true
+   ---
+Email_Attachment.from (that:Enso_File) = Email_Attachment.File that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Email/Email_Attachment.enso
@@ -4,14 +4,15 @@ import project.Metadata.Display
 import project.Metadata.Widget
 import project.Network.URI.URI
 import project.System.File.File
+import project.System.File.Generic.File_Like.File_Like
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Text_Input, Vector_Editor, Single_Choice
-import project.Enso_Cloud.Enso_File.Enso_File
 
 ## The attachment of an email.
 type Email_Attachment
     ## A file attachment.
-    File file:Text|URI|File|Enso_File=(Missing_Argument.throw "file") name:Text=""
+    @file (Widget.Text_Input display=Display.Always)
+    File file:Text|URI|File|File_Like=(Missing_Argument.throw "file") name:Text=""
 
     ## ---
        private: true
@@ -33,8 +34,3 @@ Email_Attachment.from (that:URI) = Email_Attachment.File that
    private: true
    ---
 Email_Attachment.from (that:Text) = Email_Attachment.File that
-
-## ---
-   private: true
-   ---
-Email_Attachment.from (that:Enso_File) = Email_Attachment.File that


### PR DESCRIPTION
### Pull Request Description

Uses the Data_Link_Helper.as_file to allow cloud fiels to be used as email attachments, by materialising them to a temporary local file.

Closes #14363 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
