### PR TITLE
Empty storage is always `makeLocal`

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -13,6 +13,7 @@ import org.enso.table.data.column.operation.masks.MaskOperation;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.PreciseTypeOptions;
+import org.enso.table.data.column.storage.TypedStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.BigDecimalType;
 import org.enso.table.data.column.storage.type.BigIntegerType;
@@ -100,6 +101,11 @@ public interface Builder {
    */
   @SuppressWarnings("unchecked")
   static <T> ColumnStorage<T> makeLocal(ColumnStorage<T> storage) {
+    if (storage.getSize() == 0) {
+      var proxyType = storage.getType();
+      var localType = StorageType.fromTypeCharAndSize(proxyType.typeChar(), proxyType.size());
+      return (ColumnStorage<T>) new TypedStorage(localType, new Object[0]);
+    }
     var data = storage.addressOfData();
     if (data != 0) {
       var size = Math.toIntExact(storage.getSize());


### PR DESCRIPTION
### Pull Request Description

- #14449 tracing shows there is a lot of zero sized storages
- those can be `Builder.makeLocal` without transferring any data 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass