### PR TITLE
Arrow-like variable size index for TextType off-heap storage

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
@@ -194,7 +194,9 @@ public class DebugLocalScope extends EnsoObject {
     if (value != null) {
       var ensoLang = EnsoLanguage.get(interop);
       var ensoCtx = EnsoContext.get(interop);
-      value = ensoLang.getLanguageView(ensoCtx, value);
+      if (ensoLang != null) {
+        value = ensoLang.getLanguageView(ensoCtx, value);
+      }
     }
     return value != null ? value : DataflowError.UNINITIALIZED;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -119,6 +119,8 @@ public interface Builder {
                 LongBuilder.fromAddress(size, data, validity, type).seal(storage, type);
             case FloatType type ->
                 DoubleBuilder.fromAddress(size, data, validity, type).seal(storage, type);
+            case TextType type ->
+                StringBuilder.fromAddress(size, data, validity, type).seal(storage, type);
             default -> storage;
           };
       assert assertSameStorages(storage, localStorage);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -1,6 +1,11 @@
 package org.enso.table.data.column.builder;
 
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
 import org.enso.table.data.column.storage.ColumnStorage;
+import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.TypedStorage;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.error.ValueTypeMismatchException;
@@ -12,6 +17,36 @@ final class StringBuilder extends TypedBuilder<String> {
   StringBuilder(int size, TextType type) {
     super(type, new String[size]);
     this.type = type;
+  }
+
+  static StringBuilder fromAddress(int size, long data, long validity, TextType type) {
+    var validityBuffer =
+        MemorySegment.ofAddress(validity).reinterpret((size + 7) / 8).asByteBuffer();
+    var bits = BitSet.valueOf(validityBuffer);
+    var rawIndexBuffer =
+        MemorySegment.ofAddress(data)
+            .reinterpret(Integer.BYTES * size + Integer.BYTES)
+            .asByteBuffer()
+            .order(ByteOrder.LITTLE_ENDIAN);
+    var indexBuffer = rawIndexBuffer.asIntBuffer();
+    var textSize = indexBuffer.get(size);
+    var textBuffer =
+        MemorySegment.ofAddress(data + indexBuffer.limit()).reinterpret(textSize).asByteBuffer();
+
+    var b = new StringBuilder(size, type);
+    for (var i = 0; i < size; i++) {
+      if (bits.get(i)) {
+        var from = indexBuffer.get(i);
+        var to = indexBuffer.get(i + 1);
+        var arr = new byte[to - from];
+        textBuffer.get(from, arr);
+        var s = new String(arr, StandardCharsets.UTF_8);
+        b.append(s);
+      } else {
+        b.appendNulls(1);
+      }
+    }
+    return b;
   }
 
   @Override
@@ -64,5 +99,9 @@ final class StringBuilder extends TypedBuilder<String> {
   @Override
   protected ColumnStorage<String> doSeal() {
     return new TypedStorage<>(type, data);
+  }
+
+  final Storage<String> seal(ColumnStorage<?> otherStorage, TextType type) {
+    return new TypedStorage<>(type, data, otherStorage);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -31,7 +31,7 @@ final class StringBuilder extends TypedBuilder<String> {
     var indexBuffer = rawIndexBuffer.asIntBuffer();
     var textSize = indexBuffer.get(size);
     var textBuffer =
-        MemorySegment.ofAddress(data + indexBuffer.limit()).reinterpret(textSize).asByteBuffer();
+        MemorySegment.ofAddress(data + rawIndexBuffer.limit()).reinterpret(textSize).asByteBuffer();
 
     var b = new StringBuilder(size, type);
     for (var i = 0; i < size; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -51,17 +51,22 @@ public class TypedStorage<T> extends Storage<T> {
       buf.position(indexSize);
       var validity = new BitSet();
       for (var value : data) {
+        var at = index.position();
         index.put(buf.position() - indexSize);
         if (value instanceof String s) {
-          validity.set(index.position(), true);
-          buf.put(s.getBytes(StandardCharsets.UTF_8));
+          validity.set(at, true);
         } else {
-          validity.set(index.position(), false);
+          validity.set(at, false);
+          continue;
         }
+        buf.put(s.getBytes(StandardCharsets.UTF_8));
       }
       assert buf.limit() == buf.position();
       index.put(buf.position() - indexSize);
+      assert index.position() == index.limit();
       buf.flip();
+      assert buf.position() == 0;
+      assert buf.limit() == fullSize;
       offheapBuffer = buf;
       validitySet = new ImmutableBitSet(validity, data.length);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -1,19 +1,83 @@
 package org.enso.table.data.column.storage;
 
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Iterator;
 import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.data.column.storage.type.TextType;
+import org.enso.table.util.ImmutableBitSet;
 
 public class TypedStorage<T> extends Storage<T> {
+  private final T[] data;
+  private final ColumnStorage<?> proxy;
+  private ByteBuffer offheapBuffer;
+  private ImmutableBitSet validitySet;
+
   /**
    * @param data the underlying data
    */
   public TypedStorage(StorageType<T> type, T[] data) {
-    super(type);
-    this.data = data;
+    this(type, data, null);
   }
 
-  protected final T[] data;
+  public TypedStorage(StorageType<T> type, T[] data, ColumnStorage<?> proxy) {
+    super(type);
+    this.data = data;
+    this.proxy = proxy;
+  }
+
+  @Override
+  public long addressOfData() {
+    if (offheapBuffer == null && getType() instanceof TextType) {
+      var textSize = 0;
+      for (var value : data) {
+        if (value instanceof String s) {
+          textSize += s.getBytes(StandardCharsets.UTF_8).length;
+        } else {
+          if (value != null) {
+            return 0L;
+          }
+        }
+      }
+
+      var indexSize = data.length * Integer.BYTES + Integer.BYTES;
+      var fullSize = indexSize + textSize;
+      var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
+      var index = buf.asIntBuffer().slice(0, data.length + 1);
+      buf.position(indexSize);
+      var validity = new BitSet();
+      for (var value : data) {
+        index.put(buf.position() - indexSize);
+        if (value instanceof String s) {
+          validity.set(index.position(), true);
+          buf.put(s.getBytes(StandardCharsets.UTF_8));
+        } else {
+          validity.set(index.position(), false);
+        }
+      }
+      assert buf.limit() == buf.position();
+      index.put(buf.position() - indexSize);
+      buf.flip();
+      offheapBuffer = buf;
+      validitySet = new ImmutableBitSet(validity, data.length);
+    }
+    if (offheapBuffer != null) {
+      return MemorySegment.ofBuffer(offheapBuffer).address();
+    }
+    return 0L;
+  }
+
+  @Override
+  public long addressOfValidity() {
+    if (addressOfData() != 0L) {
+      return MemorySegment.ofBuffer(validitySet.rawData()).address();
+    }
+    return 0L;
+  }
 
   @Override
   public final long getSize() {

--- a/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/StringStorageTest.java
+++ b/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/StringStorageTest.java
@@ -1,0 +1,37 @@
+package org.enso.base.polyglot.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import org.enso.table.data.column.builder.Builder;
+import org.enso.table.data.column.storage.type.TextType;
+import org.enso.test.utils.ContextUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class StringStorageTest {
+  @ClassRule
+  public static final ContextUtils ctx = ContextUtils.newBuilder("enso").assertGC(false).build();
+
+  @BeforeClass
+  public static void importAll() {
+    ctx.eval("enso", "from Standard.Base import all");
+  }
+
+  @Test
+  public void makeLocalFromStringStorage() {
+    var b = Builder.getForText(TextType.VARIABLE_LENGTH, 3);
+    b.append("Hello").appendNulls(1).append("World!");
+    var storage = b.seal();
+    var localStorage = Builder.makeLocal(storage);
+    assertNotSame("local storage is a copy of storage", storage, localStorage);
+    assertEquals("They have the same size", storage.getSize(), localStorage.getSize());
+    assertEquals("They have the same type", storage.getType(), localStorage.getType());
+    for (var i = 0L; i < storage.getSize(); i++) {
+      var elem = storage.getItemBoxed(i);
+      var localElem = localStorage.getItemBoxed(i);
+      assertEquals("At " + i, elem, localElem);
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description

- in tradition of #14459
- and  #14436
- and #14309
- let's transfer `TextType` off-heap between the _dual JVMs_

### Important Notes

- attempts to follow [Variable-size Binary Layout](https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-layout)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
