### PR TITLE
Stop running mssql test container

### DIFF
--- a/build_tools/build/src/sqlserver.rs
+++ b/build_tools/build/src/sqlserver.rs
@@ -196,6 +196,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore]
     async fn start_sqlserver() -> Result {
         let config = Configuration {
             sqlserver_container: ContainerId("something".into()),


### PR DESCRIPTION
### Pull Request Description

Not sure if that test is responsible for constant flakines in mssql setup but I can definitely see `something` containers on our self hosted runners. "Something" that should not take place.
Notice that `sqlserver.rs` has been mostly c&p from `postgres.rs`, except for the `ignore` tag.

### Important Notes
This is a result of me having a (yet another) stab at investigating mssql server setup [flakiness](https://github.com/enso-org/enso/actions/runs/20804586941/job/59756593450#step:14:999) which causes frequent CI failures.

