### PR TITLE
Suspended union type check like `~b=Text|Nothing=Nothing` fails

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -202,20 +202,40 @@ public class ExecStrictCompilerTest {
         def a:Integer ~b:Text|Nothing=Nothing -> Text:Nothing =
             if a < 0 then "Minus" else
                 b
+        call_def_with_thunk a:Integer =
+            def a 6*7
         """;
     var module = ctxRule.eval(LanguageInfo.ID, code);
     var def = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "def");
     var hi = def.execute(1, "Hi");
     assertEquals("Hi", hi.asString());
     try {
-      var r = def.execute(-2, 20);
-      fail("We don't expect any result, but exception: " + r);
+      var noResult = def.execute(-2, 20);
+      fail("Invoking def with second argument being Integer yields an exception: " + noResult);
     } catch (PolyglotException ex) {
       assertThat(
           ex.getMessage(),
           AllOf.allOf(
               containsString("expected `b` to be Text"), containsString("but got Integer")));
     }
-    assertTrue("Returns nothing", def.execute(3).isNull());
+    assertTrue("Default value is Nothing. Returns Nothing.", def.execute(3).isNull());
+    assertTrue("Passing null is OK.", def.execute(4, null).isNull());
+    var thunkArg = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "call_def_with_thunk");
+    var m = thunkArg.execute(-1);
+    assertEquals(
+        "Invoking def with second argument being a Thunk passes the type check",
+        "Minus",
+        m.asString());
+    try {
+      var fail = thunkArg.execute(1);
+      fail(
+          "Non-negative first argument requires evaluation of the second and that fails on type"
+              + " check.");
+    } catch (PolyglotException ex) {
+      assertThat(
+          ex.getMessage(),
+          AllOf.allOf(
+              containsString("expected `b` to be Text"), containsString("but got Integer")));
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -193,4 +193,29 @@ public class ExecStrictCompilerTest {
           AllOf.allOf(containsString("The name `f`"), containsString("could not be found")));
     }
   }
+
+  @Test
+  public void suspendedDefaultedUnionArgument() throws Exception {
+    var code =
+        """
+        from Standard.Base import all
+        def a:Integer ~b:Text|Nothing=Nothing -> Text:Nothing =
+            if a < 0 then "Minus" else
+                b
+        """;
+    var module = ctxRule.eval(LanguageInfo.ID, code);
+    var def = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "def");
+    var hi = def.execute(1, "Hi");
+    assertEquals("Hi", hi.asString());
+    try {
+      var r = def.execute(-2, 20);
+      fail("We don't expect any result, but exception: " + r);
+    } catch (PolyglotException ex) {
+      assertThat(
+          ex.getMessage(),
+          AllOf.allOf(
+              containsString("expected `b` to be Text"), containsString("but got Integer")));
+    }
+    assertTrue("Returns nothing", def.execute(3).isNull());
+  }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -199,7 +199,7 @@ public class ExecStrictCompilerTest {
     var code =
         """
         from Standard.Base import all
-        def a:Integer ~b:Text|Nothing=Nothing -> Text:Nothing =
+        def a:Integer ~b:Text|Nothing=Nothing -> Text|Nothing =
             if a < 0 then "Minus" else
                 b
         call_def_with_thunk a:Integer =

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 import org.enso.interpreter.node.expression.builtin.meta.IsValueOfTypeNode;
@@ -27,7 +26,6 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   private final Type expectedType;
   @Node.Child IsValueOfTypeNode checkType;
   @CompilerDirectives.CompilationFinal private String expectedTypeMessage;
-  @CompilerDirectives.CompilationFinal private LazyCheckRootNode lazyCheck;
   @Node.Child private EnsoMultiValue.CastToNode castTo;
 
   SingleTypeCheckNode(String name, Type expectedType) {
@@ -79,14 +77,7 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   @ExplodeLoop
   private final Object directMatchImpl(Object v) {
     if (v instanceof Function fn && fn.isThunk()) {
-      if (lazyCheck == null) {
-        CompilerDirectives.transferToInterpreter();
-        var enso = EnsoLanguage.get(this);
-        var node = (AbstractTypeCheckNode) copy();
-        lazyCheck = new LazyCheckRootNode(enso, new TypeCheckValueNode(node, isAllTypes()));
-      }
-      var lazyCheckFn = lazyCheck.wrapThunk(fn);
-      return lazyCheckFn;
+      return fn;
     }
     assert EnsoContext.get(this).getBuiltins().any() != expectedType
         : "Don't check for Any: " + expectedType;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.enso.compiler.core.ir.AscriptionReason;
+import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.builtin.meta.AtomWithAHoleNode;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -89,8 +90,20 @@ public final class TypeCheckValueNode extends Node {
     }
   }
 
+  @CompilerDirectives.CompilationFinal private LazyCheckRootNode lazyCheck;
+
   private final Object handleCheckOrConversionImpl(VirtualFrame frame, Object value) {
     var direct = check.findDirectMatch(frame, value);
+    if (direct instanceof Function fn && fn.isThunk()) {
+      if (lazyCheck == null) {
+        CompilerDirectives.transferToInterpreter();
+        var enso = EnsoLanguage.get(this);
+        var node = (AbstractTypeCheckNode) check.copy();
+        lazyCheck = new LazyCheckRootNode(enso, new TypeCheckValueNode(node, isAllTypes()));
+      }
+      var lazyCheckFn = lazyCheck.wrapThunk(fn);
+      return lazyCheckFn;
+    }
     if (direct != null) {
       return direct;
     }


### PR DESCRIPTION
### Pull Request Description

When checking for union type (like `Text|Nothing`) only `Text` was allowed to go thru, not the other union types. Moving the `LazyCheckRootNode` creation to `TypeCheckValueNode` fixes the problem.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.

