### PR TITLE
Workaround NI on MacOS issues with NaN formatting

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/formatting/DecimalFormatter.java
+++ b/std-bits/table/src/main/java/org/enso/table/formatting/DecimalFormatter.java
@@ -31,6 +31,7 @@ public class DecimalFormatter implements DataFormatter {
     }
 
     symbols.setInfinity(INFINITY);
+    symbols.setNaN("NaN");
     decimalFormat.setDecimalFormatSymbols(symbols);
     decimalFormat.setDecimalSeparatorAlwaysShown(true);
     decimalFormat.setMaximumFractionDigits(Integer.MAX_VALUE);


### PR DESCRIPTION
### Pull Request Description

`DecimalFormat` suddenly decided to format Double.NaN as `U+FFFD REPLACEMENT CHARACTER` (or `?`) on MacOS in NI mode. There were no changes to the underlying code or configs so it's a bit of a mystery why it started now when it worked before.

Setting explicitly the name in `DecimalFormatSymbols` does the job, because modifying reflection configs for NI didn't help.

Closes #14567.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
