### PR TITLE
Fix transient IO failures on Windows

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -1078,8 +1078,8 @@ type File
     list_immediate_children : Vector File
     private list_immediate_children self =
         File_Error.handle_java_exceptions self <|
-            path_children = Java_Files.list self.java_path . toList
-            path_children.map (File.Value _)
+            paths = File_Utils.listImmediateChildren self.java_path
+            paths.map (File.Value _)
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -55,7 +55,6 @@ polyglot java import java.nio.file.FileSystemException
 polyglot java import java.nio.file.NoSuchFileException
 polyglot java import java.nio.file.Path as Java_Path
 polyglot java import java.nio.ByteBuffer
-polyglot java import java.nio.file.attribute.PosixFilePermissions
 polyglot java import java.nio.file.StandardCopyOption
 polyglot java import java.nio.file.StandardOpenOption
 polyglot java import java.time.ZonedDateTime
@@ -604,8 +603,7 @@ type File
     posix_permissions : File_Permissions
     posix_permissions self =
         File_Permissions.from_java_set <|
-            perms = Java_Files.getPosixFilePermissions self.java_path
-            PosixFilePermissions.toString perms
+            File_Utils.getPosixPermissions self.java_path
 
     ## ---
        group: Metadata
@@ -886,7 +884,7 @@ type File
     delete : Boolean -> Nothing ! File_Error
     delete self (recursive : Boolean = False) -> Nothing ! File_Error =
         Context.Output.if_enabled disabled_message="As writing is disabled, cannot delete file. Press the Write button ▶ to perform the operation." panic=False <|
-            File_Error.handle_java_exceptions self (File_Helpers.delete self recursive)
+            File_Error.handle_java_exceptions self (File_Utils.delete self.java_path recursive)
 
     ## ---
        icon: data_output

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Internal/File_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Internal/File_Helpers.enso
@@ -10,7 +10,6 @@ import project.System.File_Format.File_Format_SPI
 import project.System.File_Format.JSON_Format
 import project.System.File_Format.Plain_Text_Format
 
-polyglot java import org.enso.base.file_system.File_Utils
 polyglot java import java.nio.file.attribute.FileTime
 polyglot java import java.nio.file.Path as Java_Path
 polyglot java import java.nio.file.Files as Java_Files

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Internal/File_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Internal/File_Helpers.enso
@@ -10,29 +10,17 @@ import project.System.File_Format.File_Format_SPI
 import project.System.File_Format.JSON_Format
 import project.System.File_Format.Plain_Text_Format
 
+polyglot java import org.enso.base.file_system.File_Utils
 polyglot java import java.nio.file.attribute.FileTime
 polyglot java import java.nio.file.Path as Java_Path
 polyglot java import java.nio.file.Files as Java_Files
 polyglot java import java.nio.file.LinkOption as Java_LinkOption
 polyglot java import java.time.ZonedDateTime as Java_ZonedDateTime
 polyglot java import java.time.ZoneOffset as Java_ZoneOffset
-polyglot java import java.util.stream.Stream
 
 ## The builtin that returns a File instance for a given path.
 get_file path:Text =
     File.Value (Java_Path.of path)
-
-delete file:File recursive:Boolean =
-    should_delete_recursively = recursive && is_dir file
-    if should_delete_recursively then delete_recursively file.java_path else
-        Java_Files.delete file.java_path
-
-delete_recursively path:Java_Path =
-    if (is_dir path).not then Java_Files.delete path else
-        children = Java_Files.list path . toList
-        children.each \child ->
-            delete_recursively child
-        Java_Files.delete path
 
 is_dir file:(File|Java_Path) -> Boolean =
     path = case file of

--- a/std-bits/base/src/main/java/org/enso/base/file_system/File_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/file_system/File_Utils.java
@@ -1,8 +1,8 @@
 package org.enso.base.file_system;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermissions;
 
 public final class File_Utils {
   private File_Utils() {}
@@ -19,5 +19,28 @@ public final class File_Utils {
 
   public static boolean matches(PathMatcher matcher, String pathStr) {
     return matcher.matches(Path.of(pathStr));
+  }
+
+  public static void delete(Path path, boolean recursive) throws IOException {
+    if (recursive && Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+      deleteRecursively(path);
+    } else {
+      Files.delete(path);
+    }
+  }
+
+  public static String getPosixPermissions(Path path) throws IOException {
+    return PosixFilePermissions.toString(Files.getPosixFilePermissions(path));
+  }
+
+  private static void deleteRecursively(Path file) throws IOException {
+    if (Files.isDirectory(file, LinkOption.NOFOLLOW_LINKS)) {
+      try (var entries = Files.newDirectoryStream(file)) {
+        for (var entry : entries) {
+          deleteRecursively(entry);
+        }
+      }
+    }
+    Files.delete(file);
   }
 }

--- a/std-bits/base/src/main/java/org/enso/base/file_system/File_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/file_system/File_Utils.java
@@ -3,6 +3,7 @@ package org.enso.base.file_system;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
 
 public final class File_Utils {
   private File_Utils() {}
@@ -31,6 +32,12 @@ public final class File_Utils {
 
   public static String getPosixPermissions(Path path) throws IOException {
     return PosixFilePermissions.toString(Files.getPosixFilePermissions(path));
+  }
+
+  public static List<Path> listImmediateChildren(Path dir) throws IOException {
+    try (var stream = Files.list(dir)) {
+      return stream.toList();
+    }
   }
 
   private static void deleteRecursively(Path file) throws IOException {


### PR DESCRIPTION
### Pull Request Description

Attempt to fix these [transient failures](https://github.com/enso-org/enso/actions/runs/19882951068/job/56986081997?pr=14409#step:14:1015) on Windows. They started to appear since #14297.

Should also fix these "Access Denied" transients: https://github.com/enso-org/enso/actions/runs/19893401902/job/57022369067?pr=14406#step:14:1749

The cause is likely related to the fact that the`java.util.Stream` of `java.io.File` created in `Java_Files.list path` in [File_Helpers.delete_recursively](https://github.com/enso-org/enso/pull/14424/files#diff-6094fb474b37009adb04d933dc5a2e7e2de5ab39e5a46862c4b118bcf21e63b5L32) was not closed.

### Important Notes

- `delete` and `deleteRecursively` moved to [std-bit/base/**/File_Utils.java](https://github.com/enso-org/enso/blob/480374db1b84bc9e0350061c2ac9ddea79aac4f4/std-bits/base/src/main/java/org/enso/base/file_system/File_Utils.java).
  - Iterating children of directory via stream is wrapped in try-with-resources.
  - Code of `delete` and `deleteRecursively` is "reverted" from https://github.com/enso-org/enso/blob/57a9c892713c90361d33004b6162bca84f0155a1/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoFile.java#L693-L713
- `getPosixPermissions` also migrated to Java.
  - So that we can [remove](https://github.com/enso-org/enso/pull/14424/files#diff-5bf80ae323f4d3988d94e6f819ae291ad18b90cd1a5b53ae16be29c759b3347fL58) polyglot java import of `java.nio.file.attribute.PosixFilePermissions`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
