### PR TITLE
Reduce max height of file browser and make all corners rounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [GeoMap visualization is now working without need of Mapbox Token in
   environment][14429]
 - [Fix non-visible button and wrong layout in GeoMap Visualization][14443]
+- [Maximum height of the file browser is slightly reduced][14467]
 
 [13685]: https://github.com/enso-org/enso/pull/13685
 [13658]: https://github.com/enso-org/enso/pull/13658
@@ -58,6 +59,7 @@
 [14403]: https://github.com/enso-org/enso/pull/14403
 [14429]: https://github.com/enso-org/enso/pull/14429
 [14443]: https://github.com/enso-org/enso/pull/14443
+[14467]: https://github.com/enso-org/enso/pull/14467
 
 #### Enso Standard Library
 

--- a/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
+++ b/app/gui/src/project-view/components/widgets/FileBrowserWidget.vue
@@ -274,10 +274,10 @@ registerHandlers({
   --corner-radius: var(--file-browser-corner-radius, var(--radius-default));
   background-color: var(--background-color);
   padding: var(--border-width);
-  border-radius: 0 0 var(--corner-radius) var(--corner-radius);
+  border-radius: var(--corner-radius);
   min-width: var(--file-browser-min-width, 400px);
   min-height: 200px;
-  max-height: 600px;
+  max-height: 412px;
   overflow: hidden;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Pull Request Description

Fixes #14425 

Reducing max height of file browser to reasonable 12½ items. Also I made top corners rounded, it looks quite weird otherwise. (it still looks weird after this change)

<img width="1352" height="960" alt="CleanShot 2025-12-10 at 15 24 27@2x" src="https://github.com/user-attachments/assets/f4713ff8-da73-4f79-9cfd-bd158ed3332b" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
