### PR TITLE
Show errors in headless environments

### DIFF
--- a/app/ydoc-shared/src/languageServer.ts
+++ b/app/ydoc-shared/src/languageServer.ts
@@ -27,6 +27,7 @@ import type {
 } from './languageServerTypes'
 import { AbortScope, exponentialBackoff } from './util/net'
 import type { ReconnectingWebSocketTransport } from './util/net/ReconnectingWSTransport'
+import { isHeadless } from './util/types'
 import type { Uuid } from './yjsModel'
 
 const debugLog = debug('ydoc-shared:languageServer')
@@ -158,11 +159,19 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
       this.emit(notification.method as keyof Notifications, [notification.params])
     })
     this.client.onError((error) => {
-      console.error('Unexpected Language Server connection error:', error)
+      console.error(
+        'Unexpected Language Server connection error:',
+        isHeadless() ? JSON.stringify(error) : error,
+      )
     })
     transport.on('error', (error) => {
       if (this.shouldReconnect) {
-        console.error('Language Server transport error:', error.message, '\n', error)
+        console.error(
+          'Language Server transport error:',
+          error.message,
+          '\n',
+          isHeadless() ? JSON.stringify(error) : error,
+        )
       }
     })
     const onTransportClosed = () => {

--- a/app/ydoc-shared/src/util/types.ts
+++ b/app/ydoc-shared/src/util/types.ts
@@ -41,3 +41,8 @@ export type ForbidExcessProps<T, S> = { [K in keyof T]: K extends keyof S ? T[K]
 export type Class<T> = Function & {
   prototype: T
 }
+
+/** Check if the the code runs in the headless environment. */
+export function isHeadless() {
+  return typeof window === 'undefined'
+}


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Debugging Ydoc connection errors in the cloud. Right now the output of the engine shows 
```
Language Server transport error: undefined
[object]
```
 which is not helpful.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
