### PR TITLE
Tweak styling for type labels

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useGraphStore } from '$/components/WithCurrentProject.vue'
 import CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
-import ComponentEditorLabel from '@/components/ComponentBrowser/ComponentEditorLabel.vue'
+import componentTypeLabel from '@/components/ComponentBrowser/componentTypeLabel.vue'
 import type { ComponentBrowserMode, Usage } from '@/components/ComponentBrowser/input'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useCodeMirror, useStringSync } from '@/util/codemirror'
@@ -76,8 +76,8 @@ const rootStyle = computed(() => {
     </div>
     <div class="componentEditorContent">
       <CodeMirrorRoot ref="editorRoot" class="componentEditorInput" />
-      <div v-if="props.mode.mode === 'componentBrowsing'" class="componentEditorLabel">
-        <ComponentEditorLabel
+      <div v-if="props.mode.mode === 'componentBrowsing'" class="componentTypeLabel">
+        <componentTypeLabel
           testId="component-editor-label"
           :typeInfo="
             props.mode.filter.selfArg?.type === 'known' ?
@@ -133,7 +133,7 @@ const rootStyle = computed(() => {
   flex-grow: 1;
 }
 
-.componentEditorLabel {
-  margin: 0 4px;
+.componentTypeLabel {
+  margin: 0 0px;
 }
 </style>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -76,7 +76,7 @@ const rootStyle = computed(() => {
     </div>
     <div class="componentEditorContent">
       <CodeMirrorRoot ref="editorRoot" class="componentEditorInput" />
-      <div v-if="props.mode.mode === 'componentBrowsing'" class="ComponentTypeLabel">
+      <div v-if="props.mode.mode === 'componentBrowsing'" class="typeLabel">
         <ComponentTypeLabel
           testId="component-editor-label"
           :typeInfo="
@@ -133,7 +133,7 @@ const rootStyle = computed(() => {
   flex-grow: 1;
 }
 
-.ComponentTypeLabel {
+.typeLabel {
   margin: 0 0px;
 }
 </style>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useGraphStore } from '$/components/WithCurrentProject.vue'
 import CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
-import componentTypeLabel from '@/components/ComponentBrowser/componentTypeLabel.vue'
+import ComponentTypeLabel from '@/components/ComponentBrowser/ComponentTypeLabel.vue'
 import type { ComponentBrowserMode, Usage } from '@/components/ComponentBrowser/input'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useCodeMirror, useStringSync } from '@/util/codemirror'
@@ -76,8 +76,8 @@ const rootStyle = computed(() => {
     </div>
     <div class="componentEditorContent">
       <CodeMirrorRoot ref="editorRoot" class="componentEditorInput" />
-      <div v-if="props.mode.mode === 'componentBrowsing'" class="componentTypeLabel">
-        <componentTypeLabel
+      <div v-if="props.mode.mode === 'componentBrowsing'" class="ComponentTypeLabel">
+        <ComponentTypeLabel
           testId="component-editor-label"
           :typeInfo="
             props.mode.filter.selfArg?.type === 'known' ?
@@ -133,7 +133,7 @@ const rootStyle = computed(() => {
   flex-grow: 1;
 }
 
-.componentTypeLabel {
+.ComponentTypeLabel {
   margin: 0 0px;
 }
 </style>

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
@@ -44,7 +44,7 @@ const label = computed(() => {
   <div v-if="label" :data-testid="props.testId" class="typeLabelBackground">
     <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1" :showOnClick="true">
       <template #default="triggerProps">
-        <span class="additionalTypesPlaceholder" v-bind="triggerProps" v-text="`${label}...`" />
+        <span v-bind="triggerProps" v-text="`${label}...`" />
       </template>
       <template #tooltip>
         <div class="flex flex-col">

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
@@ -41,7 +41,7 @@ const label = computed(() => {
 </script>
 
 <template>
-  <div v-if="label" :data-testid="props.testId" class="componentTypeLabel">
+  <div v-if="label" :data-testid="props.testId" class="typeLabelBackground">
     <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1" :showOnClick="true">
       <template #default="triggerProps">
         <span class="additionalTypesPlaceholder" v-bind="triggerProps" v-text="`${label}...`" />
@@ -58,7 +58,7 @@ const label = computed(() => {
 </template>
 
 <style scoped>
-.componentTypeLabel {
+.typeLabelBackground {
   background-color: rgba(0, 0, 0, 0.1);
   padding: 3px 6px;
   border-radius: 20px;

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
@@ -41,13 +41,13 @@ const label = computed(() => {
 </script>
 
 <template>
-  <div v-if="label" :data-testid="props.testId" class="componentEditorLabel">
+  <div v-if="label" :data-testid="props.testId" class="componentTypeLabel">
     <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1" :showOnClick="true">
       <template #default="triggerProps">
         <span
           class="additionalTypesPlaceholder"
           v-bind="triggerProps"
-          v-text="`${label} & +${additionalTypes.length + hiddenTypes.length - 1}`"
+          v-text="`${label}...`"
         />
       </template>
       <template #tooltip>
@@ -62,15 +62,10 @@ const label = computed(() => {
 </template>
 
 <style scoped>
-.additionalTypesPlaceholder {
+.componentTypeLabel {
   background-color: rgba(0, 0, 0, 0.1);
-  padding: 1px 3px;
-  border-radius: 2px;
-}
-
-.componentEditorLabel {
-  white-space: nowrap;
-  opacity: 0.7;
+  padding: 3px 6px;
+  border-radius: 20px;
 }
 
 .hiddenType {

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
@@ -41,7 +41,7 @@ const label = computed(() => {
 </script>
 
 <template>
-  <div v-if="label" :data-testid="props.testId" class="typeLabelBackground">
+  <div v-if="label" :data-testid="props.testId" class="ComponentTypeLabel">
     <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1" :showOnClick="true">
       <template #default="triggerProps">
         <span v-bind="triggerProps" v-text="`${label}...`" />
@@ -58,7 +58,7 @@ const label = computed(() => {
 </template>
 
 <style scoped>
-.typeLabelBackground {
+.ComponentTypeLabel {
   background-color: rgba(0, 0, 0, 0.1);
   padding: 3px 6px;
   border-radius: 20px;

--- a/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
+++ b/app/gui/src/project-view/components/ComponentBrowser/ComponentTypeLabel.vue
@@ -44,11 +44,7 @@ const label = computed(() => {
   <div v-if="label" :data-testid="props.testId" class="componentTypeLabel">
     <TooltipTrigger v-if="additionalTypes.length + hiddenTypes.length > 1" :showOnClick="true">
       <template #default="triggerProps">
-        <span
-          class="additionalTypesPlaceholder"
-          v-bind="triggerProps"
-          v-text="`${label}...`"
-        />
+        <span class="additionalTypesPlaceholder" v-bind="triggerProps" v-text="`${label}...`" />
       </template>
       <template #tooltip>
         <div class="flex flex-col">

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TypeInfo } from '$/providers/openedProjects/project/computedValueRegistry'
 import ActionButton from '@/components/ActionButton.vue'
-import componentTypeLabel from '@/components/ComponentBrowser/componentTypeLabel.vue'
+import ComponentTypeLabel from '@/components/ComponentBrowser/ComponentTypeLabel.vue'
 import { useVisualizationSelector } from '@/components/GraphEditor/GraphVisualization/visualizationSelector'
 import SelectionDropdown from '@/components/SelectionDropdown.vue'
 import SelectionDropdownText from '@/components/SelectionDropdownText.vue'
@@ -86,7 +86,7 @@ const visualizationSelector = useVisualizationSelector({
       </div>
     </template>
     <div class="after-toolbars node-type" data-testid="visualisationNodeType">
-      <componentTypeLabel
+      <ComponentTypeLabel
         v-if="props.typeinfo"
         :unknownLabel="UNKNOWN_TYPE"
         :typeInfo="props.typeinfo"

--- a/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphVisualization/VisualizationToolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TypeInfo } from '$/providers/openedProjects/project/computedValueRegistry'
 import ActionButton from '@/components/ActionButton.vue'
-import ComponentEditorLabel from '@/components/ComponentBrowser/ComponentEditorLabel.vue'
+import componentTypeLabel from '@/components/ComponentBrowser/componentTypeLabel.vue'
 import { useVisualizationSelector } from '@/components/GraphEditor/GraphVisualization/visualizationSelector'
 import SelectionDropdown from '@/components/SelectionDropdown.vue'
 import SelectionDropdownText from '@/components/SelectionDropdownText.vue'
@@ -86,7 +86,7 @@ const visualizationSelector = useVisualizationSelector({
       </div>
     </template>
     <div class="after-toolbars node-type" data-testid="visualisationNodeType">
-      <ComponentEditorLabel
+      <componentTypeLabel
         v-if="props.typeinfo"
         :unknownLabel="UNKNOWN_TYPE"
         :typeInfo="props.typeinfo"
@@ -115,6 +115,8 @@ const visualizationSelector = useVisualizationSelector({
   margin-left: auto;
   margin-right: 8px;
   overflow: hidden;
+  display: flex;
+  align-items: center;
 }
 
 .node-type {


### PR DESCRIPTION
### Pull Request Description

This 
- Standardises the styling for Plain types and intersection types
- Makes the styling match the Enso style (No right angles)
- Removes the & +4 in favour of a more standard ... indicating there are more than just the base type

Before:

<img width="427" height="209" alt="image" src="https://github.com/user-attachments/assets/86bd86bb-9641-4208-b028-1dc45e635256" />

After:

<img width="425" height="198" alt="image" src="https://github.com/user-attachments/assets/e2296d7a-814f-4be6-9e79-07ec564a913b" />

Before:

<img width="149" height="162" alt="image" src="https://github.com/user-attachments/assets/f510838a-7558-4b91-a614-22c39a093c28" />

After:

<img width="176" height="156" alt="image" src="https://github.com/user-attachments/assets/877b97bc-1975-43c1-ae1c-ae1d69f652f3" />

Before:

<img width="784" height="167" alt="image" src="https://github.com/user-attachments/assets/16b489a7-93ef-4db5-969f-5cf123ebae93" />

After:

<img width="731" height="189" alt="image" src="https://github.com/user-attachments/assets/525a92b6-284d-4f02-9fe2-30feb9cfab75" />

Before:

<img width="768" height="190" alt="image" src="https://github.com/user-attachments/assets/741fb249-040c-4ffe-92a3-94dbc663080f" />

After:

<img width="793" height="219" alt="image" src="https://github.com/user-attachments/assets/2db3e27c-9fc7-40d7-a353-f6e633ff1f62" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
