### PR TITLE
Fix in db set from constant

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -328,7 +328,7 @@ type DB_Table_Implementation
             _ : Column ->
                 if Helpers.check_integrity this_table value then value else
                     Error.throw (Integrity_Error.Error "Column "+value.name)
-            _ : Constant_Column -> this_table.make_constant_column value
+            _ : Constant_Column -> this_table.make_constant_column value.value
             _ : Simple_Expression -> value.evaluate this_table (set_mode==Set_Mode.Update && as=="") on_problems
             _ : SQL_Function -> _resolve_sql_function this_table value
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -715,7 +715,7 @@ type Cross_Join_Row_Limit_Exceeded
        Create a human-readable version of the error.
     to_display_text : Text
     to_display_text self =
-        "The cross join operation exceeded the maximum number of rows allowed. The limit is "+self.limit.to_text+" and the number of rows in the right table was "+self.existing_rows.to_text+". The limit may be turned off by setting the `right_row_limit` option to `Nothing`."
+        "The cross join operation exceeded the maximum number of rows allowed. The limit is "+self.limit.to_text+" and the number of rows in the right table was "+self.existing_rows.to_text+". The limit may be turned off by setting the `right_row_limit` option to `..No_Limit`."
 
 type Row_Count_Mismatch
     ## ---

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -239,13 +239,13 @@ add_core_specs suite_builder setup =
             t2.get "foo" . to_vector . should_equal [Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column" <|
-            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="bar3"
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15 zone=Time_Zone.utc) as="bar3"
             t3 = t2.read.format "bar3" "yyyy-MM-dd HH:mm:ss"
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
             t3.get "bar3" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column overriding an existing column" <|
-            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="foo"
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15 zone=Time_Zone.utc) as="foo"
             t3 = t2.read.format "foo" "yyyy-MM-dd HH:mm:ss"
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
             t3.get "foo" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -187,6 +187,11 @@ add_core_specs suite_builder setup =
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]
                 Problems.test_problem_handling action2 problems2 tester2
 
+        group_builder.specify "qwershould allow adding a constant integer column" <|
+            t2 = data.table.set 42 as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal [42, 42, 42]
+
         group_builder.specify "should gracefully handle columns from different backends" <|
             t1 = build_sorted_table [["A", [1, 2, 3]]]
             alternative_connection = Database.connect (SQLite.In_Memory)

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -240,13 +240,15 @@ add_core_specs suite_builder setup =
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column" <|
             t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="bar3"
-            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
-            t2.get "bar3" . to_vector . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
+            t3 = t2.format "bar3" "yyyy-MM-dd HH:mm:ss"
+            t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t3.get "bar3" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column overriding an existing column" <|
             t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="foo"
