### PR TITLE
Language server can download libraries from a server

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -322,7 +322,6 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     RuntimeOptions.LOG_MASKING,
     Masking.isMaskingEnabled.toString
   )
-  extraOptions.put(RuntimeOptions.EDITION_OVERRIDE, BuildVersion.currentEdition)
   extraOptions.put(
     RuntimeOptions.JOB_PARALLELISM,
     Runtime.getRuntime.availableProcessors().toString

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MockLogHandler.java
@@ -29,6 +29,13 @@ public final class MockLogHandler extends Handler {
     logs.clear();
   }
 
+  List<String> getRawLogMessages(String loggerName) {
+    return logs.stream()
+        .filter(r -> r.getLoggerName().equals(loggerName))
+        .map(LogRecord::getMessage)
+        .toList();
+  }
+
   public void reset() {
     logs.clear();
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
@@ -1,5 +1,7 @@
 package org.enso.interpreter.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 
 import org.enso.common.RuntimeOptions;
@@ -98,10 +100,13 @@ public class NonStrictModeTests {
     String line1 =
         "Unnamed:1:1: error: Package containing the module That.Does.Not.Exist could not be loaded:"
             + " The package could not be resolved: The library `That.Does` is not defined within"
-            + " the edition.";
+            + " the edition";
     String line2 = "    1 | import That.Does.Not.Exist";
     String line3 = "      | ^~~~~~~~~~~~~~~~~~~~~~~~~~";
-    logHandler.assertMessage(
-        "enso.org.enso.compiler.Compiler", line1 + "\n" + line2 + "\n" + line3);
+    var logMessages = logHandler.getRawLogMessages("enso.org.enso.compiler.Compiler");
+    assertEquals(1, logMessages.size());
+    assertThat(
+        logMessages.get(0),
+        allOf(containsString(line1), containsString(line2), containsString(line3)));
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/NonStrictModeTests.java
@@ -1,7 +1,8 @@
 package org.enso.interpreter.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import org.enso.common.RuntimeOptions;

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -39,7 +39,7 @@ class ImportsTest extends PackageTest {
     outLines(0) should include(
       "Package containing the module Surely_This.Does_Not_Exist.My_Module " +
       "could not be loaded: The package could not be resolved: The library " +
-      "`Surely_This.Does_Not_Exist` is not defined within the edition."
+      "`Surely_This.Does_Not_Exist` is not defined within the edition"
     )
     outLines(1) should include(
       "The module Enso_Test.Test_Bad_Imports.Oopsie does not exist."

--- a/lib/scala/library-manager/src/main/scala/org/enso/librarymanager/LibraryResolver.scala
+++ b/lib/scala/library-manager/src/main/scala/org/enso/librarymanager/LibraryResolver.scala
@@ -69,7 +69,7 @@ case class LibraryResolver(
           Left(
             LibraryResolutionError(
               s"The library `$libraryName` is not defined within " +
-              s"the edition."
+              s"the edition $edition."
             )
           )
       }


### PR DESCRIPTION
Part of #14319.

### Pull Request Description

Necessary modification to make #14319 work in the IDE.

### Important Notes

Basically reverts #4117 which is now pointless anyway.

### How to download custom library in IDE?

Follow the steps from https://github.com/enso-org/enso/issues/14319#issuecomment-3613498086 with the only modification of step (5) - instead of running enso engine directly, just run the IDE (with modified [ENSO_ENGINE_PATH](https://github.com/enso-org/enso/blob/0a0be245967089fb7adbcaa346226d7e3567570b/docs/CONTRIBUTING.md#L578-L580).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
