### PR TITLE
Ignore tests that rely on external service

### DIFF
--- a/test/Cloud_Tests/src/Network/URI_Spec.enso
+++ b/test/Cloud_Tests/src/Network/URI_Spec.enso
@@ -365,7 +365,7 @@ add_specs suite_builder =
             secret.should_succeed
             Panic.with_finalizer secret.delete (action secret)
 
-        group_builder.specify "EnsoSecreetReader cache should be cleared when a reload is detected" pending=cloud_setup.pending <| Test.with_retries <|
+        group_builder.specify "EnsoSecreetReader cache should be cleared when a reload is detected" pending="https://github.com/enso-org/enso/issues/12575" <| Test.with_retries <|
             cloud_setup.with_prepared_environment <|
                 with_secret secret1-> with_secret secret2->
                     base_uri = URI.from 'https://httpbin.org/bytes/50'


### PR DESCRIPTION
Part of #12575

### Pull Request Description

Ignore a test that uses `httpbin.org` service, which is down for several days.

