### PR TITLE
Fix Code Editor positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [Fix non-visible button and wrong layout in GeoMap Visualization][14443]
 - [Added additonal file and site options for MS365 credentials][14477]
 - [Maximum height of the file browser is slightly reduced][14467]
+- [Fix mispositioned bottom panel][14506]
 
 [13685]: https://github.com/enso-org/enso/pull/13685
 [13658]: https://github.com/enso-org/enso/pull/13658
@@ -72,6 +73,7 @@
 [14443]: https://github.com/enso-org/enso/pull/14443
 [14477]: https://github.com/enso-org/enso/pull/14477
 [14467]: https://github.com/enso-org/enso/pull/14467
+[14506]: https://github.com/enso-org/enso/pull/14506
 
 #### Enso Standard Library
 

--- a/app/gui/src/project-view/components/BottomPanel.vue
+++ b/app/gui/src/project-view/components/BottomPanel.vue
@@ -38,6 +38,11 @@ const style = computed(() =>
 </script>
 
 <template>
+  <ActionButton
+    action="graph.toggleCodeEditor"
+    class="gutterButton bottomOfGutter"
+    :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
+  />
   <Transition>
     <div
       v-if="show"
@@ -45,12 +50,8 @@ const style = computed(() =>
       class="BottomPanel dock"
       :style="style"
       data-testid="bottomDock"
+      v-bind="$attrs"
     >
-      <ActionButton
-        action="graph.toggleCodeEditor"
-        class="gutterButton bottomOfGutter"
-        :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
-      />
       <WithFullscreenMode v-model="fullscreen" @update:animating="fullscreenAnimating = $event">
         <ActionButton
           action="panel.fullscreen"

--- a/app/gui/src/project-view/components/BottomPanel.vue
+++ b/app/gui/src/project-view/components/BottomPanel.vue
@@ -38,36 +38,34 @@ const style = computed(() =>
 </script>
 
 <template>
-  <div>
-    <ActionButton
-      action="graph.toggleCodeEditor"
-      class="gutterButton bottomOfGutter"
-      :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
-    />
-    <Transition>
-      <div
-        v-if="show"
-        ref="rootElement"
-        class="BottomPanel dock"
-        :style="style"
-        data-testid="bottomDock"
-      >
-        <WithFullscreenMode v-model="fullscreen" @update:animating="fullscreenAnimating = $event">
-          <ActionButton
-            action="panel.fullscreen"
-            class="gutterButton topOfGutter"
-            :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
-          />
-          <slot />
-        </WithFullscreenMode>
-        <ResizeHandles
-          top
-          :modelValue="computedBounds"
-          @update:modelValue="savedSize = { height: $event.height }"
+  <Transition>
+    <div
+      v-if="show"
+      ref="rootElement"
+      class="BottomPanel dock"
+      :style="style"
+      data-testid="bottomDock"
+    >
+      <ActionButton
+        action="graph.toggleCodeEditor"
+        class="gutterButton bottomOfGutter"
+        :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
+      />
+      <WithFullscreenMode v-model="fullscreen" @update:animating="fullscreenAnimating = $event">
+        <ActionButton
+          action="panel.fullscreen"
+          class="gutterButton topOfGutter"
+          :class="{ aboveFullscreen: fullscreen || fullscreenAnimating }"
         />
-      </div>
-    </Transition>
-  </div>
+        <slot />
+      </WithFullscreenMode>
+      <ResizeHandles
+        top
+        :modelValue="computedBounds"
+        @update:modelValue="savedSize = { height: $event.height }"
+      />
+    </div>
+  </Transition>
 </template>
 
 <style scoped>

--- a/app/gui/src/project-view/components/GraphEditor.vue
+++ b/app/gui/src/project-view/components/GraphEditor.vue
@@ -764,7 +764,7 @@ const contextMenuActions: DisplayableActionName[] = [
 .vertical {
   display: flex;
   flex-direction: column;
-  & .bottomPanel {
+  & :deep(.bottomPanel) {
     flex: none;
   }
   & .viewportPanel {


### PR DESCRIPTION
### Pull Request Description

Fixes #14505

Removed wrapped div, which broke the code edito height if no height was set in app storage (i.e. user has not resize panel yet). ~~Put buttons inside proper div, because they have absolute position anyway.~~ The attributes are now passed to inner div.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
