### PR TITLE
Track self argument as a dependent of application

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -351,6 +351,16 @@ case object DataflowAnalysis extends IRPass {
         val fnDep     = asStatic(prefix.function)
         val prefixDep = asStatic(prefix)
         info.dependents.updateAt(fnDep, Set(prefixDep))
+        prefix.arguments().headOption.map(_.value()).foreach {
+          case literalSelfArg: Name.Literal =>
+            // Self arguments are cached, so whenever the type (or method in it)
+            // changes, then it should be invalidated as well.
+            // Tracking a dependency between the application
+            // and the self argument ensures correct invalidation.
+            val selfArgDep = asStatic(literalSelfArg)
+            info.dependents.updateAt(prefixDep, Set(selfArgDep))
+          case _ =>
+        }
         info.dependencies.updateAt(prefixDep, Set(fnDep))
         prefix.arguments.foreach(arg => {
           val argDep = asStatic(arg)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -408,7 +408,15 @@ class DataflowAnalysisTest extends CompilerTest {
 
     "correctly identify global symbol indirect dependents" in {
       depInfo.dependents.get(frobnicateSymbol) shouldEqual Some(
-        Set(frobFnId, frobExprId, fnBodyId, fnId, methodId)
+        Set(
+          frobFnId,
+          frobExprId,
+          fnBodyId,
+          fnId,
+          methodId,
+          frobArgAId,
+          frobArgAExprId
+        )
       )
       depInfo.dependents.get(ioSymbol) shouldEqual Some(
         Set(printlnArgIOExprId, printlnArgIOId, printlnExprId)
@@ -420,7 +428,11 @@ class DataflowAnalysisTest extends CompilerTest {
         Set(
           plusExprFnId,
           plusExprId,
+          plusExprArgAExprId,
+          plusExprArgAId,
           cBindExprId,
+          frobArgAExprId,
+          frobArgAId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -474,7 +486,7 @@ class DataflowAnalysisTest extends CompilerTest {
         Set(cBindExprId)
       )
       depInfo.dependents.getDirect(plusExprId) shouldEqual Some(
-        Set(cBindExprId)
+        Set(cBindExprId, plusExprArgAExprId)
       )
       depInfo.dependents.getDirect(plusExprFnId) shouldEqual Some(
         Set(plusExprId)
@@ -493,7 +505,9 @@ class DataflowAnalysisTest extends CompilerTest {
       )
 
       // The `frobnicate` expression
-      depInfo.dependents.getDirect(frobExprId) shouldEqual Some(Set(fnBodyId))
+      depInfo.dependents.getDirect(frobExprId) shouldEqual Some(
+        Set(fnBodyId, frobArgAExprId)
+      )
       depInfo.dependents.getDirect(frobFnId) shouldEqual Some(Set(frobExprId))
       depInfo.dependents.getDirect(frobArgAId) shouldEqual Some(Set(frobExprId))
       depInfo.dependents.getDirect(frobArgAExprId) shouldEqual Some(
@@ -582,7 +596,11 @@ class DataflowAnalysisTest extends CompilerTest {
           plusExprArgBExprId,
           plusExprArgBId,
           plusExprId,
+          plusExprArgAExprId,
+          plusExprArgAId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -609,11 +627,22 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The `c = ` expression
       depInfo.dependents.get(cBindExprId) shouldEqual Some(
-        Set(frobArgCExprId, frobArgCId, frobExprId, fnBodyId, fnId, methodId)
+        Set(
+          frobArgAId,
+          frobArgAExprId,
+          frobArgCExprId,
+          frobArgCId,
+          frobExprId,
+          fnBodyId,
+          fnId,
+          methodId
+        )
       )
       depInfo.dependents.get(cBindNameId) shouldEqual Some(
         Set(
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -625,6 +654,11 @@ class DataflowAnalysisTest extends CompilerTest {
       depInfo.dependents.get(plusExprId) shouldEqual Some(
         Set(
           cBindExprId,
+          plusExprId,
+          plusExprArgAId,
+          plusExprArgAExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -636,7 +670,11 @@ class DataflowAnalysisTest extends CompilerTest {
       depInfo.dependents.get(plusExprFnId) shouldEqual Some(
         Set(
           plusExprId,
+          plusExprArgAId,
+          plusExprArgAExprId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -647,8 +685,12 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       depInfo.dependents.get(plusExprArgAId) shouldEqual Some(
         Set(
+          plusExprArgAId,
+          plusExprArgAExprId,
           plusExprId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -659,9 +701,12 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       depInfo.dependents.get(plusExprArgAExprId) shouldEqual Some(
         Set(
+          plusExprArgAExprId,
           plusExprArgAId,
           plusExprId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -673,8 +718,12 @@ class DataflowAnalysisTest extends CompilerTest {
 
       depInfo.dependents.get(plusExprArgBId) shouldEqual Some(
         Set(
+          plusExprArgAExprId,
+          plusExprArgAId,
           plusExprId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -685,9 +734,13 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       depInfo.dependents.get(plusExprArgBExprId) shouldEqual Some(
         Set(
+          plusExprArgAExprId,
+          plusExprArgAId,
           plusExprArgBId,
           plusExprId,
           cBindExprId,
+          frobArgAId,
+          frobArgAExprId,
           frobArgCExprId,
           frobArgCId,
           frobExprId,
@@ -700,25 +753,36 @@ class DataflowAnalysisTest extends CompilerTest {
       // The `frobnicate` expression
       depInfo.dependents.get(frobExprId) shouldEqual Some(
         Set(
+          frobArgAExprId,
+          frobArgAId,
+          frobExprId,
           fnBodyId,
           fnId,
           methodId
         )
       )
       depInfo.dependents.get(frobFnId) shouldEqual Some(
-        Set(frobExprId, fnBodyId, fnId, methodId)
+        Set(frobArgAExprId, frobArgAId, frobExprId, fnBodyId, fnId, methodId)
       )
       depInfo.dependents.get(frobArgAId) shouldEqual Some(
-        Set(frobExprId, fnBodyId, fnId, methodId)
+        Set(frobArgAExprId, frobArgAId, frobExprId, fnBodyId, fnId, methodId)
       )
       depInfo.dependents.get(frobArgAExprId) shouldEqual Some(
-        Set(frobArgAId, frobExprId, fnBodyId, fnId, methodId)
+        Set(frobArgAExprId, frobArgAId, frobExprId, fnBodyId, fnId, methodId)
       )
       depInfo.dependents.get(frobArgCId) shouldEqual Some(
-        Set(frobExprId, fnBodyId, fnId, methodId)
+        Set(frobArgAExprId, frobArgAId, frobExprId, fnBodyId, fnId, methodId)
       )
       depInfo.dependents.get(frobArgCExprId) shouldEqual Some(
-        Set(frobArgCId, frobExprId, fnBodyId, fnId, methodId)
+        Set(
+          frobArgAExprId,
+          frobArgAId,
+          frobArgCId,
+          frobExprId,
+          fnBodyId,
+          fnId,
+          methodId
+        )
       )
     }
 
@@ -982,7 +1046,7 @@ class DataflowAnalysisTest extends CompilerTest {
       // The Tests for dependents
       dependents.getDirect(fnId) should not be defined
       dependents.getDirect(fnArgYId) shouldEqual Some(Set(plusArgYExprId))
-      dependents.getDirect(fnBodyId) shouldEqual Some(Set(fnId))
+      dependents.getDirect(fnBodyId) shouldEqual Some(Set(fnId, plusArgXExprId))
       dependents.getDirect(plusSym) shouldEqual Some(Set(plusFnId))
       dependents.getDirect(plusArgXId) shouldEqual Some(Set(fnBodyId))
       dependents.getDirect(plusArgXExprId) shouldEqual Some(Set(plusArgXId))
@@ -1065,7 +1129,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependents.getDirect(lamArgXId) shouldEqual Some(
         Set(mulArg1ExprId, mulArg2ExprId)
       )
-      dependents.getDirect(mulId) shouldEqual Some(Set(lamId))
+      dependents.getDirect(mulId) shouldEqual Some(Set(lamId, mulArg1ExprId))
       dependents.getDirect(mulFnId) shouldEqual Some(Set(mulId))
       dependents.getDirect(mulArg1Id) shouldEqual Some(Set(mulId))
       dependents.getDirect(mulArg1ExprId) shouldEqual Some(Set(mulArg1Id))
@@ -1427,7 +1491,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
 
       dependents.getDirect(consBranchExpressionId) shouldEqual Some(
-        Set(consBranchId)
+        Set(consBranchId, aUseId)
       )
       dependents.getDirect(aArgId) shouldEqual Some(Set(consBranchExpressionId))
       dependents.getDirect(aUseId) shouldEqual Some(Set(aArgId))
@@ -1602,7 +1666,9 @@ class DataflowAnalysisTest extends CompilerTest {
       dependents.getDirect(fnArgThisId) shouldBe empty
       dependents.getDirect(fnArgValueId) shouldBe Some(Set(fooArg1ExprId))
       dependents.getDirect(fnBodyId) shouldBe Some(Set(lambdaId))
-      dependents.getDirect(fooExprId) shouldBe Some(Set(fnBodyId))
+      dependents.getDirect(fooExprId) shouldBe Some(
+        Set(fnBodyId, fooArg1ExprId)
+      )
       dependents.getDirect(fooFunctionId) shouldBe Some(Set(fooExprId))
       dependents.getDirect(fooArg1Id) shouldBe Some(Set(fooExprId))
       dependents.getDirect(fooArg1ExprId) shouldBe Some(Set(fooArg1Id))

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRecomputeTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRecomputeTest.scala
@@ -841,7 +841,7 @@ class RuntimeRecomputeTest
       )
     )
     context.receiveNIgnorePendingExpressionUpdates(
-      4
+      5
     ) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
       TestMessages.update(
@@ -875,6 +875,12 @@ class RuntimeRecomputeTest
             Vector()
           )
         )
+      ),
+      TestMessages.update(
+        contextId,
+        idX,
+        "Enso_Test.Test.Main.Test",
+        typeChanged = false
       ),
       context.executionComplete(contextId)
     )

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -1428,9 +1428,9 @@ class RuntimeRefactoringTest
     val moduleName      = "Enso_Test.Test.Main"
 
     val metadata      = new Metadata
-    val operator1Id   = metadata.addItem(75, 2)
-    val operator2Id   = metadata.addItem(94, 24)
-    val selfOperator2 = metadata.addItem(94, 4)
+    val operator1Id   = metadata.addItem(75, 2, "aa")
+    val operator2Id   = metadata.addItem(94, 24, "ba")
+    val selfOperator2 = metadata.addItem(94, 4, "bb")
     val code =
       """from Standard.Base import all
         |
@@ -1558,7 +1558,7 @@ class RuntimeRefactoringTest
     )
     val afterModificationResponse =
       context.receiveNIgnorePendingExpressionUpdates(
-        3,
+        4,
         timeoutSeconds = 10
       )
     afterModificationResponse should contain allOf (
@@ -1570,7 +1570,13 @@ class RuntimeRefactoringTest
         methodCall = Some(
           Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "function2"))
         )
-      )
+      ),
+      TestMessages.update(
+        contextId,
+        selfOperator2,
+        moduleName,
+        typeChanged = false
+      ),
     )
     context.consumeOut shouldEqual List("42")
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -1422,13 +1422,15 @@ class RuntimeRefactoringTest
   }
 
   it should "rename module method in main body by applying text edit" in {
-    val contextId  = UUID.randomUUID()
-    val requestId  = UUID.randomUUID()
-    val moduleName = "Enso_Test.Test.Main"
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+    val moduleName      = "Enso_Test.Test.Main"
 
-    val metadata    = new Metadata
-    val operator1Id = metadata.addItem(75, 2)
-    val operator2Id = metadata.addItem(94, 24)
+    val metadata      = new Metadata
+    val operator1Id   = metadata.addItem(75, 2)
+    val operator2Id   = metadata.addItem(94, 24)
+    val selfOperator2 = metadata.addItem(94, 4)
     val code =
       """from Standard.Base import all
         |
@@ -1471,7 +1473,7 @@ class RuntimeRefactoringTest
       )
     )
 
-    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+    context.receiveNIgnoreStdLib(5) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, operator1Id, ConstantsGen.INTEGER),
       TestMessages.update(
@@ -1482,9 +1484,54 @@ class RuntimeRefactoringTest
           Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "function1"))
         )
       ),
+      TestMessages.update(
+        contextId,
+        selfOperator2,
+        moduleName
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("42")
+
+    // attach visualization
+    context.send(
+      Api.Request(
+        requestId,
+        Api.AttachVisualization(
+          visualizationId,
+          operator2Id,
+          Api.VisualizationConfiguration(
+            contextId,
+            Api.VisualizationExpression.Text(
+              moduleName,
+              "x -> x.to_text",
+              Vector()
+            ),
+            moduleName
+          )
+        )
+      )
+    )
+    val attachVisualizationResponses =
+      context.receiveNIgnoreExpressionUpdates(2, timeoutSeconds = 10)
+    attachVisualizationResponses should contain(
+      Api.Response(requestId, Api.VisualizationAttached())
+    )
+    val Some(data) = attachVisualizationResponses.collectFirst {
+      case Api.Response(
+            None,
+            Api.VisualizationUpdate(
+              Api.VisualizationContext(
+                `visualizationId`,
+                `contextId`,
+                `operator2Id`
+              ),
+              data
+            )
+          ) =>
+        data
+    }
+    data.sameElements("42".getBytes) shouldBe true
 
     // rename function1
     val newName = "function2"
@@ -1509,9 +1556,12 @@ class RuntimeRefactoringTest
         )
       )
     )
-    context.receiveNIgnorePendingExpressionUpdates(
-      2
-    ) should contain theSameElementsAs Seq(
+    val afterModificationResponse =
+      context.receiveNIgnorePendingExpressionUpdates(
+        3,
+        timeoutSeconds = 10
+      )
+    afterModificationResponse should contain allOf (
       context.executionComplete(contextId),
       TestMessages.update(
         contextId,
@@ -1523,5 +1573,22 @@ class RuntimeRefactoringTest
       )
     )
     context.consumeOut shouldEqual List("42")
+
+    val Some(data2) = afterModificationResponse.collectFirst {
+      case Api.Response(
+            None,
+            Api.VisualizationUpdate(
+              Api.VisualizationContext(
+                `visualizationId`,
+                `contextId`,
+                `operator2Id`
+              ),
+              data
+            )
+          ) =>
+        data
+    }
+    data2.sameElements("42".getBytes) shouldBe true
+
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -1420,4 +1420,108 @@ class RuntimeRefactoringTest
     )
     context.consumeOut shouldEqual List("42")
   }
+
+  it should "rename module method in main body by applying text edit" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Enso_Test.Test.Main"
+
+    val metadata    = new Metadata
+    val operator1Id = metadata.addItem(75, 2)
+    val operator2Id = metadata.addItem(94, 24)
+    val code =
+      """from Standard.Base import all
+        |
+        |function1 x = x + 1
+        |
+        |main =
+        |    operator1 = 41
+        |    operator2 = Main.function1 operator1
+        |    IO.println operator2
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // open file
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, moduleName, "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+
+    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(contextId, operator1Id, ConstantsGen.INTEGER),
+      TestMessages.update(
+        contextId,
+        operator2Id,
+        ConstantsGen.INTEGER,
+        methodCall = Some(
+          Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "function1"))
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("42")
+
+    // rename function1
+    val newName = "function2"
+    val edits = Vector(
+      TextEdit(
+        model.Range(model.Position(2, 0), model.Position(2, 9)),
+        newName
+      ),
+      TextEdit(
+        model.Range(model.Position(6, 21), model.Position(6, 30)),
+        newName
+      )
+    )
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          edits,
+          execute = true,
+          idMap   = None
+        )
+      )
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      2
+    ) should contain theSameElementsAs Seq(
+      context.executionComplete(contextId),
+      TestMessages.update(
+        contextId,
+        operator2Id,
+        ConstantsGen.INTEGER,
+        methodCall = Some(
+          Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "function2"))
+        )
+      )
+    )
+    context.consumeOut shouldEqual List("42")
+  }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -7718,14 +7718,14 @@ class RuntimeServerTest
         contextId,
         idXSelfMain,
         moduleName,
-        fromCache   = true,
+        fromCache   = false,
         typeChanged = false
       ),
       TestMessages.update(
         contextId,
         idYSelfMain,
         moduleName,
-        fromCache   = true,
+        fromCache   = false,
         typeChanged = false
       ),
       context.executionComplete(contextId)


### PR DESCRIPTION
### Pull Request Description

Self arguments are cached. This means that if the type definition or its methods change, then any method invocation on that type also needs to be invalidated.
This is now possible, as invalidating the whole application will also invalidate the self argument and ensure that types' module scope is updated.

Caching self argument probably hid more of similar caching bugs and this change should ensure that we don't see them.

Closes #14412.

### Important Notes

The change involves some (small) cost, as can be seen in the changed tests. But whatever hack we would add, it would be inevitable to some extent.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
