### PR TITLE
Add additional refined types to table expression editor.

### DIFF
--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -61,13 +61,13 @@ const COLUMN_TYPE = ProjectPath.create(
 )
 
 const NUMERIC_COLUMN_TYPE = ProjectPath.create(
-    'Standard.Table' as QualifiedName,
-    'Refined_Types.Numeric_Column.Numeric_Column' as QualifiedName,
+  'Standard.Table' as QualifiedName,
+  'Refined_Types.Numeric_Column.Numeric_Column' as QualifiedName,
 )
 
 const TEXT_COLUMN_TYPE = ProjectPath.create(
-    'Standard.Table' as QualifiedName,
-    'Refined_Types.Text_Column.Text_Column' as QualifiedName,
+  'Standard.Table' as QualifiedName,
+  'Refined_Types.Text_Column.Text_Column' as QualifiedName,
 )
 
 const EXPRESSION_STATICS_TYPE = ProjectPath.create(

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -34,6 +34,8 @@ export function useTableExpressionExtension(
           [
             ...suggestionDb.value.methods(EXPRESSION_STATICS_METHODS),
             ...suggestionDb.value.methods(COLUMN_METHODS),
+            ...suggestionDb.value.methods(NUMERIC_COLUMN_METHODS),
+            ...suggestionDb.value.methods(TEXT_COLUMN_METHODS),
           ].map((entry) => [entry.name, entry]),
         ).values(),
         methodInfoFromEntry,
@@ -58,17 +60,35 @@ const COLUMN_TYPE = ProjectPath.create(
   'Column.Column' as QualifiedName,
 )
 
+const NUMERIC_COLUMN_TYPE = ProjectPath.create(
+    'Standard.Table' as QualifiedName,
+    'Refined_Types.Numeric_Column.Numeric_Column' as QualifiedName,
+)
+
+const TEXT_COLUMN_TYPE = ProjectPath.create(
+    'Standard.Table' as QualifiedName,
+    'Refined_Types.Text_Column.Text_Column' as QualifiedName,
+)
+
 const EXPRESSION_STATICS_TYPE = ProjectPath.create(
   'Standard.Table' as QualifiedName,
   'Internal.Expression_Statics.Expression_Statics' as QualifiedName,
 )
 
-const EXPRESSION_STATICS_METHODS = {
-  memberOf: EXPRESSION_STATICS_TYPE,
-}
 const COLUMN_METHODS = {
   selfType: COLUMN_TYPE,
   name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
+}
+const NUMERIC_COLUMN_METHODS = {
+  selfType: NUMERIC_COLUMN_TYPE,
+  name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
+}
+const TEXT_COLUMN_METHODS = {
+  selfType: TEXT_COLUMN_TYPE,
+  name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
+}
+const EXPRESSION_STATICS_METHODS = {
+  memberOf: EXPRESSION_STATICS_TYPE,
 }
 
 function methodInfoFromEntry(entry: MethodSuggestionEntry): MethodCompletionInfo {
@@ -81,7 +101,6 @@ function methodInfoFromEntry(entry: MethodSuggestionEntry): MethodCompletionInfo
 }
 
 const EXCLUDED_COLUMN_METHODS = new Set([
-  'iif', // Used to implement `if`; no reason to call it as a method.
   'info', // Technically works, probably not useful.
   'rename', // When used with `Column.set`, this is redundant and doesn't work.
   'to_table', // Does nothing, successfully but inefficiently.


### PR DESCRIPTION
### Pull Request Description

- Adds Numeric and Text column to the list of methods for expression editor.
- Unblock `iif` as common use in other tools.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
