### PR TITLE
Data for bench website generation are gathered from 2025-10-01

### DIFF
--- a/tools/performance/engine-benchmarks/website_regen.py
+++ b/tools/performance/engine-benchmarks/website_regen.py
@@ -16,8 +16,8 @@ from bench_tool.remote_cache import SyncRemoteCache
 from bench_tool.website import generate_bench_website
 
 # The inception date of the benchmarks, i.e., the date of the first benchmark run.
-ENGINE_SINCE = datetime.fromisoformat("2025-04-01")
-STDLIB_SINCE = datetime.fromisoformat("2025-04-01")
+ENGINE_SINCE = datetime.fromisoformat("2025-10-01")
+STDLIB_SINCE = datetime.fromisoformat("2025-10-01")
 
 _logger = logging.getLogger("website_regen")
 


### PR DESCRIPTION
Fix the [Benchmarks Upload](https://github.com/enso-org/enso/actions/workflows/bench-upload.yml) workflow.

Previous related PR #13399.

### Pull Request Description

Recent failure at https://github.com/enso-org/enso/actions/runs/20223327873 shows that the generated website for stdlib benchmarks is above 100 MB and therefore cannot be pushed to the repo. Fixing this by gathering data for the websites from 2025-10-01 instead of 2025-04-01.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Manually trigger the workflow to ensure it works
