### PR TITLE
Separating Root and RootBody nodes to support unwinding

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.debug.SuspendedEvent;
 import com.oracle.truffle.api.nodes.LanguageInfo;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -184,6 +186,93 @@ public class DebuggingEnsoTest {
       Assert.assertEquals("5!", 120, fac5.asInt());
     }
     assertEquals("Accumulator gets following values one by one", Set.of(1, 5, 20, 60, 120), values);
+  }
+
+  @Test
+  public void unwindFrameTest() {
+    var log = new StringWriter();
+    log.append("\n");
+
+    final Value compute =
+        createEnsoMethod(
+            """
+            from Standard.Base import all
+
+            combine a b =
+                p =
+                    x = a + b
+                    x
+                m =
+                    a - b
+                p * m
+
+            compute u v =
+                combine u v
+            """,
+            "compute");
+
+    var check = compute.execute(5, 3);
+    assertTrue("An integer produced", check.fitsInInt());
+    assertEquals("Result is good", 16, check.asInt());
+
+    final var values = new LinkedList<Integer>();
+    final var rewinded = new boolean[] {false};
+    try (var session =
+        debugger.startSession(
+            (event) -> {
+              var aValue = findDebugValue(event, "a");
+              var bValue = findDebugValue(event, "b");
+              log.append("a " + aValue + " b " + bValue + "\n");
+              var xValue = findDebugValue(event, "x");
+              if (xValue != null && xValue.fitsInInt()) {
+                log.append("x " + xValue + "\n");
+                values.add(xValue.asInt());
+                if (!rewinded[0]) {
+                  rewinded[0] = true;
+                  var it = event.getStackFrames().iterator();
+                  var frame = it.next();
+                  event.prepareUnwindFrame(frame);
+                  return;
+                }
+              }
+              if (aValue != null && aValue.fitsInInt() && bValue != null && bValue.fitsInInt()) {
+                values.add(aValue.asInt());
+                values.add(bValue.asInt());
+              }
+              event.getSession().suspendNextExecution();
+            })) {
+      session.suspendNextExecution();
+      var ab = compute.execute(5, 3);
+      assertTrue("An integer produced again: " + ab + log, ab.fitsInInt());
+      assertEquals("Same result as before" + log, 16, ab.asInt());
+    }
+    assertEquals(
+        "Up to x=8, then again and then final result",
+        List.of(
+            5,
+            3,
+            5,
+            3,
+            5,
+            3,
+            5,
+            3,
+            8, // unwinded here
+            5,
+            3,
+            5,
+            3,
+            5,
+            3,
+            5,
+            3,
+            8, // not unwinded again
+            5,
+            3,
+            5,
+            3 // computed to the end
+            ),
+        values);
   }
 
   /**
@@ -1004,9 +1093,11 @@ public class DebuggingEnsoTest {
 
   private static DebugValue findDebugValue(SuspendedEvent event, final String n)
       throws DebugException {
-    for (var v : event.getTopStackFrame().getScope().getDeclaredValues()) {
-      if (v.getName().contains(n)) {
-        return v;
+    for (var frame : event.getStackFrames()) {
+      for (var v : frame.getScope().getDeclaredValues()) {
+        if (v.getName().contains(n)) {
+          return v;
+        }
       }
     }
     return null;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/BlockNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/BlockNode.java
@@ -45,6 +45,17 @@ public class BlockNode extends ExpressionNode {
   }
 
   /**
+   * Creates a "root body tagged" instance of block node.
+   *
+   * @param expressions the function body
+   * @param returnExpr the return expression from the function
+   * @return a node representing a block expression
+   */
+  public static BlockNode buildRootBody(ExpressionNode[] expressions, ExpressionNode returnExpr) {
+    return new RootBody(expressions, returnExpr);
+  }
+
+  /**
    * Creates a block node with statements. When instrumented, the statements get wrapped in a into a
    * {@link StatementNode} so one can step over them.
    *
@@ -107,7 +118,21 @@ public class BlockNode extends ExpressionNode {
       if (super.hasTag(tag)) {
         return true;
       }
-      return tag == StandardTags.RootBodyTag.class || tag == StandardTags.RootTag.class;
+      return tag == StandardTags.RootTag.class;
+    }
+  }
+
+  private static final class RootBody extends BlockNode {
+    RootBody(ExpressionNode[] expressions, ExpressionNode returnExpr) {
+      super(expressions, returnExpr);
+    }
+
+    @Override
+    public boolean hasTag(Class<? extends Tag> tag) {
+      if (super.hasTag(tag)) {
+        return true;
+      }
+      return tag == StandardTags.RootBodyTag.class;
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/AtomConstructor.java
@@ -296,7 +296,7 @@ public final class AtomConstructor extends EnsoObject {
     if (section != null) {
       instantiateNode.setSourceLocation(section.start(), section.length());
     }
-    BlockNode instantiateBlock = BlockNode.buildRoot(assignments, instantiateNode);
+    BlockNode instantiateBlock = BlockNode.buildRootBody(assignments, instantiateNode);
     RootNode rootNode =
         MethodRootNode.buildConstructor(
             language,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2185,13 +2185,13 @@ private[runtime] class IrToTruffle(
         if (!operation.isInstanceOf[BlockNode]) {
           operation = BlockNode.buildStatements(Array(), operation)
         }
-        val body = if (defineRoot) {
-          BlockNode.buildRootBody(Array(), operation)
-        } else {
-          BlockNode.buildInvisible(Array(), operation)
-        }
-        val initVariablesAndThenBody =
+        val initVariablesAndThenBody = if (defineRoot) {
+          val body =
+            BlockNode.buildRootBody(Array(), operation)
           BlockNode.buildRoot(argsExpr._1, body)
+        } else {
+          BlockNode.buildInvisible(argsExpr._1, operation)
+        }
         initVariablesAndThenBody
       }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2186,12 +2186,12 @@ private[runtime] class IrToTruffle(
           operation = BlockNode.buildStatements(Array(), operation)
         }
         val body = if (defineRoot) {
-          BlockNode.buildRoot(Array(), operation)
+          BlockNode.buildRootBody(Array(), operation)
         } else {
           BlockNode.buildInvisible(Array(), operation)
         }
         val initVariablesAndThenBody =
-          BlockNode.buildInvisible(argsExpr._1, body)
+          BlockNode.buildRoot(argsExpr._1, body)
         initVariablesAndThenBody
       }
 


### PR DESCRIPTION
### Pull Request Description

- Enso (as any other Truffle language) should support _unwinding_
- the ultimate goal is to make following _Restart frame_ action enabled and work:

<img width="1138" height="255" alt="obrazek" src="https://github.com/user-attachments/assets/29c68335-3f79-4a3b-b9a1-e88593b5a8fa" />

- however that's slightly distant dream...

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
