### PR TITLE
Propagate context from real node to DataflowError constructor

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CaughtPanicConvertToDataflowErrorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CaughtPanicConvertToDataflowErrorNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.atom.Atom;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.error.DataflowError;
@@ -29,11 +28,12 @@ public abstract class CaughtPanicConvertToDataflowErrorNode extends Node {
       Atom self,
       @CachedLibrary(limit = "5") InteropLibrary interopLibrary,
       @CachedLibrary(limit = "5") StructsLibrary structs) {
-    Builtins builtins = EnsoContext.get(this).getBuiltins();
+    var ctx = EnsoContext.get(this);
+    var builtins = ctx.getBuiltins();
     var payload = structs.getField(self, 0);
     var originalException = structs.getField(self, 1);
     if (interopLibrary.isException(originalException)) {
-      return DataflowError.withTrace(payload, (AbstractTruffleException) originalException);
+      return DataflowError.withTrace(ctx, payload, (AbstractTruffleException) originalException);
     } else {
       throw new PanicException(
           builtins

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/AtVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/AtVectorNode.java
@@ -27,7 +27,7 @@ public class AtVectorNode extends Node {
       var len = len(arrayLike);
       var ctx = EnsoContext.get(this);
       var payload = ctx.getBuiltins().error().makeIndexOutOfBounds(index, len);
-      return DataflowError.withTrace(payload, new PanicException(payload, this));
+      return DataflowError.withTrace(ctx, payload, new PanicException(payload, this));
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/SuspendedFieldGetterNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/SuspendedFieldGetterNode.java
@@ -102,7 +102,8 @@ final class SuspendedFieldGetterNode extends UnboxingAtom.FieldGetterNode {
         return newValue;
       } catch (AbstractTruffleException ex) {
         exceptionalState.enter();
-        var rethrow = DataflowError.withTrace(ex, ex);
+        var ctx = EnsoContext.get(this);
+        var rethrow = DataflowError.withTrace(ctx, ex, ex);
         set.execute(atom, rethrow);
         throw ex;
       } finally {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -84,13 +84,15 @@ public final class DataflowError extends AbstractTruffleException {
    * <p>This is useful for when the dataflow error is created from the recovery of a panic, and we
    * want to point to the original location of the panic.
    *
+   * @param ctx Enso context to operate in
    * @param payload the user-provided value carried by the error
    * @param prototype the exception to derive the stacktrace from
    * @return a new dataflow error
    */
-  public static DataflowError withTrace(Object payload, AbstractTruffleException prototype) {
+  public static DataflowError withTrace(
+      EnsoContext ctx, Object payload, AbstractTruffleException prototype) {
     assert payload != null;
-    var result = new DataflowError(payload, prototype);
+    var result = new DataflowError(ctx, payload, prototype);
     TruffleStackTrace.fillIn(result);
     return result;
   }
@@ -110,11 +112,11 @@ public final class DataflowError extends AbstractTruffleException {
     this.ctx = EnsoContext.get(location);
   }
 
-  private DataflowError(Object payload, AbstractTruffleException prototype) {
+  private DataflowError(EnsoContext ctx, Object payload, AbstractTruffleException prototype) {
     super(prototype);
     this.payload = payload;
     this.ownTrace = false;
-    this.ctx = prototype instanceof PanicException panic ? panic.ctx() : EnsoContext.get(null);
+    this.ctx = ctx;
   }
 
   private DataflowError(Object payload, int stackTraceElementLimit, Node location) {


### PR DESCRIPTION
### Pull Request Description

- fixes #14532 
- by propagating `EnsoContext` from a real `Node`
- to the `DataflowError` constructor 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass