### PR TITLE
Speeding up of `Vector.build` in order of magnitudes

### DIFF
--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBuilderBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBuilderBenchmarks.java
@@ -1,0 +1,169 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import org.enso.compiler.benchmarks.Utils;
+import org.graalvm.polyglot.Value;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class VectorBuilderBenchmarks {
+  private Value create;
+  private Value self;
+  private int length;
+  private Object value;
+  private Object specialValue;
+  private int at;
+
+  @Setup
+  public void initializeBenchmark(BenchmarkParams params) throws Exception {
+    var ctx = Utils.createDefaultContextBuilder().build();
+    var benchmarkName = SrcUtil.findName(params);
+    var code =
+        """
+        from Standard.Base import all
+
+        create value size:Integer special_value at =
+            Vector.build b->
+                0.up_to size . each index->
+                    if index == at then b.append special_value else
+                        b.append value
+        """;
+
+    var module = ctx.eval(SrcUtil.source(benchmarkName, code));
+
+    this.self = module.invokeMember("get_associated_type");
+    Function<String, Value> getMethod = (name) -> module.invokeMember("get_method", self, name);
+
+    this.length = Integer.parseInt(regex(".*Length([0-9]+).*", benchmarkName, null));
+    var valueType = regex(".*Type([A-Z][a-z]+).*", benchmarkName, null);
+    this.value = valueFor(valueType);
+    this.specialValue = valueFor(regex(".*With([A-Z][a-z]*).*", benchmarkName, valueType));
+    this.at = Integer.parseInt(regex(".*At([0-9]+).*", benchmarkName, "-1"));
+    this.create = getMethod.apply("create");
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength5(Blackhole matter) {
+    // default size of Vector.build is 10
+    // e.g. this benchmark fits into initial size
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength15(Blackhole matter) {
+    // default size of Vector.build is 10
+    // e.g. this benchmark exceeds initial size
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength150(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength1500(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeFloatLength15(Blackhole matter) {
+    // default size of Vector.build is 10
+    // e.g. this benchmark exceeds initial size
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeFloatLength150(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeFloatLength1500(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeTextLength15(Blackhole matter) {
+    // default size of Vector.build is 10
+    // e.g. this benchmark exceeds initial size
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeTextLength150(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeTextLength1500(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength5WithFloatAt2(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength15WithFloatAt2(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void buildTypeIntegerLength150WithFloatAt2(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  private void performBenchmark(Blackhole hole) throws AssertionError {
+    var result = create.execute(self, value, length, specialValue, at);
+    if (!result.hasArrayElements()) {
+      throw new IllegalStateException("Expecting array, but got: " + result);
+    }
+    var realLength = result.getArraySize();
+    if (realLength != length) {
+      throw new IllegalStateException(
+          "Expecting array size " + length + " , but got: " + realLength);
+    }
+    hole.consume(result);
+  }
+
+  private static String regex(String pattern, String benchmarkName, String def) {
+    var matcher = Pattern.compile(pattern).matcher(benchmarkName);
+    if (!matcher.matches()) {
+      if (def != null) {
+        return def;
+      }
+      throw new IllegalStateException("No match of " + pattern + " in " + benchmarkName);
+    }
+    return matcher.group(1);
+  }
+
+  private static Object valueFor(String type) throws IllegalStateException {
+    return switch (type) {
+      case "Integer" -> 42L;
+      case "Float" -> Math.PI;
+      case "Text" -> "Hello";
+      case "Nothing" -> null;
+      case Object unknown -> throw new IllegalStateException("Unknwon value type " + unknown);
+    };
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
@@ -62,24 +62,22 @@ final class ArrayBuilder extends EnsoObject {
     } else if (primitiveArray instanceof long[] longArray) {
       if (e instanceof Long l) {
         if (size == longArray.length) {
-          primitiveArray = longArray = boundaryCopyOf(longArray, size * 2);
+          reallocAndAddToLongArray(longArray, l);
+        } else {
+          longArray[size++] = l;
         }
-        longArray[size++] = l;
       } else {
-        objectArray = boundaryCopyOfLongToObject(longArray, size);
-        primitiveArray = null;
-        addToObjectArray(e);
+        boundaryCopyOfLongToObject(longArray, e);
       }
     } else if (primitiveArray instanceof double[] doubleArray) {
       if (e instanceof Double d) {
         if (size == doubleArray.length) {
-          primitiveArray = doubleArray = boundaryCopyOf(doubleArray, size * 2);
+          reallocAndAddToDoubleArray(doubleArray, d);
+        } else {
+          doubleArray[size++] = d;
         }
-        doubleArray[size++] = d;
       } else {
-        objectArray = boundaryCopyOfDoubleToObject(doubleArray, size);
-        primitiveArray = null;
-        addToObjectArray(e);
+        boundaryCopyOfDoubleToObject(doubleArray, e);
       }
     } else {
       assert objectArray == null;
@@ -108,9 +106,10 @@ final class ArrayBuilder extends EnsoObject {
 
   private void addToObjectArray(Object e) {
     if (size == objectArray.length) {
-      objectArray = boundaryCopyOf(objectArray, size * 2);
+      reallocAndAddToObjectArray(e);
+    } else {
+      objectArray[size++] = e;
     }
-    objectArray[size++] = e;
   }
 
   /** Obtains an element from the builder */
@@ -237,21 +236,43 @@ final class ArrayBuilder extends EnsoObject {
   }
 
   @TruffleBoundary
-  private static Object[] boundaryCopyOfLongToObject(long[] longArray, int size) {
+  private void reallocAndAddToLongArray(long[] longArray, long l) {
+    primitiveArray = longArray = boundaryCopyOf(longArray, size * 2);
+    longArray[size++] = l;
+  }
+
+  @TruffleBoundary
+  private void reallocAndAddToDoubleArray(double[] doubleArray, double l) {
+    primitiveArray = doubleArray = boundaryCopyOf(doubleArray, size * 2);
+    doubleArray[size++] = l;
+  }
+
+  @TruffleBoundary
+  private void reallocAndAddToObjectArray(Object e) {
+    objectArray = boundaryCopyOf(objectArray, size * 2);
+    objectArray[size++] = e;
+  }
+
+  @TruffleBoundary
+  private void boundaryCopyOfLongToObject(long[] longArray, Object e) {
     var arr = new Object[longArray.length];
     for (int i = 0; i < size; i++) {
       arr[i] = longArray[i];
     }
-    return arr;
+    objectArray = arr;
+    primitiveArray = null;
+    addToObjectArray(e);
   }
 
   @TruffleBoundary
-  private static Object[] boundaryCopyOfDoubleToObject(double[] doubleArray, int size) {
+  private void boundaryCopyOfDoubleToObject(double[] doubleArray, Object e) {
     var arr = new Object[doubleArray.length];
     for (int i = 0; i < size; i++) {
       arr[i] = doubleArray[i];
     }
-    return arr;
+    objectArray = arr;
+    primitiveArray = null;
+    addToObjectArray(e);
   }
 
   @TruffleBoundary

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
@@ -1,6 +1,6 @@
 package org.enso.interpreter.runtime.data.vector;
 
-import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
@@ -62,32 +62,22 @@ final class ArrayBuilder extends EnsoObject {
     } else if (primitiveArray instanceof long[] longArray) {
       if (e instanceof Long l) {
         if (size == longArray.length) {
-          CompilerDirectives.transferToInterpreter();
-          primitiveArray = longArray = Arrays.copyOf(longArray, size * 2);
+          primitiveArray = longArray = boundaryCopyOf(longArray, size * 2);
         }
         longArray[size++] = l;
       } else {
-        CompilerDirectives.transferToInterpreter();
-        objectArray = new Object[longArray.length];
-        for (int i = 0; i < size; i++) {
-          objectArray[i] = longArray[i];
-        }
+        objectArray = boundaryCopyOfLongToObject(longArray, size);
         primitiveArray = null;
         addToObjectArray(e);
       }
     } else if (primitiveArray instanceof double[] doubleArray) {
       if (e instanceof Double d) {
         if (size == doubleArray.length) {
-          CompilerDirectives.transferToInterpreter();
-          primitiveArray = doubleArray = Arrays.copyOf(doubleArray, size * 2);
+          primitiveArray = doubleArray = boundaryCopyOf(doubleArray, size * 2);
         }
         doubleArray[size++] = d;
       } else {
-        CompilerDirectives.transferToInterpreter();
-        objectArray = new Object[doubleArray.length];
-        for (int i = 0; i < size; i++) {
-          objectArray[i] = doubleArray[i];
-        }
+        objectArray = boundaryCopyOfDoubleToObject(doubleArray, size);
         primitiveArray = null;
         addToObjectArray(e);
       }
@@ -118,8 +108,7 @@ final class ArrayBuilder extends EnsoObject {
 
   private void addToObjectArray(Object e) {
     if (size == objectArray.length) {
-      CompilerDirectives.transferToInterpreter();
-      objectArray = Arrays.copyOf(objectArray, size * 2);
+      objectArray = boundaryCopyOf(objectArray, size * 2);
     }
     objectArray[size++] = e;
   }
@@ -142,31 +131,17 @@ final class ArrayBuilder extends EnsoObject {
     }
   }
 
-  private static boolean checkArraySize(boolean mustBeExact, int real, int expected) {
-    if (real == expected) {
-      return true;
-    } else {
-      if (mustBeExact) {
-        CompilerDirectives.transferToInterpreter();
-      }
-      return false;
-    }
-  }
-
   /** Returns the current array of the builder. */
   private Object toArray(boolean mustBeExact) {
     if (objectArray != null) {
-      return checkArraySize(mustBeExact, objectArray.length, size)
-          ? objectArray
-          : Arrays.copyOf(objectArray, size);
+      assert !mustBeExact || objectArray.length == size;
+      return objectArray.length == size ? objectArray : boundaryCopyOf(objectArray, size);
     } else if (primitiveArray instanceof long[] longArray) {
-      return checkArraySize(mustBeExact, longArray.length, size)
-          ? longArray
-          : Arrays.copyOf(longArray, size);
+      assert !mustBeExact || longArray.length == size;
+      return longArray.length == size ? longArray : boundaryCopyOf(longArray, size);
     } else if (primitiveArray instanceof double[] doubleArray) {
-      return checkArraySize(mustBeExact, doubleArray.length, size)
-          ? doubleArray
-          : Arrays.copyOf(doubleArray, size);
+      assert !mustBeExact || doubleArray.length == size;
+      return doubleArray.length == size ? doubleArray : boundaryCopyOf(doubleArray, size);
     } else {
       return null;
     }
@@ -259,5 +234,38 @@ final class ArrayBuilder extends EnsoObject {
     } else {
       return Vector.fromEnsoOnlyArray((Object[]) res);
     }
+  }
+
+  @TruffleBoundary
+  private static Object[] boundaryCopyOfLongToObject(long[] longArray, int size) {
+    var arr = new Object[longArray.length];
+    for (int i = 0; i < size; i++) {
+      arr[i] = longArray[i];
+    }
+    return arr;
+  }
+
+  @TruffleBoundary
+  private static Object[] boundaryCopyOfDoubleToObject(double[] doubleArray, int size) {
+    var arr = new Object[doubleArray.length];
+    for (int i = 0; i < size; i++) {
+      arr[i] = doubleArray[i];
+    }
+    return arr;
+  }
+
+  @TruffleBoundary
+  private static double[] boundaryCopyOf(double[] arr, int size) {
+    return Arrays.copyOf(arr, size);
+  }
+
+  @TruffleBoundary
+  private static long[] boundaryCopyOf(long[] arr, int size) {
+    return Arrays.copyOf(arr, size);
+  }
+
+  @TruffleBoundary
+  private static Object[] boundaryCopyOf(Object[] arr, int size) {
+    return Arrays.copyOf(arr, size);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.runtime.data.vector;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
@@ -107,7 +106,6 @@ final class ArrayBuilder extends EnsoObject {
 
   private void addToObjectArray(Object e) {
     if (size == objectArray.length) {
-      CompilerDirectives.transferToInterpreter();
       reallocAndAddToObjectArray(e);
     } else {
       objectArray[size++] = e;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayBuilder.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.runtime.data.vector;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
@@ -106,6 +107,7 @@ final class ArrayBuilder extends EnsoObject {
 
   private void addToObjectArray(Object e) {
     if (size == objectArray.length) {
+      CompilerDirectives.transferToInterpreter();
       reallocAndAddToObjectArray(e);
     } else {
       objectArray[size++] = e;


### PR DESCRIPTION
### Pull Request Description

- while investigating #14513 crashes, 
- I was running `./enso --vm.D=polyglot.engine.TraceTransferToInterpreter=true --run test/Base_Tests`
  - the output shows a lot of "deoptimizations" in `ArrayBuilder`
  - let's investigate them!
- first of all let's write a new benchmark - done in dfb48e2405bdd7369a1a3d09ed225d9ede47b8e6
- then replace `transferToInterpreter()` with `@TruffleBoundary`
   - that removes the notifications of "deoptimizations" in `ArrayBuffer`
- observe [magnitudes of speed up](https://github.com/enso-org/enso/pull/14510#issuecomment-3668355010) then!

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
- [x] Benchmarks are fine
   - [x] [engine run](https://github.com/enso-org/enso/actions/runs/20272209201)
   - [x] [stdlib run](https://github.com/enso-org/enso/actions/runs/20272217622)
   - especially the [new benchmark is convicing](https://github.com/enso-org/enso/pull/14510#issuecomment-3668355010)
