### PR TITLE
Trace local variable read/write via Truffle instrumentation

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/common/NameResolutionAlgorithm.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/common/NameResolutionAlgorithm.java
@@ -42,7 +42,7 @@ public abstract class NameResolutionAlgorithm<ResultType, LocalNameLinkType, Met
     if (meta != null) {
       var maybeLocalLink = findLocalLink(meta);
       if (maybeLocalLink.isDefined()) {
-        return resolveLocalName(maybeLocalLink.get());
+        return resolveLocalName(name.name(), maybeLocalLink.get());
       }
     }
 
@@ -69,7 +69,7 @@ public abstract class NameResolutionAlgorithm<ResultType, LocalNameLinkType, Met
    */
   protected abstract Option<LocalNameLinkType> findLocalLink(MetadataType metadata);
 
-  protected abstract ResultType resolveLocalName(LocalNameLinkType localLink);
+  protected abstract ResultType resolveLocalName(String name, LocalNameLinkType localLink);
 
   protected abstract ResultType resolveGlobalName(
       BindingsMap.ResolvedName resolvedName, IR relatedIr);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/types/TypePropagation.java
@@ -578,7 +578,7 @@ abstract class TypePropagation {
     }
 
     @Override
-    protected TypeRepresentation resolveLocalName(LinkInfo localLink) {
+    protected TypeRepresentation resolveLocalName(String name, LinkInfo localLink) {
       return localBindingsTyping.getBindingType(localLink.graph, localLink.link.target());
     }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -281,7 +281,7 @@ public class IncrementalUpdatesTest {
     Assert.assertEquals(List.newBuilder().addOne(originalOutput), context.consumeOut());
 
     var allNodesAfterException =
-        nodeCountingInstrument.assertNewNodes("Execution creates some nodes", 30, 41);
+        nodeCountingInstrument.assertNewNodes("Execution creates some nodes", 30, 45);
 
     // push foo call
     context.send(

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
@@ -1,0 +1,77 @@
+package org.enso.interpreter.test.instrument;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.function.Consumer;
+import org.enso.interpreter.test.instruments.VariablesTestInstrument;
+import org.enso.test.utils.ContextUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class InstrumentReadWriteForEnsoTest {
+  @ClassRule
+  public static final ContextUtils ctxRule = ContextUtils.newBuilder().assertGC(false).build();
+
+  @Test
+  public void verifyInJavaScript() throws Exception {
+    var context = ctxRule.context();
+    var main =
+        context.eval(
+            "js",
+            """
+            (function main(n) {
+              let a = n + 2;
+              let b = n * 3;
+              let r = b - a;
+              return r;
+            });
+            """);
+
+    var w = new StringWriter();
+    var pw = new PrintWriter(w);
+
+    var instr = context.getEngine().getInstruments();
+    var vars = instr.get(VariablesTestInstrument.ID);
+    assertNotNull("VariablesInstrument found among " + instr, vars);
+    @SuppressWarnings("unchecked")
+    Consumer<PrintWriter> tracer = vars.lookup(Consumer.class);
+
+    tracer.accept(pw);
+    var res = main.execute(5);
+    tracer.accept(null);
+
+    assertEquals(8, res.asInt());
+    var expectedTrace =
+        """
+        writeVariableNameEnter n
+        writeVariableNameReturn = 5
+        writeVariableNameEnter a
+          readVariableNameEnter n
+          readVariableNameReturn = 5
+        writeVariableNameReturn = 7
+        writeVariableNameEnter b
+          readVariableNameEnter n
+          readVariableNameReturn = 5
+        writeVariableNameReturn = 15
+        writeVariableNameEnter r
+          readVariableNameEnter b
+          readVariableNameReturn = 15
+          readVariableNameEnter a
+          readVariableNameReturn = 7
+        writeVariableNameReturn = 8
+        readVariableNameEnter r
+        readVariableNameReturn = 8
+        """;
+    var trace = w.toString();
+    assertEquals(
+        "Expected traces generated and show that:" //
+            + "- a depends on n" //
+            + "- b depends on n" //
+            + "- r depends on a and b", //
+        expectedTrace,
+        trace);
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
@@ -85,7 +85,7 @@ public class InstrumentReadWriteForEnsoTest {
         readVariableNameEnter r
         readVariableNameReturn = 8
         """;
-    var trace = w.toString();
+    var trace = w.toString().replace("\r\n", "\n");
     assertEquals(
         "Expected traces generated and show that:" //
             + "- a depends on n" //

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InstrumentReadWriteForEnsoTest.java
@@ -8,6 +8,7 @@ import java.io.StringWriter;
 import java.util.function.Consumer;
 import org.enso.interpreter.test.instruments.VariablesTestInstrument;
 import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Value;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -29,11 +30,30 @@ public class InstrumentReadWriteForEnsoTest {
               return r;
             });
             """);
+    verifyReadAndWriteTrace(main);
+  }
 
+  @Test
+  public void verifyInEnso() throws Exception {
+    var main =
+        ctxRule.evalModule(
+            """
+            from Standard.Base import all
+
+            main n =
+              a = n + 2
+              b = n * 3
+              r = b - a
+              r
+            """);
+    verifyReadAndWriteTrace(main);
+  }
+
+  private void verifyReadAndWriteTrace(Value main) {
     var w = new StringWriter();
     var pw = new PrintWriter(w);
 
-    var instr = context.getEngine().getInstruments();
+    var instr = ctxRule.context().getEngine().getInstruments();
     var vars = instr.get(VariablesTestInstrument.ID);
     assertNotNull("VariablesInstrument found among " + instr, vars);
     @SuppressWarnings("unchecked")

--- a/engine/runtime-test-instruments/src/main/java/module-info.java
+++ b/engine/runtime-test-instruments/src/main/java/module-info.java
@@ -12,5 +12,6 @@ module org.enso.runtime.test {
   provides com.oracle.truffle.api.instrumentation.provider.TruffleInstrumentProvider with
       org.enso.interpreter.test.instruments.CodeIdsTestInstrumentProvider,
       org.enso.interpreter.test.instruments.CodeLocationsTestInstrumentProvider,
-      org.enso.interpreter.test.instruments.NodeCountingTestInstrumentProvider;
+      org.enso.interpreter.test.instruments.NodeCountingTestInstrumentProvider,
+      org.enso.interpreter.test.instruments.VariablesTestInstrumentProvider;
 }

--- a/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/VariablesTestInstrument.java
+++ b/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/VariablesTestInstrument.java
@@ -1,0 +1,94 @@
+package org.enso.interpreter.test.instruments;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.EventBinding;
+import com.oracle.truffle.api.instrumentation.EventContext;
+import com.oracle.truffle.api.instrumentation.ExecutionEventListener;
+import com.oracle.truffle.api.instrumentation.Instrumenter;
+import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import com.oracle.truffle.api.instrumentation.TruffleInstrument;
+import com.oracle.truffle.api.interop.InteropException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import java.io.PrintWriter;
+import java.util.function.Consumer;
+
+@TruffleInstrument.Registration(id = VariablesTestInstrument.ID, services = Consumer.class)
+public final class VariablesTestInstrument extends TruffleInstrument
+    implements Consumer<PrintWriter> {
+  public static final String ID = "varibles-read-write-test";
+
+  private Instrumenter instr;
+  private EventBinding<VariablesTestInstrument.TraceExecution> close1;
+  private EventBinding<VariablesTestInstrument.TraceExecution> close2;
+
+  @Override
+  protected void onCreate(TruffleInstrument.Env env) {
+    instr = env.getInstrumenter();
+    env.registerService(this);
+  }
+
+  @Override
+  public void accept(PrintWriter pw) {
+    if (close1 != null) {
+      close1.dispose();
+      close2.dispose();
+    }
+    if (pw != null) {
+      var indent = new StringBuilder();
+
+      var filterRead =
+          SourceSectionFilter.newBuilder().tagIs(StandardTags.ReadVariableTag.class).build();
+      close1 =
+          instr.attachExecutionEventListener(
+              filterRead, new TraceExecution(StandardTags.ReadVariableTag.NAME, pw, indent));
+      var filterWrite =
+          SourceSectionFilter.newBuilder().tagIs(StandardTags.WriteVariableTag.class).build();
+      close2 =
+          instr.attachExecutionEventListener(
+              filterWrite, new TraceExecution(StandardTags.WriteVariableTag.NAME, pw, indent));
+    }
+  }
+
+  private static final class TraceExecution implements ExecutionEventListener {
+    private final String attrName;
+    private final PrintWriter output;
+    private final StringBuilder indent;
+
+    TraceExecution(String memberName, PrintWriter output, StringBuilder indent) {
+      this.attrName = memberName;
+      this.output = output;
+      this.indent = indent;
+    }
+
+    @Override
+    public void onEnter(EventContext context, VirtualFrame frame) {
+      try {
+        var to = context.getNodeObject();
+        var iop = InteropLibrary.getUncached();
+        Object name = "";
+        if (iop.isMemberReadable(to, attrName)) {
+          name = iop.readMember(to, attrName);
+        }
+        output.println(indent + attrName + "Enter " + name);
+      } catch (InteropException ex) {
+        ex.printStackTrace(output);
+      }
+      indent.append("  ");
+    }
+
+    @Override
+    public void onReturnValue(EventContext context, VirtualFrame frame, Object result) {
+      indent.delete(0, 2);
+      output.println(indent + attrName + "Return = " + result);
+      output.flush();
+    }
+
+    @Override
+    public void onReturnExceptional(EventContext context, VirtualFrame frame, Throwable exception) {
+      indent.delete(0, 2);
+      output.println(indent + attrName + "ReturnExceptional");
+      exception.printStackTrace(output);
+    }
+  }
+}

--- a/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/VariablesTestInstrument.java
+++ b/engine/runtime-test-instruments/src/main/java/org/enso/interpreter/test/instruments/VariablesTestInstrument.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import java.io.PrintWriter;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 @TruffleInstrument.Registration(id = VariablesTestInstrument.ID, services = Consumer.class)
 public final class VariablesTestInstrument extends TruffleInstrument
@@ -36,14 +37,23 @@ public final class VariablesTestInstrument extends TruffleInstrument
     }
     if (pw != null) {
       var indent = new StringBuilder();
-
+      Predicate<String> nameCheck =
+          (n) -> {
+            return n.endsWith("main");
+          };
       var filterRead =
-          SourceSectionFilter.newBuilder().tagIs(StandardTags.ReadVariableTag.class).build();
+          SourceSectionFilter.newBuilder()
+              .rootNameIs(nameCheck)
+              .tagIs(StandardTags.ReadVariableTag.class)
+              .build();
       close1 =
           instr.attachExecutionEventListener(
               filterRead, new TraceExecution(StandardTags.ReadVariableTag.NAME, pw, indent));
       var filterWrite =
-          SourceSectionFilter.newBuilder().tagIs(StandardTags.WriteVariableTag.class).build();
+          SourceSectionFilter.newBuilder()
+              .rootNameIs(nameCheck)
+              .tagIs(StandardTags.WriteVariableTag.class)
+              .build();
       close2 =
           instr.attachExecutionEventListener(
               filterWrite, new TraceExecution(StandardTags.WriteVariableTag.NAME, pw, indent));

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -112,6 +112,8 @@ import scala.collection.immutable.Seq;
   StandardTags.RootTag.class,
   StandardTags.RootBodyTag.class,
   StandardTags.TryBlockTag.class,
+  StandardTags.ReadVariableTag.class,
+  StandardTags.WriteVariableTag.class,
   IdentifiedTag.class,
   AvoidIdInstrumentationTag.class,
   Patchable.Tag.class

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignLocalVariableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignLocalVariableNode.java
@@ -5,11 +5,17 @@ import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.instrumentation.Tag;
 import org.enso.interpreter.node.ExpressionNode;
 
-final class VariableAccessNode extends ExpressionNode {
+/**
+ * Tracks local variable assignment for instrumentation. Used by {@link AssignmentNode} when {@link
+ * StandardTags.WriteVariableTag} instrumentation is requested. By having a dedicated node the
+ * instrumentation can check the "on return value" that's being assigned to the local variable.
+ * That's contrary to {@link AssignmentNode} which always returns {@code Nothing}.
+ */
+final class AssignLocalVariableNode extends ExpressionNode {
   private final String name;
   @Child private ExpressionNode rhs;
 
-  VariableAccessNode(String name, ExpressionNode expression) {
+  AssignLocalVariableNode(String name, ExpressionNode expression) {
     this.name = name;
     this.rhs = expression;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -5,6 +5,8 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -64,5 +66,14 @@ public abstract class AssignmentNode extends ExpressionNode {
   boolean isLongOrIllegal(VirtualFrame frame) {
     FrameSlotKind kind = frame.getFrameDescriptor().getSlotKind(frameSlotIdx);
     return kind == FrameSlotKind.Long || kind == FrameSlotKind.Illegal;
+  }
+
+  @Override
+  public boolean hasTag(Class<? extends Tag> tag) {
+    if (super.hasTag(tag)) {
+      return true;
+    } else {
+      return getSourceSectionBounds() != null && StandardTags.WriteVariableTag.class == tag;
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.node.scope;
 
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -13,10 +14,13 @@ import org.enso.interpreter.runtime.EnsoContext;
 
 /** This node represents an assignment to a variable in a given scope. */
 @NodeInfo(shortName = "=", description = "Assigns expression result to a variable.")
+@NodeField(name = "name", type = String.class)
 @NodeChild(value = "rhsNode", type = ExpressionNode.class)
 public abstract class AssignmentNode extends ExpressionNode {
 
   private final int frameSlotIdx;
+
+  abstract String getName();
 
   AssignmentNode(int frameSlotIdx) {
     this.frameSlotIdx = frameSlotIdx;
@@ -29,8 +33,8 @@ public abstract class AssignmentNode extends ExpressionNode {
    * @param frameSlotIdx the slot index to which {@code expression} is being assigned
    * @return a node representing an assignment
    */
-  public static AssignmentNode build(ExpressionNode expression, int frameSlotIdx) {
-    return AssignmentNodeGen.create(frameSlotIdx, expression);
+  public static AssignmentNode build(String name, ExpressionNode expression, int frameSlotIdx) {
+    return AssignmentNodeGen.create(frameSlotIdx, expression, name);
   }
 
   /**
@@ -66,6 +70,11 @@ public abstract class AssignmentNode extends ExpressionNode {
   boolean isLongOrIllegal(VirtualFrame frame) {
     FrameSlotKind kind = frame.getFrameDescriptor().getSlotKind(frameSlotIdx);
     return kind == FrameSlotKind.Long || kind == FrameSlotKind.Illegal;
+  }
+
+  @Override
+  public Object getNodeObject() {
+    return new VariableNodeObject(StandardTags.WriteVariableTag.NAME, getName());
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -1,14 +1,18 @@
 package org.enso.interpreter.node.scope;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.InstrumentableNode;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.nodes.NodeUtil;
+import java.util.Set;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.EnsoContext;
 
@@ -21,6 +25,8 @@ public abstract class AssignmentNode extends ExpressionNode {
   private final int frameSlotIdx;
 
   abstract String getName();
+
+  abstract ExpressionNode getRhsNode();
 
   AssignmentNode(int frameSlotIdx) {
     this.frameSlotIdx = frameSlotIdx;
@@ -73,16 +79,25 @@ public abstract class AssignmentNode extends ExpressionNode {
   }
 
   @Override
-  public Object getNodeObject() {
-    return new VariableNodeObject(StandardTags.WriteVariableTag.NAME, getName());
+  public InstrumentableNode materializeInstrumentableNodes(
+      Set<Class<? extends Tag>> materializedTags) {
+    if (materializedTags.contains(StandardTags.WriteVariableTag.class)) {
+      var rhs = getRhsNode();
+      var bounds = getSourceSectionBounds();
+      if (bounds != null && !isNodeWrapped(rhs)) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        var newRhs = new VariableAccessNode(getName(), rhs);
+        newRhs.setSourceLocation(bounds[0], bounds[1]);
+        var res = NodeUtil.replaceChild(this, getRhsNode(), newRhs);
+        insert(newRhs);
+        notifyInserted(newRhs);
+        assert res;
+      }
+    }
+    return this;
   }
 
-  @Override
-  public boolean hasTag(Class<? extends Tag> tag) {
-    if (super.hasTag(tag)) {
-      return true;
-    } else {
-      return getSourceSectionBounds() != null && StandardTags.WriteVariableTag.class == tag;
-    }
+  private static boolean isNodeWrapped(ExpressionNode node) {
+    return node instanceof VariableAccessNode || ExpressionNode.isWrapper(node);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -19,12 +19,15 @@ import org.enso.interpreter.runtime.EnsoContext;
 /** This node represents an assignment to a variable in a given scope. */
 @NodeInfo(shortName = "=", description = "Assigns expression result to a variable.")
 @NodeField(name = "name", type = String.class)
+@NodeField(name = "assignmentBounds", type = int[].class)
 @NodeChild(value = "rhsNode", type = ExpressionNode.class)
 public abstract class AssignmentNode extends ExpressionNode {
 
   private final int frameSlotIdx;
 
   abstract String getName();
+
+  abstract int[] getAssignmentBounds();
 
   abstract ExpressionNode getRhsNode();
 
@@ -35,12 +38,16 @@ public abstract class AssignmentNode extends ExpressionNode {
   /**
    * Creates an instance of this node.
    *
+   * @param name the name of the variable to assign to
+   * @param bounds the location of the assignment for {@link StandardTags.WriteVariableTag}
+   *     instrumentation
    * @param expression the expression being assigned
    * @param frameSlotIdx the slot index to which {@code expression} is being assigned
    * @return a node representing an assignment
    */
-  public static AssignmentNode build(String name, ExpressionNode expression, int frameSlotIdx) {
-    return AssignmentNodeGen.create(frameSlotIdx, expression, name);
+  public static AssignmentNode build(
+      String name, int[] bounds, ExpressionNode expression, int frameSlotIdx) {
+    return AssignmentNodeGen.create(frameSlotIdx, expression, name, bounds);
   }
 
   /**
@@ -83,10 +90,13 @@ public abstract class AssignmentNode extends ExpressionNode {
       Set<Class<? extends Tag>> materializedTags) {
     if (materializedTags.contains(StandardTags.WriteVariableTag.class)) {
       var rhs = getRhsNode();
-      var bounds = getSourceSectionBounds();
+      var bounds = getAssignmentBounds();
+      if (bounds == null) {
+        bounds = getSourceSectionBounds();
+      }
       if (bounds != null && !isNodeWrapped(rhs)) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        var newRhs = new VariableAccessNode(getName(), rhs);
+        var newRhs = new AssignLocalVariableNode(getName(), rhs);
         newRhs.setSourceLocation(bounds[0], bounds[1]);
         var res = NodeUtil.replaceChild(this, getRhsNode(), newRhs);
         insert(newRhs);
@@ -98,6 +108,6 @@ public abstract class AssignmentNode extends ExpressionNode {
   }
 
   private static boolean isNodeWrapped(ExpressionNode node) {
-    return node instanceof VariableAccessNode || ExpressionNode.isWrapper(node);
+    return node instanceof AssignLocalVariableNode || ExpressionNode.isWrapper(node);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/ReadLocalVariableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/ReadLocalVariableNode.java
@@ -6,6 +6,8 @@ import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.compiler.pass.analyse.FramePointer;
@@ -101,5 +103,14 @@ public abstract class ReadLocalVariableNode extends ExpressionNode {
       currentFrame = getParentFrame(currentFrame);
     }
     return currentFrame;
+  }
+
+  @Override
+  public boolean hasTag(Class<? extends Tag> tag) {
+    if (super.hasTag(tag)) {
+      return true;
+    } else {
+      return getSourceSectionBounds() != null && StandardTags.ReadVariableTag.class == tag;
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/ReadLocalVariableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/ReadLocalVariableNode.java
@@ -21,20 +21,24 @@ import org.enso.interpreter.runtime.callable.function.Function;
  * {@link Frame}. The {@code framePointer} field may point to the parent frame.
  */
 @NodeInfo(shortName = "readVar", description = "Access local variable value.")
+@NodeField(name = "name", type = String.class)
 @NodeField(name = "framePointer", type = FramePointer.class)
 public abstract class ReadLocalVariableNode extends ExpressionNode {
-  public abstract FramePointer getFramePointer();
+  abstract FramePointer getFramePointer();
+
+  abstract String getName();
 
   ReadLocalVariableNode() {}
 
   /**
    * Creates an instance of this node.
    *
+   * @param name the name of variable to read
    * @param pointer the pointer to the local target
    * @return a node that reads from {@code pointer}
    */
-  public static ReadLocalVariableNode build(FramePointer pointer) {
-    return ReadLocalVariableNodeGen.create(pointer);
+  public static ReadLocalVariableNode build(String name, FramePointer pointer) {
+    return ReadLocalVariableNodeGen.create(name, pointer);
   }
 
   /**
@@ -103,6 +107,11 @@ public abstract class ReadLocalVariableNode extends ExpressionNode {
       currentFrame = getParentFrame(currentFrame);
     }
     return currentFrame;
+  }
+
+  @Override
+  public Object getNodeObject() {
+    return new VariableNodeObject(StandardTags.ReadVariableTag.NAME, getName());
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/VariableAccessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/VariableAccessNode.java
@@ -1,0 +1,36 @@
+package org.enso.interpreter.node.scope;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import com.oracle.truffle.api.instrumentation.Tag;
+import org.enso.interpreter.node.ExpressionNode;
+
+final class VariableAccessNode extends ExpressionNode {
+  private final String name;
+  @Child private ExpressionNode rhs;
+
+  VariableAccessNode(String name, ExpressionNode expression) {
+    this.name = name;
+    this.rhs = expression;
+  }
+
+  @Override
+  public Object executeGeneric(VirtualFrame frame) {
+    return rhs.executeGeneric(frame);
+  }
+
+  @Override
+  public Object getNodeObject() {
+    return new VariableNodeObject(StandardTags.WriteVariableTag.NAME, name);
+  }
+
+  @Override
+  public boolean hasTag(Class<? extends Tag> tag) {
+    if (super.hasTag(tag)) {
+      return true;
+    } else {
+      assert getSourceSectionBounds() != null;
+      return StandardTags.WriteVariableTag.class == tag;
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/VariableNodeObject.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/VariableNodeObject.java
@@ -1,0 +1,42 @@
+package org.enso.interpreter.node.scope;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
+
+@ExportLibrary(InteropLibrary.class)
+final class VariableNodeObject implements TruffleObject {
+  final String key;
+  final String value;
+
+  VariableNodeObject(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  @ExportMessage
+  boolean hasMembers() {
+    return true;
+  }
+
+  @ExportMessage
+  Object getMembers(boolean includeInternal) {
+    return ArrayLikeHelpers.wrapStrings(key);
+  }
+
+  @ExportMessage
+  Object readMember(String id) throws UnknownIdentifierException {
+    if (id.equals(key)) {
+      return value;
+    }
+    throw UnknownIdentifierException.create(id);
+  }
+
+  @ExportMessage
+  boolean isMemberReadable(String member) {
+    return true;
+  }
+}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -486,10 +486,14 @@ private[runtime] class IrToTruffle(
               idx,
               arg.getDefaultValue.orElse(null)
             )
-          val readArg       = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
-          val assignmentArg = AssignmentNode.build(readArg, slotIdx)
+          val readArg = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
+          val assignmentArg =
+            AssignmentNode.build(arg.getName, readArg, slotIdx)
           val argRead =
-            ReadLocalVariableNode.build(new FramePointer(0, slotIdx))
+            ReadLocalVariableNode.build(
+              arg.getName,
+              new FramePointer(0, slotIdx)
+            )
           argumentExpressions.append((assignmentArg, argRead))
         }
 
@@ -1844,7 +1848,11 @@ private[runtime] class IrToTruffle(
       currentVarName = binding.name.name
       val slotIdx = fp.frameSlotIdx()
       setLocation(
-        AssignmentNode.build(this.run(binding.expression, true, true), slotIdx),
+        AssignmentNode.build(
+          binding.name.name,
+          this.run(binding.expression, true, true),
+          slotIdx
+        ),
         binding.location
       )
     }
@@ -1973,9 +1981,10 @@ private[runtime] class IrToTruffle(
       }
 
       override protected def resolveLocalName(
+        name: String,
         localLink: FramePointer
       ): RuntimeExpression =
-        ReadLocalVariableNode.build(localLink)
+        ReadLocalVariableNode.build(name, localLink)
 
       override protected def resolveGlobalName(
         resolvedName: BindingsMap.ResolvedName,
@@ -2249,7 +2258,7 @@ private[runtime] class IrToTruffle(
             val readArgNoCheck =
               setLocation(readArgNoCheck0, unprocessedArg.name().location())
             val readArg   = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
-            val assignArg = AssignmentNode.build(readArg, slotIdx)
+            val assignArg = AssignmentNode.build(arg.getName, readArg, slotIdx)
 
             argExpressions.append(assignArg)
 
@@ -2286,7 +2295,8 @@ private[runtime] class IrToTruffle(
       val src = b.build()
       val argumentReaders = argumentSlotIdxs
         .map(slotIdx =>
-          ReadLocalVariableNode.build(new FramePointer(0, slotIdx))
+          ReadLocalVariableNode
+            .build(argumentNames(slotIdx), new FramePointer(0, slotIdx))
         )
         .toArray[RuntimeExpression]
       ForeignMethodCallNode.buildDeferred(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2257,8 +2257,11 @@ private[runtime] class IrToTruffle(
               )
             val readArgNoCheck =
               setLocation(readArgNoCheck0, unprocessedArg.name().location())
-            val readArg   = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
-            val assignArg = AssignmentNode.build(arg.getName, readArg, slotIdx)
+            val readArg = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
+            val assignArgNoLock =
+              AssignmentNode.build(arg.getName, readArg, slotIdx)
+            val assignArg =
+              setLocation(assignArgNoLock, unprocessedArg.name().location())
 
             argExpressions.append(assignArg)
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2296,11 +2296,11 @@ private[runtime] class IrToTruffle(
       val b    = Source.newBuilder("epb", language + ":" + line + "#" + code, name)
       b.uri(source.getURI())
       val src = b.build()
-      val argumentReaders = argumentSlotIdxs
-        .map(slotIdx =>
+      val argumentReaders = argumentSlotIdxs.zipWithIndex
+        .map { case (slotIdx, i) =>
           ReadLocalVariableNode
-            .build(argumentNames(slotIdx), new FramePointer(0, slotIdx))
-        )
+            .build(argumentNames(i), new FramePointer(0, slotIdx))
+        }
         .toArray[RuntimeExpression]
       ForeignMethodCallNode.buildDeferred(
         src,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -488,7 +488,12 @@ private[runtime] class IrToTruffle(
             )
           val readArg = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
           val assignmentArg =
-            AssignmentNode.build(arg.getName, readArg, slotIdx)
+            AssignmentNode.build(
+              arg.getName,
+              readArgNoCheck.getSourceSectionBounds,
+              readArg,
+              slotIdx
+            )
           val argRead =
             ReadLocalVariableNode.build(
               arg.getName,
@@ -1850,6 +1855,7 @@ private[runtime] class IrToTruffle(
       setLocation(
         AssignmentNode.build(
           binding.name.name,
+          null,
           this.run(binding.expression, true, true),
           slotIdx
         ),
@@ -2259,11 +2265,14 @@ private[runtime] class IrToTruffle(
               setLocation(readArgNoCheck0, unprocessedArg.name().location())
             val readArg = TypeCheckValueNode.wrap(readArgNoCheck, checkNode)
             val assignArgNoLock =
-              AssignmentNode.build(arg.getName, readArg, slotIdx)
-            val assignArg =
-              setLocation(assignArgNoLock, unprocessedArg.name().location())
+              AssignmentNode.build(
+                arg.getName,
+                readArgNoCheck.getSourceSectionBounds,
+                readArg,
+                slotIdx
+              )
 
-            argExpressions.append(assignArg)
+            argExpressions.append(assignArgNoLock)
 
             val argName = arg.getName
 


### PR DESCRIPTION
### Pull Request Description

- adds support for `ReadVariableTag` and `WriteVariableTag` to Enso 
   - to be on par with instrumentation capabilities of Graal.js
- cfd9abfbad04d1d6c923fda7bfd6eab262955532 shows what kind of instrumentation is available in JavaScript
- 7665a43 expands the test also to Enso
- provide the same instrumentation for Enso
   - 647592e provides these tags,
   - 036474b exposes proper variable names
   - ffc63fb adds tracking of argument names assignments
- then 9108e77f30ef1c1dabb1a16b9800fc5ebb714fa0 makes it all work with existing tests
- may help with #10525
- would work great with GraalVM Insight once enhanced by https://github.com/oracle/graal/pull/12760


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] engine [benchmark run](https://github.com/enso-org/enso/actions/runs/20550081137) is fine
- [x] standard libs [benchmark run](https://github.com/enso-org/enso/actions/runs/20550083443) is fine
