### PR TITLE
`Ref.new lazy=True` to defer initialization of Ref'ed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 
 - [`Panic.rethrow` keeps original location][14480]
 - [Use `State.get if_missing` to avoid too frequent `Panic.throw`][14490]
+- [Lazily initialized local variables with Ref.memoize][14554].
 
 [14480]: https://github.com/enso-org/enso/pull/14480
 [14490]: https://github.com/enso-org/enso/pull/14490
+[14536]: https://github.com/enso-org/enso/pull/14554
 
 # Next Release
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/Ref.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/Ref.md
@@ -2,8 +2,9 @@
 ## module Standard.Base.Runtime.Ref
 - type Ref
     - get self -> Standard.Base.Any.Any
+    - memoize ~value:Standard.Base.Any.Any -> Standard.Base.Runtime.Ref.Ref
     - modify self fun:Standard.Base.Any.Any -> Standard.Base.Any.Any
-    - new value:Standard.Base.Any.Any -> Standard.Base.Any.Any
+    - new value:Standard.Base.Any.Any -> Standard.Base.Runtime.Ref.Ref
     - put self new_value:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - with_modification self modifier:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - with_value self new_value:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/Ref.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Runtime/Ref.md
@@ -2,9 +2,8 @@
 ## module Standard.Base.Runtime.Ref
 - type Ref
     - get self -> Standard.Base.Any.Any
-    - memoize ~value:Standard.Base.Any.Any -> Standard.Base.Runtime.Ref.Ref
     - modify self fun:Standard.Base.Any.Any -> Standard.Base.Any.Any
-    - new value:Standard.Base.Any.Any -> Standard.Base.Runtime.Ref.Ref
+    - new ~value:Standard.Base.Any.Any lazy:Standard.Base.Data.Boolean.Boolean= -> Standard.Base.Runtime.Ref.Ref
     - put self new_value:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - with_modification self modifier:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - with_value self new_value:Standard.Base.Any.Any ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Runtime_Helpers.enso
@@ -44,3 +44,7 @@ state_put key new_state = @Builtin_Method "State.put"
 state_uninitialized key =
     Panic.throw
         Uninitialized_State.Error key
+
+ref_new ~value = @Builtin_Method "Ref.alloc"
+ref_get ref = @Builtin_Method "Ref.get"
+ref_put ref new_value = @Builtin_Method "Ref.put"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
@@ -1,4 +1,6 @@
 import project.Any.Any
+import project.Data.Boolean.Boolean
+from project.Data.Boolean.Boolean import False
 import project.Internal.Runtime_Helpers
 
 ## ---
@@ -16,6 +18,7 @@ type Ref
 
        ## Arguments
         - `value`: The value to be contained in the ref.
+        - `lazy`: should the evaluation of `value` be deferred until used by `Ref.get`
 
        ## Examples
        ### Creating a new reference containing the value 7.
@@ -23,25 +26,20 @@ type Ref
        ```
              Ref.new 7
        ```
-    new value -> Ref = Ref.memoize value
 
-    ## ---
-       private: true
-       advanced: true
-       ---
-       Creates a new reference with a lazily initialized value
-
-       ## Arguments
-        - `value`: lazy computation to create a value to be contained in the ref.
-
-       ## Examples
        ### Defer initialization of local values until needed
 
        ```
-             value_ref = Ref.memoize(long_computation_yielding 7)
+             value_ref = Ref.new lazy=True (long_computation_yielding 7)
              value =
                  value_ref.get
-    memoize ~value -> Ref = Runtime_Helpers.ref_new value
+       ```
+    new ~value lazy:Boolean=False -> Ref = 
+        ref = Runtime_Helpers.ref_new value
+        if lazy.not then
+            # initialize immediatelly
+            ref.get
+        ref
 
     ## ---
        group: Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
@@ -38,7 +38,7 @@ type Ref
        ### Defer initialization of local values until needed
 
        ```
-             value_ref = Ref.new (long_computation_yielding 7)
+             value_ref = Ref.memoize(long_computation_yielding 7)
              value =
                  value_ref.get
     memoize ~value -> Ref = Runtime_Helpers.ref_new value

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
@@ -1,4 +1,5 @@
 import project.Any.Any
+import project.Internal.Runtime_Helpers
 
 ## ---
    private: true
@@ -22,8 +23,25 @@ type Ref
        ```
              Ref.new 7
        ```
-    new : Any -> Ref
-    new value = @Builtin_Method "Ref.new"
+    new value -> Ref = Ref.memoize value
+
+    ## ---
+       private: true
+       advanced: true
+       ---
+       Creates a new reference with a lazily initialized value
+
+       ## Arguments
+        - `value`: lazy computation to create a value to be contained in the ref.
+
+       ## Examples
+       ### Defer initialization of local values until needed
+
+       ```
+             value_ref = Ref.new (long_computation_yielding 7)
+             value =
+                 value_ref.get
+    memoize ~value -> Ref = Runtime_Helpers.ref_new value
 
     ## ---
        group: Metadata
