### PR TITLE
Remove MacOSAMD64 platform from JarExtractor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,6 @@ import Dependencies.*
 import JarExtractor.{
   CopyToOutputJar,
   LinuxAMD64,
-  MacOSAMD64,
   MacOSArm64,
   PolyglotLib,
   WindowsAMD64
@@ -5326,7 +5325,6 @@ lazy val `opencv-wrapper` = project
     jarExtractor := JarExtractor(
       "nu/pattern/opencv/linux/x86_64/*.so"    -> PolyglotLib(LinuxAMD64),
       "nu/pattern/opencv/osx/ARMv8/*.dylib"    -> PolyglotLib(MacOSArm64),
-      "nu/pattern/opencv/osx/x86_64/*.dylib"   -> PolyglotLib(MacOSAMD64),
       "nu/pattern/opencv/windows/x86_64/*.dll" -> PolyglotLib(WindowsAMD64),
       "nu/pattern/*.class"                     -> CopyToOutputJar,
       "META-INF/**"                            -> CopyToOutputJar,
@@ -5344,9 +5342,6 @@ lazy val `jna-wrapper-extracted` = project
     jarExtractor := JarExtractor(
       "com/sun/jna/linux-x86-64/libjnidispatch.so" -> PolyglotLib(LinuxAMD64),
       "com/sun/jna/win32-x86-64/jnidispatch.dll"   -> PolyglotLib(WindowsAMD64),
-      "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib" -> PolyglotLib(
-        MacOSAMD64
-      ),
       "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib" -> PolyglotLib(
         MacOSArm64
       ),
@@ -5400,9 +5395,6 @@ lazy val `netty-tc-native-wrapper` = project
     jarExtractor := JarExtractor(
       "META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib" -> PolyglotLib(
         MacOSArm64
-      ),
-      "META-INF/native/libnetty_tcnative_osx_x86_64.jnilib" -> PolyglotLib(
-        MacOSAMD64
       ),
       "META-INF/native/netty_tcnative_windows_x86_64.dll" -> PolyglotLib(
         WindowsAMD64
@@ -5487,7 +5479,6 @@ lazy val `tableau-wrapper` = project
     },
     jarExtractor := JarExtractor(
       "darwin-aarch64/libtableauhyperapi.dylib" -> PolyglotLib(MacOSArm64),
-      "darwin-x86-64/libtableauhyperapi.dylib"  -> PolyglotLib(MacOSAMD64),
       "linux-x86-64/libtableauhyperapi.so"      -> PolyglotLib(LinuxAMD64),
       "win32-x86-64/tableauhyperapi.dll"        -> PolyglotLib(WindowsAMD64)
     )
@@ -5510,9 +5501,6 @@ lazy val `grpc-wrapper` = project
       ),
       "META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_aarch_64.jnilib" -> PolyglotLib(
         MacOSArm64
-      ),
-      "META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib" -> PolyglotLib(
-        MacOSAMD64
       ),
       "META-INF/native/io_grpc_netty_shaded_netty_tcnative_windows_x86_64.dll" -> PolyglotLib(
         WindowsAMD64
@@ -5555,9 +5543,6 @@ lazy val `jline-wrapper` = project
       "org/jline/nativ/Mac/arm64/libjlinenative.jnilib" -> PolyglotLib(
         MacOSArm64
       ),
-      "org/jline/nativ/Mac/x86_64/libjlinenative.jnilib" -> PolyglotLib(
-        MacOSAMD64
-      ),
       "org/jline/nativ/Windows/x86_64/jlinenative.dll" -> PolyglotLib(
         WindowsAMD64
       ),
@@ -5579,9 +5564,6 @@ lazy val `conscrypt-wrapper` = project
     jarExtractor := JarExtractor(
       "META-INF/native/libconscrypt_openjdk_jni-linux-x86_64.so" -> PolyglotLib(
         LinuxAMD64
-      ),
-      "META-INF/native/libconscrypt_openjdk_jni-osx-x86_64.dylib" -> PolyglotLib(
-        MacOSAMD64
       ),
       "META-INF/native/conscrypt_openjdk_jni-windows-x86_64.dll" -> PolyglotLib(
         WindowsAMD64
@@ -5606,9 +5588,6 @@ lazy val `sqlite-wrapper` = project
       ),
       "org/sqlite/native/Mac/aarch64/libsqlitejdbc.dylib" -> PolyglotLib(
         MacOSArm64
-      ),
-      "org/sqlite/native/Mac/x86_64/libsqlitejdbc.dylib" -> PolyglotLib(
-        MacOSAMD64
       ),
       "org/sqlite/native/Windows/x86_64/sqlitejdbc.dll" -> PolyglotLib(
         WindowsAMD64
@@ -5636,7 +5615,6 @@ lazy val `duckdb-wrapper` = project
     jarExtractor := JarExtractor(
       "libduckdb_java.so_linux_amd64"   -> PolyglotLib(LinuxAMD64),
       "libduckdb_java.so_osx_universal" -> PolyglotLib(MacOSArm64),
-      "libduckdb_java.so_osx_universal" -> PolyglotLib(MacOSAMD64),
       "libduckdb_java.so_windows_amd64" -> PolyglotLib(WindowsAMD64),
       "META-INF/**"                     -> CopyToOutputJar,
       "org/**/*.class"                  -> CopyToOutputJar

--- a/project/JarExtractor.scala
+++ b/project/JarExtractor.scala
@@ -44,11 +44,6 @@ object JarExtractor {
     override val extension: String                      = "dll"
     override val prefix: Option[Either[String, String]] = Some(Left("lib"))
   }
-  case object MacOSAMD64 extends NativeLibArch {
-    override val path: String                           = "amd64/macos"
-    override val extension: String                      = "dylib"
-    override val prefix: Option[Either[String, String]] = Some(Right("lib"))
-  }
   case object MacOSArm64 extends NativeLibArch {
     override val path: String                           = "aarch64/macos"
     override val extension: String                      = "dylib"
@@ -169,7 +164,6 @@ object JarExtractor {
     (arch, Platform.osName(), Platform.arch()) match {
       case (LinuxAMD64, "linux", "x86_64")     => true
       case (WindowsAMD64, "windows", "x86_64") => true
-      case (MacOSAMD64, "osx", "x86_64")       => true
       case (MacOSArm64, "osx", "aarch64")      => true
       case _                                   => false
     }


### PR DESCRIPTION
### Pull Request Description

MacOS AMD64 is no longer supported. This PR removes this platform type from [JarExtractor](https://github.com/enso-org/enso/blob/a63f2d767887ad6e032bf9b7b12a3ceaaacc5fc9/project/JarExtractor.scala).

`JarExtractor` is responsible for extracting native libraries from 3rd JAR dependencies.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md).
- [X] Unit tests have been written where possible.
