### PR TITLE
Fix broken suspention/restoration of Expression Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - [Fix non-visible button and wrong layout in GeoMap Visualization][14443]
 - [Added additonal file and site options for MS365 credentials][14477]
 - [Maximum height of the file browser is slightly reduced][14467]
+- [Fix bug where Table Expressions weren't saved after finishing edit by mouse
+  click][14500]
 
 [13685]: https://github.com/enso-org/enso/pull/13685
 [13658]: https://github.com/enso-org/enso/pull/13658
@@ -70,6 +72,7 @@
 [14443]: https://github.com/enso-org/enso/pull/14443
 [14477]: https://github.com/enso-org/enso/pull/14477
 [14467]: https://github.com/enso-org/enso/pull/14467
+[14500]: https://github.com/enso-org/enso/pull/14500
 
 #### Enso Standard Library
 

--- a/app/gui/src/providers/openedProjects/widgetRegistry/editHandler.ts
+++ b/app/gui/src/providers/openedProjects/widgetRegistry/editHandler.ts
@@ -5,7 +5,16 @@ import type { PortId } from '@/providers/portInfo'
 import { injectWidgetTree, type CurrentEdit } from '@/providers/widgetTree'
 import type { Ast } from '@/util/ast'
 import { ArgumentInfoKey } from '@/util/callTree'
-import { computed, markRaw, shallowRef, useId, watch, type ShallowRef, type WatchSource } from 'vue'
+import {
+  computed,
+  markRaw,
+  shallowRef,
+  toValue,
+  useId,
+  watch,
+  type ShallowRef,
+  type WatchSource,
+} from 'vue'
 import { assertDefined } from 'ydoc-shared/util/assert'
 
 declare const widgetInstanceIdBrand: unique symbol
@@ -303,10 +312,10 @@ export class WidgetEditHandler extends WidgetEditHandlerParent {
     )
     assertDefined(currentHandler.value)
     watch(
-      [currentHandler, widgetInstanceId],
-      ([handler, id], _, onCleanup) => {
-        handler.tryResume(id, handler.portId)
-        onCleanup(() => handler.suspend(id))
+      currentHandler,
+      (handler, _, onCleanup) => {
+        handler.tryResume(toValue(widgetInstanceId), handler.portId)
+        onCleanup(() => handler.suspend(toValue(widgetInstanceId)))
       },
       { immediate: true },
     )


### PR DESCRIPTION
### Pull Request Description

Fixes #14413 

The problem was our suspension mechanism: the widget was suspended when widgetInstanceId was updated. We then tried to resume edit, but with new id what failed. Without active edit, pointerdown handlers in interactions didn't work properly in blurring and saving edits.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
