### PR TITLE
Add padding to index column in Table Vis

### DIFF
--- a/app/gui/src/project-view/components/visualizations/TableVisualization.vue
+++ b/app/gui/src/project-view/components/visualizations/TableVisualization.vue
@@ -832,6 +832,8 @@ function toLinkField(fieldName: string, options: LinkFieldOptions): ColDef {
       params.value !== null && params.value !== undefined ?
         `<div class='link'> ${params.value} </div>`
       : null,
+    cellStyle: { 'padding-left': '13px', 'border-right': '1px solid #C0C0C0' },
+    headerClass: 'indexColumnHeader',
     filter: fieldName != INDEX_FIELD_NAME,
   }
 }
@@ -1279,5 +1281,9 @@ config.setToolbar(
   flex-direction: row;
   justify-content: space-between;
   width: inherit;
+}
+
+:deep(.indexColumnHeader) {
+  padding-left: 13px;
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

Fixes #14455

Added some padding to index column, so table vis roundings do not interfere with it.

<img width="1204" height="1150" alt="image" src="https://github.com/user-attachments/assets/3d4d50e0-26d2-4afa-a47b-49170b419816" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
