### PR TITLE
IR processor generates fully qualified names

### DIFF
--- a/engine/runtime-parser-processor-tests/src/test/java/org/enso/runtime/parser/processor/test/TestIRProcessorInline.java
+++ b/engine/runtime-parser-processor-tests/src/test/java/org/enso/runtime/parser/processor/test/TestIRProcessorInline.java
@@ -174,7 +174,9 @@ public class TestIRProcessorInline {
               }
         """;
     var generatedClass = generatedClass("MyIR", src);
-    assertThat(generatedClass, containsString("class MyIRGen implements IR, MySuperIR"));
+    assertThat(
+        generatedClass,
+        containsString("class MyIRGen implements org.enso.compiler.core.IR, MySuperIR"));
   }
 
   @Test
@@ -201,7 +203,9 @@ public class TestIRProcessorInline {
 """;
     var generatedClass = generatedClass("MyIR", src);
     assertThat(
-        generatedClass, containsString("class MyIRGen implements IR, MySuperIR_1, MySuperIR_2"));
+        generatedClass,
+        containsString(
+            "class MyIRGen implements org.enso.compiler.core.IR, MySuperIR_1, MySuperIR_2"));
   }
 
   @Test
@@ -569,7 +573,7 @@ public class TestIRProcessorInline {
               }
             }
             """);
-    assertThat(genSrc, containsString("Expression expression()"));
+    assertThat(genSrc, containsString("org.enso.compiler.core.ir.Expression expression()"));
   }
 
   @Test
@@ -724,7 +728,7 @@ public class TestIRProcessorInline {
               }
             }
             """);
-    assertThat(src, containsString("class JBlankGen implements IR, JName"));
+    assertThat(src, containsString("class JBlankGen implements org.enso.compiler.core.IR, JName"));
     assertThat(src, containsString("String name()"));
   }
 
@@ -754,7 +758,9 @@ public class TestIRProcessorInline {
             }
             """);
     assertThat(src, containsString("class JNameGen"));
-    assertThat(src, containsString("List<IR> expressions"));
+    assertThat(
+        src,
+        containsString("scala.collection.immutable.List<org.enso.compiler.core.IR> expressions"));
   }
 
   @Test
@@ -783,7 +789,9 @@ public class TestIRProcessorInline {
             }
             """);
     assertThat(src, containsString("class JNameGen"));
-    assertThat(src, containsString("List<IR> expressions"));
+    assertThat(
+        src,
+        containsString("scala.collection.immutable.List<org.enso.compiler.core.IR> expressions"));
     // expressions child is not required, so there must be somewhere a check
     // that it is not null.
     assertThat(src, containsString("expressions != null"));
@@ -816,7 +824,10 @@ public class TestIRProcessorInline {
             }
             """);
     assertThat(src, containsString("class JNameGen"));
-    assertThat(src, containsString("Option<List<IR>> expressions"));
+    assertThat(
+        src,
+        containsString(
+            "Option<scala.collection.immutable.List<org.enso.compiler.core.IR>> expressions"));
     assertThat(src, containsString("expressions.isDefined"));
   }
 
@@ -846,7 +857,10 @@ public class TestIRProcessorInline {
             }
             """);
     assertThat(src, containsString("class JNameGen"));
-    assertThat("has getter method for expression", src, containsString("Option<IR> expression()"));
+    assertThat(
+        "has getter method for expression",
+        src,
+        containsString("Option<org.enso.compiler.core.IR> expression()"));
   }
 
   @Test
@@ -878,7 +892,8 @@ public class TestIRProcessorInline {
     assertThat(
         "has getter method for expression with the same return type",
         src,
-        containsString("Reference<IR> expression()"));
+        containsString(
+            "org.enso.persist.Persistance.Reference<org.enso.compiler.core.IR> expression()"));
   }
 
   /** JCase contains JExpr and JBranch, JExpr references JBranch as its IRChild. */

--- a/engine/runtime-parser-processor-tests/src/test/java/org/enso/runtime/parser/processor/test/TestIRProcessorInline.java
+++ b/engine/runtime-parser-processor-tests/src/test/java/org/enso/runtime/parser/processor/test/TestIRProcessorInline.java
@@ -11,6 +11,8 @@ import com.google.testing.compile.CompilationSubject;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import java.io.IOException;
+import java.util.List;
+import javax.tools.JavaFileObject;
 import org.enso.runtime.parser.processor.IRProcessor;
 import org.junit.Test;
 
@@ -40,8 +42,12 @@ public class TestIRProcessorInline {
 
   private static Compilation expectCompilationSuccessful(String name, String src) {
     var srcObject = JavaFileObjects.forSourceString(name, src);
+    return expectCompilationSuccessful(List.of(srcObject));
+  }
+
+  private static Compilation expectCompilationSuccessful(List<JavaFileObject> srcs) {
     var compiler = Compiler.javac().withProcessors(new IRProcessor());
-    var compilation = compiler.compile(srcObject);
+    var compilation = compiler.compile(srcs);
     if (compilation.status() != Status.SUCCESS) {
       var failureMsg = new StringBuilder();
       failureMsg.append("Compilation failed with diagnostics: ");
@@ -939,5 +945,68 @@ public class TestIRProcessorInline {
             """);
     var generatedSrcs = compilation.generatedSourceFiles();
     assertThat(generatedSrcs.size(), is(2));
+  }
+
+  @Test
+  public void resolvesSimpleTypeNameClashes() {
+    var pkg = "processor.test";
+
+    var literalNameCode =
+        """
+        package ${pkg};
+
+        import org.enso.runtime.parser.dsl.GenerateIR;
+        import org.enso.runtime.parser.dsl.GenerateFields;
+        import org.enso.runtime.parser.dsl.IRField;
+        import org.enso.compiler.core.IR;
+
+        public interface JLiteral extends IR {
+          @GenerateIR(interfaces = {JLiteral.class})
+          final class Name extends LiteralNameGen {
+            @GenerateFields
+            public Name(@IRField String name) {
+              super(name);
+            }
+
+            @Override
+            public String showCode(int indent) {
+              return name();
+            }
+          }
+        }
+        """
+            .replace("${pkg}", pkg);
+
+    var patternNameCode =
+        """
+        package ${pkg};
+
+        import org.enso.runtime.parser.dsl.GenerateIR;
+        import org.enso.runtime.parser.dsl.GenerateFields;
+        import org.enso.runtime.parser.dsl.IRField;
+        import org.enso.runtime.parser.dsl.IRChild;
+        import org.enso.compiler.core.IR;
+        import ${pkg}.JLiteral;
+
+        public interface JPattern extends IR {
+          @GenerateIR(interfaces = {JPattern.class})
+          final class Name extends PatternNameGen {
+            @GenerateFields
+            public Name(@IRChild JLiteral.Name litName) {
+              super(litName);
+            }
+
+            @Override
+            public String showCode(int indent) {
+              return litName().name();
+            }
+          }
+        }
+        """
+            .replace("${pkg}", pkg);
+    var litSrc = JavaFileObjects.forSourceString(pkg + ".JLiteral", literalNameCode);
+    var patSrc = JavaFileObjects.forSourceString(pkg + ".JPattern", patternNameCode);
+    var compilation = expectCompilationSuccessful(List.of(litSrc, patSrc));
+    assertThat(compilation.generatedSourceFiles().size(), is(2));
   }
 }

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/ClassField.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/ClassField.java
@@ -51,11 +51,7 @@ public final class ClassField {
   }
 
   public String getTypeName() {
-    return type.toString();
-  }
-
-  public String getSimpleTypeName() {
-    return Utils.simpleTypeName(type);
+    return Utils.qualifiedTypeName(type);
   }
 
   public boolean isPrimitive() {

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/GeneratedClassContext.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/GeneratedClassContext.java
@@ -137,6 +137,14 @@ public final class GeneratedClassContext {
     return processedClass;
   }
 
+  /**
+   * Returns qualified name of the class that is being processed. More specifically of the class
+   * that is annotated with {@link org.enso.runtime.parser.dsl.GenerateIR}.
+   */
+  public String getProcessedClassName() {
+    return processedClass.getClazz().getQualifiedName().toString();
+  }
+
   public TypeElement getSuperClass() {
     var clazz = getProcessedClass().getClazz().getSuperclass();
     var superClassType = getProcessingEnvironment().getTypeUtils().asElement(clazz);
@@ -230,7 +238,7 @@ public final class GeneratedClassContext {
     }
 
     String simpleTypeName() {
-      return Utils.simpleTypeName(type);
+      return Utils.qualifiedTypeName(type);
     }
   }
 }

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
@@ -1,13 +1,9 @@
 package org.enso.runtime.parser.processor;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import org.enso.runtime.parser.processor.field.Field;
 import org.enso.runtime.parser.processor.field.FieldCollector;
@@ -98,58 +94,11 @@ final class IRNodeClassGenerator {
     return className;
   }
 
-  private boolean isInSameCompilationUnit(Field field) {
-    var elem = processingEnv.getTypeUtils().asElement(field.getType());
-    var enclosingElem = elem.getEnclosingElement();
-    var thisEnclosingElem = processedClass.getClazz().getEnclosingElement();
-    if (enclosingElem instanceof TypeElement enclosingTypeElem
-        && thisEnclosingElem instanceof TypeElement thisEnclosingTypeElem) {
-      return enclosingTypeElem.getQualifiedName().equals(thisEnclosingTypeElem.getQualifiedName());
-    }
-    return false;
-  }
-
   /** Returns set of import statements that should be included in the generated class. */
   Set<String> imports() {
-    var importsForFields =
-        generatedClassContext.getUserFields().stream()
-            .filter(field -> !field.isPrimitive())
-            .filter(field -> !isInSameCompilationUnit(field))
-            .flatMap(field -> field.getImportedTypes().stream())
-            .collect(Collectors.toUnmodifiableSet());
-    var allImports = new HashSet<String>();
-    allImports.addAll(defaultImportedTypes);
-    addImportForType(allImports, processedClass.getClazz());
-    for (var ifaceToImplement : processedClass.getInterfaces()) {
-      addImportForType(allImports, ifaceToImplement);
-    }
-    allImports.addAll(importsForFields);
-    return allImports.stream()
+    return defaultImportedTypes.stream()
         .map(importedType -> "import " + importedType + ";")
         .collect(Collectors.toUnmodifiableSet());
-  }
-
-  /**
-   * Adds import for a type that is not in an unnamed package.
-   *
-   * @param imports Set of imports to potentially add to
-   */
-  private void addImportForType(Set<String> imports, TypeElement type) {
-    if (!isInUnnamedPackage(type)) {
-      imports.add(type.getQualifiedName().toString());
-    }
-  }
-
-  private boolean isInUnnamedPackage(TypeElement type) {
-    Element enclosingElement = type.getEnclosingElement();
-    while (enclosingElement != null) {
-      if (enclosingElement.getKind() == ElementKind.PACKAGE) {
-        var pkg = (PackageElement) enclosingElement;
-        return pkg.isUnnamed();
-      }
-      enclosingElement = enclosingElement.getEnclosingElement();
-    }
-    return false;
   }
 
   /** Generates the body of the class - fields, field setters, method overrides, builder, etc. */
@@ -226,7 +175,7 @@ final class IRNodeClassGenerator {
                     """
                     private final ${type} ${name};
                     """
-                        .replace("${type}", field.getSimpleTypeName())
+                        .replace("${type}", field.getQualifiedTypeName())
                         .replace("${name}", field.getName()))
             .collect(Collectors.joining(System.lineSeparator()));
     var comment =
@@ -320,7 +269,7 @@ final class IRNodeClassGenerator {
             .map(
                 consParam ->
                     "$consType $consName"
-                        .replace("$consType", consParam.getSimpleTypeName())
+                        .replace("$consType", consParam.getTypeName())
                         .replace("$consName", consParam.name()))
             .collect(Collectors.joining(", "));
     sb.append(inParens).append(") {").append(System.lineSeparator());
@@ -469,7 +418,7 @@ final class IRNodeClassGenerator {
           }
           """
               .replace("${comment}", commentForField(field))
-              .replace("${returnType}", field.getSimpleTypeName())
+              .replace("${returnType}", field.getQualifiedTypeName())
               .replace("${fieldName}", field.getName());
       sb.append(code);
       sb.append(System.lineSeparator());

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java
@@ -54,9 +54,7 @@ final class IRNodeClassGenerator {
           "org.enso.compiler.core.IR",
           "org.enso.compiler.core.ir.DiagnosticStorage",
           "org.enso.compiler.core.ir.DiagnosticStorage$",
-          "org.enso.compiler.core.ir.Expression",
           "org.enso.compiler.core.ir.IdentifiedLocation",
-          "org.enso.compiler.core.ir.Name",
           "org.enso.compiler.core.ir.MetadataStorage",
           "scala.Option");
 

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
@@ -378,7 +378,7 @@ public class IRProcessor extends AbstractProcessor {
     var pkg = pkgName.isEmpty() ? "" : "package " + pkgName + ";";
     var interfaces =
         processedClass.getInterfaces().stream()
-            .map(TypeElement::getSimpleName)
+            .map(TypeElement::getQualifiedName)
             .collect(Collectors.joining(", "));
     var code =
         """

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
@@ -164,7 +164,7 @@ public class IRProcessor extends AbstractProcessor {
     try {
       DependencySorter.ensureNoCycles(dependencies);
     } catch (CyclicDependencyException e) {
-      throw new IRProcessingException("Cyclic dependency detected", null, e);
+      throw new IRProcessingException("Cyclic dependency detected: " + e.getMessage(), null, e);
     }
     var sortedDeps = DependencySorter.topologicalSort(dependencies);
     // Map class names to their TypeElements

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRProcessor.java
@@ -114,7 +114,7 @@ public class IRProcessor extends AbstractProcessor {
    *     set.
    */
   private List<TypeElement> orderByReferences(Set<TypeElement> classesToProcess) {
-    var classesToProcessSimpleNames =
+    var classesToProcessNames =
         classesToProcess.stream().map(type -> type.getSimpleName().toString()).toList();
     var classesToProcessMap =
         classesToProcess.stream()
@@ -145,12 +145,17 @@ public class IRProcessor extends AbstractProcessor {
                       throw new IRProcessingException(
                           "Cannot find element for type " + paramType, null);
                     }
-                    return paramTypeElem.getSimpleName().toString();
+                    if (paramTypeElem instanceof TypeElement typeElem) {
+                      return typeElem.getQualifiedName().toString();
+                    } else {
+                      throw new IRProcessingException(
+                          "Parameter type is not a TypeElement: " + paramTypeElem, paramTypeElem);
+                    }
                   })
               .toList();
       for (var childTypeName : childTypeNames) {
-        if (classesToProcessSimpleNames.contains(childTypeName)) {
-          var clazzName = clazz.getSimpleName().toString();
+        if (classesToProcessNames.contains(childTypeName)) {
+          var clazzName = clazz.getQualifiedName().toString();
           var deps = dependencies.computeIfAbsent(clazzName, k -> new HashSet<>());
           deps.add(childTypeName);
         }
@@ -200,7 +205,7 @@ public class IRProcessor extends AbstractProcessor {
               + "sortedDepTypes: "
               + sortedDepTypes
               + ", classesToProcess: "
-              + classesToProcessSimpleNames,
+              + classesToProcessNames,
           null);
     }
     return sortedDepTypes;

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/field/Field.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/field/Field.java
@@ -1,6 +1,5 @@
 package org.enso.runtime.parser.processor.field;
 
-import java.util.List;
 import java.util.function.Function;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
@@ -37,8 +36,8 @@ public abstract class Field {
    * Does not return null. If the type is generic, the type parameter is included in the name.
    * Returns non-qualified name.
    */
-  public String getSimpleTypeName() {
-    return Utils.simpleTypeName(type);
+  public String getQualifiedTypeName() {
+    return Utils.qualifiedTypeName(type);
   }
 
   /**
@@ -54,14 +53,6 @@ public abstract class Field {
    * @return
    */
   public abstract boolean isNullable();
-
-  /**
-   * Returns list of (fully-qualified) types that are necessary to import in order to use simple
-   * type names.
-   */
-  public List<String> getImportedTypes() {
-    return Utils.getImportedTypes(type);
-  }
 
   /** Returns true if this field is a scala immutable list. */
   public boolean isList() {

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/BuilderMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/BuilderMethodGenerator.java
@@ -26,7 +26,7 @@ public class BuilderMethodGenerator {
                 field -> {
                   var initializer = field.initializer() != null ? " = " + field.initializer() : "";
                   return "private $type $name $initializer;"
-                      .replace("$type", field.getSimpleTypeName())
+                      .replace("$type", field.getTypeName())
                       .replace("$name", field.name())
                       .replace("$initializer", initializer);
                 })
@@ -43,7 +43,7 @@ public class BuilderMethodGenerator {
                     }
                     """
                         .replace("$fieldName", field.name())
-                        .replace("$fieldType", field.getSimpleTypeName()))
+                        .replace("$fieldType", field.getTypeName()))
             .collect(Collectors.joining(System.lineSeparator()));
 
     // Validation code for all non-nullable user fields
@@ -104,19 +104,17 @@ public class BuilderMethodGenerator {
         """;
     sb.append(docs);
     sb.append("Builder(")
-        .append(generatedClassContext.getProcessedClass().getClazz().getSimpleName())
+        .append(generatedClassContext.getProcessedClassName())
         .append(" obj) {")
         .append(System.lineSeparator());
-    var clazz = generatedClassContext.getProcessedClass().getClazz().getSuperclass();
-    var superClassType =
-        generatedClassContext.getProcessingEnvironment().getTypeUtils().asElement(clazz);
+    var superClass = generatedClassContext.getProcessedClass().getClazz().getSuperclass();
     // Meta fields are accessed directly.
     for (var metaField : generatedClassContext.getMetaFields()) {
       sb.append("  ")
           .append("this.")
           .append(metaField.name())
           .append(" = ((")
-          .append(superClassType.getSimpleName().toString())
+          .append(superClass)
           .append(")obj).")
           .append(metaField.name())
           .append(";")
@@ -138,8 +136,7 @@ public class BuilderMethodGenerator {
 
   private String buildMethod() {
     var sb = new StringBuilder();
-    var processedClassName =
-        generatedClassContext.getProcessedClass().getClazz().getSimpleName().toString();
+    var processedClassName = generatedClassContext.getProcessedClassName();
     var ctorParams = generatedClassContext.getSubclassConstructorParameters();
     var ctorParamsStr = ctorParams.stream().map(ClassField::name).collect(Collectors.joining(", "));
     var fieldsNotInCtor = Utils.diff(generatedClassContext.getAllFields(), ctorParams);

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/ChildrenMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/ChildrenMethodGenerator.java
@@ -88,7 +88,7 @@ public final class ChildrenMethodGenerator {
         list.add(${fieldName}.get(${type}.class));
         """
             .replace("${fieldName}", field.getName())
-            .replace("${type}", field.getTypeParameter().getSimpleName().toString());
+            .replace("${type}", field.getTypeParameter().getQualifiedName().toString());
     return code;
   }
 

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/CopyMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/CopyMethodGenerator.java
@@ -64,12 +64,12 @@ public final class CopyMethodGenerator {
   }
 
   private String copyMethodRetType() {
-    return ctx.getProcessedClass().getClazz().getSimpleName().toString();
+    return ctx.getProcessedClassName();
   }
 
   private List<String> parameters() {
     return ctx.getAllFields().stream()
-        .map(field -> field.getSimpleTypeName() + " " + field.name())
+        .map(field -> field.getTypeName() + " " + field.name())
         .toList();
   }
 

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/DuplicateMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/DuplicateMethodGenerator.java
@@ -85,10 +85,10 @@ public class DuplicateMethodGenerator {
           idDuplicated = this.id;
         }
         """
-            .replace("$locType", ctx.getLocationMetaField().getSimpleTypeName())
-            .replace("$metaType", ctx.getPassDataMetaField().getSimpleTypeName())
-            .replace("$diagType", ctx.getDiagnosticsMetaField().getSimpleTypeName())
-            .replace("$idType", ctx.getIdMetaField().getSimpleTypeName());
+            .replace("$locType", ctx.getLocationMetaField().getTypeName())
+            .replace("$metaType", ctx.getPassDataMetaField().getTypeName())
+            .replace("$diagType", ctx.getDiagnosticsMetaField().getTypeName())
+            .replace("$idType", ctx.getIdMetaField().getTypeName());
     sb.append(Utils.indent(duplicateMetaFieldsCode, 2));
     sb.append(System.lineSeparator());
     for (var metaVar : metaFields()) {
@@ -205,7 +205,7 @@ public class DuplicateMethodGenerator {
         }
       }
     """
-        .replace("$childType", nullableChild.getSimpleTypeName())
+        .replace("$childType", nullableChild.getQualifiedTypeName())
         .replace("$childName", nullableChild.getName())
         .replace("$dupName", dupFieldName(nullableChild))
         .replace("$parameterNames", String.join(", ", parameterNames()));
@@ -219,7 +219,7 @@ public class DuplicateMethodGenerator {
       throw new IllegalStateException("Duplicated child is not of the expected type: " + $dupName);
     }
     """
-        .replace("$childType", child.getSimpleTypeName())
+        .replace("$childType", child.getQualifiedTypeName())
         .replace("$childName", child.getName())
         .replace("$dupName", dupFieldName(child))
         .replace("$parameterNames", String.join(", ", parameterNames()));
@@ -239,8 +239,8 @@ public class DuplicateMethodGenerator {
       });
     }
     """
-        .replace("$childListType", listChild.getSimpleTypeName())
-        .replace("$childType", listChild.getTypeParameter().getSimpleName())
+        .replace("$childListType", listChild.getQualifiedTypeName())
+        .replace("$childType", listChild.getTypeParameter().getQualifiedName())
         .replace("$childName", listChild.getName())
         .replace("$dupName", dupFieldName(listChild))
         .replace("$parameterNames", String.join(", ", parameterNames()));
@@ -258,8 +258,8 @@ public class DuplicateMethodGenerator {
       $dupName = Option.apply(duplicated);
     }
     """
-        .replace("$childOptType", optionChild.getSimpleTypeName())
-        .replace("$childType", optionChild.getTypeParameter().getSimpleName())
+        .replace("$childOptType", optionChild.getQualifiedTypeName())
+        .replace("$childType", optionChild.getTypeParameter().getQualifiedName())
         .replace("$childName", optionChild.getName())
         .replace("$dupName", dupFieldName(optionChild))
         .replace("$parameterNames", String.join(", ", parameterNames()));
@@ -279,7 +279,7 @@ public class DuplicateMethodGenerator {
     }
     """
         .replace("${childName}", optionListChild.getName())
-        .replace("${childType}", optionListChild.getNestedTypeParameter().getSimpleName())
+        .replace("${childType}", optionListChild.getNestedTypeParameter().getQualifiedName())
         .replace("${dupName}", dupFieldName(optionListChild))
         .replace("${parameterNames}", String.join(", ", parameterNames()));
   }
@@ -292,11 +292,11 @@ public class DuplicateMethodGenerator {
       ${type} duplicated = ${childName}
           .get(${type}.class)
           .duplicate(${parameterNames});
-      ${dupName} = Reference.of(duplicated);
+      ${dupName} = org.enso.persist.Persistance.Reference.of(duplicated);
     }
     """
-        .replace("${perRefType}", perRefChild.getSimpleTypeName())
-        .replace("${type}", perRefChild.getTypeParameter().getSimpleName())
+        .replace("${perRefType}", perRefChild.getQualifiedTypeName())
+        .replace("${type}", perRefChild.getTypeParameter().getQualifiedName())
         .replace("${childName}", perRefChild.getName())
         .replace("${dupName}", dupFieldName(perRefChild))
         .replace("${parameterNames}", String.join(", ", parameterNames()));
@@ -307,7 +307,7 @@ public class DuplicateMethodGenerator {
     return """
     $childType $dupName = $childName;
     """
-        .replace("$childType", field.getSimpleTypeName())
+        .replace("$childType", field.getQualifiedTypeName())
         .replace("$childName", field.getName())
         .replace("$dupName", dupFieldName(field));
   }
@@ -318,7 +318,7 @@ public class DuplicateMethodGenerator {
 
   /** Generate code for call of a constructor of the subclass. */
   private String newSubclass(List<DuplicateVar> ctorParams) {
-    var subClassType = ctx.getProcessedClass().getClazz().getSimpleName().toString();
+    var subClassType = ctx.getProcessedClassName();
     var ctor = ctx.getProcessedClass().getCtor();
     Utils.hardAssert(ctor.getParameters().size() == ctorParams.size());
     var sb = new StringBuilder();
@@ -334,7 +334,10 @@ public class DuplicateMethodGenerator {
             .map(
                 ctorParam -> {
                   if (ctorParam.needsCast) {
-                    return "(" + ctorParam.type + ") " + ctorParam.duplicatedName;
+                    return "("
+                        + Utils.qualifiedTypeName(ctorParam.type)
+                        + ") "
+                        + ctorParam.duplicatedName;
                   } else {
                     return ctorParam.duplicatedName;
                   }
@@ -377,7 +380,7 @@ public class DuplicateMethodGenerator {
   }
 
   private String dupMethodRetType() {
-    return ctx.getProcessedClass().getClazz().getSimpleName().toString();
+    return ctx.getProcessedClassName();
   }
 
   /**

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
@@ -50,7 +50,7 @@ public final class MapExpressionsMethodGenerator {
 
   public String generateMapExpressionsMethodCode() {
     var sb = new StringBuilder();
-    var subclassType = ctx.getProcessedClass().getClazz().getSimpleName().toString();
+    var subclassType = ctx.getProcessedClassName();
     sb.append(doMapExprCode());
     sb.append(System.lineSeparator());
     sb.append(System.lineSeparator());
@@ -61,7 +61,9 @@ public final class MapExpressionsMethodGenerator {
         .append(" ")
         .append(METHOD_NAME)
         .append("(")
-        .append("java.util.function.Function<Expression, Expression> fn")
+        .append(
+            "java.util.function.Function<org.enso.compiler.core.ir.Expression,"
+                + " org.enso.compiler.core.ir.Expression> fn")
         .append(") {")
         .append(System.lineSeparator());
 
@@ -103,7 +105,7 @@ public final class MapExpressionsMethodGenerator {
                         !typeUtils.isSameType(
                             childTypeParameter.asType(), childsMapExprMethodRetType.asType());
                   }
-                  String newChildType = childsMapExprMethodRetType.getSimpleName().toString();
+                  var newChildType = Utils.qualifiedTypeName(childsMapExprMethodRetType);
 
                   var newChildName = child.getName() + "Mapped";
                   var mapCode =
@@ -139,7 +141,7 @@ public final class MapExpressionsMethodGenerator {
     if (newChildren.isEmpty()) {
       sb.append("  return ")
           .append("(")
-          .append(ctx.getProcessedClass().getClazz().getSimpleName().toString())
+          .append(ctx.getProcessedClassName())
           .append(") this;")
           .append(System.lineSeparator());
       sb.append("}").append(System.lineSeparator());
@@ -163,7 +165,7 @@ public final class MapExpressionsMethodGenerator {
             .append("if (!(")
             .append(newChild.newChildName)
             .append(" instanceof ")
-            .append(newChild.child.getSimpleTypeName())
+            .append(newChild.child.getQualifiedTypeName())
             .append(")) {")
             .append(System.lineSeparator());
         sb.append("      ")
@@ -177,7 +179,7 @@ public final class MapExpressionsMethodGenerator {
       }
       sb.append("    ").append("bldr.").append(newChild.child.getName()).append("(");
       if (newChild.shouldCast) {
-        sb.append("(").append(newChild.child.getSimpleTypeName()).append(") ");
+        sb.append("(").append(newChild.child.getQualifiedTypeName()).append(") ");
       }
       sb.append(newChild.newChildName).append(");").append(System.lineSeparator());
     }
@@ -216,7 +218,7 @@ public final class MapExpressionsMethodGenerator {
         .append(System.lineSeparator());
     sb.append("    return ")
         .append("(")
-        .append(ctx.getProcessedClass().getClazz().getSimpleName().toString())
+        .append(ctx.getProcessedClassName())
         .append(") this;")
         .append(System.lineSeparator());
     sb.append("  }").append(System.lineSeparator());
@@ -295,12 +297,12 @@ public final class MapExpressionsMethodGenerator {
         @SuppressWarnings("unchecked")
         private <T extends IR> T doMapExpr(
             T ir,
-            java.util.function.Function<Expression, Expression> fn) {
+            java.util.function.Function<org.enso.compiler.core.ir.Expression, org.enso.compiler.core.ir.Expression> fn) {
           ${specialHandling}
           // Either recurse to `mapExpression` or call `fn.apply` on the expression.
           return switch(ir) {
             case org.enso.compiler.core.ir.Name.MethodReference nameRef -> (T) nameRef.mapExpressions(fn);
-            case Expression expr -> (T) fn.apply(expr);
+            case org.enso.compiler.core.ir.Expression expr -> (T) fn.apply(expr);
             default -> (T) ir.mapExpressions(fn);
           };
         }
@@ -322,7 +324,9 @@ public final class MapExpressionsMethodGenerator {
 
   private String mapOptionListField(String newVarName, OptionListField field) {
     var newVarType =
-        "Option<List<" + field.getNestedTypeParameter().getSimpleName().toString() + ">>";
+        "Option<scala.collection.immutable.List<"
+            + field.getNestedTypeParameter().getQualifiedName()
+            + ">>";
     var code =
         """
         ${newVarType} ${newVarName} = Option.empty();
@@ -340,18 +344,19 @@ public final class MapExpressionsMethodGenerator {
   private String mapPersistanceReference(String newVarName, PersistanceReferenceField field) {
     var code =
         """
-        var ${newVarName} = Reference.of(
+        var ${newVarName} = org.enso.persist.Persistance.Reference.of(
             doMapExpr(${fieldName}.get(${type}.class), fn)
         );
         """
             .replace("${newVarName}", newVarName)
             .replace("${fieldName}", field.getName())
-            .replace("${type}", field.getTypeParameter().getSimpleName().toString());
+            .replace("${type}", field.getTypeParameter().getQualifiedName().toString());
     return code;
   }
 
   private String mapList(String newVarName, ListField field) {
-    var newVarType = "List<" + field.getTypeParameter().getSimpleName().toString() + ">";
+    var newVarType =
+        "scala.collection.immutable.List<" + field.getTypeParameter().getQualifiedName() + ">";
     var code =
         """
         ${newVarType} ${newVarName} = null;
@@ -366,8 +371,8 @@ public final class MapExpressionsMethodGenerator {
   }
 
   private String mapOption(String newVarName, OptionField field) {
-    var newVarType = "Option<" + field.getTypeParameter().getSimpleName().toString() + ">";
-    var type = field.getTypeParameter().getSimpleName();
+    var newVarType = "Option<" + field.getTypeParameter().getQualifiedName() + ">";
+    var type = field.getTypeParameter().getQualifiedName();
     var code =
         """
         ${newVarType} ${newVarName} = Option.empty();

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/SetLocationMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/SetLocationMethodGenerator.java
@@ -46,6 +46,6 @@ public class SetLocationMethodGenerator {
   }
 
   private String retType() {
-    return ctx.getProcessedClass().getClazz().getSimpleName().toString();
+    return ctx.getProcessedClassName();
   }
 }

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/utils/Utils.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/utils/Utils.java
@@ -2,13 +2,11 @@ package org.enso.runtime.parser.processor.utils;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -76,13 +74,6 @@ public final class Utils {
     return anot != null && superClassDoesNotExist;
   }
 
-  /** Returns true if the given {@code type} is an {@code org.enso.compiler.core.IR} interface. */
-  public static boolean isIRInterface(TypeMirror type, ProcessingEnvironment processingEnv) {
-    var elem = processingEnv.getTypeUtils().asElement(type);
-    return elem.getKind() == ElementKind.INTERFACE
-        && elem.getSimpleName().toString().equals(IR_INTERFACE_SIMPLE_NAME);
-  }
-
   public static TypeElement irTypeElement(ProcessingEnvironment procEnv) {
     var ret = procEnv.getElementUtils().getTypeElement(IR_INTERFACE_FQN);
     hardAssert(
@@ -127,14 +118,6 @@ public final class Utils {
     return ret;
   }
 
-  public static boolean isExpression(Element elem, ProcessingEnvironment processingEnvironment) {
-    if (elem instanceof TypeElement typeElem) {
-      var exprType = expressionType(processingEnvironment);
-      return processingEnvironment.getTypeUtils().isSameType(typeElem.asType(), exprType.asType());
-    }
-    return false;
-  }
-
   /** Returns true if the given type extends {@code org.enso.compiler.core.ir.Expression} */
   public static boolean isSubtypeOfExpression(
       TypeMirror type, ProcessingEnvironment processingEnv) {
@@ -146,41 +129,32 @@ public final class Utils {
     return procEnv.getElementUtils().getTypeElement(EXPRESSION_FQN);
   }
 
-  /** Converts all the FQN parts of the type name to simple names. Includes type arguments. */
-  public static String simpleTypeName(TypeMirror typeMirror) {
+  /**
+   * Returns the qualified type name of the given {@code typeMirror}. For generic types, the type
+   * arguments are included, e.g., {@code java.util.List<java.lang.String>}.
+   */
+  public static String qualifiedTypeName(TypeMirror typeMirror) {
     if (typeMirror.getKind() == TypeKind.DECLARED) {
       var declared = (DeclaredType) typeMirror;
       var typeArgs = declared.getTypeArguments();
       var typeElem = (TypeElement) declared.asElement();
       if (!typeArgs.isEmpty()) {
         var typeArgsStr =
-            typeArgs.stream().map(Utils::simpleTypeName).collect(Collectors.joining(", "));
-        return typeElem.getSimpleName().toString() + "<" + typeArgsStr + ">";
+            typeArgs.stream().map(Utils::qualifiedTypeName).collect(Collectors.joining(", "));
+        return typeElem.getQualifiedName() + "<" + typeArgsStr + ">";
       } else {
-        return typeElem.getSimpleName().toString();
+        return typeElem.getQualifiedName().toString();
       }
     }
     return typeMirror.toString();
   }
 
-  /**
-   * Returns (a possibly empty) list of FQN that should be imported in order to use the given {@code
-   * typeMirror}.
-   *
-   * @return List of FQN, intended to be used in import statements.
-   */
-  public static List<String> getImportedTypes(TypeMirror typeMirror) {
-    var importedTypes = new ArrayList<String>();
-    if (typeMirror.getKind() == TypeKind.DECLARED) {
-      var declared = (DeclaredType) typeMirror;
-      var typeElem = (TypeElement) declared.asElement();
-      var typeArgs = declared.getTypeArguments();
-      importedTypes.add(typeElem.getQualifiedName().toString());
-      for (var typeArg : typeArgs) {
-        importedTypes.addAll(getImportedTypes(typeArg));
-      }
+  public static String qualifiedTypeName(Element element) {
+    if (element instanceof TypeElement typeElem) {
+      return typeElem.getQualifiedName().toString();
+    } else {
+      return element.getSimpleName().toString();
     }
-    return importedTypes;
   }
 
   public static String indent(String code, int indentation) {


### PR DESCRIPTION
Blocks #14548 and #14244.

Part of #14115.

### Pull Request Description

Previously, [IRNodeClassGenerator](https://github.com/enso-org/enso/blob/3de331eac97decc031b57b589e4adde745749188/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/IRNodeClassGenerator.java) generated a lot of imports and used simple type names. This has lead to import name clashes on #14548 and resulted in compilation errors. This PR solves this issue, and unblocks #14548 by modifying the processor to generate FQN of all types.

I have also tried more sophisticated approach in https://github.com/enso-org/enso/pull/14548/changes/5138ea1fd7399d82409770680b64b5d87bb2075c where FQN were generated only in some circumstances. But that started to be too complicated and unnecessary - after all this is just generated code, and we don't care much about formatting in the generated code, as long as it compiles and works.

### Important Notes

- Another annotation processor test added in f19d2f79a3899bc3b4a17423136193e4a136120b
- 0effab020a70babb1c36056046e5f759e5d20366 was necessary to get that test working.
- No [serial version of Persistance](https://github.com/enso-org/enso/blob/e44095c3a319621ab97b8dd85a0fb82f3afdcecf/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java#L9) should be necessary, as the only change is basically just formatting of the generated code.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [X] Unit tests have been written where possible.
