### PR TITLE
Expression support for Spatial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - [Support for reading JSON lines files.][14439]
 - [Add Custom SQL to in database aggregates.][14472]
 - [Add spatial functions and `write_spatial_file` to DuckDB.][14488]
+- [Add spatial function support to expressions.][14492]
 
 [13769]: https://github.com/enso-org/enso/pull/13769
 [14026]: https://github.com/enso-org/enso/pull/14026
@@ -137,6 +138,7 @@
 [14439]: https://github.com/enso-org/enso/pull/14439
 [14472]: https://github.com/enso-org/enso/pull/14472
 [14488]: https://github.com/enso-org/enso/pull/14488
+[14492]: https://github.com/enso-org/enso/pull/14492
 
 #### Enso Language & Runtime
 

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -37,6 +37,7 @@ export function useTableExpressionExtension(
             ...suggestionDb.value.methods(NUMERIC_COLUMN_METHODS),
             ...suggestionDb.value.methods(TEXT_COLUMN_METHODS),
             ...suggestionDb.value.methods(SPATIAL_COLUMN_METHODS),
+            ...suggestionDb.value.methods(SPATIAL_INPUT_COLUMN_METHODS),
           ].map((entry) => [entry.name, entry]),
         ).values(),
         methodInfoFromEntry,
@@ -76,6 +77,11 @@ const SPATIAL_COLUMN_TYPE = ProjectPath.create(
     'Refined_Types.Spatial_Column.Spatial_Column' as QualifiedName,
 )
 
