### PR TITLE
if/then/else static resolution works now

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
@@ -192,7 +192,7 @@ type Faker
         sign = if self.integer 0 2 == 0 then 1 else -1
         mantissa = self.float 0 max_mantissa
         exponent = self.integer 0 max_exponent+1
-        (2.0 ^ exponent) * sign * mantissa
+        sign * mantissa * (2.0 ^ exponent)
 
     ## ---
        group: Standard.Base.Random

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeCompatibility.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypeCompatibility.java
@@ -56,6 +56,12 @@ class TypeCompatibility {
       }
     }
 
+    if (provided.equals(BuiltinTypes.NUMBER)) {
+      if (expected.equals(BuiltinTypes.INTEGER) || expected.equals(BuiltinTypes.FLOAT)) {
+        return Compatibility.UNKNOWN;
+      }
+    }
+
     // This is a proof of concept. There is not much sense in implementing these branches until we
     // can handle conversions anyway.
     // So these TODOs will be addressed in future iterations.

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
@@ -9,6 +9,7 @@ import org.enso.compiler.core.CompilerError;
 import org.enso.compiler.core.ConstantsNames;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.CallArgument;
+import org.enso.compiler.core.ir.Empty;
 import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.core.ir.Function;
 import org.enso.compiler.core.ir.Literal;
@@ -155,8 +156,9 @@ abstract class TypePropagation {
           }
           case Function.Lambda f -> processLambda(f, localBindingsTyping);
           case Literal l -> processLiteral(l);
-          case Application.Sequence sequence -> BuiltinTypes.VECTOR;
+          case Application.Sequence _ -> BuiltinTypes.VECTOR;
           case Case.Expr caseExpr -> processCaseExpression(caseExpr, localBindingsTyping);
+          case Empty _ -> BuiltinTypes.NOTHING;
           default -> {
             logger.trace(
                 "type propagation: UNKNOWN branch: {}", expression.getClass().getCanonicalName());

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -485,7 +485,6 @@ public class TypeInferenceTest extends StaticAnalysisTest {
         Optional.of(myType), getInferredTypeOption(ModuleUtils.findAssignment(foo, "x7")));
   }
 
-  @Ignore("TODO: ifte")
   @Test
   public void commonIfThenElse() throws Exception {
     final URI uri = new URI("memory://commonIfThenElse.enso");
@@ -667,7 +666,6 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     assertSumType(ModuleUtils.findAssignment(f, "y"), "My_Type", "Other_Type");
   }
 
-  @Ignore("TODO: ifte")
   @Test
   public void sumTypeFromIf() throws Exception {
     final URI uri = new URI("memory://sumTypeFromIf.enso");
@@ -688,7 +686,6 @@ public class TypeInferenceTest extends StaticAnalysisTest {
     assertSumType(ModuleUtils.findAssignment(f, "y"), "Text", "Integer");
   }
 
-  @Ignore("TODO: ifte")
   @Test
   public void sumTypeFromIfWithoutElse() throws Exception {
     final URI uri = new URI("memory://sumTypeFromIf.enso");

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/TypeInferenceTest.java
@@ -1114,6 +1114,40 @@ public class TypeInferenceTest extends StaticAnalysisTest {
   }
 
   @Test
+  public void integerIsSubclassOfNumber() throws Exception {
+    final URI uri = new URI("memory://notInvokable.enso");
+    final Source src =
+        Source.newBuilder(
+                "enso",
+                """
+                from Standard.Base import Integer, Number
+
+                foo =
+                    num -> Number = 42
+                    neg n:Integer -> Integer = -n
+                    neg num
+                """,
+                uri.getAuthority())
+            .uri(uri)
+            .buildLiteral();
+
+    var module = compile(src);
+    var foo = ModuleUtils.findStaticMethod(module, "foo");
+    foo.preorder()
+        .foreach(
+            (ir) -> {
+              if (ir.getDiagnostics().toList().nonEmpty()) {
+                fail(
+                    "There should be no warnings "
+                        + ir.getDiagnostics().toList()
+                        + " at "
+                        + ir.showCode());
+              }
+              return null;
+            });
+  }
+
+  @Test
   public void noTypeErrorIfUnsure() throws Exception {
     final URI uri = new URI("memory://notInvokable.enso");
     final Source src =


### PR DESCRIPTION
### Pull Request Description

- as a _"by product"_ of #11365 
   - e.g. `if_then_else` is now treated the same as `case of` construct
- thus static resolution works and tests written by @radeusgd can be un-`@Ignore`d
- one fix - support for `Empty` IR - needed
- also fixing `Number` vs. `Integer` or `Float` incorrect mismatch: 56e3868ee04f81fc37f8d6cee78b9bf9da040d4d

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
