### PR TITLE
Show content of data directory

### DIFF
--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
@@ -1,6 +1,9 @@
 package org.enso.tools.enso4igv.enso;
 
 import java.awt.GraphicsEnvironment;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.beans.BeanInfo;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -31,6 +34,7 @@ import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.datatransfer.ExTransferable;
 import org.openide.util.lookup.Lookups;
 
 @NbBundle.Messages({
@@ -291,7 +295,20 @@ public final class EnsoYamlProject implements Project {
       try {
         var data = p.root.getFileObject("data", true);
         if (data != null) {
-          var dataNode = DataObject.find(data).getNodeDelegate().cloneNode();
+          var dataNode = new FilterNode(DataObject.find(data).getNodeDelegate()) {
+              @Override
+              public Transferable clipboardCopy() throws IOException {
+                  var t = ExTransferable.create(super.clipboardCopy());
+                  var dataDir = new ExTransferable.Single(DataFlavor.stringFlavor) {
+                      @Override
+                      protected Object getData() throws IOException, UnsupportedFlavorException {
+                          return "Meta.Enso_Project.enso_project.data";
+                      }
+                  };
+                  t.put(dataDir);
+                  return t;
+              }
+          };
           dataNode.setDisplayName(Bundle.LAB_EnsoData());
           ch.add(new Node[]{dataNode});
         }

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoYamlProject.java
@@ -36,6 +36,7 @@ import org.openide.util.lookup.Lookups;
 @NbBundle.Messages({
   "LAB_EnsoSources=Enso Sources",
   "LAB_EnsoDocumentation=Documentation",
+  "LAB_EnsoData=Data",
   "LAB_EnsoPolyglot=Polyglot Sources"
 })
 public final class EnsoYamlProject implements Project {
@@ -283,6 +284,16 @@ public final class EnsoYamlProject implements Project {
           var docsNode = DataObject.find(docs).getNodeDelegate().cloneNode();
           docsNode.setDisplayName(Bundle.LAB_EnsoDocumentation());
           ch.add(new Node[]{docsNode});
+        }
+      } catch (DataObjectNotFoundException ex) {
+        Exceptions.printStackTrace(ex);
+      }
+      try {
+        var data = p.root.getFileObject("data", true);
+        if (data != null) {
+          var dataNode = DataObject.find(data).getNodeDelegate().cloneNode();
+          dataNode.setDisplayName(Bundle.LAB_EnsoData());
+          ch.add(new Node[]{dataNode});
         }
       } catch (DataObjectNotFoundException ex) {
         Exceptions.printStackTrace(ex);

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
@@ -1,5 +1,6 @@
 package org.enso.tools.enso4igv.enso;
 
+import java.awt.datatransfer.DataFlavor;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -14,6 +15,7 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.spi.project.ui.LogicalViewProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.nodes.Node;
 import org.openide.util.Utilities;
 
 public class EnsoYamlProjectTest extends NbTestCase {
@@ -149,6 +151,38 @@ public class EnsoYamlProjectTest extends NbTestCase {
     var packages = javaLibs[0].getChildren().getNodes(true);
     var testCasePkg = Stream.of(packages).filter(n -> TestCase.class.getPackageName().equals(n.getName())).findAny();
     assertTrue("junit framework package is found among " + Arrays.toString(packages), testCasePkg.isPresent());
+  }
+
+  public void testData() throws Exception {
+    var yaml = FileUtil.createData(root, "data/package.yaml");
+    var main = FileUtil.createData(root, "data/src/Main.enso");
+    var input = FileUtil.createData(root, "data/data/input.txt");
+
+    var rootFO = root.getFileObject("data");
+    var poly = ProjectManager.getDefault().findProject(rootFO);
+    assertNotNull("Project found", poly);
+    var lvp = poly.getLookup().lookup(LogicalViewProvider.class);
+
+    var node = lvp.createLogicalView();
+
+    assertEquals("data", node.getName());
+    var prjNodes = node.getChildren().getNodes(true);
+    assertEquals("Three nodes", 3, prjNodes.length);
+
+    assertEquals("package.yaml", prjNodes[2].getName());
+    assertEquals("represents the package.yaml file", yaml, prjNodes[2].getLookup().lookup(FileObject.class));
+
+    assertEquals("src", prjNodes[0].getName());
+    assertEquals("Enso Sources", prjNodes[0].getDisplayName());
+
+    var dataNode = prjNodes[1];
+    assertEquals("data", dataNode.getName());
+    assertEquals("Data", dataNode.getDisplayName());
+    var dataNodes = dataNode.getChildren().getNodes(true);
+    assertEquals("One nodes: " + Arrays.toString(dataNodes), 1, dataNodes.length);
+    assertEquals("input.txt", dataNodes[0].getName());
+    
+    assertEquals(input, dataNodes[0].getLookup().lookup(FileObject.class));
   }
 
   public void testDocumentation() throws Exception {

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/enso/EnsoYamlProjectTest.java
@@ -181,8 +181,12 @@ public class EnsoYamlProjectTest extends NbTestCase {
     var dataNodes = dataNode.getChildren().getNodes(true);
     assertEquals("One nodes: " + Arrays.toString(dataNodes), 1, dataNodes.length);
     assertEquals("input.txt", dataNodes[0].getName());
-    
+
     assertEquals(input, dataNodes[0].getLookup().lookup(FileObject.class));
+
+    var copy = dataNode.clipboardCopy();
+    var text = copy.getTransferData(DataFlavor.stringFlavor);
+    assertEquals("Meta.Enso_Project.enso_project.data", text);
   }
 
   public void testDocumentation() throws Exception {


### PR DESCRIPTION
### Pull Request Description

- working with [AOC template project](https://github.com/JaroslavTulach/AOC-2025-Enso/) revealed there is **no easy access** to `input.txt`
- this PR fixes it by showing `Data` folder in logical structure of Enso projects

<img width="738" height="1099" alt="Base_Tests" src="https://github.com/user-attachments/assets/d35531ca-9144-4567-9ce0-e9e79475f68f" />

- this is how the template AoC project would look like in VSCode

<img width="688" height="324" alt="Dec00" src="https://github.com/user-attachments/assets/2add39b9-d26c-4425-bf9d-0b9e19fde6c2" />



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
