### PR TITLE
--compile creates source archives

### DIFF
--- a/docs/libraries/repositories.md
+++ b/docs/libraries/repositories.md
@@ -21,6 +21,8 @@ libraries and Editions.
 - [Editions Repository](#editions-repository)
   - [Naming the Editions](#naming-the-editions)
   - [Example Edition Provider Repository](#example-edition-provider-repository)
+- [The Simple Library Server](#the-simple-library-server)
+- [Try it out locally](#try-it-out-locally)
 
 <!-- /MarkdownTOC -->
 
@@ -37,6 +39,9 @@ but this is optional and sending them without compression is also acceptable.
 Nonetheless, Enso tools will send `Accept-Encoding: gzip` to indicate that they
 support compressed transmission.
 
+Note that since [#14486](https://github.com/enso-org/enso/pull/14486), the
+library repository can be a single zip archive with `jar` URL scheme.
+
 ## Libraries Repository
 
 The library repository should contain separate 'directories' for each prefix and
@@ -45,7 +50,8 @@ inside of them each library has its own directory named after the library name.
 Inside that directory are the following files:
 
 - `manifest.yaml` - the helper file that tells the tool what it should download,
-  it is explained in more detail below;
+  it is explained in more detail below. This file is created when the library is
+  compiled;
 - `package.yaml` -
   [the package file](../distribution/packaging.md#the-packageyaml-file) of the
   library;
@@ -55,7 +61,8 @@ Inside that directory are the following files:
   this, however if the file is not present a warning will be emitted during
   installation;
 - `*.tgz` packages containing sources and other data files of the library, split
-  into components as explained below.
+  into components as explained below. This file is created when the library is
+  compiled.
 
 The directory structure is as below:
 
@@ -236,6 +243,9 @@ them), it will result in the following merged directory structure:
 
 ### Publishing
 
+Before a library can be uploaded, it must first be compiled. See help for the
+`--compile` command.
+
 To be able to publish libraries to a repository, the repository must provide an
 upload endpoint which satisfies the following requirements.
 
@@ -326,3 +336,109 @@ Currently it relies on Node.js, but that may change with future updates.
 See
 [`tools/simple-library-server/README.md`](../../tools/simple-library-server/README.md)
 for more details.
+
+## Try it out locally
+
+This section demonstrates how to host a library server locally.
+
+### (1) Create custom library
+
+- Create custom library `Foo.Bar` in `$LIBS` directory (may be arbitrary
+  location).
+  - Tip: Use the `enso --new` command.
+- Contents of the `$LIBS` directory will be:
+
+```
+$LIBS
+└── Foo
+    └── Bar
+        └── 1.0.0
+            ├── package.yaml
+            └── src
+                └── Main.enso
+
+5 directories, 2 files
+```
+
+with `src/Main.enso`:
+
+```
+from Standard.Base import all
+
+foo =
+    vec = [1, 2, 3, 4, 5]
+    vec.length
+```
+
+and `package.yaml`:
+
+```yaml
+namespace: Foo
+name: Bar
+version: 1.0.0
+```
+
+### (2) Compile the library
+
+Compile the library with `enso --compile $LIBS/Foo/Bar/1.0.0`. This will create
+`manifest.yaml` and `main.tgz` files in the library directory.
+
+### (3) Define edition repository
+
+- Create custom edition definition in the `$EDITIONS` directory
+- See [Editions Repository](#editions-repository) for details.
+- This directory contains yaml files. Each yaml file represents a separate
+  definition of an edition.
+- Name of the yaml file corresponds to the name of the edition.
+- In our case, there will be only a single yaml:
+
+`testlocal.yaml`:
+
+```yaml
+# This declares the "0.0.0-dev" edition as a parent edition.
+# Without it, we would not be able to import Standard.Base from the Foo.Bar library
+extends: 0.0.0-dev
+engine-version: 0.0.0-dev
+repositories:
+  - name: main_repo
+    url: http://localhost:8093/
+libraries:
+  - name: Foo.Bar
+    version: 1.0.0
+    repository: main_repo
+```
+
+### (4) Create project that uses the library
+
+Create a dummy project with arbitrary name in the `$PROJ` directory. It's
+`Main.enso`:
+
+```
+from Foo.Bar import all
+main = foo
+```
+
+It's `package.yaml`:
+
+```yaml
+name: Proj
+namespace: local
+edition: "testlocal"
+```
+
+### (5) Start simple-library-server
+
+Start [simple-library-server](#the-simple-library-server) with:
+
+```sh
+cd tools/simple-library-server && npm install && ./main.js --port 8093 --root $LIBRARIES
+```
+
+This is just a simple ExpressJS server that serves the `$LIBRARIES` directory
+via HTTP.
+
+### (6) Run the project
+
+```
+env ENSO_EDITION_PATH=$EDITIONS enso --run $PROJ
+```

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -113,7 +113,8 @@ public class Main {
   private static final String DEFAULT_MAIN_METHOD_NAME = "main";
 
   /** Value of this sys prop is comma-separated list of project paths. */
-  private static final String CREATE_SRC_ARCHIVES_SYS_PROP = "org.enso.compiler.createSourceArchives";
+  private static final String DONT_CREATE_SRC_ARCHIVES_SYS_PROP =
+      "org.enso.compiler.noSourceArchives";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
@@ -745,17 +746,17 @@ public class Main {
   }
 
   private static boolean shouldCreateSourceArchiveForProject(String projPath) {
-    var prop = System.getProperty(CREATE_SRC_ARCHIVES_SYS_PROP);
+    var prop = System.getProperty(DONT_CREATE_SRC_ARCHIVES_SYS_PROP);
     if (prop == null) {
-      return false;
+      return true;
     }
     var paths = prop.split(",");
     for (var p : paths) {
       if (p.equals(projPath)) {
-        return true;
+        return false;
       }
     }
-    return false;
+    return true;
   }
 
   /**

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -103,7 +103,6 @@ public class Main {
   private static final String LOGGER_CONNECT = "logger-connect";
   private static final String NO_LOG_MASKING = "no-log-masking";
   private static final String UPLOAD_OPTION = "upload";
-  private static final String UPDATE_MANIFEST_OPTION = "update-manifest";
   private static final String HIDE_PROGRESS = "hide-progress";
   private static final String AUTH_TOKEN = "auth-token";
   private static final String AUTO_PARALLELISM_OPTION = "with-auto-parallelism";
@@ -393,11 +392,6 @@ public class Main {
                 "Uploads the library to a repository. "
                     + "The url defines the repository to upload to.")
             .build();
-    var updateManifestOption =
-        cliOptionBuilder()
-            .longOpt(UPDATE_MANIFEST_OPTION)
-            .desc("Updates the library manifest with the updated list of direct " + "dependencies.")
-            .build();
     var hideProgressOption =
         cliOptionBuilder()
             .longOpt(HIDE_PROGRESS)
@@ -548,7 +542,6 @@ public class Main {
         .addOption(loggerConnectOption)
         .addOption(noLogMaskingOption)
         .addOption(uploadOption)
-        .addOption(updateManifestOption)
         .addOption(hideProgressOption)
         .addOption(authTokenOption)
         .addOption(noReadIrCachesOption)
@@ -1179,23 +1172,6 @@ public class Main {
         // The error itself is already logged.
         throw exitFail(ex.getMessage());
       }
-    }
-
-    if (line.hasOption(UPDATE_MANIFEST_OPTION)) {
-      Path projectRoot =
-          scala.Option.apply(line.getOptionValue(IN_PROJECT_OPTION))
-              .map(x -> Path.of(x))
-              .getOrElse(
-                  () -> {
-                    throw exitFail("The " + IN_PROJECT_OPTION + " is mandatory.");
-                  });
-      try {
-        ProjectUploader.updateManifest(projectRoot, logLevel);
-      } catch (Throwable err) {
-        err.printStackTrace();
-        throw exitFail(err.getMessage());
-      }
-      throw exitSuccess();
     }
 
     if (line.hasOption(COMPILE_OPTION)) {

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -707,8 +707,9 @@ public class Main {
       if (isProjectMode) {
         var topScope = context.getTopScope();
         topScope.compile(shouldCompileDependencies, paths);
-        updateManifests(paths, logLevel);
-        maybeCreateSourceArchives(paths, logLevel, showProgress);
+        for (var path : paths) {
+          updateManifestAndCreateArchive(path, logLevel, showProgress);
+        }
       } else {
         context.evalModule(fileAndProject._2());
       }
@@ -730,22 +731,16 @@ public class Main {
     }
   }
 
-  private static void updateManifests(String[] paths, Level logLevel) {
-    for (var path : paths) {
-      ProjectUploader.updateManifest(Path.of(path), logLevel);
-    }
-  }
-
   /**
-   * Creates source tarball ({@code .tgz}) archives for projects that are specified in {@link
-   * #CREATE_SRC_ARCHIVE_SYS_PROP} system property.
+   * Updates the manifest of the project specified by its path and maybe creates a source archive.
    */
-  private static void maybeCreateSourceArchives(
-      String[] paths, Level logLevel, boolean showProgress) {
-    for (var path : paths) {
-      if (shouldCreateSourceArchiveForProject(path)) {
-        ProjectUploader.createSourceArchive(Path.of(path), logLevel, showProgress);
-      }
+  private static void updateManifestAndCreateArchive(
+      String path, Level logLevel, boolean showProgress) {
+    var shouldCreateArchive = shouldCreateSourceArchiveForProject(path);
+    var p = Path.of(path);
+    ProjectUploader.updateManifest(p, logLevel, shouldCreateArchive);
+    if (shouldCreateArchive) {
+      ProjectUploader.createSourceArchive(p, logLevel, showProgress);
     }
   }
 

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -112,6 +112,9 @@ public class Main {
 
   private static final String DEFAULT_MAIN_METHOD_NAME = "main";
 
+  /** Value of this sys prop is comma-separated list of project paths. */
+  private static final String CREATE_SRC_ARCHIVE_SYS_PROP = "org.enso.compiler.createSourceArchive";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
   Main() {}
@@ -705,7 +708,7 @@ public class Main {
         var topScope = context.getTopScope();
         topScope.compile(shouldCompileDependencies, paths);
         updateManifests(paths, logLevel);
-        createSourceArchives(paths, logLevel, showProgress);
+        maybeCreateSourceArchives(paths, logLevel, showProgress);
       } else {
         context.evalModule(fileAndProject._2());
       }
@@ -733,10 +736,31 @@ public class Main {
     }
   }
 
-  private static void createSourceArchives(String[] paths, Level logLevel, boolean showProgress) {
+  /**
+   * Creates source tarball ({@code .tgz}) archives for projects that are specified in {@link
+   * #CREATE_SRC_ARCHIVE_SYS_PROP} system property.
+   */
+  private static void maybeCreateSourceArchives(
+      String[] paths, Level logLevel, boolean showProgress) {
     for (var path : paths) {
-      ProjectUploader.createSourceArchive(Path.of(path), logLevel, showProgress);
+      if (shouldCreateSourceArchiveForProject(path)) {
+        ProjectUploader.createSourceArchive(Path.of(path), logLevel, showProgress);
+      }
     }
+  }
+
+  private static boolean shouldCreateSourceArchiveForProject(String projPath) {
+    var prop = System.getProperty(CREATE_SRC_ARCHIVE_SYS_PROP);
+    if (prop == null) {
+      return false;
+    }
+    var paths = prop.split(",");
+    for (var p : paths) {
+      if (p.equals(projPath)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -113,7 +113,7 @@ public class Main {
   private static final String DEFAULT_MAIN_METHOD_NAME = "main";
 
   /** Value of this sys prop is comma-separated list of project paths. */
-  private static final String CREATE_SRC_ARCHIVE_SYS_PROP = "org.enso.compiler.createSourceArchive";
+  private static final String CREATE_SRC_ARCHIVES_SYS_PROP = "org.enso.compiler.createSourceArchives";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
@@ -745,7 +745,7 @@ public class Main {
   }
 
   private static boolean shouldCreateSourceArchiveForProject(String projPath) {
-    var prop = System.getProperty(CREATE_SRC_ARCHIVE_SYS_PROP);
+    var prop = System.getProperty(CREATE_SRC_ARCHIVES_SYS_PROP);
     if (prop == null) {
       return false;
     }

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -675,6 +675,7 @@ public class Main {
       boolean disablePrivateCheck,
       boolean enableStaticAnalysis,
       boolean treatWarningsAsErrors,
+      boolean showProgress,
       Level logLevel,
       boolean logMasking)
       throws IOException {
@@ -704,6 +705,7 @@ public class Main {
         var topScope = context.getTopScope();
         topScope.compile(shouldCompileDependencies, paths);
         updateManifests(paths, logLevel);
+        createSourceArchives(paths, logLevel, showProgress);
       } else {
         context.evalModule(fileAndProject._2());
       }
@@ -728,6 +730,12 @@ public class Main {
   private static void updateManifests(String[] paths, Level logLevel) {
     for (var path : paths) {
       ProjectUploader.updateManifest(Path.of(path), logLevel);
+    }
+  }
+
+  private static void createSourceArchives(String[] paths, Level logLevel, boolean showProgress) {
+    for (var path : paths) {
+      ProjectUploader.createSourceArchive(Path.of(path), logLevel, showProgress);
     }
   }
 
@@ -1186,6 +1194,7 @@ public class Main {
           line.hasOption(DISABLE_PRIVATE_CHECK_OPTION),
           line.hasOption(ENABLE_STATIC_ANALYSIS_OPTION),
           line.hasOption(TREAT_WARNINGS_AS_ERRORS_OPTION),
+          !line.hasOption(HIDE_PROGRESS),
           logLevel,
           logMasking);
     }

--- a/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
+++ b/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
@@ -3,7 +3,6 @@ package org.enso.runner;
 import java.nio.file.Path;
 import org.enso.cli.ProgressBar;
 import org.enso.cli.task.ProgressReporter;
-import org.enso.cli.task.TaskProgress;
 import org.enso.libraryupload.LibraryUploader;
 import org.enso.libraryupload.auth.NoAuthorization$;
 import org.enso.libraryupload.auth.SimpleHeaderToken;

--- a/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
+++ b/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
@@ -1,6 +1,7 @@
 package org.enso.runner;
 
 import java.nio.file.Path;
+import java.util.List;
 import org.enso.cli.ProgressBar;
 import org.enso.cli.task.ProgressReporter;
 import org.enso.libraryupload.LibraryUploader;
@@ -13,8 +14,6 @@ import org.enso.runner.common.CompilerBasedDependencyExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
-import scala.collection.immutable.Seq;
-import scala.collection.immutable.Seq$;
 
 final class ProjectUploader {
   private ProjectUploader() {}
@@ -77,24 +76,8 @@ final class ProjectUploader {
     var dependencyExtractor = new CompilerBasedDependencyExtractor(logLevel);
     var libraryUploader = new LibraryUploader(dependencyExtractor);
     var archiveName = LibraryUploader$.MODULE$.mainArchiveName();
-    Seq<String> archives;
-    if (willCreateSrcArchive) {
-      archives = seq(archiveName);
-    } else {
-      archives = emptySeq();
-    }
+    List<String> archives = willCreateSrcArchive ? List.of(archiveName) : List.of();
     var uploadedRes = libraryUploader.updateManifest(pkg, archives);
     uploadedRes.get();
-  }
-
-  private static <T> Seq<T> seq(T item) {
-    var mutableSeq = new scala.collection.mutable.ArrayBuffer<T>();
-    mutableSeq.append(item);
-    return mutableSeq.toSeq();
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Seq<String> emptySeq() {
-    return (Seq<String>) Seq$.MODULE$.empty();
   }
 }

--- a/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
+++ b/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
@@ -19,6 +19,15 @@ final class ProjectUploader {
 
   private static final Logger logger = LoggerFactory.getLogger(ProjectUploader.class);
 
+  private static ProgressReporter progressReporter(boolean showProgress) {
+    return (message, task) -> {
+      logger.info(message);
+      if (showProgress) {
+        ProgressBar.waitWithProgress(task);
+      }
+    };
+  }
+
   /**
    * Uploads a project to a library repository
    *
@@ -31,16 +40,7 @@ final class ProjectUploader {
    */
   static void uploadProject(
       Path projectRoot, String uploadUrl, String authToken, boolean showProgress, Level logLevel) {
-    var progressReporter =
-        new ProgressReporter() {
-          @Override
-          public void trackProgress(String message, TaskProgress<?> task) {
-            logger.info(message);
-            if (showProgress) {
-              ProgressBar.waitWithProgress(task);
-            }
-          }
-        };
+    var progressReporter = progressReporter(showProgress);
 
     Token token;
     if (authToken != null) {
@@ -54,6 +54,13 @@ final class ProjectUploader {
     var uploadedRes =
         libraryUploader.uploadLibrary(projectRoot, uploadUrl, token, progressReporter);
     uploadedRes.get();
+  }
+
+  static void createSourceArchive(Path projectRoot, Level logLevel, boolean showProgress) {
+    var reporter = progressReporter(showProgress);
+    var dependencyExtractor = new CompilerBasedDependencyExtractor(logLevel);
+    var libraryUploader = new LibraryUploader(dependencyExtractor);
+    libraryUploader.createMainArchive(projectRoot, reporter);
   }
 
   /**

--- a/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
+++ b/engine/runner/src/main/java/org/enso/runner/ProjectUploader.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import org.enso.cli.ProgressBar;
 import org.enso.cli.task.ProgressReporter;
 import org.enso.libraryupload.LibraryUploader;
+import org.enso.libraryupload.LibraryUploader$;
 import org.enso.libraryupload.auth.NoAuthorization$;
 import org.enso.libraryupload.auth.SimpleHeaderToken;
 import org.enso.libraryupload.auth.Token;
@@ -12,6 +13,8 @@ import org.enso.runner.common.CompilerBasedDependencyExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
+import scala.collection.immutable.Seq;
+import scala.collection.immutable.Seq$;
 
 final class ProjectUploader {
   private ProjectUploader() {}
@@ -68,12 +71,30 @@ final class ProjectUploader {
    * @param projectRoot path to the root of the project
    * @param logLevel the log level to use for the context gathering dependencies
    */
-  static void updateManifest(Path projectRoot, Level logLevel) {
+  static void updateManifest(Path projectRoot, Level logLevel, boolean willCreateSrcArchive) {
     var pkg = PackageManager.Default().loadPackage(projectRoot.toFile()).get();
 
     var dependencyExtractor = new CompilerBasedDependencyExtractor(logLevel);
     var libraryUploader = new LibraryUploader(dependencyExtractor);
-    var uploadedRes = libraryUploader.updateManifest(pkg);
+    var archiveName = LibraryUploader$.MODULE$.mainArchiveName();
+    Seq<String> archives;
+    if (willCreateSrcArchive) {
+      archives = seq(archiveName);
+    } else {
+      archives = emptySeq();
+    }
+    var uploadedRes = libraryUploader.updateManifest(pkg, archives);
     uploadedRes.get();
+  }
+
+  private static <T> Seq<T> seq(T item) {
+    var mutableSeq = new scala.collection.mutable.ArrayBuffer<T>();
+    mutableSeq.append(item);
+    return mutableSeq.toSeq();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Seq<String> emptySeq() {
+    return (Seq<String>) Seq$.MODULE$.empty();
   }
 }

--- a/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
+++ b/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
@@ -118,6 +118,24 @@ class LibraryUploader(dependencyExtractor: DependencyExtractor[File]) {
       .build()
   }
 
+  def createMainArchive(
+    projectRoot: Path,
+    progressReporter: ProgressReporter
+  ): Unit = {
+    val filesToIgnoreInArchive = Seq(
+      Package.configFileName,
+      LibraryManifest.filename
+    )
+    val archivePath = projectRoot / mainArchiveName
+    val compressing =
+      createMainArchive(projectRoot, filesToIgnoreInArchive, archivePath)
+    progressReporter.trackProgress(
+      s"Creating the [$mainArchiveName] archive.",
+      compressing
+    )
+    compressing.force()
+  }
+
   /** Gathers project files to create the main archive.
     *
     * For now it just filters out the files like manifest which are uploaded

--- a/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
+++ b/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
@@ -108,6 +108,13 @@ class LibraryUploader(dependencyExtractor: DependencyExtractor[File]) {
     FileSystem.writeTextFile(manifestPath, YamlHelper.toYaml(updatedManifest))
   }
 
+  def updateManifest(
+    pkg: Package[File],
+    archives: java.util.List[String]
+  ): Try[Unit] = {
+    updateManifest(pkg, archives.asScala.toSeq)
+  }
+
   /** Creates an URL for the upload, including information identifying the
     * library version.
     */

--- a/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
+++ b/lib/scala/library-manager/src/main/scala/org/enso/libraryupload/LibraryUploader.scala
@@ -9,7 +9,10 @@ import org.enso.downloader.archive.TarGzWriter
 import org.enso.downloader.http.{HTTPDownload, HTTPRequestBuilder, URIBuilder}
 import org.enso.editions.LibraryName
 import org.enso.librarymanager.published.repository.LibraryManifest
-import org.enso.libraryupload.LibraryUploader.UploadFailedError
+import org.enso.libraryupload.LibraryUploader.{
+  mainArchiveName,
+  UploadFailedError
+}
 import org.enso.pkg.{Package, PackageManager}
 import org.enso.yaml.YamlHelper
 
@@ -86,21 +89,24 @@ class LibraryUploader(dependencyExtractor: DependencyExtractor[File]) {
   /** Updates the project's manifest by computing its dependencies.
     *
     * @param pkg package of the project that is to be updated
+    * @param archives names of the archives that are about to be created in
+    *                 the project dir
     */
-  def updateManifest(pkg: Package[File]): Try[Unit] = Try {
+  def updateManifest(
+    pkg: Package[File],
+    archives: Seq[String] = Seq(mainArchiveName)
+  ): Try[Unit] = Try {
     val directDependencies = dependencyExtractor.findDependencies(pkg)
 
     val manifestPath = pkg.root.toPath / LibraryManifest.filename
     val loadedManifest =
       loadSavedManifest(manifestPath).getOrElse(LibraryManifest.empty)
     val updatedManifest = loadedManifest.copy(
-      archives     = Seq(mainArchiveName),
+      archives     = archives,
       dependencies = directDependencies.toSeq
     )
     FileSystem.writeTextFile(manifestPath, YamlHelper.toYaml(updatedManifest))
   }
-
-  private val mainArchiveName = "main.tgz"
 
   /** Creates an URL for the upload, including information identifying the
     * library version.
@@ -231,4 +237,5 @@ object LibraryUploader {
   case class UploadFailedError(message: String)
       extends RuntimeException(message)
 
+  val mainArchiveName: String = "main.tgz"
 }

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -383,7 +383,8 @@ object DistributionPackage {
     jvmOptName: String,
     pb: java.lang.ProcessBuilder,
     appendJvmOpts: String     = "-ea",
-    cwd: Option[java.io.File] = None
+    cwd: Option[java.io.File] = None,
+    env: Map[String, String]  = Map.empty
   ): java.lang.Process = {
     val envToFill: java.util.Map[String, String] = pb.environment()
     var atEnv                                    = args.indexOf("--env")
@@ -415,6 +416,16 @@ object DistributionPackage {
       envToFill.put(jvmOptName, prevValue)
     }
 
+    for ((k, v) <- env) {
+      val prev = envToFill.get(k)
+      val newValue = if (prev != null) {
+        prev + " " + v
+      } else {
+        v
+      }
+      envToFill.put(k, newValue)
+    }
+
     pb.command(args)
     cwd.map { d =>
       pb.directory(d)
@@ -439,7 +450,8 @@ object DistributionPackage {
     distributionRoot: File,
     args: Seq[String],
     log: Logger,
-    cwd: Option[java.io.File] = None
+    cwd: Option[java.io.File] = None,
+    env: Map[String, String]  = Map.empty
   ): Boolean = {
     import scala.collection.JavaConverters._
 
@@ -472,7 +484,14 @@ object DistributionPackage {
       all.set(atIndex + 1, fileToRun.getPath)
     }
     val p =
-      adjustArgsAndStart(log, all, "JAVA_TOOL_OPTIONS", pb, cwd = adjustedCwd)
+      adjustArgsAndStart(
+        log,
+        all,
+        "JAVA_TOOL_OPTIONS",
+        pb,
+        cwd = adjustedCwd,
+        env = env
+      )
     val exitCode = p.waitFor()
     if (exitCode != 0) {
       log.warn(enso + " finished with exit code " + exitCode)

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -271,22 +271,24 @@ object DistributionPackage {
     log.info(s"Generating indexes for libraries [$libNames]")
     val javaCommand = javaExecutable()
 
-    // Don't create source archives for standard libraries.
-    val noSrcArchivesOpt =
-      "--vm.D=org.enso.compiler.noSourceArchives=" +
-      libPaths.mkString(",")
-
     val command = Seq(
       javaCommand
     ) ++ javaOpts ++ Seq(
-      noSrcArchivesOpt,
       "--no-compile-dependencies",
       "--compile"
     ) ++ libPaths
     log.debug(command.mkString(" "))
-    val allEnv = mapAppend(
+    val allEnv1 = mapAppend(
       env,
       "NO_COLOR" -> "true"
+    )
+    // Don't create source archives for standard libraries.
+    val noSrcArchivesSysProp =
+      "-Dorg.enso.compiler.noSourceArchives=" +
+      libPaths.mkString(",")
+    val allEnv = mapAppend(
+      allEnv1,
+      "JAVA_TOOL_OPTIONS" -> noSrcArchivesSysProp
     )
     val procBldr = new java.lang.ProcessBuilder(asJava(command))
     val cwd      = libRootDirs.head.getAbsoluteFile.getParentFile

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -271,9 +271,15 @@ object DistributionPackage {
     log.info(s"Generating indexes for libraries [$libNames]")
     val javaCommand = javaExecutable()
 
+    // Don't create source archives for standard libraries.
+    val noSrcArchivesOpt =
+      "--vm.D=org.enso.compiler.noSourceArchives=" +
+      libPaths.mkString(",")
+
     val command = Seq(
       javaCommand
     ) ++ javaOpts ++ Seq(
+      noSrcArchivesOpt,
       "--no-compile-dependencies",
       "--compile"
     ) ++ libPaths

--- a/project/EnsoLint.scala
+++ b/project/EnsoLint.scala
@@ -73,8 +73,13 @@ class EnsoLint(
     } else {
       Seq()
     }
+    val env = Map(
+      "JAVA_TOOL_OPTIONS" ->
+      ("-Dorg.enso.compiler.noSourceArchives=" + absPaths.mkString(","))
+    )
     val args = disablePrivateCheckArg ++ Seq(
       "--enable-static-analysis",
+      "--hide-progress",
       "-Werror",
       "--compile"
     ) ++ absPaths
@@ -83,7 +88,8 @@ class EnsoLint(
       engineDistributionRoot,
       args,
       log,
-      Some(paths.head.getAbsoluteFile.getParentFile)
+      Some(paths.head.getAbsoluteFile.getParentFile),
+      env = env
     )
   }
 

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -114,7 +114,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
 
         Panic.with_finalizer cleanup <|
             proj_dir = create_new_project tmp_dir "Proj" "main = 42"
-            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--vm.D=org.enso.compiler.createSourceArchive="+proj_dir.path, "--compile", proj_dir.path]
+            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--vm.D=org.enso.compiler.createSourceArchives="+proj_dir.path, "--compile", proj_dir.path]
             manifest = proj_dir / "manifest.yaml"
             manifest_lines = manifest.read_text.lines . map (_.trim)
             manifest_lines . should_contain "archives:"

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -106,7 +106,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             manifest_lines.at dep_idx . should_contain "Standard.Base"
             manifest_lines.at (dep_idx + 1) . should_contain "Standard.Image"
 
-    group_builder.specify "--compile creates source archive only when sys prop is set" <|
+    group_builder.specify "--compile creates source archive by default" <|
         tmp_dir = create_tmp_dir
 
         cleanup =
@@ -114,7 +114,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
 
         Panic.with_finalizer cleanup <|
             proj_dir = create_new_project tmp_dir "Proj" "main = 42"
-            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--vm.D=org.enso.compiler.createSourceArchives="+proj_dir.path, "--compile", proj_dir.path]
+            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--compile", proj_dir.path]
             manifest = proj_dir / "manifest.yaml"
             manifest_lines = manifest.read_text.lines . map (_.trim)
             manifest_lines . should_contain "archives:"
@@ -124,7 +124,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             archive = proj_dir / archive_name
             archive . exists . should_be_true
 
-    group_builder.specify "--compile does not create any archives by default" <|
+    group_builder.specify "--compile does not create any archives when sys prop is set" <|
         tmp_dir = create_tmp_dir
 
         cleanup =
@@ -132,7 +132,7 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
 
         Panic.with_finalizer cleanup <|
             proj_dir = create_new_project tmp_dir "Proj" "main = 42"
-            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--compile", proj_dir.path]
+            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--vm.D=org.enso.compiler.noSourceArchives="+proj_dir.path, "--compile", proj_dir.path]
             manifest = proj_dir / "manifest.yaml"
             manifest_lines = manifest.read_text.lines . map (_.trim)
             manifest_lines . should_not_contain "archives:"

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -106,7 +106,25 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             manifest_lines.at dep_idx . should_contain "Standard.Base"
             manifest_lines.at (dep_idx + 1) . should_contain "Standard.Image"
 
-    group_builder.specify "--compile creates source archive" <|
+    group_builder.specify "--compile creates source archive only when sys prop is set" <|
+        tmp_dir = create_tmp_dir
+
+        cleanup =
+            tmp_dir.delete recursive=True
+
+        Panic.with_finalizer cleanup <|
+            proj_dir = create_new_project tmp_dir "Proj" "main = 42"
+            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--vm.D=org.enso.compiler.createSourceArchive="+proj_dir.path, "--compile", proj_dir.path]
+            manifest = proj_dir / "manifest.yaml"
+            manifest_lines = manifest.read_text.lines . map (_.trim)
+            manifest_lines . should_contain "archives:"
+            srcs_idx = manifest_lines.index_of (_ == "archives:") + 1
+            archive_name = manifest_lines.at srcs_idx . replace (regex "^\s*-") "" . trim
+            archive_name . ends_with "tgz" . should_be_true
+            archive = proj_dir / archive_name
+            archive . exists . should_be_true
+
+    group_builder.specify "--compile does not create any archives by default" <|
         tmp_dir = create_tmp_dir
 
         cleanup =
@@ -117,12 +135,10 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--compile", proj_dir.path]
             manifest = proj_dir / "manifest.yaml"
             manifest_lines = manifest.read_text.lines . map (_.trim)
-            manifest_lines . should_contain "archives:"
-            srcs_idx = manifest_lines.index_of (_ == "archives:") + 1
-            archive_name = manifest_lines.at srcs_idx . replace (regex "^\s*-") "" . trim
-            archive_name . ends_with "tgz" . should_be_true
-            archive = proj_dir / archive_name
-            archive . exists . should_be_true
+            manifest_lines . should_not_contain "archives:"
+            file_names = proj_dir.list.map (_.name)
+            Test.with_clue ("No .tgz files in " + file_names.to_text) <|
+                file_names.filter (_.ends_with "tgz") . is_empty . should_be_true
 
 
 main filter=Nothing =

--- a/test/Base_Tests/src/System/Runner_Spec.enso
+++ b/test/Base_Tests/src/System/Runner_Spec.enso
@@ -106,6 +106,24 @@ add_specs suite_builder = suite_builder.group "Engine runner" group_builder->
             manifest_lines.at dep_idx . should_contain "Standard.Base"
             manifest_lines.at (dep_idx + 1) . should_contain "Standard.Image"
 
+    group_builder.specify "--compile creates source archive" <|
+        tmp_dir = create_tmp_dir
+
+        cleanup =
+            tmp_dir.delete recursive=True
+
+        Panic.with_finalizer cleanup <|
+            proj_dir = create_new_project tmp_dir "Proj" "main = 42"
+            enso_run args=["--vm.D=polyglot.enso.checkCurrentDirectory=false", "--compile", proj_dir.path]
+            manifest = proj_dir / "manifest.yaml"
+            manifest_lines = manifest.read_text.lines . map (_.trim)
+            manifest_lines . should_contain "archives:"
+            srcs_idx = manifest_lines.index_of (_ == "archives:") + 1
+            archive_name = manifest_lines.at srcs_idx . replace (regex "^\s*-") "" . trim
+            archive_name . ends_with "tgz" . should_be_true
+            archive = proj_dir / archive_name
+            archive . exists . should_be_true
+
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
Follow-up of #14542.

Part of #14319.

### Pull Request Description

Source archive is created as part of `--compile` of a project. This is needed so that the compiled project can be uploaded to a [library repository](https://github.com/enso-org/enso/blob/3c3ccd80f91e03de2c871ea82ea14e267ed13c09/docs/libraries/repositories.md#L45).

### Important Notes

- Can opt-out via [org.enso.compiler.noSourceArchives](https://github.com/enso-org/enso/blob/72ed89ac4fc4700555dde4d3850ae5334d6a13c2/engine/runner/src/main/java/org/enso/runner/Main.java#L115-L117) sys prop.
- `buildEngineDistribution` creates no archives - bee00c71b03b27de7aec5005e7444afe8b00e683
  - i.e., `buildEngineDistribution` retains the old behavior.
- Docs for local library server deployment added in https://github.com/enso-org/enso/pull/14589/commits/3c3ccd80f91e03de2c871ea82ea14e267ed13c09

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