@@ -38,7 +56,7 @@ type Ref
              (Ref.new 0) . get
        ```
     get : Any
-    get self = @Builtin_Method "Ref.get"
+    get self = Runtime_Helpers.ref_get self
 
     ## ---
        icon: edit
@@ -55,7 +73,7 @@ type Ref
              (Ref.new 0) . put 10
        ```
     put : Any -> Any
-    put self new_value = @Builtin_Method "Ref.put"
+    put self new_value = Runtime_Helpers.ref_put self new_value
 
     ## ---
        group: Calculations

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/RefTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/runtime/RefTest.java
@@ -39,7 +39,7 @@ public class RefTest {
   }
 
   private static Value newRef(Object object) {
-    return refType.invokeMember("new", refType, object);
+    return refType.invokeMember("new", refType, object, false);
   }
 
   @Test

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Ref.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Ref.java
@@ -6,13 +6,19 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import org.enso.interpreter.dsl.Builtin;
+import org.enso.interpreter.dsl.Suspend;
 import org.enso.interpreter.runtime.builtin.BuiltinObject;
+import org.enso.interpreter.runtime.callable.function.Function;
 
 /** A mutable reference type. */
 @ExportLibrary(InteropLibrary.class)
 @Builtin(pkg = "mutable", stdlibName = "Standard.Base.Runtime.Ref.Ref")
 public final class Ref extends BuiltinObject {
   private volatile Object value;
+
+  private Ref(Object v) {
+    this.value = v;
+  }
 
   @Override
   protected String builtinName() {
@@ -25,17 +31,12 @@ public final class Ref extends BuiltinObject {
    * @param value the initial value to store in the reference.
    */
   @Builtin.Method(description = "Creates a new Ref", autoRegister = false)
-  public Ref(Object value) {
-    this.value = value;
+  public static Ref alloc(@Suspend Object value) {
+    return new Ref(value);
   }
 
-  /**
-   * @return the current value of the reference.
-   */
-  @Builtin.Method(name = "get", description = "Gets the value stored in the reference")
-  @SuppressWarnings("generic-enso-builtin-type")
-  public Object getValue() {
-    return value;
+  final boolean needsEval() {
+    return value instanceof Function fn && fn.isFullyApplied();
   }
 
   /**
@@ -46,9 +47,9 @@ public final class Ref extends BuiltinObject {
    */
   @Builtin.Method(name = "put", description = "Stores a new value in the reference")
   @SuppressWarnings("generic-enso-builtin-type")
-  public Object setValue(Object value) {
-    Object old = this.value;
-    this.value = value;
+  public static Object putValue(Ref ref, Object value) {
+    Object old = ref.value;
+    ref.value = value;
     return old;
   }
 
@@ -63,5 +64,9 @@ public final class Ref extends BuiltinObject {
   @ExportMessage.Ignore
   public Object toDisplayString(boolean allowSideEffects) {
     return toDisplayString(allowSideEffects, InteropLibrary.getUncached());
+  }
+
+  final Object value() {
+    return value;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/RefGetNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/RefGetNode.java
@@ -26,7 +26,7 @@ final class RefGetNode extends BaseNode {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         thunkNode = ThunkExecutorNode.build();
       }
-      var ctx = EnsoContext.get(null);
+      var ctx = EnsoContext.get(this);
       var state = ctx.currentState();
       var newValue =
           thunkNode.executeThunk(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/RefGetNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/RefGetNode.java
@@ -1,0 +1,38 @@
+package org.enso.interpreter.runtime.data;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.BaseNode;
+import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
+import org.enso.interpreter.runtime.EnsoContext;
+
+@BuiltinMethod(name = "get", description = "Gets the value stored in the reference", type = "Ref")
+final class RefGetNode extends BaseNode {
+  @Child private ThunkExecutorNode thunkNode;
+
+  @NeverDefault
+  static RefGetNode build() {
+    return new RefGetNode();
+  }
+
+  /**
+   * @return the current value of the reference. Evaluates it if it is not yet evaluated.
+   */
+  final Object execute(VirtualFrame frame, Ref ref) {
+    if (ref.needsEval()) {
+      if (thunkNode == null) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        thunkNode = ThunkExecutorNode.build();
+      }
+      var ctx = EnsoContext.get(null);
+      var state = ctx.currentState();
+      var newValue =
+          thunkNode.executeThunk(
+              frame.materialize(), ref.value(), state, BaseNode.TailStatus.NOT_TAIL);
+      Ref.putValue(ref, newValue);
+    }
+    return ref.value();
+  }
+}

--- a/test/Base_Tests/src/Runtime/Ref_Spec.enso
+++ b/test/Base_Tests/src/Runtime/Ref_Spec.enso
@@ -53,7 +53,7 @@ add_specs suite_builder = suite_builder.group "Refs" group_builder->
     group_builder.specify "lazy local variable memoization" <|
         counter = Ref.new 0
 
-        memo_ref = Ref.memoize <|
+        memo_ref = Ref.new lazy=True <|
             # count costly computation
             counter.modify (_+1)
             6*7
@@ -90,15 +90,15 @@ add_specs suite_builder = suite_builder.group "Refs" group_builder->
         # Ref.new initialized even it is never needed
         counter.get . should_equal 1
 
-    group_builder.specify "layz initialization of Ref.memoize" <|
-        counter = Ref.new 0
+    group_builder.specify "lazy initialization of Ref.new lazy=True" <|
+        counter = Ref.new 0 False
 
-        _ = Ref.memoize <|
+        _ = Ref.new lazy=True <|
             # count costly computation
             counter.modify (_+1)
             6*7
 
-        # Ref.memoize is never initialized when not needed
+        # Lazy Ref.new is never initialized when not needed
         counter.get . should_equal 0
 
 main filter=Nothing =

--- a/test/Base_Tests/src/Runtime/Ref_Spec.enso
+++ b/test/Base_Tests/src/Runtime/Ref_Spec.enso
@@ -50,6 +50,57 @@ add_specs suite_builder = suite_builder.group "Refs" group_builder->
         is_eleven.should_be_true
         r.get . should_equal 10
 
+    group_builder.specify "lazy local variable memoization" <|
+        counter = Ref.new 0
+
+        memo_ref = Ref.memoize <|
+            # count costly computation
+            counter.modify (_+1)
+            6*7
+        memo -> Integer =
+            memo_ref.get
+
+        # no "expensive computation" happened so far
+        # even we have memo variable defined
+        counter.get . should_equal 0
+
+        # first access to memo variable triggers
+        # computation
+        memo . should_equal 42
+        counter.get . should_equal 1
+
+        # subsequent access to memo doesn't
+        # trigger any computation as the value
+        # has been memoized
+        memo . should_equal 42
+        counter.get . should_equal 1
+
+        # no computation on any other access
+        memo . should_equal 42
+        counter.get . should_equal 1
+
+    group_builder.specify "eager initialization of Ref.new" <|
+        counter = Ref.new 0
+
+        _ = Ref.new <|
+            # count costly computation
+            counter.modify (_+1)
+            6*7
+
+        # Ref.new initialized even it is never needed
+        counter.get . should_equal 1
+
+    group_builder.specify "layz initialization of Ref.memoize" <|
+        counter = Ref.new 0
+
+        _ = Ref.memoize <|
+            # count costly computation
+            counter.modify (_+1)
+            6*7
+
+        # Ref.memoize is never initialized when not needed
+        counter.get . should_equal 0
+
 main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder

--- a/test/Cloud_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Cloud_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -397,7 +397,7 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
     Local_File_Spec.add_copy_edge_cases_specs group_builder test_root.get
 
 private add_data_specs setup:Cloud_Tests_Setup suite_builder root_provider =
-    my_dir_ref = Ref.memoize (root_provider.get / "data_specs-").create_directory
+    my_dir_ref = Ref.new lazy=True (root_provider.get / "data_specs-").create_directory
     my_dir =
         my_dir_ref.get
     file_maker path_element:Text = my_dir / (path_element+".txt")

--- a/test/Cloud_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Cloud_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -397,10 +397,8 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
     Local_File_Spec.add_copy_edge_cases_specs group_builder test_root.get
 
 private add_data_specs setup:Cloud_Tests_Setup suite_builder root_provider =
-    my_dir_ref = Ref.new Nothing
+    my_dir_ref = Ref.memoize (root_provider.get / "data_specs-").create_directory
     my_dir =
-        if my_dir_ref.get.is_nothing then
-            my_dir_ref.put (root_provider.get / "data_specs-").create_directory
         my_dir_ref.get
     file_maker path_element:Text = my_dir / (path_element+".txt")
     Data_Spec.add_specs pending=setup.real_cloud_pending "(Enso_File) " suite_builder file_maker

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Ref.enso
@@ -1,4 +1,6 @@
 @Builtin_Type
 type Ref
 
-new value = @Builtin_Method "Ref.new"
+new value = ref_alloc value
+
+private ref_alloc value = @Builtin_Method "Ref.alloc"


### PR DESCRIPTION
### Pull Request Description

- introducing new way to _lazily initialize_ `Ref`
- such a way can be used to create _lazily initialized local variables_
```ruby
v_ref = Ref.new lazy=True <|
   # long computation
   42
v =
    v_ref.get
```
- only when `v` is accessed for the first time the _long computation_ is performed
- other changes:
   - moving builtin definitions outside of `Ref.enso` module
   - into a `private` module `Runtime_Helpers`
  
### Important Notes

- previous investigation of this issue lead to few conclusion
   -  done in #14530
   - rather than changing interpretation of _suspended blocks_
   - or introducing new syntax for _lazily initialized variables_
- this PR enhances a _veil API_ with an _expert only_ method argument
- which seems like a good balance between making the functionality available
- and not annoying regular users with it

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
