### PR TITLE
Avoid parser crash after Enter on multiline constructor definition

### DIFF
--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -197,6 +197,16 @@ fn type_constructors() {
 }
 
 #[test]
+fn type_constructors_crash_with_a_new_line() {
+    test_module!([
+            "type Missing",
+            "    Error",
+            "        (argument_name : Text) (function_name : Text | Nothing = Nothing) (call_location : Source_Location | Nothing = Nothing)",
+        ].join("\n"),
+        @"(BodyBlock #((TypeDef Missing)))");
+}
+
+#[test]
 fn type_constructor_documentation() {
     test_module!("type Foo\n ## Bar\n Baz",
         @r#"(BodyBlock #((TypeDef Foo #() #((ConstructorDefinition ((#((Section " Bar"))) #(())) #() () Baz #() #())))))"#);

--- a/lib/rust/parser/src/syntax/statement/function_def.rs
+++ b/lib/rust/parser/src/syntax/statement/function_def.rs
@@ -434,7 +434,7 @@ fn parse_arg_def<'s>(
     let mut open2 = None;
     let mut close2 = None;
     let mut suspension_and_pattern = None;
-    let type_ = type_.map(|(parenthesized, type_)| {
+    let type_option = type_.map(|(parenthesized, type_)| {
         let mut parenthesized_body = None;
         if parenthesized == Parenthesized
             && (start..items.len()).len() == 1
@@ -450,17 +450,24 @@ fn parse_arg_def<'s>(
         }
         let items = parenthesized_body.as_mut().unwrap_or(items);
         let tree = expression_parser.parse_non_section_offset(start + type_ + 1, items);
-        let operator = items.pop().unwrap().into_token().unwrap();
-        let type_ = tree.unwrap_or_else(|| {
-            empty_tree(operator.code.position_after()).with_error(SyntaxError::ExpectedType)
-        });
-        let token::Variant::TypeAnnotationOperator(variant) = operator.variant else {
-            unreachable!()
-        };
-        let operator = operator.with_variant(variant);
-        suspension_and_pattern = Some(parse_pattern(items, start, expression_parser));
-        ArgumentType { operator, type_ }
+        let item_option = items.pop();
+        let item = item_option.unwrap();
+        let operator_option = item.into_token();
+        if let Some(operator) = operator_option {
+            let type_ = tree.unwrap_or_else(|| {
+                empty_tree(operator.code.position_after()).with_error(SyntaxError::ExpectedType)
+            });
+            let token::Variant::TypeAnnotationOperator(variant) = operator.variant else {
+                unreachable!()
+            };
+            let operator = operator.with_variant(variant);
+            suspension_and_pattern = Some(parse_pattern(items, start, expression_parser));
+            Some(ArgumentType { operator, type_ })
+        } else {
+            None
+        }
     });
+    let type_ = type_option.unwrap_or_default();
     let (suspension, pattern) =
         suspension_and_pattern.unwrap_or_else(|| parse_pattern(items, start, expression_parser));
     let pattern = pattern.unwrap_or_else(|| {


### PR DESCRIPTION
### Pull Request Description

- VSCode and NetBeans integration is crashing when one presses Enter after `Error ` followed by argument line.
- this PR provides a test crashing the parser the same way
- and a fix that avoid crashing
- TODO: Specify proper _expected AST_ to make the test pass

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] Unit tests have been written where possible.