+const SPATIAL_INPUT_COLUMN_TYPE = ProjectPath.create(
+    'Standard.Table' as QualifiedName,
+    'Refined_Types.Spatial_Column.Spatial_Input_Column' as QualifiedName,
+)
+
 const EXPRESSION_STATICS_TYPE = ProjectPath.create(
   'Standard.Table' as QualifiedName,
   'Internal.Expression_Statics.Expression_Statics' as QualifiedName,
@@ -95,6 +101,10 @@ const TEXT_COLUMN_METHODS = {
 }
 const SPATIAL_COLUMN_METHODS = {
   selfType: SPATIAL_COLUMN_TYPE,
+  name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
+}
+const SPATIAL_INPUT_COLUMN_METHODS = {
+  selfType: SPATIAL_INPUT_COLUMN_TYPE,
   name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
 }
 const EXPRESSION_STATICS_METHODS = {

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -73,13 +73,13 @@ const TEXT_COLUMN_TYPE = ProjectPath.create(
 )
 
 const SPATIAL_COLUMN_TYPE = ProjectPath.create(
-    'Standard.Table' as QualifiedName,
-    'Refined_Types.Spatial_Column.Spatial_Column' as QualifiedName,
+  'Standard.Table' as QualifiedName,
+  'Refined_Types.Spatial_Column.Spatial_Column' as QualifiedName,
 )
 
 const SPATIAL_INPUT_COLUMN_TYPE = ProjectPath.create(
-    'Standard.Table' as QualifiedName,
-    'Refined_Types.Spatial_Column.Spatial_Input_Column' as QualifiedName,
+  'Standard.Table' as QualifiedName,
+  'Refined_Types.Spatial_Column.Spatial_Input_Column' as QualifiedName,
 )
 
 const EXPRESSION_STATICS_TYPE = ProjectPath.create(

--- a/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
+++ b/app/gui/src/project-view/util/codemirror/language/tableExpression/index.ts
@@ -36,6 +36,7 @@ export function useTableExpressionExtension(
             ...suggestionDb.value.methods(COLUMN_METHODS),
             ...suggestionDb.value.methods(NUMERIC_COLUMN_METHODS),
             ...suggestionDb.value.methods(TEXT_COLUMN_METHODS),
+            ...suggestionDb.value.methods(SPATIAL_COLUMN_METHODS),
           ].map((entry) => [entry.name, entry]),
         ).values(),
         methodInfoFromEntry,
@@ -70,6 +71,11 @@ const TEXT_COLUMN_TYPE = ProjectPath.create(
   'Refined_Types.Text_Column.Text_Column' as QualifiedName,
 )
 
+const SPATIAL_COLUMN_TYPE = ProjectPath.create(
+    'Standard.Table' as QualifiedName,
+    'Refined_Types.Spatial_Column.Spatial_Column' as QualifiedName,
+)
+
 const EXPRESSION_STATICS_TYPE = ProjectPath.create(
   'Standard.Table' as QualifiedName,
   'Internal.Expression_Statics.Expression_Statics' as QualifiedName,
@@ -85,6 +91,10 @@ const NUMERIC_COLUMN_METHODS = {
 }
 const TEXT_COLUMN_METHODS = {
   selfType: TEXT_COLUMN_TYPE,
+  name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
+}
+const SPATIAL_COLUMN_METHODS = {
+  selfType: SPATIAL_COLUMN_TYPE,
   name: (name: string) => !EXCLUDED_COLUMN_METHODS.has(name),
 }
 const EXPRESSION_STATICS_METHODS = {

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -39,6 +39,7 @@ import Standard.Table.Internal.Table_Ref.Table_Ref
 import Standard.Table.Internal.Value_Type_Helpers
 import Standard.Table.Internal.Widget_Helpers
 import Standard.Table.Prefix_Name.Prefix_Name
+import Standard.Table.Refined_Types.Spatial_Column.Spatial_Column
 import Standard.Table.Row_Limit.Row_Limit
 import Standard.Table.Rows_To_Read.Rows_To_Read
 import Standard.Table.Spatial_Table.Lat_Long_Type
@@ -78,6 +79,10 @@ from project.Internal.DB_Column_Implementation import make_unary_op
 
 type DB_Table_Implementation
     name (this_table : Table & DB_Table) = this_table.internal_name
+
+    pretty_implementation (this_table : Table & DB_Table) =
+        data = this_table.columns.map c->("[" + c.name.pretty + ", " + c.to_vector.pretty + "]") . join ", "
+        "DB_Table.new [" + data + "]"
 
     display (this_table : Table & DB_Table) show_rows:Integer format_terminal:Boolean =
         data_fragment_with_warning = this_table.read (..First_With_Warning show_rows)
@@ -775,7 +780,7 @@ type DB_Table_Implementation
         is_spatial = case column.value_type of
             Value_Type.Unsupported_Data_Type type_name _ -> dialect.spatial_types.contains type_name
             _ -> False
-        if is_spatial then Spatial_Column.Value column (this_table:Spatial_Table) else
+        if is_spatial then Spatial_Column.Value column this_table else
             Panic.throw (Type_Error.Error Spatial_Column column "The column '"+column.name+"' is not a spatial column.")
 
     spatial_point (this_table : Table & DB_Table) (longitude : Column) (latitude : Column) (as : Text) =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/DB_Table_Implementation.enso
@@ -769,6 +769,15 @@ type DB_Table_Implementation
                 this_table.connection.dialect.spatial_types.contains type_name
             _ -> False
 
+    as_spatial_column (this_table : Table & DB_Table) (column : Column) =
+        dialect = this_table.connection.dialect
+        if dialect.is_feature_supported ..Spatial . not then Panic.throw (Type_Error.Error Spatial_Column column "Spatial functions are not currently implemented for "+dialect.name+".")
+        is_spatial = case column.value_type of
+            Value_Type.Unsupported_Data_Type type_name _ -> dialect.spatial_types.contains type_name
+            _ -> False
+        if is_spatial then Spatial_Column.Value column (this_table:Spatial_Table) else
+            Panic.throw (Type_Error.Error Spatial_Column column "The column '"+column.name+"' is not a spatial column.")
+
     spatial_point (this_table : Table & DB_Table) (longitude : Column) (latitude : Column) (as : Text) =
         Feature.Spatial.if_supported_else_throw this_table.connection.dialect "st_point" <| Value_Type.expect_numeric longitude <| Value_Type.expect_numeric latitude <|
             new_column = _resolve_sql_function this_table (SQL_Function.SQL "ST_Point" [longitude, latitude])

--- a/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Dialect.enso
+++ b/distribution/lib/Standard/DuckDB/0.0.0-dev/src/Internal/DuckDB_Dialect.enso
@@ -387,8 +387,7 @@ type DuckDB_Dialect
     spatial_types : Hashset Text
     spatial_types self =
         _ = self
-        Hashset.from_vector ["GEOMETRY"]
-
+        Hashset.from_vector ["GEOMETRY", "POINT_2D", "LINESTRING_2D", "BOX_2D", "POLYGON_2D"]
 ## ---
    private: true
    ---

--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Refined_Types/Spatial_Column.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Refined_Types/Spatial_Column.md
@@ -1,0 +1,20 @@
+## Enso Signatures 1.0
+## module Standard.Table.Refined_Types.Spatial_Column
+- type Spatial_Column
+    - Value column:Standard.Base.Any.Any parent_table:Standard.Table.Spatial_Table.Spatial_Table
+    - st_area self -> Standard.Base.Any.Any
+    - st_centroid self -> Standard.Base.Any.Any
+    - st_distance self to_column:(Standard.Table.Column.Column|Standard.Table.Expression.Expression|Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= -> Standard.Base.Any.Any
+    - st_extent self -> Standard.Base.Any.Any
+    - st_geometry_type self -> Standard.Base.Any.Any
+    - st_latitude self value:Standard.Table.Spatial_Table.Lat_Long_Type= -> Standard.Base.Any.Any
+    - st_length self to_column:(Standard.Table.Column.Column|Standard.Table.Expression.Expression|Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= -> Standard.Base.Any.Any
+    - st_longitude self value:Standard.Table.Spatial_Table.Lat_Long_Type= -> Standard.Base.Any.Any
+    - st_perimeter self -> Standard.Base.Any.Any
+    - st_to_geojson self -> Standard.Base.Any.Any
+    - st_to_wkt self -> Standard.Base.Any.Any
+- type Spatial_Input_Column
+    - Value column:Standard.Base.Any.Any parent_table:Standard.Table.Spatial_Table.Spatial_Table
+    - st_from_geojson self -> Standard.Base.Any.Any
+    - st_from_wkt self -> Standard.Base.Any.Any
+    - st_point self latitude:(Standard.Table.Column.Column|Standard.Table.Expression.Expression|Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Spatial_Table.md
+++ b/distribution/lib/Standard/Table/0.0.0-dev/docs/api/Spatial_Table.md
@@ -15,6 +15,9 @@
     - Touches left:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= right:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)=
     - Within left:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= right:(Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)=
 - type Spatial_Table
+    - as_spatial_column self column:Standard.Table.Column.Column -> Standard.Base.Any.Any
+    - read_as_geojson self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> (Standard.Table.Table.Table&Standard.Base.Any.Any)
+    - read_as_wkt self max_rows:Standard.Table.Rows_To_Read.Rows_To_Read= -> (Standard.Table.Table.Table&Standard.Base.Any.Any)
     - spatial_columns self -> Standard.Base.Any.Any
     - st_area self column:(Standard.Table.Column.Column|Standard.Table.Expression.Expression|Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= as:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - st_centroid self column:(Standard.Table.Column.Column|Standard.Table.Expression.Expression|Standard.Base.Data.Text.Text|Standard.Base.Data.Numbers.Integer)= as:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -70,8 +70,8 @@ type Expression
         mr2 = ExpressionVisitorImpl.newMethodResolver Column_Module Column isStaticMethod=False makeTypedColumn=c->c
         mr3 = ExpressionVisitorImpl.newMethodResolver Numeric_Column_Module Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         mr4 = ExpressionVisitorImpl.newMethodResolver Text_Column_Module Text_Column isStaticMethod=False makeTypedColumn=c->(c : Text_Column)
-        mr5 = ExpressionVisitorImpl.newMethodResolver Spatial_Column_Module Spatial_Column isStaticMethod=False makeTypedColumn=c-> (table : Spatial_Table).as_spatial_column c
-        method_resolvers = [mr1, mr2, mr3, mr4]
+        mr6 = ExpressionVisitorImpl.newMethodResolver Spatial_Column_Module Spatial_Column isStaticMethod=False makeTypedColumn=c-> (table : Spatial_Table).as_spatial_column c
+        method_resolvers = [mr1, mr2, mr3, mr4, mr6]
 
         ## Define error handlers to convert java exceptions to Enso errors
         handle_parse_error = Panic.catch SyntaxErrorException handler=(cause-> Error.throw (Expression_Error.Syntax_Error cause.payload.getMessage cause.payload.getLine cause.payload.getColumn))

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -8,8 +8,11 @@ import project.Internal.Expression_Statics as Expression_Statics_Module
 import project.Internal.Expression_Statics.Expression_Statics
 import project.Refined_Types.Numeric_Column as Numeric_Column_Module
 import project.Refined_Types.Numeric_Column.Numeric_Column
+import project.Refined_Types.Spatial_Column as Spatial_Column_Module
+import project.Refined_Types.Spatial_Column.Spatial_Column
 import project.Refined_Types.Text_Column as Text_Column_Module
 import project.Refined_Types.Text_Column.Text_Column
+import project.Spatial_Table.Spatial_Table
 import project.Table.Table
 
 polyglot java import java.lang.IllegalArgumentException
@@ -67,6 +70,7 @@ type Expression
         mr2 = ExpressionVisitorImpl.newMethodResolver Column_Module Column isStaticMethod=False makeTypedColumn=c->c
         mr3 = ExpressionVisitorImpl.newMethodResolver Numeric_Column_Module Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         mr4 = ExpressionVisitorImpl.newMethodResolver Text_Column_Module Text_Column isStaticMethod=False makeTypedColumn=c->(c : Text_Column)
+        mr5 = ExpressionVisitorImpl.newMethodResolver Spatial_Column_Module Spatial_Column isStaticMethod=False makeTypedColumn=c-> (table : Spatial_Table).as_spatial_column c
         method_resolvers = [mr1, mr2, mr3, mr4]
 
         ## Define error handlers to convert java exceptions to Enso errors

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -10,6 +10,7 @@ import project.Refined_Types.Numeric_Column as Numeric_Column_Module
 import project.Refined_Types.Numeric_Column.Numeric_Column
 import project.Refined_Types.Spatial_Column as Spatial_Column_Module
 import project.Refined_Types.Spatial_Column.Spatial_Column
+import project.Refined_Types.Spatial_Column.Spatial_Input_Column
 import project.Refined_Types.Text_Column as Text_Column_Module
 import project.Refined_Types.Text_Column.Text_Column
 import project.Spatial_Table.Spatial_Table
@@ -71,7 +72,8 @@ type Expression
         mr3 = ExpressionVisitorImpl.newMethodResolver Numeric_Column_Module Numeric_Column isStaticMethod=False makeTypedColumn=c->(c : Numeric_Column)
         mr4 = ExpressionVisitorImpl.newMethodResolver Text_Column_Module Text_Column isStaticMethod=False makeTypedColumn=c->(c : Text_Column)
         mr6 = ExpressionVisitorImpl.newMethodResolver Spatial_Column_Module Spatial_Column isStaticMethod=False makeTypedColumn=c-> (table : Spatial_Table).as_spatial_column c
-        method_resolvers = [mr1, mr2, mr3, mr4, mr6]
+        mr7 = ExpressionVisitorImpl.newMethodResolver Spatial_Column_Module Spatial_Input_Column isStaticMethod=False makeTypedColumn=c-> Spatial_Input_Column.Value c table
+        method_resolvers = [mr1, mr2, mr3, mr4, mr6, mr7]
 
         ## Define error handlers to convert java exceptions to Enso errors
         handle_parse_error = Panic.catch SyntaxErrorException handler=(cause-> Error.throw (Expression_Error.Syntax_Error cause.payload.getMessage cause.payload.getLine cause.payload.getColumn))

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/In_Memory_Table_Implementation.enso
@@ -61,6 +61,7 @@ import project.Join_Kind.Join_Kind
 import project.Match_Columns.Match_Columns
 import project.Position.Position
 import project.Prefix_Name.Prefix_Name
+import project.Refined_Types.Spatial_Column.Spatial_Column
 import project.Row.Row
 import project.Row_Limit.Row_Limit
 import project.Rows_To_Read.Rows_To_Read
@@ -763,6 +764,10 @@ type In_Memory_Table_Implementation
     spatial_columns (this_table : Table & In_Memory_Table) =
         _ = this_table
         []
+
+    as_spatial_column (this_table : Table & In_Memory_Table) (column : Column) =
+        _ = [this_table, column]
+        Panic.throw (Type_Error.Error Spatial_Column column "Spatial functions are not currently implemented for in-memory tables.")
 
     spatial_point (this_table : Table & In_Memory_Table) (longitude : Column) (latitude : Column) (as : Text) =
         _ = [this_table, longitude, latitude, as]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -19,7 +19,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
     st_geometry_type self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_geometry_type self.column as=temp_name . get temp_name
 
     ## ---
@@ -36,7 +36,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new longitude column.
     st_longitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_longitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -53,7 +53,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new latitude column.
     st_latitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_latitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -65,7 +65,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the centroid points.
     st_centroid self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_centroid self.column as=temp_name . get temp_name
 
     ## ---
@@ -77,7 +77,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the bounding boxes.
     st_extent self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_extent self.column as=temp_name . get temp_name
 
     ## ---
@@ -90,7 +90,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the perimeter.
     st_perimeter self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_perimeter self.column as=temp_name . get temp_name
 
     ## ---
@@ -103,7 +103,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the area.
     st_area self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_area self.column as=temp_name . get temp_name
 
     ## ---
@@ -121,7 +121,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_distance self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -140,7 +140,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.st_length self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -153,7 +153,7 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
     st_to_geojson self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.spatial_to_geojson self.column as=temp_name . get temp_name
 
     ## ---
@@ -167,5 +167,5 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
     st_to_wkt self =
-        temp_name = self.parent_table..underlying.make_temp_column_name
+        temp_name = self.parent_table.underlying.make_temp_column_name
         self.parent_table.spatial_to_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -169,3 +169,50 @@ type Spatial_Column
     st_to_wkt self =
         temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_to_wkt self.column as=temp_name . get temp_name
+
+## A column that contains spatial values - designed for use by Expression at the moment.
+type Spatial_Input_Column
+    Value column parent_table:Spatial_Table
+
+    ## ---
+       aliases: [create_points]
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Creates a new column containing points from longitude and latitude columns.
+       Note: Enso assumes that the points are in WGS84 coordinate system (EPSG:4326).
+
+       ## Arguments
+        - `latitude`: The column, expression, or name/index of the column containing latitude values
+
+       ## Returns
+       A new table with the existing columns and the new point column.
+    st_point self (latitude : Column | Expression | Text | Integer = Missing_Argument.throw "latitude") =
+        temp_name = self.parent_table.parent.make_temp_column_name
+        self.parent_table.st_point self.column latitude as=temp_name . get temp_name
+
+    ## ---
+       group: Standard.Base.Conversions
+       icon: convert
+       ---
+       Converts a text column in GeoJSON format to spatial objects.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the
+       spatial objects.
+    st_from_geojson self =
+        temp_name = self.parent_table.parent.make_temp_column_name
+        self.parent_table.st_from_geojson self.column as=temp_name . get temp_name
+
+    ## ---
+       group: Standard.Base.Conversions
+       icon: convert
+       ---
+       Converts a text column in Well Known Text format to spatial objects.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the
+       spatial objects.
+    st_from_wkt self =
+        temp_name = self.parent_table.parent.make_temp_column_name
+        self.parent_table.st_from_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -19,7 +19,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
     st_geometry_type self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_geometry_type self.column as=temp_name . get temp_name
 
     ## ---
@@ -36,7 +36,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new longitude column.
     st_longitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_longitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -53,7 +53,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new latitude column.
     st_latitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_latitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -65,7 +65,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the centroid points.
     st_centroid self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_centroid self.column as=temp_name . get temp_name
 
     ## ---
@@ -77,7 +77,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the bounding boxes.
     st_extent self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_extent self.column as=temp_name . get temp_name
 
     ## ---
@@ -90,7 +90,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the perimeter.
     st_perimeter self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_perimeter self.column as=temp_name . get temp_name
 
     ## ---
@@ -103,7 +103,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the area.
     st_area self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_area self.column as=temp_name . get temp_name
 
     ## ---
@@ -121,7 +121,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_distance self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -140,7 +140,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.st_length self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -153,7 +153,7 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
     st_to_geojson self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.spatial_to_geojson self.column as=temp_name . get temp_name
 
     ## ---
@@ -167,5 +167,5 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
     st_to_wkt self =
-        temp_name = self.parent_table.underlying.make_temp_column_name
+        temp_name = self.parent_table.parent.make_temp_column_name
         self.parent_table.spatial_to_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -113,7 +113,6 @@ type Spatial_Column
        Gets the distance between two spatial objects on each row.
        Note this will be the distance in the coordinate system of the spatial objects, i.e. for
          WGS84 coordinates this will be in degrees. For distance in metres use st_length.
-       The self argument is used as the starting spatial object.
 
        ## Arguments
         - `end_column`: The column, expression, or name/index of the column containing the ending spatial objects.
@@ -131,7 +130,6 @@ type Spatial_Column
        ---
        Gets the distance in meters between two spatial objects on each row.
        Note this assumes that the spatial objects are in WGS84 coordinate system (EPSG:4326).
-       The self argument is used as the starting spatial object.
 
 
        ## Arguments

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -1,0 +1,153 @@
+from Standard.Base import all
+
+import project.Column.Column
+import project.Expression.Expression
+import project.Spatial_Table.Lat_Long_Type
+import project.Spatial_Table.Spatial_Table
+
+## A column that contains spatial values - designed for use by Expression at the moment.
+type Spatial_Column
+    private Value column parent_table:Spatial_Table
+
+    ## ---
+       aliases: [create_points]
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the geometry type of each spatial object in the spatial column.
+
+       ## Returns
+       A new table with the existing columns and the new geometry type column as text.
+    st_geometry_type self as:Text="" = self.parent_table.st_geometry_type self.column as
+
+    ## ---
+       aliases: [st_x]
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the longitude values from each point in the spatial column.
+
+       ## Arguments
+        - `value`: Specifies whether to get the minimum, maximum, or default longitude value
+           from each spatial object.
+
+       ## Returns
+       A new table with the existing columns and the new longitude column.
+    st_longitude self (value:Lat_Long_Type=..Default) as:Text="" = self.parent_table.st_longitude self.column value as
+
+    ## ---
+       aliases: [st_y]
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the latitude values from each point in the spatial column.
+
+       ## Arguments
+        - `value`: Specifies whether to get the minimum, maximum, or default latitude value
+           from each spatial object.
+
+       ## Returns
+       A new table with the existing columns and the new latitude column.
+    st_latitude self (value:Lat_Long_Type=..Default) as:Text="" = self.parent_table.st_latitude self.column value as
+
+    ## ---
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the centroid point of each spatial object in the spatial column.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the centroid points.
+    st_centroid self as:Text="" = self.parent_table.st_centroid self.column as
+
+    ## ---
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the bounding box surrounding each spatial object in the spatial column.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the bounding boxes.
+    st_extent self as:Text="" = self.parent_table.st_extent self.column as
+
+    ## ---
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the perimeter of each spatial object in the spatial column in meters.
+       Note this assumes that the spatial objects are in WGS84 coordinate system (EPSG:4326).
+
+       ## Returns
+       A new table with the existing columns and a new column containing the perimeter.
+    st_perimeter self as:Text="" = self.parent_table.st_perimeter self.column as
+
+    ## ---
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the area of each spatial object in the spatial column in meters².
+       Note this assumes that the spatial objects are in WGS84 coordinate system (EPSG:4326).
+
+       ## Returns
+       A new table with the existing columns and a new column containing the area.
+    st_area self as:Text="" = self.parent_table.st_area self.column as
+
+    ## ---
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the distance between two spatial objects on each row.
+       Note this will be the distance in the coordinate system of the spatial objects, i.e. for
+         WGS84 coordinates this will be in degrees. For distance in metres use st_length.
+       The self argument is used as the starting spatial object.
+
+       ## Arguments
+        - `end_column`: The column, expression, or name/index of the column containing the ending spatial objects.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the distance.
+    st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
+        self.parent_table.st_distance self.column self.parent as
+
+    ## ---
+       aliases: [st_distance]
+       group: Standard.Base.Calculations
+       icon: spatial
+       ---
+       Gets the distance in meters between two spatial objects on each row.
+       Note this assumes that the spatial objects are in WGS84 coordinate system (EPSG:4326).
+       The self argument is used as the starting spatial object.
+
+
+       ## Arguments
+        - `end_column`: The column, expression, or name/index of the column containing the ending spatial objects.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the distance.
+    st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
+        self.parent_table.st_length self.column self.parent as
+
+    ## ---
+       group: Standard.Base.Conversions
+       icon: convert
+       ---
+       Converts the spatial objects in the specified column to GeoJSON format.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the
+       GeoJSON representation as text of the spatial objects.
+    @column _spatial_widget single_choice=True
+    st_to_geojson self as:Text="" = self.parent_table.spatial_to_geojson self.column as
+
+    ## ---
+       group: Standard.Base.Conversions
+       icon: convert
+       ---
+       Converts the spatial objects in the specified column to Well Known Text
+       format.
+
+       ## Returns
+       A new table with the existing columns and a new column containing the
+       WKT representation of the spatial objects.
+    @column _spatial_widget single_choice=True
+    st_to_wkt self as:Text="" = self.parent_table.spatial_to_wkt self.column as

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -154,7 +154,7 @@ type Spatial_Column
        GeoJSON representation as text of the spatial objects.
     st_to_geojson self =
         temp_name = self.parent_table.parent.make_temp_column_name
-        self.parent_table.spatial_to_geojson self.column as=temp_name . get temp_name
+        self.parent_table.st_to_geojson self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Conversions
@@ -168,4 +168,4 @@ type Spatial_Column
        WKT representation of the spatial objects.
     st_to_wkt self =
         temp_name = self.parent_table.parent.make_temp_column_name
-        self.parent_table.spatial_to_wkt self.column as=temp_name . get temp_name
+        self.parent_table.st_to_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -18,8 +18,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
-    st_geometry_type self as:Text="" =
-        self.parent_table.st_geometry_type self.column as
+    st_geometry_type self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_geometry_type self.column as=temp_name . get temp_name
 
     ## ---
        aliases: [st_x]
@@ -34,7 +35,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and the new longitude column.
-    st_longitude self (value:Lat_Long_Type=..Default) as:Text="" = self.parent_table.st_longitude self.column value as
+    st_longitude self (value:Lat_Long_Type=..Default) =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_longitude self.column value as=temp_name . get temp_name
 
     ## ---
        aliases: [st_y]
@@ -49,7 +52,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and the new latitude column.
-    st_latitude self (value:Lat_Long_Type=..Default) as:Text="" = self.parent_table.st_latitude self.column value as
+    st_latitude self (value:Lat_Long_Type=..Default) =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_latitude self.column value as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Calculations
@@ -59,7 +64,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the centroid points.
-    st_centroid self as:Text="" = self.parent_table.st_centroid self.column as
+    st_centroid self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_centroid self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Calculations
@@ -69,7 +76,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the bounding boxes.
-    st_extent self as:Text="" = self.parent_table.st_extent self.column as
+    st_extent self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_extent self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Calculations
@@ -80,7 +89,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the perimeter.
-    st_perimeter self as:Text="" = self.parent_table.st_perimeter self.column as
+    st_perimeter self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_perimeter self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Calculations
@@ -91,7 +102,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the area.
-    st_area self as:Text="" = self.parent_table.st_area self.column as
+    st_area self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_area self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Calculations
@@ -107,8 +120,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the distance.
-    st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
-        self.parent_table.st_distance self.column to_column as
+    st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_distance self.column to_column as=temp_name . get temp_name
 
     ## ---
        aliases: [st_distance]
@@ -125,8 +139,9 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and a new column containing the distance.
-    st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
-        self.parent_table.st_length self.column to_column as
+    st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.st_length self.column to_column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Conversions
@@ -137,7 +152,9 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
-    st_to_geojson self as:Text="" = self.parent_table.spatial_to_geojson self.column as
+    st_to_geojson self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.spatial_to_geojson self.column as=temp_name . get temp_name
 
     ## ---
        group: Standard.Base.Conversions
@@ -149,4 +166,6 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
-    st_to_wkt self as:Text="" = self.parent_table.spatial_to_wkt self.column as
+    st_to_wkt self =
+        temp_name = self.parent_table.make_temp_column_name
+        self.parent_table.spatial_to_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -7,7 +7,7 @@ import project.Spatial_Table.Spatial_Table
 
 ## A column that contains spatial values - designed for use by Expression at the moment.
 type Spatial_Column
-    private Value column parent_table:Spatial_Table
+    Value column parent_table:Spatial_Table
 
     ## ---
        aliases: [create_points]
@@ -18,7 +18,8 @@ type Spatial_Column
 
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
-    st_geometry_type self as:Text="" = self.parent_table.st_geometry_type self.column as
+    st_geometry_type self as:Text="" =
+        self.parent_table.st_geometry_type self.column as
 
     ## ---
        aliases: [st_x]
@@ -107,7 +108,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
-        self.parent_table.st_distance self.column self.parent as
+        self.parent_table.st_distance self.column to_column as
 
     ## ---
        aliases: [st_distance]
@@ -125,7 +126,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") as:Text="" =
-        self.parent_table.st_length self.column self.parent as
+        self.parent_table.st_length self.column to_column as
 
     ## ---
        group: Standard.Base.Conversions
@@ -136,7 +137,6 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
-    @column _spatial_widget single_choice=True
     st_to_geojson self as:Text="" = self.parent_table.spatial_to_geojson self.column as
 
     ## ---
@@ -149,5 +149,4 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
-    @column _spatial_widget single_choice=True
     st_to_wkt self as:Text="" = self.parent_table.spatial_to_wkt self.column as

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Refined_Types/Spatial_Column.enso
@@ -19,7 +19,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
     st_geometry_type self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_geometry_type self.column as=temp_name . get temp_name
 
     ## ---
@@ -36,7 +36,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new longitude column.
     st_longitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_longitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -53,7 +53,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and the new latitude column.
     st_latitude self (value:Lat_Long_Type=..Default) =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_latitude self.column value as=temp_name . get temp_name
 
     ## ---
@@ -65,7 +65,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the centroid points.
     st_centroid self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_centroid self.column as=temp_name . get temp_name
 
     ## ---
@@ -77,7 +77,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the bounding boxes.
     st_extent self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_extent self.column as=temp_name . get temp_name
 
     ## ---
@@ -90,7 +90,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the perimeter.
     st_perimeter self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_perimeter self.column as=temp_name . get temp_name
 
     ## ---
@@ -103,7 +103,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the area.
     st_area self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_area self.column as=temp_name . get temp_name
 
     ## ---
@@ -121,7 +121,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_distance self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_distance self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -140,7 +140,7 @@ type Spatial_Column
        ## Returns
        A new table with the existing columns and a new column containing the distance.
     st_length self (to_column : Column | Expression | Text | Integer = Missing_Argument.throw "to_column") =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.st_length self.column to_column as=temp_name . get temp_name
 
     ## ---
@@ -153,7 +153,7 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
     st_to_geojson self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.spatial_to_geojson self.column as=temp_name . get temp_name
 
     ## ---
@@ -167,5 +167,5 @@ type Spatial_Column
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
     st_to_wkt self =
-        temp_name = self.parent_table.make_temp_column_name
+        temp_name = self.parent_table..underlying.make_temp_column_name
         self.parent_table.spatial_to_wkt self.column as=temp_name . get temp_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
@@ -4,9 +4,9 @@ import Standard.Base.Runtime.Ref.Ref
 from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import Single_Choice, Multiple_Choice
 
-from Standard.Table import Column
-import Standard.Table.Expression.Expression
 
+import project.Column.Column
+import project.Expression.Expression
 import project.Internal.Widget_Helpers
 import project.Join_Condition.Join_Condition
 import project.Table.Table
@@ -14,6 +14,16 @@ import project.Table.Table
 ## Extension methods for Spatial Tables
 type Spatial_Table
     private Table parent:Table
+
+    ## ---
+       group: Standard.Base.Metadata
+       icon: spatial
+       private: true
+       ---
+       If the column is a spatial column, returns it as a Spatial_Column
+       otherwise throws a type error.
+    as_spatial_columns self column:Column =
+        (self:Table).implementation.as_spatial_columns self.parent.underlying column
 
     ## ---
        group: Standard.Base.Metadata
@@ -58,7 +68,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and the new geometry type column as text.
     @column _spatial_widget single_choice=True
-    st_geometry_type self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_geometry_type self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_geometry_type self.parent.underlying resolved as
 
@@ -77,7 +87,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and the new longitude column.
     @column _spatial_widget single_choice=True
-    st_longitude self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") (value:Lat_Long_Type=..Default) as:Text="" =
+    st_longitude self (column : Column | Expression | Text | Integer = _default_if_single self) (value:Lat_Long_Type=..Default) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_longitude self.parent.underlying resolved value as
 
@@ -96,7 +106,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and the new latitude column.
     @column _spatial_widget single_choice=True
-    st_latitude self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") (value:Lat_Long_Type=..Default) as:Text="" =
+    st_latitude self (column : Column | Expression | Text | Integer = _default_if_single self) (value:Lat_Long_Type=..Default) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_latitude self.parent.underlying resolved value as
 
@@ -112,7 +122,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and a new column containing the centroid points.
     @column _spatial_widget single_choice=True
-    st_centroid self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_centroid self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_centroid self.parent.underlying resolved as
 
@@ -128,7 +138,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and a new column containing the bounding boxes.
     @column _spatial_widget single_choice=True
-    st_extent self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_extent self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_extent self.parent.underlying resolved as
 
@@ -145,7 +155,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and a new column containing the perimeter.
     @column _spatial_widget single_choice=True
-    st_perimeter self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_perimeter self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_perimeter self.parent.underlying resolved as
 
@@ -162,7 +172,7 @@ type Spatial_Table
        ## Returns
        A new table with the existing columns and a new column containing the area.
     @column _spatial_widget single_choice=True
-    st_area self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_area self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_area self.parent.underlying resolved as
 
@@ -260,7 +270,7 @@ type Spatial_Table
        A new table with the existing columns and a new column containing the
        GeoJSON representation as text of the spatial objects.
     @column _spatial_widget single_choice=True
-    st_to_geojson self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_to_geojson self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_to_geojson self.parent.underlying resolved as
 
@@ -278,7 +288,7 @@ type Spatial_Table
        A new table with the existing columns and a new column containing the
        spatial objects.
     @column Widget_Helpers.make_column_name_selector add_expression=True
-    st_from_geojson self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_from_geojson self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_from_geojson self.parent.underlying resolved as
 
@@ -297,7 +307,7 @@ type Spatial_Table
        A new table with the existing columns and a new column containing the
        WKT representation of the spatial objects.
     @column _spatial_widget single_choice=True
-    st_to_wkt self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_to_wkt self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_to_wkt self.parent.underlying resolved as
 
@@ -315,7 +325,7 @@ type Spatial_Table
        A new table with the existing columns and a new column containing the
        spatial objects.
     @column Widget_Helpers.make_column_name_selector add_expression=True
-    st_from_wkt self (column : Column | Expression | Text | Integer = Missing_Argument.throw "column") as:Text="" =
+    st_from_wkt self (column : Column | Expression | Text | Integer = _default_if_single self) as:Text="" =
         resolved = _resolve_column column self.parent
         (self:Table).implementation.spatial_from_wkt self.parent.underlying resolved as
 
@@ -428,3 +438,7 @@ private _resolve_column column parent = case column of
     _ : Column -> column
     _ : Expression -> parent.evaluate_expression column ..Report_Warning
     _ -> parent.at column
+
+private _default_if_single table =
+    spatial_cols = table.spatial_columns
+    if spatial_cols.length == 1 then spatial_cols.first.name else Missing_Argument.throw "column"

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
@@ -4,11 +4,11 @@ import Standard.Base.Runtime.Ref.Ref
 from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import Single_Choice, Multiple_Choice
 
-
 import project.Column.Column
 import project.Expression.Expression
 import project.Internal.Widget_Helpers
 import project.Join_Condition.Join_Condition
+import project.Rows_To_Read.Rows_To_Read
 import project.Table.Table
 
 ## Extension methods for Spatial Tables
@@ -33,6 +33,34 @@ type Spatial_Table
        Get the columns in the table which contain spatial data.
     spatial_columns self =
         (self:Table).implementation.spatial_columns self.parent.underlying
+
+    ## ---
+       icon: data_input
+       ---
+       Returns a materialized dataframe containing rows of this table but with
+       any spatial columns materialized as GeoJSON. This is useful for exporting
+       data to other systems that may not support spatial data types.
+
+       ## Arguments
+        - `max_rows`: specifies the maximum number of rows to read.
+    @max_rows Rows_To_Read.default_widget
+    read_as_geojson self (max_rows : Rows_To_Read = self.implementation.default_max_rows) -> Table & Any =
+        folded = self.spatial_columns.fold self cur->col-> cur.st_to_geojson col as=col.name
+        folded.read max_rows
+
+    ## ---
+       icon: data_input
+       ---
+       Returns a materialized dataframe containing rows of this table but with
+       any spatial columns materialized as GeoJSON. This is useful for exporting
+       data to other systems that may not support spatial data types.
+
+       ## Arguments
+        - `max_rows`: specifies the maximum number of rows to read.
+    @max_rows Rows_To_Read.default_widget
+    read_as_wkt self (max_rows : Rows_To_Read = self.implementation.default_max_rows) -> Table & Any =
+        folded = self.spatial_columns.fold self cur->col-> cur.st_to_wkt col as=col.name
+        folded.read max_rows
 
     ## ---
        aliases: [create_points]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
@@ -44,7 +44,7 @@ type Spatial_Table
        ## Arguments
         - `max_rows`: specifies the maximum number of rows to read.
     @max_rows Rows_To_Read.default_widget
-    read_as_geojson self (max_rows : Rows_To_Read = self.implementation.default_max_rows) -> Table & Any =
+    read_as_geojson self (max_rows : Rows_To_Read = (self:Table).implementation.default_max_rows) -> Table & Any =
         folded = self.spatial_columns.fold self cur->col-> cur.st_to_geojson col as=col.name
         folded.read max_rows
 
@@ -52,13 +52,13 @@ type Spatial_Table
        icon: data_input
        ---
        Returns a materialized dataframe containing rows of this table but with
-       any spatial columns materialized as GeoJSON. This is useful for exporting
-       data to other systems that may not support spatial data types.
+       any spatial columns materialized as well-known text. This is useful for
+       exporting data to other systems that may not support spatial data types.
 
        ## Arguments
         - `max_rows`: specifies the maximum number of rows to read.
     @max_rows Rows_To_Read.default_widget
-    read_as_wkt self (max_rows : Rows_To_Read = self.implementation.default_max_rows) -> Table & Any =
+    read_as_wkt self (max_rows : Rows_To_Read = (self:Table).implementation.default_max_rows) -> Table & Any =
         folded = self.spatial_columns.fold self cur->col-> cur.st_to_wkt col as=col.name
         folded.read max_rows
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Spatial_Table.enso
@@ -22,8 +22,8 @@ type Spatial_Table
        ---
        If the column is a spatial column, returns it as a Spatial_Column
        otherwise throws a type error.
-    as_spatial_columns self column:Column =
-        (self:Table).implementation.as_spatial_columns self.parent.underlying column
+    as_spatial_column self column:Column =
+        (self:Table).implementation.as_spatial_column self.parent.underlying column
 
     ## ---
        group: Standard.Base.Metadata

--- a/project/IRCaches.scala
+++ b/project/IRCaches.scala
@@ -7,7 +7,7 @@ object IRCaches {
   /** As of 2025-11-04, on latest develop (https://github.com/enso-org/enso/actions/runs/19065973719/job/54456606143?pr=14223#step:10:3289),
     * the total cache size is 90.49 MB.
     */
-  val EXPECTED_MAX_SIZE_MB = 100
+  val EXPECTED_MAX_SIZE_MB = 105
 
   /** Ensures that IR caches of all standard libraries
     * are within the size limit.


### PR DESCRIPTION
### Pull Request Description

- Adds a `Spatial_Column` and a `Spatial_Input_Column` allowing spatial function use from expressions.
- Add `as_spatial_column` to `Spatial_Table` getting a column as a `Spatial_Column` or a type error if not spatial.
- Expand types identified as spatial by `DuckDB_Dialect`.
- Add `read_as_geojson` and `read_as_wkt` as fast ways to read spatial tables into memory with spatial objects converted.
- Adds extra types to the expression editor.

<img width="1039" height="247" alt="image" src="https://github.com/user-attachments/assets/9289a8cc-e608-4fe9-920f-4c75d4c957b6" />

<img width="693" height="130" alt="image" src="https://github.com/user-attachments/assets/8ea1a514-ccc0-4ed9-ae4d-a9fdc833af3d" />

<img width="477" height="117" alt="image" src="https://github.com/user-attachments/assets/40163ea7-6315-44da-bcbc-34f8ea392ef9" />

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
