### PR TITLE
Use `State.get` `if_missing` to avoid too frequent `Panic.throw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next Next Release
+
+#### Enso Language & Runtime
+
+- [Use `State.get if_missing` to avoid too frequent `Panic.throw`][14490]
+
+[14490]: https://github.com/enso-org/enso/pull/14490
+
 # Next Release
 
 #### Enso IDE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 #### Enso Language & Runtime
 
+- [`Panic.rethrow` keeps original location][14480]
 - [Use `State.get if_missing` to avoid too frequent `Panic.throw`][14490]
 
-[14490]: https://github.com/enso-org/enso/pull/14490
-- [`Panic.rethrow` keeps original location][14480]
-
 [14480]: https://github.com/enso-org/enso/pull/14480
+[14490]: https://github.com/enso-org/enso/pull/14490
 
 # Next Release
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/State.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/State.md
@@ -1,5 +1,5 @@
 ## Enso Signatures 1.0
 ## module Standard.Base.Runtime.State
-- get key:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- get key:Standard.Base.Any.Any ~if_missing:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - put key:Standard.Base.Any.Any new_state:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - run key:Standard.Base.Any.Any local_state:Standard.Base.Any.Any ~computation:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
@@ -4,9 +4,11 @@ import project.Data.Numbers.Integer
 import project.Data.Range.Extensions
 import project.Error.Error
 import project.Errors.Illegal_Argument.Illegal_Argument
+import project.Panic.Panic
 import project.Logging.Progress
 import project.Nothing.Nothing
 
+from project.Errors.Common import Uninitialized_State
 polyglot java import java.lang.Thread
 
 ## ---
@@ -32,3 +34,10 @@ sleep milliseconds:Integer ~result=Nothing sleep=(\n -> Thread.sleep n) =
                     sleep remaining
                 p.advance 100
     result
+
+state_run key state ~computation = @Builtin_Method "State.run"
+state_get key ~if_missing = @Builtin_Method "State.get"
+state_put key new_state = @Builtin_Method "State.put"
+state_uninitialized key =
+    Panic.throw
+        Uninitialized_State.Error key

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
@@ -36,8 +36,11 @@ sleep milliseconds:Integer ~result=Nothing sleep=(\n -> Thread.sleep n) =
     result
 
 state_run key state ~computation = @Builtin_Method "State.run"
+
 state_get key ~if_missing = @Builtin_Method "State.get"
+
 state_put key new_state = @Builtin_Method "State.put"
+
 state_uninitialized key =
     Panic.throw
         Uninitialized_State.Error key

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
@@ -4,6 +4,7 @@
 
 import project.Any.Any
 from project.Errors.Common import Uninitialized_State
+import project.Internal.Runtime_Helpers
 
 ## ---
    private: true
@@ -25,7 +26,8 @@ from project.Errors.Common import Uninitialized_State
          State.run Integer 0 <| IO.println (State.get Integer)
    ```
 run : Any -> Any -> Any -> Any
-run key local_state ~computation = @Builtin_Method "State.run"
+run key local_state ~computation =
+    Runtime_Helpers.state_run key local_state computation
 
 ## ---
    private: true
@@ -38,6 +40,7 @@ run key local_state ~computation = @Builtin_Method "State.run"
 
    ## Arguments
     - `key`: The key into the state to get the associated value for.
+    - `if_missing`: action to perform when the state isn't set, by default throws Uninitialized_State panic
 
    ## Examples
    ### Get the value of state for a key.
@@ -46,8 +49,9 @@ run key local_state ~computation = @Builtin_Method "State.run"
 
          State.get Float
    ```
-get : Any -> Any ! Uninitialized_State
-get key = @Builtin_Method "State.get"
+get : Any -> Any -> Any ! Uninitialized_State
+get key ~if_missing=(Runtime_Helpers.state_uninitialized key ...) =
+    Runtime_Helpers.state_get key (if_missing...)
 
 ## ---
    private: true
@@ -71,4 +75,5 @@ get key = @Builtin_Method "State.get"
          State.put Text 2821
    ```
 put : Any -> Any -> Any ! Uninitialized_State
-put key new_state = @Builtin_Method "State.put"
+put key new_state =
+    Runtime_Helpers.state_put key new_state

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.State
-from Standard.Base.Errors.Common import Uninitialized_State
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
@@ -12,8 +12,7 @@ type In_Transaction
        ---
        Checks if a transaction is currently being run.
     is_in_transaction : Boolean
-    is_in_transaction =
-        Panic.catch Uninitialized_State (State.get In_Transaction) (_->False)
+    is_in_transaction = State.get In_Transaction if_missing=False
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
@@ -125,7 +125,7 @@ type Test
        ---
     enrich_message_with_clue : Text -> Text
     enrich_message_with_clue message =
