### PR TITLE
getAssetsDetails must not be persistent

### DIFF
--- a/app/gui/src/project-view/composables/backend.ts
+++ b/app/gui/src/project-view/composables/backend.ts
@@ -33,6 +33,7 @@ const noFresh = { staleTime: 0 }
 const methodDefaultOptions: Partial<Record<BackendQueryMethod, ExtraOptions>> = {
   listDirectory: { ...noPersist, ...noFresh },
   getFileDetails: { ...noPersist },
+  getAssetDetails: { ...noPersist },
 }
 
 /** Commonly used options for tanstack queries to backend. */

--- a/app/gui/src/providers/rightPanel.ts
+++ b/app/gui/src/providers/rightPanel.ts
@@ -224,6 +224,7 @@ function useRightPanel(
       return await backendForType(backendType).getAssetDetails(currentItem.id, undefined)
     },
     enabled: () => backendType.value != null && focusedAsset.value != null,
+    meta: { persist: false },
   })
   const focusedAssetDetails = focusedAssetDetailsQuery.data
 


### PR DESCRIPTION
### Pull Request Description

Fixes https://github.com/enso-org/cloud-v2/issues/2288

This is a hotfix, which does not address the core issue — duplicate (triplicate?) definitions of `backendQueryOptions` in the codebase.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
