### PR TITLE
Fix structural pattern match on intersection types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ eslint_report.json
 .enso-sources*
 .metals
 tools/performance/engine-benchmarks/generated_site
+.venv
 *.tsbuildinfo
 vite.config.ts.timestamp-*.mjs
 vitest.config.ts.timestamp-*.mjs

--- a/docs/types/intersection-types.md
+++ b/docs/types/intersection-types.md
@@ -78,6 +78,7 @@ requested).
 The following operations consider only the _visible_ part of the type:
 
 - [dynamic dispatch](../types/dynamic-dispatch.md)
+- [Positional (structural) pattern matching](./pattern-matching.md#positional-matching)
 - cases when value is passed as an argument
 
 However the value still keeps internal knowledge of all the types it represents.

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -61,7 +61,7 @@ public abstract class ConstructorBranchNode extends BranchNode {
       @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib,
       @Cached EnsoMultiValue.CastToNode castNode) {
     var expectedType = matcher.getType();
-    if (profile.profile(isValueOfTypeNode.execute(expectedType, target, true))) {
+    if (profile.profile(isValueOfTypeNode.execute(expectedType, target, false))) {
       var replacement = castNode.findTypeOrNull(expectedType, target, true, false);
       assert replacement != null : "Must find the type, when isValueOfTypeNode is true";
       var arr = fieldsFromObject(replacement, matcher, structsLib);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -1,16 +1,18 @@
 package org.enso.interpreter.node.controlflow.caseexpr;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
+import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
+import org.enso.interpreter.runtime.data.EnsoMultiValue;
 import org.enso.interpreter.runtime.data.atom.Atom;
 import org.enso.interpreter.runtime.data.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
@@ -40,9 +42,29 @@ public abstract class ConstructorBranchNode extends BranchNode {
 
   @Specialization
   void doAtom(
-      VirtualFrame frame, Object state, Atom target, @Cached FieldsAsArrayNode toArrayNode) {
+      VirtualFrame frame,
+      Object state,
+      Atom target,
+      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
     if (profile.profile(matcher == target.getConstructor())) {
-      var arr = toArrayNode.executeFields(target);
+      var arr = fieldsFromObject(target, matcher, structsLib);
+      accept(frame, state, arr);
+    }
+  }
+
+  @Specialization
+  void doMultiValue(
+      VirtualFrame frame,
+      Object state,
+      EnsoMultiValue target,
+      @Cached IsValueOfTypeNode isValueOfTypeNode,
+      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib,
+      @Cached EnsoMultiValue.CastToNode castNode) {
+    var expectedType = matcher.getType();
+    if (profile.profile(isValueOfTypeNode.execute(expectedType, target, true))) {
+      var replacement = castNode.findTypeOrNull(expectedType, target, true, true);
+      assert replacement != null : "Must find the type, when isValueOfTypeNode is true";
+      var arr = fieldsFromObject(replacement, matcher, structsLib);
       accept(frame, state, arr);
     }
   }
@@ -50,28 +72,14 @@ public abstract class ConstructorBranchNode extends BranchNode {
   @Fallback
   void doFallback(VirtualFrame frame, Object state, Object target) {}
 
-  abstract static class FieldsAsArrayNode extends Node {
-    abstract Object[] executeFields(Atom target);
-
-    @Specialization(
-        limit = "3",
-        guards = {"atom.getConstructor() == cons"})
-    @ExplodeLoop
-    Object[] fieldsFromAtomCached(
-        Atom atom,
-        @Cached("atom.getConstructor()") AtomConstructor cons,
-        @CachedLibrary(limit = "3") StructsLibrary structs) {
-      var arr = new Object[cons.getArity()];
-      for (var i = 0; i < arr.length; i++) {
-        arr[i] = structs.getField(atom, i);
-      }
-      return arr;
+  @ExplodeLoop
+  private static Object[] fieldsFromObject(
+      Object obj, AtomConstructor cons, StructsLibrary structsLib) {
+    CompilerAsserts.partialEvaluationConstant(cons);
+    var arr = new Object[cons.getArity()];
+    for (var i = 0; i < arr.length; i++) {
+      arr[i] = structsLib.getField(obj, i);
     }
-
-    @Specialization
-    @TruffleBoundary
-    Object[] fieldsFromAtomUncached(Atom atom) {
-      return fieldsFromAtomCached(atom, atom.getConstructor(), StructsLibrary.getUncached());
-    }
+    return arr;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -62,8 +62,16 @@ public abstract class ConstructorBranchNode extends BranchNode {
       @Cached EnsoMultiValue.CastToNode castNode) {
     var expectedType = matcher.getType();
     if (profile.profile(isValueOfTypeNode.execute(expectedType, target, false))) {
+      // replacement is the narrowed (type) value.
       var replacement = castNode.findTypeOrNull(expectedType, target, true, false);
       assert replacement != null : "Must find the type, when isValueOfTypeNode is true";
+      if (replacement instanceof EnsoMultiValue mv
+          && mv.firstDispatchValue() instanceof Atom replacementAtom) {
+        if (matcher != replacementAtom.getConstructor()) {
+          // The narrowed value atom has a different constructor - it cannot match.
+          return;
+        }
+      }
       var arr = fieldsFromObject(replacement, matcher, structsLib);
       accept(frame, state, arr);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -62,7 +62,7 @@ public abstract class ConstructorBranchNode extends BranchNode {
       @Cached EnsoMultiValue.CastToNode castNode) {
     var expectedType = matcher.getType();
     if (profile.profile(isValueOfTypeNode.execute(expectedType, target, true))) {
-      var replacement = castNode.findTypeOrNull(expectedType, target, true, true);
+      var replacement = castNode.findTypeOrNull(expectedType, target, true, false);
       assert replacement != null : "Must find the type, when isValueOfTypeNode is true";
       var arr = fieldsFromObject(replacement, matcher, structsLib);
       accept(frame, state, arr);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
@@ -58,7 +58,7 @@ import org.graalvm.collections.Pair;
  * EnsoMultiValue#values} (both visible and hidden). If any of the stored values is a primitive, the
  * {@link EnsoMultiValue} will respond positively to the corresponding interop query (like {@code
  * isNumber}) and will delegate the conversion to that value. If multiple stored values match the
- * same primitive category, an arbitrary one is chosen for the conversion.
+ * same primitive category, the first one is chosen for the conversion.
  *
  * <p>See, e.g., {@link EnsoMultiValue#isBoolean(InteropLibrary)}.
  *

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
@@ -41,14 +41,50 @@ import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.graalvm.collections.Pair;
 
+/**
+ * This class represents a value that can have multiple types at the same time - an intersection
+ * type.
+ *
+ * <h2>Method invocation</h2>
+ *
+ * Method invocation on {@link EnsoMultiValue} dispatches the method based on the {@link
+ * EnsoMultiValue#getVisibleTypes() visible types} only. The {@link EnsoMultiValue#getExtraTypes()
+ * hidden types} are not considered during method dispatch, but they are still part of the {@link
+ * EnsoMultiValue}'s type set and can be cast to.
+ *
+ * <h2>Primitive values</h2>
+ *
+ * For interop purposes, primitive values are detected among all the values stored in the {@link
+ * EnsoMultiValue#values} (both visible and hidden). If any of the stored values is a primitive, the
+ * {@link EnsoMultiValue} will respond positively to the corresponding interop query (like {@code
+ * isNumber}) and will delegate the conversion to that value. If multiple stored values match the
+ * same primitive category, an arbitrary one is chosen for the conversion.
+ *
+ * <p>See, e.g., {@link EnsoMultiValue#isBoolean(InteropLibrary)}.
+ *
+ * <h2>Documentation</h2>
+ *
+ * @see <a
+ *     href="https://github.com/enso-org/enso/blob/3e730e9569cd3692c3acb35b35f62e48e5b18dee/docs/types/intersection-types.md">
+ *     Intersection types documentation </a>
+ */
 @ExportLibrary(TypesLibrary.class)
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(value = StructsLibrary.class)
 public final class EnsoMultiValue extends EnsoObject {
+  /** <i>Visible</i> types. */
   private final EnsoMultiType dispatch;
+
+  /** <i>Hidden</i> types. */
   private final EnsoMultiType extra;
+
+  /** Index into {@link #values} where the first {@link #dispatch} value is located. */
   private final int firstDispatch;
 
+  /**
+   * All the values that this {@link EnsoMultiValue} can represent. Length of this array is the same
+   * as number of types in {@link #dispatch} and {@link #extra} combined.
+   */
   @CompilationFinal(dimensions = 1)
   private final Object[] values;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
@@ -96,7 +96,7 @@ public final class EnsoMultiValue extends EnsoObject {
     this.values = values;
   }
 
-  final Object firstDispatchValue() {
+  public Object firstDispatchValue() {
     return values[firstDispatch];
   }
 

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -238,47 +238,14 @@ add_specs suite_builder =
                 Wrapper.Wrapper_Ctor (A.A_Ctor _) -> Nothing
                 _ -> Test.fail "should match A.A_Ctor inside Wrapper"
 
-        group_builder.specify "structural pattern match keeps warning on field - first visible type" <|
+        # See test "constructor pattern match does not preserve warning on a field"
+        # In Warnings_Spec.enso
+        group_builder.specify "structural pattern match drops warning from field" <|
             field_with_warn = Warning.attach "warn" 42
             ab = make_a_and_b field=field_with_warn
             case ab of
                 A.A_Ctor x ->
-                    Warning.has_warnings x . should_be_true
-                _ -> Test.fail "should match A.A_Ctor"
-
-        group_builder.specify "structural pattern match keeps warning on field - second visible type" <|
-            field_with_warn = Warning.attach "warn" 42
-            ab = make_a_and_b field=field_with_warn
-            case ab of
-                B.B_Ctor (A.A_Ctor x) ->
-                    Warning.has_warnings x . should_be_true
-                _ -> Test.fail "should match B.B_Ctor"
-
-        group_builder.specify "structural pattern match keeps warning on field after narrowing to first visible type" <|
-            field_with_warn = Warning.attach "warn" 42
-            ab = make_a_and_b field=field_with_warn
-            a = ab:A
-            case a of
-                A.A_Ctor x ->
-                    Warning.has_warnings x . should_be_true
-                _ -> Test.fail "should match A.A_Ctor"
-
-        group_builder.specify "structural pattern match keeps warning on field after narrowing to second visible type" <|
-            field_with_warn = Warning.attach "warn" 42
-            ab = make_a_and_b field=field_with_warn
-            b = ab:B
-            case b of
-                B.B_Ctor (A.A_Ctor x) ->
-                    Warning.has_warnings x . should_be_true
-                _ -> Test.fail "should match B.B_Ctor"
-
-        group_builder.specify "nested structural pattern match keeps warning on field" <|
-            field_with_warn = Warning.attach "warn" 42
-            ab = make_a_and_b field=field_with_warn
-            wrapper = Wrapper.Wrapper_Ctor ab
-            case wrapper of
-                Wrapper.Wrapper_Ctor (A.A_Ctor x) ->
-                    Warning.has_warnings x . should_be_true
+                    Warning.has_warnings x . should_be_false
                 _ -> Test.fail "should match A.A_Ctor"
 
         group_builder.specify "calling a method on one of the types should not lose the intersection type" <|

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -23,6 +23,10 @@ type C
 
 C.from (that:B) = C.C_Ctor that
 
+type Wrapper
+    Wrapper_Ctor x
+
+
 add_specs suite_builder =
     suite_builder.group "Multi Value as type refinement" group_builder->
         group_builder.specify "conversion A -> B should not be available" <|
@@ -198,6 +202,27 @@ add_specs suite_builder =
                 B.B_Ctor x -> "matched: "+x.to_text
                 _ -> "structural matching of B.B_Ctor failed"
             r.should_equal "matched: (A_Ctor 1)"
+
+        group_builder.specify "structural pattern matchings match on open intersection type" <|
+            a = A.A_Ctor 1
+            a_any = (a : A & Any)
+            case a_any of
+                A.A_Ctor _ -> Nothing
+                _ -> Test.fail "should match A.A_Ctor"
+
+        group_builder.specify "structural pattern matchings match on open type" <|
+            a = A.A_Ctor 1
+            any = (a : Any)
+            case any of
+                A.A_Ctor _ -> Nothing
+                _ -> Test.fail "should match A.A_Ctor"
+
+        group_builder.specify "nested structural pattern matching on primary type" <|
+            ab = make_a_and_b
+            wrapper = Wrapper.Wrapper_Ctor ab
+            case wrapper of
+                Wrapper.Wrapper_Ctor (A.A_Ctor _) -> Nothing
+                _ -> Test.fail "should match A.A_Ctor inside Wrapper"
 
         group_builder.specify "calling a method on one of the types should not lose the intersection type" <|
             ab = make_a_and_b

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -196,7 +196,7 @@ add_specs suite_builder =
                 _ -> "structural matching of A.A_Ctor failed"
             r.should_equal "matched: 1"
 
-        group_builder.specify "should structural matching match other types" <|
+        group_builder.specify "should structural matching match other visible type" <|
             ab = make_a_and_b
             r = case ab of
                 B.B_Ctor x -> "matched: "+x.to_text
@@ -217,20 +217,19 @@ add_specs suite_builder =
                 A.A_Ctor _ -> Nothing
                 _ -> Test.fail "should match A.A_Ctor"
 
-        group_builder.specify "structural pattern matching on hidden type" <|
+        group_builder.specify "structural pattern matching on hidden type should fail" <|
             ab = make_a_and_b
             a_only = (ab : A)
             case a_only of
-                B.B_Ctor _ -> Nothing
-                _ -> Test.fail "should match B.B_Ctor"
+                B.B_Ctor _ -> Test.fail "should not match B.B_Ctor"
+                _ -> Nothing
 
-        group_builder.specify "structural pattern matching on hidden type - destruct" <|
+        group_builder.specify "structural destruct pattern matching on hidden type should fail" <|
             ab = make_a_and_b
             a_only = (ab : A)
             case a_only of
-                B.B_Ctor (A.A_Ctor x) ->
-                    x.should_equal 1
-                _ -> Test.fail "should match B.B_Ctor"
+                B.B_Ctor (A.A_Ctor x) -> Test.fail "should not match B.B_Ctor"
+                _ -> Nothing
 
         group_builder.specify "nested structural pattern matching on primary type" <|
             ab = make_a_and_b

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -185,14 +185,14 @@ add_specs suite_builder =
             (c:A).to_text . should_equal "(A_Ctor 1)"
             (c:B).to_text . should_equal "(B_Ctor (A_Ctor 1))"
 
-        group_builder.specify "structural pattern matching should be able to match the primary type" pending="Pattern matching: #12142" <|
+        group_builder.specify "structural pattern matching should be able to match the primary type" <|
             ab = make_a_and_b
             r = case ab of
                 A.A_Ctor x -> "matched: "+x.to_text
                 _ -> "structural matching of A.A_Ctor failed"
             r.should_equal "matched: 1"
 
-        group_builder.specify "should structural matching match other types?" pending="Pattern matching: decide if we keep this test in #12142" <|
+        group_builder.specify "should structural matching match other types?" <|
             ab = make_a_and_b
             r = case ab of
                 B.B_Ctor x -> "matched: "+x.to_text

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -238,6 +238,49 @@ add_specs suite_builder =
                 Wrapper.Wrapper_Ctor (A.A_Ctor _) -> Nothing
                 _ -> Test.fail "should match A.A_Ctor inside Wrapper"
 
+        group_builder.specify "structural pattern match keeps warning on field - first visible type" <|
+            field_with_warn = Warning.attach "warn" 42
+            ab = make_a_and_b field=field_with_warn
+            case ab of
+                A.A_Ctor x ->
+                    Warning.has_warnings x . should_be_true
+                _ -> Test.fail "should match A.A_Ctor"
+
+        group_builder.specify "structural pattern match keeps warning on field - second visible type" <|
+            field_with_warn = Warning.attach "warn" 42
+            ab = make_a_and_b field=field_with_warn
+            case ab of
+                B.B_Ctor (A.A_Ctor x) ->
+                    Warning.has_warnings x . should_be_true
+                _ -> Test.fail "should match B.B_Ctor"
+
+        group_builder.specify "structural pattern match keeps warning on field after narrowing to first visible type" <|
+            field_with_warn = Warning.attach "warn" 42
+            ab = make_a_and_b field=field_with_warn
+            a = ab:A
+            case a of
+                A.A_Ctor x ->
+                    Warning.has_warnings x . should_be_true
+                _ -> Test.fail "should match A.A_Ctor"
+
+        group_builder.specify "structural pattern match keeps warning on field after narrowing to second visible type" <|
+            field_with_warn = Warning.attach "warn" 42
+            ab = make_a_and_b field=field_with_warn
+            b = ab:B
+            case b of
+                B.B_Ctor (A.A_Ctor x) ->
+                    Warning.has_warnings x . should_be_true
+                _ -> Test.fail "should match B.B_Ctor"
+
+        group_builder.specify "nested structural pattern match keeps warning on field" <|
+            field_with_warn = Warning.attach "warn" 42
+            ab = make_a_and_b field=field_with_warn
+            wrapper = Wrapper.Wrapper_Ctor ab
+            case wrapper of
+                Wrapper.Wrapper_Ctor (A.A_Ctor x) ->
+                    Warning.has_warnings x . should_be_true
+                _ -> Test.fail "should match A.A_Ctor"
+
         group_builder.specify "calling a method on one of the types should not lose the intersection type" <|
             ab = make_a_and_b
 

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -196,7 +196,7 @@ add_specs suite_builder =
                 _ -> "structural matching of A.A_Ctor failed"
             r.should_equal "matched: 1"
 
-        group_builder.specify "should structural matching match other types?" <|
+        group_builder.specify "should structural matching match other types" <|
             ab = make_a_and_b
             r = case ab of
                 B.B_Ctor x -> "matched: "+x.to_text
@@ -216,6 +216,21 @@ add_specs suite_builder =
             case any of
                 A.A_Ctor _ -> Nothing
                 _ -> Test.fail "should match A.A_Ctor"
+
+        group_builder.specify "structural pattern matching on hidden type" <|
+            ab = make_a_and_b
+            a_only = (ab : A)
+            case a_only of
+                B.B_Ctor _ -> Nothing
+                _ -> Test.fail "should match B.B_Ctor"
+
+        group_builder.specify "structural pattern matching on hidden type - destruct" <|
+            ab = make_a_and_b
+            a_only = (ab : A)
+            case a_only of
+                B.B_Ctor (A.A_Ctor x) ->
+                    x.should_equal 1
+                _ -> Test.fail "should match B.B_Ctor"
 
         group_builder.specify "nested structural pattern matching on primary type" <|
             ab = make_a_and_b

--- a/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_As_Type_Refinement_Spec.enso
@@ -228,7 +228,7 @@ add_specs suite_builder =
             ab = make_a_and_b
             a_only = (ab : A)
             case a_only of
-                B.B_Ctor (A.A_Ctor x) -> Test.fail "should not match B.B_Ctor"
+                B.B_Ctor (A.A_Ctor _) -> Test.fail "should not match B.B_Ctor"
                 _ -> Nothing
 
         group_builder.specify "nested structural pattern matching on primary type" <|

--- a/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
@@ -178,6 +178,27 @@ add_specs suite_builder =
             Test.expect_panic Type_Error <|
                 a : C
 
+    suite_builder.group "MultiValue with warnings" group_builder->
+        group_builder.specify "warning is propagated to the outer MultiValue" <|
+            field_with_warn = Warning.attach "warn" 42
+            b = B.B field_with_warn
+            b_and_c = b : B & C
+            Warning.has_warnings b_and_c . should_be_true
+
+        group_builder.specify "warning should be preserved on the field" <|
+            field_with_warn = Warning.attach "warn" 42
+            b = B.B field_with_warn
+            b_and_c = b : B & C
+            b_only = b_and_c : B
+            Warning.has_warnings b_only.v . should_be_true
+
+        group_builder.specify "warning should be preserved on the field after narrowing" <|
+            field_with_warn = Warning.attach "warn" 42
+            b = B.B field_with_warn
+            b_and_c = b : B & C
+            c = b_and_c : C
+            Warning.has_warnings c.v . should_be_true
+
 Any.confuse_me self = self
 
 main filter=Nothing =

--- a/test/Base_Tests/src/Semantic/Type_Refinement/Types.enso
+++ b/test/Base_Tests/src/Semantic/Type_Refinement/Types.enso
@@ -19,8 +19,8 @@ type X
 
     x_method self = "X method"
 
-make_a_and_b -> A & B =
-    a = A.A_Ctor 1
+make_a_and_b field=1 -> A & B =
+    a = A.A_Ctor field
     # Relies on the hidden conversion
     (a : A & B)
 

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -160,6 +160,14 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         r.should_equal 6
         Warning.get_all r . map .value . should_equal [My_Warning.Value "warn!", My_Warning.Value "warn!!", My_Warning.Value "warn!!!"]
 
+    group_builder.specify "constructor pattern match does not preserve warning on a field" <|
+        field_with_warn = Warning.attach "warn" 42
+        obj = Wrap.Value field_with_warn
+        case obj of
+            Wrap.Value x ->
+                Warning.has_warnings x . should_be_false
+            _ -> Test.fail "Should match on Wrap.Value ctor"
+
     group_builder.specify "should thread warnings through conversions" <|
         z = Wrap.Value (Warning.attach 'warn!' 1)
         i = Integer.from z


### PR DESCRIPTION
Fixes #12142

### Pull Request Description

Fixes destruct pattern matching for multivalue types - pattern matching on constructors should now have the same semantics as pattern matching on types for multivalue types.

### Important Notes

Pattern matching on constructors (structural pattern match) does not respect hidden types. See https://github.com/enso-org/enso/pull/14498#discussion_r2624154880

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Unit tests have been written where possible.
- [x] Run engine benchs - https://github.com/enso-org/enso/actions/runs/20365845092
- [x] add a "Structural Pattern Match" section to [docs](https://github.com/enso-org/enso/blob/880df112e41ef4f505f63cb2bab7402392ffbac0/docs/types/intersection-types.md#narrowing-type-check)