-        clue = Panic.catch Uninitialized_State (State.get Clue) handler=(_-> Nothing)
+        clue = State.get Clue if_missing=Nothing
         case clue of
             Clue.Value add_clue -> add_clue message
             _                   -> message

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 import Standard.Base.Data.Vector.Builder
-from Standard.Base.Errors.Common import Uninitialized_State
 from Standard.Base.Runtime import State
 
 import project.Clue.Clue

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/InstrumentorBuiltin.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/InstrumentorBuiltin.java
@@ -1,6 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.Builtin;
@@ -25,10 +27,10 @@ public class InstrumentorBuiltin extends Node {
 
   @SuppressWarnings("unchecked")
   @CompilerDirectives.TruffleBoundary
-  private static Object findUuid(Object uuid, EnsoContext ctx) {
+  private static Object findUuid(MaterializedFrame frame, Object uuid, EnsoContext ctx) {
     var key = ctx.getBuiltins().instrumentor();
     try {
-      var obj = GetStateNode.getUncached().executeGet(key);
+      var obj = GetStateNode.getUncached().executeGet(frame, key, null);
       if (obj instanceof java.util.function.Function cache) {
         return cache.apply(uuid.toString());
       }
@@ -38,12 +40,12 @@ public class InstrumentorBuiltin extends Node {
     return null;
   }
 
-  Object execute(Text operation, Object args) {
+  Object execute(VirtualFrame frame, Text operation, Object args) {
     var ctx = EnsoContext.get(this);
     var op = operation.toString();
     try {
       if ("uuid".equals(op)) {
-        var res = findUuid(args, ctx);
+        var res = findUuid(frame.materialize(), args, ctx);
         if (res == null) {
           return ctx.getBuiltins().nothing();
         } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/GetStateNode.java
@@ -1,16 +1,20 @@
 package org.enso.interpreter.runtime.state;
 
 import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObjectLibrary;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.dsl.Suspend;
+import org.enso.interpreter.node.BaseNode.TailStatus;
+import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.error.PanicException;
 
 /** Use this node to manipulate {@link State}. */
 @BuiltinMethod(
@@ -31,18 +35,20 @@ public abstract class GetStateNode extends Node {
 
   GetStateNode() {}
 
-  final Object execute(Object key) {
-    return executeGet(key);
+  final Object execute(VirtualFrame frame, Object key, @Suspend Object ifMissing) {
+    return executeGet(frame, key, ifMissing);
   }
 
   /**
    * Reads value associated with a key from the {@link State}.
    *
+   * @param frame the current execution frame
    * @param key the key to read the value for
+   * @param ifMissing value to evaluate when state isn't set
    * @return the value associated with the key
    * @throws {@link PanicException} when there is no such key in the {@link State}
    */
-  public abstract Object executeGet(Object key);
+  public abstract Object executeGet(VirtualFrame frame, Object key, Object ifMissing);
 
   final State state() {
     return EnsoContext.get(this).currentState();
@@ -51,14 +57,16 @@ public abstract class GetStateNode extends Node {
   @Specialization(guards = "objects.containsKey(data, key)")
   Object doRead(
       Object key,
+      Object ifMissing,
       @Bind("state().getContainer()") State.Container data,
       @CachedLibrary(limit = "10") DynamicObjectLibrary objects) {
     return objects.getOrDefault(data, key, null);
   }
 
   @Fallback
-  Object doMissing(Object key) {
-    throw new PanicException(
-        EnsoContext.get(this).getBuiltins().error().makeUninitializedStateError(key), this);
+  Object doMissing(
+      VirtualFrame frame, Object key, Object ifMissing, @Cached ThunkExecutorNode evalNode) {
+    var missingResult = evalNode.executeThunk(frame, ifMissing, state(), TailStatus.NOT_TAIL);
+    return missingResult;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/RunStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/state/RunStateNode.java
@@ -86,8 +86,9 @@ public abstract class RunStateNode extends Node {
       @Shared("dynamicObjectLib") @CachedLibrary(limit = "10") DynamicObjectLibrary objects) {
     objects.put(data, key, local);
     try {
-      return thunkExecutorNode.executeThunk(
-          frame, computation, state(), BaseNode.TailStatus.NOT_TAIL);
+      var res =
+          thunkExecutorNode.executeThunk(frame, computation, state(), BaseNode.TailStatus.NOT_TAIL);
+      return res;
     } finally {
       objects.removeKey(data, key);
     }

--- a/test/Base_Tests/src/Runtime/State_Spec.enso
+++ b/test/Base_Tests/src/Runtime/State_Spec.enso
@@ -58,6 +58,10 @@ add_specs suite_builder = suite_builder.group "State" group_builder->
             CallbackHelper.runCallbackInt obtain_state -1
         s . should_equal 41
 
+    group_builder.specify "State if_missing" <|
+        s = State.get Test if_missing=41
+        s . should_equal 41
+
 main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
@@ -1,3 +1,6 @@
 run key local_state ~computation = @Builtin_Method "State.run"
-get key = @Builtin_Method "State.get"
+get key if_nothing=(0/1) =
+    get_impl key if_nothing
 put key new_state = @Builtin_Method "State.put"
+
+private get_impl key = @Builtin_Method "State.get"


### PR DESCRIPTION
### Pull Request Description

There are cases when one reads a `State.get` value from the _state monad_, but is ready to handle cases when the value is missing. Traditionally this has been handled by wrapping the `State.get` call by `Panic.catch`. That's OK from runtime perspective. However it causes _problems for debugging_. Often a breakpoint in `PanicException` constructor is used to stop at _unexpected state_. Using `Panic.throw` and `Panic.catch` for regular workflow (like in [In_Transaction](https://github.com/enso-org/enso/compare/wip/jtulach/StateGetIfMissing?expand=1#diff-8100b064ddd2b18466d5159993a26143ec5f98922b2200ccaa988c6ba65d7cb1R15)) renders such a technique useless by generating too many false positive exceptions. Let's avoid such a coding practice by allowing `State.get if_missing=Nothing`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
