### PR TITLE
Use realpath to resolve symlinks

### DIFF
--- a/distribution/bin/enso
+++ b/distribution/bin/enso
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-COMP_PATH=$(dirname "$0")/../component
+COMP_PATH=$(dirname `realpath "$0"`)/../component
 JAVA_OPTS="--enable-native-access=org.graalvm.truffle --sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED"
 exec java --module-path "$COMP_PATH" $JAVA_OPTS -m org.enso.runner/org.enso.runner.Main "$@"
 exit


### PR DESCRIPTION
### Pull Request Description

During development I often use:
```
enso$ ENSO_LAUNCHER=shell sbt buildEngineDistribution
enso$ ./enso
./enso 
Error occurred during initialization of boot layer
java.lang.module.FindException: Module org.enso.runner not found
```
this PR fixes the errors by properly resolving location of `enso` shell script.

### Important Notes

This change doesn't influence production, as these _shell launchers_ aren't used in production.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the style guides. 
- [x] Manually tested