-            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
-            t2.get "foo" . to_vector . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
+            t3 = t2.format "foo" "yyyy-MM-dd HH:mm:ss"
+            t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t3.get "foo" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
 
         group_builder.specify "should gracefully handle columns from different backends" <|
             t1 = build_sorted_table [["A", [1, 2, 3]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -187,6 +187,17 @@ add_core_specs suite_builder setup =
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]
                 Problems.test_problem_handling action2 problems2 tester2
 
+        
+        group_builder.specify "should allow adding a constant text column" <|
+            t2 = data.table.set "Expelliarmus" as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal ["Expelliarmus", "Expelliarmus", "Expelliarmus"]
+
+        group_builder.specify "should allow adding a constant text column overriding an existing column" <|
+            t2 = data.table.set "Expelliarmus" as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal ["Expelliarmus", "Expelliarmus", "Expelliarmus"]
+        
         group_builder.specify "should allow adding a constant integer column" <|
             t2 = data.table.set 42 as="bar3"
             t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
@@ -196,6 +207,46 @@ add_core_specs suite_builder setup =
             t2 = data.table.set 42 as="foo"
             t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
             t2.get "foo" . to_vector . should_equal [42, 42, 42]
+
+        group_builder.specify "should allow adding a constant boolean column" <|
+            t2 = data.table.set True as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal [True, True, True]
+
+        group_builder.specify "should allow adding a constant boolean column overriding an existing column" <|
+            t2 = data.table.set False as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal [False, False, False]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant date column" <|
+            t2 = data.table.set (Date.new 2025 12 9) as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal [Date.new 2025 12 9, Date.new 2025 12 9, Date.new 2025 12 9]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant date column overriding an existing column" <|
+            t2 = data.table.set (Date.new 2025 12 9) as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal [Date.new 2025 12 9, Date.new 2025 12 9, Date.new 2025 12 9]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant time column" <|
+            t2 = data.table.set (Time_Of_Day.new 15 59 15) as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal [Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant time column overriding an existing column" <|
+            t2 = data.table.set (Time_Of_Day.new 15 59 15) as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal [Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column" <|
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.get "bar3" . to_vector . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
+
+        if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column overriding an existing column" <|
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
 
         group_builder.specify "should gracefully handle columns from different backends" <|
             t1 = build_sorted_table [["A", [1, 2, 3]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -187,10 +187,15 @@ add_core_specs suite_builder setup =
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]
                 Problems.test_problem_handling action2 problems2 tester2
 
-        group_builder.specify "qwershould allow adding a constant integer column" <|
+        group_builder.specify "should allow adding a constant integer column" <|
             t2 = data.table.set 42 as="bar3"
             t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
             t2.get "bar3" . to_vector . should_equal [42, 42, 42]
+
+        group_builder.specify "should allow adding a constant integer column overriding an existing column" <|
+            t2 = data.table.set 42 as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.get "foo" . to_vector . should_equal [42, 42, 42]
 
         group_builder.specify "should gracefully handle columns from different backends" <|
             t1 = build_sorted_table [["A", [1, 2, 3]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -239,16 +239,22 @@ add_core_specs suite_builder setup =
             t2.get "foo" . to_vector . should_equal [Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15, Time_Of_Day.new 15 59 15]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column" <|
-            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15 zone=Time_Zone.utc) as="bar3"
-            t3 = t2.read.format "bar3" "yyyy-MM-dd HH:mm:ss"
-            t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
-            t3.get "bar3" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
+            ## The DB may change the timezone of the values, so we need to convert them back to be able to check for equality.
+                   All that we require is that the instant in time represented by the values is preserved.
+            at_system_tz dt =
+                dt.at_zone Time_Zone.system
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="bar3"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
+            t2.at "bar3" . to_vector . map at_system_tz . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column overriding an existing column" <|
-            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15 zone=Time_Zone.utc) as="foo"
-            t3 = t2.read.format "foo" "yyyy-MM-dd HH:mm:ss"
-            t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
-            t3.get "foo" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
+            ## The DB may change the timezone of the values, so we need to convert them back to be able to check for equality.
+                   All that we require is that the instant in time represented by the values is preserved.
+            at_system_tz dt =
+                dt.at_zone Time_Zone.system
+            t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="foo"
+            t2.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
+            t2.at "foo" . to_vector . map at_system_tz . should_equal [Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15, Date_Time.new 2025 12 9 15 59 15]
 
         group_builder.specify "should gracefully handle columns from different backends" <|
             t1 = build_sorted_table [["A", [1, 2, 3]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -240,13 +240,13 @@ add_core_specs suite_builder setup =
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column" <|
             t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="bar3"
-            t3 = t2.format "bar3" "yyyy-MM-dd HH:mm:ss"
+            t3 = t2.read.format "bar3" "yyyy-MM-dd HH:mm:ss"
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123","bar3"]
             t3.get "bar3" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
 
         if setup.flagged ..Date_Time then group_builder.specify "should allow adding a constant datetime column overriding an existing column" <|
             t2 = data.table.set (Date_Time.new 2025 12 9 15 59 15) as="foo"
-            t3 = t2.format "foo" "yyyy-MM-dd HH:mm:ss"
+            t3 = t2.read.format "foo" "yyyy-MM-dd HH:mm:ss"
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123"]
             t3.get "foo" . to_vector . should_equal ["2025-12-09 15:59:15", "2025-12-09 15:59:15", "2025-12-09 15:59:15"]
 


### PR DESCRIPTION
### Pull Request Description

- Fixes In-DB set from constant
- Fixes cross_join warning text

<img width="1551" height="444" alt="image" src="https://github.com/user-attachments/assets/77a9c370-3934-4730-8e16-e126f2860e88" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
