### PR TITLE
Eliminate obscure NI serialization problem

### DIFF
--- a/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/serialization-config.json
+++ b/engine/language-server/src/main/resources/META-INF/native-image/org/enso/languageserver/serialization-config.json
@@ -19,13 +19,28 @@
       "name":"ch.qos.logback.classic.spi.ThrowableProxyVO"
     },
     {
-      "name":"org.slf4j.helpers.BasicMarker"
+      "name":"java.io.IOException"
+    },
+    {
+      "name":"java.lang.Exception"
+    },
+    {
+      "name":"java.lang.Object"
     },
     {
       "name":"java.lang.StackTraceElement"
     },
     {
       "name":"java.lang.String"
+    },
+    {
+      "name":"java.lang.Throwable"
+    },
+    {
+      "name":"java.net.SocketException"
+    },
+    {
+      "name":"java.util.ArrayList"
     },
     {
       "name":"java.util.Collections$EmptyMap"
@@ -37,22 +52,10 @@
       "name":"java.util.HashMap"
     },
     {
-      "name":"java.lang.Throwable"
-    },
-    {
-      "name":"java.lang.Object"
-    },
-    {
-      "name":"java.lang.Exception"
-    },
-    {
-      "name":"java.io.IOException"
-    },
-    {
-      "name":"java.util.ArrayList"
-    },
-    {
       "name":"java.util.concurrent.CopyOnWriteArrayList"
+    },
+    {
+      "name":"org.slf4j.helpers.BasicMarker"
     }
   ],
   "lambdaCapturingTypes":[


### PR DESCRIPTION
### Pull Request Description

Workaround for a randomly happening serialization problem
```
Error: 1mpw:browser [pid=310699][out] [ERROR] [2026-01-05T16:25:43.456] [com.oracle.svm.core.util.VMError] Internal error during serialization: SerializationConstructorAccessor class not found for declaringClass: java.net.SocketException (targetConstructorClass: java.lang.Object). Usually adding java.net.SocketException to serialization-config.json fixes the problem. +2s
  pw:browser [pid=310699][out] com.oracle.svm.core.jdk.UnsupportedFeatureError: SerializationConstructorAccessor class not found for declaringClass: java.net.SocketException (targetConstructorClass: java.lang.Object). Usually adding java.net.SocketException to serialization-config.json fixes the problem. +0ms
  pw:browser [pid=310699][out] 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:121) +0ms
  pw:browser [pid=310699][out] 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.serialize.SerializationSupport.getSerializationConstructorAccessor(SerializationSupport.java:286) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/jdk.internal.reflect.ReflectionFactory.generateConstructor(ReflectionFactory.java:2439) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/jdk.internal.reflect.ReflectionFactory.newConstructorForSerialization(ReflectionFactory.java:297) +1ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ObjectStreamClass.getSerializableConstructor(ObjectStreamClass.java:1319) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ObjectStreamClass.<init>(ObjectStreamClass.java:371) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:93) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:90) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ClassCache$1.computeValue(ClassCache.java:78) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ClassCache$1.computeValue(ClassCache.java:75) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.lang.ClassValue.get(JavaLangSubstitutions.java:542) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ClassCache.get(ClassCache.java:89) +0ms
  pw:browser [pid=310699][out] 	at java.base@25.0.1/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:76) 
```
https://github.com/enso-org/enso/actions/runs/20719067507/job/59480320243?pr=14563#step:15:251
