### PR TITLE
Reverts to workaround Windows segfaults

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -208,45 +208,5 @@ class RuntimeManagementTest extends InterpreterTest {
       def all                         = 0.to(4).map(mkAccessStr) ++ List(1, 3).map(mkFreeStr)
       totalOut should contain theSameElementsAs all
     }
-
-    "Allow for multithreaded polyglot class loading" in {
-      val langCtx = interpreterContext
-        .ctx()
-        .getBindings(LanguageInfo.ID)
-        .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
-        .asHostObject[EnsoContext]()
-
-      val code =
-        """import Standard.Base.Data.Numbers
-          |polyglot java import org.enso.example.TestClass
-          |main =
-          |    instance = TestClass.new (x -> x * 2)
-          |    instance.callFunctionAndIncrement 10
-          |""".stripMargin
-
-      val main = getMain(code)
-
-      def runMain()
-        : java.util.concurrent.CompletableFuture[org.graalvm.polyglot.Value] =
-        langCtx.getThreadManager.submit(() => {
-          main.execute()
-        })
-
-      def runTest(): Unit = {
-        val futures = 0.until(parallelism).map(_ => runMain())
-        val combinedFuture = java.util.concurrent.CompletableFuture
-          .allOf(futures: _*)
-          .thenApply(_ => {
-            futures
-              .map(_.get(10, java.util.concurrent.TimeUnit.SECONDS).asInt())
-          })
-        val result =
-          combinedFuture.get(20, java.util.concurrent.TimeUnit.SECONDS)
-        result should equal(List(21, 21, 21, 21, 21))
-        futures.forall(_.isDone) shouldBe true
-      }
-
-      runTest()
-    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
@@ -30,7 +30,7 @@ public abstract class AddToClassPathNode extends Node {
     var file = ctx.getTruffleFile(new File(expectStringNode.execute(path)));
     if (getRootNode() instanceof ClosureRootNode crn) {
       var pkg = crn.getModuleScope().getModule().getPackage();
-      ctx.addToClassPath(pkg, file, true);
+      ctx.addToClassPath(pkg, file);
     } else {
       throw ctx.raiseAssertionPanic(this, "Cannot find package", null);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -100,9 +100,6 @@ public final class EnsoContext {
   private final LockManager lockManager;
   private final AtomicLong clock = new AtomicLong();
 
-  /**
-   * @GuardedBy("REFERENCE") - need some private lock
-   */
   @CompilationFinal(dimensions = 1)
   private Object[] extraValues = new Object[0];
 
@@ -1002,16 +999,14 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      synchronized (REFERENCE) {
-        if (index >= extraValues.length) {
-          extraValues = Arrays.copyOf(extraValues, index + 1);
-        }
-        extraValues[index] = init.apply(this);
-        assert extraValues[index] != null;
+      if (index >= extraValues.length) {
+        extraValues = Arrays.copyOf(extraValues, index + 1);
       }
+      extraValues[index] = init.apply(this);
+      assert extraValues[index] != null;
     }
     return extraValues[index];
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -513,17 +513,16 @@ public final class EnsoContext {
    *
    * @param who who requests the addition
    * @param file the file to register
-   * @param polyglotContextEntered true if a polyglot context has been entered, false otherwise
    */
   @TruffleBoundary
-  public void addToClassPath(Package<?> who, TruffleFile file, boolean polyglotContextEntered) {
+  public void addToClassPath(Package<?> who, TruffleFile file) {
     assert who != null;
     var path = new File(file.toUri()).getAbsoluteFile();
     if (!path.exists()) {
       throw new IllegalStateException("File not found " + path);
     }
     try {
-      EnsoPolyglotJava.addToClassPath(this, who, path, polyglotContextEntered);
+      EnsoPolyglotJava.addToClassPath(this, who, path);
     } catch (InteropException ex) {
       throw raiseAssertionPanic(null, "Cannot add " + file + " to classpath", ex);
     }
@@ -999,12 +998,10 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      if (index >= extraValues.length) {
-        extraValues = Arrays.copyOf(extraValues, index + 1);
-      }
+      extraValues = Arrays.copyOf(extraValues, Extra.COUNTER.get());
       extraValues[index] = init.apply(this);
       assert extraValues[index] != null;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.ExportLibrary;
@@ -14,11 +13,11 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.source.Source;
 import java.io.File;
 import java.lang.System.Logger.Level;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Semaphore;
 import org.enso.common.HostEnsoUtils;
 import org.enso.common.RuntimeOptions;
@@ -37,27 +36,17 @@ final class EnsoPolyglotJava {
 
   private final EnsoContext ctx;
   private final boolean isHostClassLoading;
-  private final List<File> classPath;
-
-  /**
-   * the amount of elements from {@link #classPath} already added to {@link
-   * #polyglotJava}. @GuardedBy("lock")
-   */
-  private int classPathSize;
-
+  private final List<File> pendingPath = new ArrayList<>();
   private Object polyglotJava = this;
   private Semaphore lock = new Semaphore(1, true);
 
   /**
    * @param ctx associated conext
    * @param isHostClassLoading do host classloading
-   * @param growingPath classpath that may receive new entries incrementally - just make sure the
-   *     list is find with multi threaded access
    */
-  private EnsoPolyglotJava(EnsoContext ctx, boolean isHostClassLoading, List<File> growingPath) {
+  private EnsoPolyglotJava(EnsoContext ctx, boolean isHostClassLoading) {
     this.ctx = ctx;
     this.isHostClassLoading = isHostClassLoading;
-    this.classPath = growingPath;
   }
 
   /**
@@ -179,34 +168,20 @@ final class EnsoPolyglotJava {
       if (polyglotJava != this) {
         return polyglotJava;
       }
-      if (polyglotJava == this) {
-        polyglotJava = createPolyglotJava(ctx);
-        try {
-          InteropLibrary.getUncached()
-              .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
-        } catch (InteropException ex) {
-          logger.log(Level.WARNING, "Cannot register findLibraries", ex);
-        }
+      polyglotJava = createPolyglotJava(ctx);
+      while (!pendingPath.isEmpty()) {
+        InteropLibrary.getUncached()
+            .invokeMember(polyglotJava, "addPath", pendingPath.remove(0).toString());
       }
-      adjustClassPath();
+      try {
+        InteropLibrary.getUncached()
+            .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
+      } catch (InteropException ex) {
+        logger.log(Level.WARNING, "Cannot register findLibraries", ex);
+      }
       return polyglotJava;
     } finally {
       lock.release();
-    }
-  }
-
-  private void adjustClassPath()
-      throws UnknownIdentifierException,
-          ArityException,
-          UnsupportedMessageException,
-          UnsupportedTypeException {
-    var size = classPath.size();
-    var iop = InteropLibrary.getUncached();
-    while (classPathSize < size) {
-      // we are the thread to add this classpath element
-      var elem = classPath.get(classPathSize);
-      iop.invokeMember(polyglotJava, "addPath", elem.toString());
-      classPathSize++;
     }
   }
 
@@ -218,10 +193,40 @@ final class EnsoPolyglotJava {
       EnsoContext ctx, Object whoIsIgnored, File path, boolean polyglotContextEntered)
       throws InteropException {
     var data = KEY.get(ctx);
-    data.classPath.add(path);
+    data.hosted.addToClassPath(path, polyglotContextEntered);
+    data.guest.addToClassPath(path, polyglotContextEntered);
   }
 
+  /**
+   * Modifies the classpath to use to lookup {@code polyglot java} imports.
+   *
+   * @param file the file to register
+   * @param polyglotContextEntered if true, any lock acquisition will be interruptable for Truffle's
+   *     Safepoints purposes
+   */
   @CompilerDirectives.TruffleBoundary
+  private final void addToClassPath(File file, boolean polyglotContextEntered)
+      throws InteropException {
+    if (polyglotContextEntered) {
+      TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+    } else {
+      try {
+        lock.acquire();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    try {
+      if (polyglotJava == this) {
+        pendingPath.add(file);
+      } else {
+        InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
+      }
+    } finally {
+      lock.release();
+    }
+  }
+
   private final void close() {
     TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
     try {
@@ -315,15 +320,13 @@ final class EnsoPolyglotJava {
   }
 
   private static final class CtxData {
-    private final List<File> classPath;
     private final EnsoPolyglotJava hosted;
     private final EnsoPolyglotJava guest;
     private final Map<String, String> hostClassLoading;
 
     CtxData(EnsoContext ctx) {
-      this.classPath = new CopyOnWriteArrayList<>();
-      this.hosted = new EnsoPolyglotJava(ctx, true, classPath);
-      this.guest = new EnsoPolyglotJava(ctx, false, classPath);
+      this.hosted = new EnsoPolyglotJava(ctx, true);
+      this.guest = new EnsoPolyglotJava(ctx, false);
       this.hostClassLoading = new LinkedHashMap<>();
       for (var entry : ctx.getHostClassLoading().split(",")) {
         var libState = entry.split(":");

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -18,7 +17,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
 import org.enso.common.HostEnsoUtils;
 import org.enso.common.RuntimeOptions;
 import org.enso.interpreter.runtime.util.TruffleFileSystem;
@@ -38,7 +36,6 @@ final class EnsoPolyglotJava {
   private final boolean isHostClassLoading;
   private final List<File> pendingPath = new ArrayList<>();
   private Object polyglotJava = this;
-  private Semaphore lock = new Semaphore(1, true);
 
   /**
    * @param ctx associated conext
@@ -159,89 +156,61 @@ final class EnsoPolyglotJava {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private Object findPolyglotJava() throws InteropException {
-    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
-    try {
-      if (polyglotJava instanceof Throwable t) {
-        throw ctx.raiseAssertionPanic(null, t.getMessage(), t);
-      }
-      if (polyglotJava != this) {
-        return polyglotJava;
-      }
-      polyglotJava = createPolyglotJava(ctx);
-      while (!pendingPath.isEmpty()) {
-        InteropLibrary.getUncached()
-            .invokeMember(polyglotJava, "addPath", pendingPath.remove(0).toString());
-      }
-      try {
-        InteropLibrary.getUncached()
-            .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
-      } catch (InteropException ex) {
-        logger.log(Level.WARNING, "Cannot register findLibraries", ex);
-      }
-      return polyglotJava;
-    } finally {
-      lock.release();
+  private synchronized Object findPolyglotJava() throws InteropException {
+    if (polyglotJava instanceof Throwable t) {
+      throw ctx.raiseAssertionPanic(null, t.getMessage(), t);
     }
+    if (polyglotJava != this) {
+      return polyglotJava;
+    }
+    polyglotJava = createPolyglotJava(ctx);
+    while (!pendingPath.isEmpty()) {
+      addToClassPath(pendingPath.remove(0));
+    }
+    try {
+      InteropLibrary.getUncached()
+          .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
+    } catch (InteropException ex) {
+      logger.log(Level.WARNING, "Cannot register findLibraries", ex);
+    }
+    return polyglotJava;
   }
 
   /**
    * This method ensure that hosted as well as guest classpath is the same. This is necessary until
    * real isolation between libraries is implemented.
    */
-  static void addToClassPath(
-      EnsoContext ctx, Object whoIsIgnored, File path, boolean polyglotContextEntered)
+  static void addToClassPath(EnsoContext ctx, Object whoIsIgnored, File path)
       throws InteropException {
     var data = KEY.get(ctx);
-    data.hosted.addToClassPath(path, polyglotContextEntered);
-    data.guest.addToClassPath(path, polyglotContextEntered);
+    data.hosted.addToClassPath(path);
+    data.guest.addToClassPath(path);
   }
 
   /**
    * Modifies the classpath to use to lookup {@code polyglot java} imports.
    *
    * @param file the file to register
-   * @param polyglotContextEntered if true, any lock acquisition will be interruptable for Truffle's
-   *     Safepoints purposes
    */
   @CompilerDirectives.TruffleBoundary
-  private final void addToClassPath(File file, boolean polyglotContextEntered)
-      throws InteropException {
-    if (polyglotContextEntered) {
-      TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+  private final synchronized void addToClassPath(File file) throws InteropException {
+    if (polyglotJava == this) {
+      pendingPath.add(file);
     } else {
-      try {
-        lock.acquire();
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    try {
-      if (polyglotJava == this) {
-        pendingPath.add(file);
-      } else {
-        InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
-      }
-    } finally {
-      lock.release();
+      InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
     }
   }
 
-  private final void close() {
-    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
-    try {
-      if (polyglotJava instanceof TruffleObject closeJava) {
-        polyglotJava = null;
-        try {
-          InteropLibrary.getUncached().invokeMember(closeJava, "close");
-        } catch (InteropException ex) {
-          logger.log(Level.WARNING, "Cannot close " + closeJava, ex);
-        }
-      } else {
-        polyglotJava = null;
+  private final synchronized void close() {
+    if (polyglotJava instanceof TruffleObject closeJava) {
+      polyglotJava = null;
+      try {
+        InteropLibrary.getUncached().invokeMember(closeJava, "close");
+      } catch (InteropException ex) {
+        logger.log(Level.WARNING, "Cannot close " + closeJava, ex);
       }
-    } finally {
-      lock.release();
+    } else {
+      polyglotJava = null;
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
@@ -40,8 +40,7 @@ final class ThreadExecutors {
   }
 
   ScheduledExecutorService newScheduledThreadPool(int cnt, String name, boolean systemThread) {
-    var s = new ScheduledThreadPoolExecutor(cnt, new Factory(name, systemThread));
-    s.allowCoreThreadTimeOut(true);
+    var s = Executors.newScheduledThreadPool(cnt, new Factory(name, systemThread));
     pools.put(s, name);
     return s;
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -214,7 +214,7 @@ private class DefaultPackageRepository(
     isLibrary: Boolean
   ): Unit = {
     val extensions = pkg.listPolyglotExtensions("java")
-    extensions.foreach(context.addToClassPath(pkg, _, false))
+    extensions.foreach(context.addToClassPath(pkg, _))
 
     val (regularModules, syntheticModulesMetadata) = pkg
       .listSources()


### PR DESCRIPTION
### Pull Request Description

This change reverts https://github.com/enso-org/enso/commit/53c7cb173ce2c03988fb09ebc501c26fa0bd4d86 and https://github.com/enso-org/enso/commit/a8d646e4896f5fafc73de1b0a6a51c3e2005a981 as the former was the followup for the latter.

The hope is that this will stop frequent segmentation faults that we currently experience with NI build on Windows.
[1st attempt](https://github.com/enso-org/enso/pull/14513) with GraalVM downgrade wasn't successful.

### Important Notes

This change obviously means that multi-threaded polyglot Java initialization will not be possible.