### PR TITLE
Fix pattern matching on Java integer field

### DIFF
--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Type_Mapping.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Type_Mapping.enso
@@ -111,11 +111,7 @@ type DuckDB_Type_Mapping
         Types.TIMESTAMP -> Value_Type.Date_Time False
         Types.BLOB -> Value_Type.Binary Nothing False
         Types.BIT -> Value_Type.Binary Nothing False
-        _ -> case sql_type.name of
-            "TIMESTAMP_NS" -> Value_Type.Date_Time False
-            "TIMESTAMPTZ" -> Value_Type.Date_Time True
-            "TIMESTAMP WITH TIME ZONE" -> Value_Type.Date_Time True
-            _ -> Value_Type.Unsupported_Data_Type sql_type.name sql_type
+        _ -> Value_Type.Unsupported_Data_Type sql_type.name sql_type
 
     ## ---
        private: true

--- a/engine/runtime-integration-tests/src/test/java/org/enso/example/TestConstants.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/example/TestConstants.java
@@ -1,0 +1,8 @@
+package org.enso.example;
+
+public class TestConstants {
+  private TestConstants() {}
+
+  public static final int A = 1;
+  public static final int B = 2020;
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/CaseOfTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/CaseOfTest.java
@@ -1,5 +1,7 @@
 package org.enso.interpreter.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import org.enso.interpreter.runtime.data.EnsoMultiValue;
@@ -54,5 +56,41 @@ public class CaseOfTest {
     assertEquals("With " + t + " we should get 1", 1, one.asInt());
     var two = choose.execute(f);
     assertEquals("With " + f + " we should get 2", 2, two.asInt());
+  }
+
+  /** See <a href="https://github.com/enso-org/enso/issues/14426">#14426</a>. */
+  @Test
+  public void caseOfJavaFinalFields_SmallInteger() {
+    var code =
+        """
+        polyglot java import org.enso.example.TestConstants
+
+        main =
+            x = 1
+            case x of
+                TestConstants.A -> "A"
+                _ -> "Unknown"
+        """;
+    var res = ctxRule.evalModule(code);
+    assertThat(res.isString(), is(true));
+    assertThat(res.asString(), is("A"));
+  }
+
+  /** See <a href="https://github.com/enso-org/enso/issues/14426">#14426</a>. */
+  @Test
+  public void caseOfJavaFinalFields_BiggerInteger() {
+    var code =
+        """
+        polyglot java import org.enso.example.TestConstants
+
+        main =
+            x = 2020
+            case x of
+                TestConstants.B -> "B"
+                _ -> "Unknown"
+        """;
+    var res = ctxRule.evalModule(code);
+    assertThat(res.isString(), is(true));
+    assertThat(res.asString(), is("B"));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -36,22 +36,9 @@ public abstract class IsSameObjectNode extends Node {
     }
   }
 
-  @Specialization(
-      guards = {
-        "interop.fitsInLong(left)",
-        "interop.fitsInLong(right)",
-      })
-  boolean isSameLong(
-      Object left,
-      Object right,
-      @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
-    try {
-      var leftLong = interop.asLong(left);
-      var rightLong = interop.asLong(right);
-      return leftLong == rightLong;
-    } catch (UnsupportedMessageException e) {
-      return false;
-    }
+  @Specialization
+  boolean isSameLong(long left, long right) {
+    return left == right;
   }
 
   @Specialization(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -38,6 +38,24 @@ public abstract class IsSameObjectNode extends Node {
 
   @Specialization(
       guards = {
+        "interop.fitsInLong(left)",
+        "interop.fitsInLong(right)",
+      })
+  boolean isSameLong(
+      Object left,
+      Object right,
+      @Shared("interop") @CachedLibrary(limit = "2") InteropLibrary interop) {
+    try {
+      var leftLong = interop.asLong(left);
+      var rightLong = interop.asLong(right);
+      return leftLong == rightLong;
+    } catch (UnsupportedMessageException e) {
+      return false;
+    }
+  }
+
+  @Specialization(
+      guards = {
         "interop.isString(left)",
         "interop.isString(right)",
       })

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/Constants.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/Constants.java
@@ -1,0 +1,11 @@
+package org.enso.base_test_helpers;
+
+public class Constants {
+  private Constants() {}
+
+  public static final int SMALL_INT = 1;
+  public static final int BIG_INT = 2020;
+  public static final long SMALL_LONG = 2L;
+  public static final long BIG_LONG = 20_000L;
+  public static final String STRING = "string";
+}

--- a/test/Base_Tests/src/Semantic/Case_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Case_Spec.enso
@@ -3,6 +3,7 @@ import Standard.Base.Data.Array as Array_Module
 import Standard.Base.Data.Text as Text_Module
 import Standard.Base.Data.Vector as Vector_Module
 
+polyglot java import org.enso.base_test_helpers.Constants as Java_Constants
 polyglot java import java.lang.Class
 polyglot java import java.lang.Long as Java_Long
 polyglot java import java.lang.Object as Java_Object
@@ -346,6 +347,23 @@ add_specs suite_builder = suite_builder.group "Pattern Matches" group_builder->
         case (.name) of
             _ : Function -> Nothing
             _ -> Test.fail "Expected to match on Function type."
+
+    group_builder.specify "should pattern match on Java constant fields" <|
+        case 1 of
+            Java_Constants.SMALL_INT -> Nothing
+            _ -> Test.fail "Expected to match on SMALL_INT."
+        case "string" of
+            Java_Constants.STRING -> Nothing
+            _ -> Test.fail "Expected to match on STRING."
+        case 2 of
+            Java_Constants.SMALL_LONG -> Nothing
+            _ -> Test.fail "Expected to match on SMALL_LONG."
+        case 20000 of
+            Java_Constants.BIG_LONG -> Nothing
+            _ -> Test.fail "Expected to match on BIG_LONG."
+        case 2020 of
+            Java_Constants.BIG_INT -> Nothing
+            _ -> Test.fail "Expected to match on BIG_INT."
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
Fixes #14426

### Pull Request Description

Fixes pattern matching on Java integer and long fields.

### Important Notes

Fallback case branch in `DuckDB_Type_Mapping.enso` no longer necessary - removed in 2a84ac477d406873fc2145b929ba9c81002a526c. See https://github.com/enso-org/enso/pull/14423#issuecomment-3606581070

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
