### PR TITLE
Small GUI fixes

### DIFF
--- a/app/common/src/text/english.json
+++ b/app/common/src/text/english.json
@@ -1256,6 +1256,8 @@
   "trialEnded": "Your cloud access trial period has endend.",
   "trialEndedExplanation": "You can proceed to checkout and extend your access or you can downgrade to Community plan. After the subscribe you will be redirected to Stripe to finalize your order.",
   "trialEndedWarning": "Moving to Community plan will discard your access to all of your cloud assets. We will permanently remove them after 90 days.",
+  "trialProgressLabel": "Trial progress",
+  "notificationProgressLabel": "Task progress",
   "downgradedTitle": "Cloud Assets Removal",
   "downgradedExplanation": "You have recently downgraded your plan to Community, which means you can no longer store assets in cloud.",
   "downgradedWarning": "We will permanently remove all of your cloud assets in $0 days and $1 hours.",

--- a/app/gui/integration-test/project-view/edgeInteractions.spec.ts
+++ b/app/gui/integration-test/project-view/edgeInteractions.spec.ts
@@ -111,7 +111,7 @@ test('Conditional ports: Disabled', async ({ editorPage, page }) => {
   const outputPort = await outputPortCoordinates(page, graphNodeByBinding(page, 'final'))
   await page.mouse.click(outputPort.x, outputPort.y)
   await conditionalPort.hover()
-  await expect(conditionalPort).not.toHaveClass(/isTarget/)
+  await expect(conditionalPort).not.toHaveClass(/isVisualTarget/)
   // We need `force: true` because ComponentBrowser appears in event's capture phase, what
   // confuses playwright's actionability checks.
   await conditionalPort.click({ force: true })
@@ -131,7 +131,7 @@ test('Conditional ports: Enabled', async ({ editorPage, page }) => {
   await expect(conditionalPort).toHaveClass(/enabled/)
 
   await conditionalPort.hover()
-  await expect(conditionalPort).toHaveClass(/isTarget/)
+  await expect(conditionalPort).toHaveClass(/isVisualTarget/)
   // We need to force port clicks; see comment in 'Connect an node to a port via dragging the edge'
   await conditionalPort.click({ force: true })
   await expect(node.locator('.WidgetToken')).toHaveText(['final'])

--- a/app/gui/integration-test/project-view/undoRedo.spec.ts
+++ b/app/gui/integration-test/project-view/undoRedo.spec.ts
@@ -61,7 +61,7 @@ test('Removing node', async ({ editorPage, page }) => {
   const nodesCount = await locate.graphNode(page).count()
   const deletedNode = locate.graphNodeByBinding(page, 'final')
   const deletedNodeBBox = await deletedNode.boundingBox()
-  await deletedNode.click()
+  await deletedNode.locator('.grab-handle').click()
   await page.keyboard.press(DELETE_KEY)
   await expect(locate.graphNode(page)).toHaveCount(nodesCount - 1)
 

--- a/app/gui/src/dashboard/pages/dashboard/UserBar/NotificationTray/NotificationItem.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/UserBar/NotificationTray/NotificationItem.tsx
@@ -25,7 +25,7 @@ export interface NotificationItemProps extends NotificationInfo {
 /** An item in the notification tray. */
 export function NotificationItem(props: NotificationItemProps) {
   const { message, icon, progress, color, timestamp, remove } = props
-  const { locale } = useText()
+  const { locale, getText } = useText()
   const dateTime = timestamp != null ? new Date(timestamp) : undefined
 
   const styles = NOTIFICATION_ITEM_STYLES()
@@ -48,7 +48,9 @@ export function NotificationItem(props: NotificationItemProps) {
         )}
         <CloseButton className={remove ? '' : 'invisible'} onPress={remove} />
       </div>
-      {progress != null && <ProgressBar progress={progress} />}
+      {progress != null && (
+        <ProgressBar progress={progress} aria-label={getText('notificationProgressLabel')} />
+      )}
     </div>
   )
 }

--- a/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
+++ b/app/gui/src/dashboard/pages/dashboard/UserBar/UserBar.tsx
@@ -115,6 +115,7 @@ export function UserBar(props: UserBarProps) {
               variant="clipped"
               className="absolute inset-0"
               progressBarClassName="bg-accent/50"
+              aria-label={getText('trialProgressLabel')}
             />
             <Text className="absolute inset-0 mx-2 cursor-help text-center">{trialText}</Text>
           </VisualTooltip>

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodeOutputPorts.vue
@@ -172,15 +172,26 @@ function portGroupStyle(port: PortData) {
 function isPlusButtonVisible(portId: AstId): boolean {
   return !componentBrowserOpened.value && isPortDisconnected(portId)
 }
+function resetHoverState() {
+  mouseOverOutput.value = undefined
+  mouseOverCreateNodeFromPortButton.value = 0
+}
+
 // Opening component browser should manually clear output hover state, because
 // plus button disappears when component browser opens, and we cannot receive pointerleave event
 // in this case.
 watch(componentBrowserOpened, (opened) => {
-  if (opened) {
-    mouseOverOutput.value = undefined
-    mouseOverCreateNodeFromPortButton.value = 0
-  }
+  if (opened) resetHoverState()
 })
+
+// When the plus button becomes invisible for the currently hovered port, we want to reset the hover state.
+// This because we won’t receive a pointerleave event in this case.
+watch(
+  () => mouseOverOutput.value && isPlusButtonVisible(mouseOverOutput.value),
+  (visible, prevVisible) => {
+    if (prevVisible && !visible) resetHoverState()
+  },
+)
 
 graph.value?.suggestEdgeFromOutput(outputHovered)
 </script>

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetArgumentName.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetArgumentName.vue
@@ -32,7 +32,7 @@ const sameInputParentWidgets = computed(() =>
 const showArgumentValue = computed(() => {
   return (
     portInfo == null ||
-    !portInfo.connected ||
+    !portInfo.hasPersistedConnection ||
     (WidgetInput.isAst(props.input) && portInfo.portId !== props.input.value?.id)
   )
 })
@@ -50,7 +50,7 @@ const innerInput = computed(() => ({
 
 const childWidgetRef = useTemplateRef<typeof NodeWidget>('childWidgetRef')
 const isChildWidgetEmpty = computed(() => !childWidgetRef.value?.isSelected)
-const connected = computed(() => portInfo?.connected ?? false)
+const visuallyHideArrow = computed(() => portInfo?.isVisualTarget ?? false)
 const showArrow = computed(() => {
   const selectionWidgetsShown =
     sameInputParentWidgets.value?.has(WidgetSelection) ||
@@ -88,7 +88,7 @@ export const ArgumentNameShownKey: unique symbol = Symbol.for('WidgetInput:Argum
   <div class="WidgetArgumentName widgetParent" :class="{ primary, missing }">
     <RequiredArgumentArrow
       v-if="showArrow"
-      :hide="connected"
+      :hide="visuallyHideArrow"
       @arrowClick="graph.createEdgeFromPort(props.input.portId, $event)"
     />
     <span class="name widgetSingleLine">

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetPort.vue
@@ -41,23 +41,21 @@ const navigator = injectGraphNavigator(true)
 const tree = injectWidgetTree()
 const selection = useGraphSelection(true)
 
-const hasConnection = computed(() => graph.isConnectedTarget(portId.value))
-const isCurrentEdgeHoverTarget = computed(
-  () =>
+const hasPersistedConnection = computed(() => graph.isConnectedTarget(portId.value))
+const isBeingDraggedAwayFrom = computed(() => graph.isTargetBeingDraggedAwayFrom(portId.value))
+const isCurrentEdgeHoverTarget = computed(() => {
+  const edgeSourceAtThisNode =
     graph.mouseEditedEdge?.source != null &&
-    selection?.hoveredPort === portId.value &&
-    (tree.externalId == null ||
-      graph.db.getPatternExpressionNodeId(graph.mouseEditedEdge.source) !== tree.externalId),
+    tree.externalId != null &&
+    graph.db.getPatternExpressionNodeId(graph.mouseEditedEdge.source) === tree.externalId
+  return selection?.hoveredPort === portId.value && !edgeSourceAtThisNode
+})
+const showConnectedStyle = computed(
+  () => hasPersistedConnection.value || isCurrentEdgeHoverTarget.value,
 )
-const isCurrentDisconnectedEdgeTarget = computed(
+const isVisualTarget = computed(
   () =>
-    graph.mouseEditedEdge?.disconnectedEdgeTarget === portId.value &&
-    graph.mouseEditedEdge?.target !== portId.value,
-)
-const connected = computed(() => hasConnection.value || isCurrentEdgeHoverTarget.value)
-const isTarget = computed(
-  () =>
-    (hasConnection.value && !isCurrentDisconnectedEdgeTarget.value) ||
+    (hasPersistedConnection.value && !isBeingDraggedAwayFrom.value) ||
     isCurrentEdgeHoverTarget.value,
 )
 
@@ -87,7 +85,7 @@ const innerWidget = computed(() => {
   return { ...props.input, forcePort: false }
 })
 
-providePortInfo(proxyRefs({ portId, connected }))
+providePortInfo(proxyRefs({ portId, hasPersistedConnection, isVisualTarget }))
 
 watchEffect(
   (onCleanup) => {
@@ -199,10 +197,10 @@ export const widgetDefinition = defineWidget(
     :data-port="props.input.portId"
     :class="{
       enabled,
-      connected,
-      isTarget,
-      widgetRounded: connected,
-      newToConnect: !hasConnection && isCurrentEdgeHoverTarget,
+      connected: showConnectedStyle,
+      isVisualTarget,
+      widgetRounded: showConnectedStyle,
+      newToConnect: !hasPersistedConnection && isCurrentEdgeHoverTarget,
       primary: props.nesting < 2,
     }"
   >

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
@@ -33,8 +33,10 @@ function sizeOptions(limitWidth: boolean): () => SizeOptions {
       const minWidth = `${Math.max(portWidth - screenOverflow, 0)}px`
       const maxWidth = getMaxWidth(portWidth, limitWidth)
 
-      Object.assign(elements.floating.style, { minWidth, maxWidth })
-      elements.floating.style.setProperty('--dropdown-max-width', maxWidth)
+      requestAnimationFrame(() => {
+        Object.assign(elements.floating.style, { minWidth, maxWidth })
+        elements.floating.style.setProperty('--dropdown-max-width', maxWidth)
+      })
     },
   })
 }

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
@@ -29,6 +29,7 @@ function sizeOptions(limitWidth: boolean): () => SizeOptions {
       const minWidth = `${Math.max(portWidth - screenOverflow, 0)}px`
       const maxWidth = limitWidth ? `${MAX_DROPDOWN_OVERSIZE_PX}px` : null
 
+      // Delay changing styles to avoid "ResizeObserver loop completed with undelivered notifications" error.
       requestAnimationFrame(() => {
         Object.assign(elements.floating.style, { minWidth, maxWidth })
         elements.floating.style.setProperty('--dropdown-max-width', maxWidth)

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetSelection/styles.ts
@@ -14,10 +14,6 @@ import { computed, type Ref } from 'vue'
 // Any text beyond that limit will receive an ellipsis and sliding animation on hover.
 const MAX_DROPDOWN_OVERSIZE_PX = 390
 
-function getMaxWidth(portWidth: number, limitWidth: boolean) {
-  return limitWidth ? `${portWidth + MAX_DROPDOWN_OVERSIZE_PX}px` : null
-}
-
 /** Limit the width of the dropdown to the width of the port. */
 function sizeOptions(limitWidth: boolean): () => SizeOptions {
   return () => ({
@@ -31,7 +27,7 @@ function sizeOptions(limitWidth: boolean): () => SizeOptions {
       const portWidth = rects.reference.width + PORT_PADDING_X * 2
 
       const minWidth = `${Math.max(portWidth - screenOverflow, 0)}px`
-      const maxWidth = getMaxWidth(portWidth, limitWidth)
+      const maxWidth = limitWidth ? `${MAX_DROPDOWN_OVERSIZE_PX}px` : null
 
       requestAnimationFrame(() => {
         Object.assign(elements.floating.style, { minWidth, maxWidth })

--- a/app/gui/src/project-view/components/widgets/DropdownWidget.vue
+++ b/app/gui/src/project-view/components/widgets/DropdownWidget.vue
@@ -170,7 +170,7 @@ export interface DropdownEntry {
   display: inline-block;
   max-width: 100%;
   white-space: nowrap;
-  overflow: hidden;
+  overflow: clip;
   vertical-align: middle;
   margin: 3px 0;
   text-wrap: nowrap;

--- a/app/gui/src/project-view/providers/portInfo.ts
+++ b/app/gui/src/project-view/providers/portInfo.ts
@@ -19,7 +19,10 @@ export function syntheticPortId(base: PortId, key: string | number): PortId {
 
 interface PortInfo {
   portId: PortId
-  connected: boolean
+  /** Has a persisted connection in the graph database. */
+  hasPersistedConnection: boolean
+  /** An edge visually points to this port, e.g. when hovering with mouse. */
+  isVisualTarget: boolean
 }
 
 export const [providePortInfo, injectPortInfo] = createContextStore('Port info', identity<PortInfo>)

--- a/app/gui/src/providers/openedProjects/graph/graph.ts
+++ b/app/gui/src/providers/openedProjects/graph/graph.ts
@@ -679,9 +679,15 @@ export function createGraphStore(
   }
 
   function isConnectedTarget(portId: PortId): boolean {
+    return isAstId(portId) && db.connections.reverseLookup(portId).size > 0
+  }
+
+  function isTargetBeingDraggedAwayFrom(portId: PortId): boolean {
+    const edge = unconnectedEdges.mouseEditedEdge.value
     return (
-      (isAstId(portId) && db.connections.reverseLookup(portId).size > 0) ||
-      unconnectedEdges.mouseEditedEdge.value?.target === portId
+      edge?.createdFrom === 'edge' &&
+      edge?.target !== portId &&
+      edge?.disconnectedEdgeTarget === portId
     )
   }
 
@@ -735,6 +741,7 @@ export function createGraphStore(
     onBeforeEdit,
     isConnectedSource,
     isConnectedTarget,
+    isTargetBeingDraggedAwayFrom,
     nodeCanBeEntered,
     connectedEdges,
     currentMethod: proxyRefs({


### PR DESCRIPTION
### Pull Request Description

Fixes #14440 
Fixes #14470 

- Fixes accessibility warnings in console from ProgressBar React component.
- Fixes errors in console about `ResizeObserver`
- Dropdown width no longer depends on port width, because it introduces unpleasant jumping when hovering the port.
- Animation of scrolling text when hovering long items in dropdown is restored

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
