### PR TITLE
Log unsuccessful `Builder.makeLocal`

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -115,14 +115,10 @@ public interface Builder {
       assert assertSameStorages(storage, localStorage);
       return (ColumnStorage<T>) localStorage;
     } else {
-      if (BuilderUtil.LOG.isLoggable(System.Logger.Level.TRACE)) {
+      if (BuilderUtil.LOG.isTraceEnabled()) {
         var t = storage.getType();
-        BuilderUtil.LOG.log(
-            System.Logger.Level.TRACE,
-            "makeLocal unsuccessful for {0}:{1} size {2}",
-            t.typeChar(),
-            t.size(),
-            storage.getSize());
+        BuilderUtil.LOG.trace(
+            "makeLocal unsuccessful for {}:{} size {}", t.typeChar(), t.size(), storage.getSize());
       }
     }
     return storage;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -114,6 +114,16 @@ public interface Builder {
           };
       assert assertSameStorages(storage, localStorage);
       return (ColumnStorage<T>) localStorage;
+    } else {
+      if (BuilderUtil.LOG.isLoggable(System.Logger.Level.TRACE)) {
+        var t = storage.getType();
+        BuilderUtil.LOG.log(
+            System.Logger.Level.TRACE,
+            "makeLocal unsuccessful for {0}:{1} size {2}",
+            t.typeChar(),
+            t.size(),
+            storage.getSize());
+      }
     }
     return storage;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderUtil.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderUtil.java
@@ -1,7 +1,10 @@
 package org.enso.table.data.column.builder;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 final class BuilderUtil {
   private BuilderUtil() {}
 
-  static final System.Logger LOG = System.getLogger(Builder.class.getPackage().getName());
+  static final Logger LOG = LoggerFactory.getLogger(BuilderUtil.class);
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderUtil.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/BuilderUtil.java
@@ -1,0 +1,7 @@
+package org.enso.table.data.column.builder;
+
+final class BuilderUtil {
+  private BuilderUtil() {}
+
+  static final System.Logger LOG = System.getLogger(Builder.class.getPackage().getName());
+}


### PR DESCRIPTION
### Pull Request Description

- the biggest slowdown in #13570  is the _boundary crossing_ 
   - e.g. when every call to `ColumnStorage.getItemBoxed` needs to _switch the JVM_
   - when the column has millions of elements, it means millions of _boundary crossings_
- to mitigate that #14357 
   -  optimizes transfer of `LongStorage`
   - `Builder.makeLocal` can transfer it _as a whole_ from one JVM to another
- #14436 is doing the same for `DoubleStorage`
- **what other storages** need to be optimized?

### Important Notes

- this PR adds tracing to highlight which storage types were not `Builder.makeLocal` optimized
   - e.g. which need to be access _item by item_
- run your workflow with `org.enso.table.data.column.builder.Logger.level=trace` property set
- for example the [Microsoft_Tests](https://github.com/enso-org/enso/tree/65be4a1c534907e1044ebd6b810f3cfb4fb11b67/test/Microsoft_Tests) can be executed in _dual JVM mock mode_ and with logging as
```bash
sbt:enso> runEngineDistribution --env ENSO_SQLSERVER_DATABASE=tempdb
   --vm.D=org.enso.table.data.column.builder.Logger.level=trace 
   --vm.D=polyglot.enso.classLoading=Standard.Microsoft:guest,hosted 
   --run test/Microsoft_Tests
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [ ] ~Unit tests have been written where possible~.
