### PR TITLE
Remove file contents for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,6 @@
 - [Context menu for connections][14325].
 - [Warnings and Errors no longer become transparent][14388]
 - [`--headless` flag to run a project without the User Interface][14310]
-- [Preview for assets (text, main files of Projects, audio, video, images) in
-  Right Sidebar][14310]
 - ["Delete and Connect Around" option in node's menu][14403]
 - [GeoMap visualization is now working without need of Mapbox Token in
   environment][14429]

--- a/app/gui/src/components/AppContainer/RightPanel.vue
+++ b/app/gui/src/components/AppContainer/RightPanel.vue
@@ -47,7 +47,9 @@ const component = computed(() => {
   }
 })
 
-const visibleTabs = computed(() => [...data.allTabs.entries()])
+const visibleTabs = computed(() =>
+  [...data.allTabs.entries()].filter(([, tabInfo]) => !toValue(tabInfo.hidden)),
+)
 
 function tabTooltip(title: ToValue<string>, enabled: ToValue<Result<void>>) {
   const enabledVal = toValue(enabled)

--- a/app/gui/src/providers/rightPanel.ts
+++ b/app/gui/src/providers/rightPanel.ts
@@ -79,6 +79,7 @@ function useRightPanelTabs(
       {
         icon: 'docs',
         enabled: Ok(),
+        hidden: true,
         title: 'Contents',
       },
     ],
@@ -181,7 +182,9 @@ function useRightPanel(
   const displayedTab = computed(() => {
     const markedTab = temporaryTab.value ?? tab.value
     if (markedTab == null) return undefined
-    if (!toValue(allTabs.get(markedTab)?.enabled)?.ok) return undefined
+    const tabInfo = allTabs.get(markedTab)
+    if (!tabInfo || toValue(tabInfo.hidden)) return undefined
+    if (!toValue(tabInfo.enabled)?.ok) return undefined
     return markedTab
   })
 


### PR DESCRIPTION
### Pull Request Description

We introduced a file contents tab right before the release. https://github.com/enso-org/enso/pull/14310

While we will want this long term it needs further design, so for now I am hiding it for the release.

I added a ticket to design and restore this https://github.com/enso-org/enso/issues/14539

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
