### PR TITLE
Multi-component color picker fix

### DIFF
--- a/app/gui/integration-test/project-view/coloringNodes.spec.ts
+++ b/app/gui/integration-test/project-view/coloringNodes.spec.ts
@@ -1,0 +1,271 @@
+import assert from 'assert'
+import { expect, test } from 'integration-test/base'
+import * as locate from './locate'
+
+test('Color picker button appears when multiple nodes are selected', async ({
+  editorPage,
+  page,
+}) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Verify color picker button is present
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await expect(colorPickerButton).toBeVisible()
+})
+
+test('Color picker menu opens when clicking the color button', async ({ editorPage, page }) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Verify color picker menu is initially hidden
+  await expect(colorPickerMenu).toBeHidden()
+
+  // Click the color picker button
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await colorPickerButton.click()
+  await page.waitForTimeout(100)
+
+  // Verify color picker menu is now visible
+  await expect(colorPickerMenu).toBeVisible()
+})
+
+test('Multiple nodes can be colored with the color picker', async ({ editorPage, page }) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Get initial node styles (to check they don't have explicit color overrides initially)
+  const node1InitialStyle = await node1.getAttribute('style')
+  const node2InitialStyle = await node2.getAttribute('style')
+
+  // Click the color picker button
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await colorPickerButton.click()
+  await page.waitForTimeout(100)
+  await expect(colorPickerMenu).toBeVisible()
+
+  // Click on a color in the color ring (click in the center-right area of the color ring)
+  const colorRing = colorPickerMenu.locator('.gradient')
+  await expect(colorRing).toBeVisible()
+  const colorRingBox = await colorRing.boundingBox()
+  assert(colorRingBox)
+  // Move to the right side of the ring (roughly 3 o'clock position) to trigger color change
+  const targetX = colorRingBox.x + colorRingBox.width * 0.85
+  const targetY = colorRingBox.y + colorRingBox.height / 2
+  await page.mouse.move(targetX, targetY)
+  await page.waitForTimeout(50)
+  // Click to finalize and close
+  await page.mouse.click(targetX, targetY)
+  await page.waitForTimeout(100)
+
+  // Get new node styles - they should now have color overrides
+  const node1NewStyle = await node1.getAttribute('style')
+  const node2NewStyle = await node2.getAttribute('style')
+
+  // Both nodes should have received color overrides
+  expect(node1NewStyle).not.toEqual(node1InitialStyle)
+  expect(node2NewStyle).not.toEqual(node2InitialStyle)
+
+  // Both nodes should have the same color applied (they should contain the same color variable)
+  expect(node1NewStyle).toContain('--node-group-color')
+  expect(node2NewStyle).toContain('--node-group-color')
+})
+
+test('Color picker can be closed by clicking outside', async ({ editorPage, page }) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Open the color picker
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await colorPickerButton.click()
+  await page.waitForTimeout(100)
+  await expect(colorPickerMenu).toBeVisible()
+
+  // Click outside the color picker (on the graph editor)
+  await page.click('.GraphEditor', { position: { x: 50, y: 50 } })
+  await page.waitForTimeout(100)
+
+  // Verify color picker menu is now hidden
+  await expect(colorPickerMenu).toBeHidden()
+})
+
+test('Color picker opens with keyboard shortcut', async ({ editorPage, page }) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Verify color picker menu is initially hidden
+  await expect(colorPickerMenu).toBeHidden()
+
+  // Use keyboard shortcut (ControlOrMeta+Shift+C)
+  await page.keyboard.press('ControlOrMeta+Shift+C')
+  await page.waitForTimeout(100)
+
+  // Verify color picker menu is now visible
+  await expect(colorPickerMenu).toBeVisible()
+})
+
+test('Color picker is not available when only one node is selected', async ({
+  editorPage,
+  page,
+}) => {
+  await editorPage
+  const node = locate.graphNodeByBinding(page, 'five')
+  const selectionMenu = page.locator('.SelectionMenu')
+
+  // Select only one node
+  await locate.graphNodeIcon(node).click()
+
+  // Selection menu should not appear (only appears for multiple selections)
+  await expect(selectionMenu).toBeHidden()
+
+  // Try using the keyboard shortcut - it should not open the color picker
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+  await page.keyboard.press('ControlOrMeta+Shift+C')
+  await page.waitForTimeout(100)
+  await expect(colorPickerMenu).toBeHidden()
+})
+
+test('Multiple color changes can be applied to the same selection', async ({
+  editorPage,
+  page,
+}) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Open the color picker
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await colorPickerButton.click()
+  await page.waitForTimeout(100)
+  await expect(colorPickerMenu).toBeVisible()
+
+  // Select first color (right side of ring)
+  const colorRing = colorPickerMenu.locator('.gradient')
+  const colorRingBox = await colorRing.boundingBox()
+  assert(colorRingBox)
+  const firstX = colorRingBox.x + colorRingBox.width * 0.85
+  const firstY = colorRingBox.y + colorRingBox.height / 2
+  await page.mouse.move(firstX, firstY)
+  await page.waitForTimeout(100)
+
+  const node1FirstColor = await node1.getAttribute('style')
+  const node2FirstColor = await node2.getAttribute('style')
+
+  // Move to a different color (bottom of ring)
+  const secondX = colorRingBox.x + colorRingBox.width / 2
+  const secondY = colorRingBox.y + colorRingBox.height * 0.85
+  await page.mouse.move(secondX, secondY)
+  await page.waitForTimeout(100)
+
+  const node1SecondColor = await node1.getAttribute('style')
+  const node2SecondColor = await node2.getAttribute('style')
+
+  // Verify that the colors changed
+  expect(node1SecondColor).not.toEqual(node1FirstColor)
+  expect(node2SecondColor).not.toEqual(node2FirstColor)
+
+  // Both nodes should still have color overrides
+  expect(node1SecondColor).toContain('--node-group-color')
+  expect(node2SecondColor).toContain('--node-group-color')
+})
+
+test('Colored nodes retain their color after deselection', async ({ editorPage, page }) => {
+  await editorPage
+  const node1 = locate.graphNodeByBinding(page, 'five')
+  const node2 = locate.graphNodeByBinding(page, 'sum')
+  const selectionMenu = page.locator('.SelectionMenu')
+  const colorPickerMenu = page.locator('.ColorPickerMenu')
+
+  // Select both nodes
+  await locate.graphNodeIcon(node1).click()
+  await page.waitForTimeout(300)
+  await locate.graphNodeIcon(node2).click({ modifiers: ['Shift'] })
+  await expect(selectionMenu).toBeVisible()
+
+  // Open the color picker and apply a color
+  const colorPickerButton = selectionMenu.getByLabel('Color Selected Components')
+  await colorPickerButton.click()
+  await page.waitForTimeout(100)
+  await expect(colorPickerMenu).toBeVisible()
+
+  const colorRing = colorPickerMenu.locator('.gradient')
+  const colorRingBox = await colorRing.boundingBox()
+  assert(colorRingBox)
+  const targetX = colorRingBox.x + colorRingBox.width * 0.85
+  const targetY = colorRingBox.y + colorRingBox.height / 2
+  await page.mouse.move(targetX, targetY)
+  await page.waitForTimeout(50)
+  await page.mouse.click(targetX, targetY)
+  await page.waitForTimeout(100)
+
+  // Get the colored styles
+  const node1ColoredStyle = await node1.getAttribute('style')
+  const node2ColoredStyle = await node2.getAttribute('style')
+
+  // Close the color picker by clicking outside
+  await page.click('.GraphEditor', { position: { x: 50, y: 50 } })
+  await page.waitForTimeout(100)
+
+  // Deselect nodes by clicking on empty space
+  await page.click('.GraphEditor', { position: { x: 100, y: 100 } })
+  await page.waitForTimeout(100)
+
+  // Verify the nodes still have the same color
+  const node1FinalStyle = await node1.getAttribute('style')
+  const node2FinalStyle = await node2.getAttribute('style')
+
+  expect(node1FinalStyle).toEqual(node1ColoredStyle)
+  expect(node2FinalStyle).toEqual(node2ColoredStyle)
+})

--- a/app/gui/src/project-view/components/SelectionMenu.vue
+++ b/app/gui/src/project-view/components/SelectionMenu.vue
@@ -19,10 +19,8 @@ const { floatingStyles, update } = useFloating(colorButtonRef, colorMenuRef, {
 
 watch(
   () => toValue(pickColorMulti.toggled),
-  async (opened) => {
-    if (!opened) return
-    await nextTick()
-    update()
+  (opened) => {
+    if (opened) nextTick(update)
   },
 )
 </script>

--- a/app/gui/src/project-view/components/SelectionMenu.vue
+++ b/app/gui/src/project-view/components/SelectionMenu.vue
@@ -3,24 +3,44 @@ import ActionButton from '@/components/ActionButton.vue'
 import ColorPickerMenu from '@/components/ColorPickerMenu.vue'
 import { resolveAction } from '@/providers/action'
 import { useGraphSelection } from '@/providers/graphSelection'
-import { toValue } from 'vue'
+import { flip, offset, shift, useFloating } from '@floating-ui/vue'
+import { nextTick, ref, toValue, watch } from 'vue'
 
 const selection = useGraphSelection()
 const pickColorMulti = resolveAction('components.pickColorMulti')
+
+const colorButtonRef = ref<HTMLElement>()
+const colorMenuRef = ref<HTMLElement>()
+const { floatingStyles, update } = useFloating(colorButtonRef, colorMenuRef, {
+  placement: 'bottom-start',
+  strategy: 'fixed',
+  middleware: [offset(6), flip(), shift({ padding: 8 })],
+})
+
+watch(
+  () => toValue(pickColorMulti.toggled),
+  async (opened) => {
+    if (!opened) return
+    await nextTick()
+    update()
+  },
+)
 </script>
 
 <template>
   <div class="SelectionMenu">
     <span v-text="`${selection.selected.size} components selected`" />
     <ActionButton action="components.collapse" />
-    <ActionButton
-      action="components.pickColorMulti"
-      :class="{
-        // Any `pointerdown` event outside the color picker will close it. Ignore clicks that occur while the color
-        // picker is open, so that it isn't toggled back open.
-        disableInput: toValue(pickColorMulti.toggled),
-      }"
-    />
+    <span ref="colorButtonRef">
+      <ActionButton
+        action="components.pickColorMulti"
+        :class="{
+          // Any `pointerdown` event outside the color picker will close it. Ignore clicks that occur while the color
+          // picker is open, so that it isn't toggled back open.
+          disableInput: toValue(pickColorMulti.toggled),
+        }"
+      />
+    </span>
     <ActionButton action="components.alignLeft" />
     <ActionButton action="components.alignCenter" />
     <ActionButton action="components.alignRight" />
@@ -28,11 +48,15 @@ const pickColorMulti = resolveAction('components.pickColorMulti')
     <ActionButton action="components.alignBottom" />
     <ActionButton action="components.copy" />
     <ActionButton action="components.deleteSelected" />
-    <ColorPickerMenu
-      v-if="toValue(pickColorMulti.toggled)"
-      class="submenu"
-      @close="pickColorMulti.action?.()"
-    />
+    <Teleport to="body">
+      <ColorPickerMenu
+        v-if="toValue(pickColorMulti.toggled)"
+        ref="colorMenuRef"
+        class="submenu"
+        :style="floatingStyles"
+        @close="pickColorMulti.action?.()"
+      />
+    </Teleport>
   </div>
 </template>
 
@@ -49,9 +73,6 @@ const pickColorMulti = resolveAction('components.pickColorMulti')
 }
 
 .submenu {
-  position: absolute;
-  top: 36px;
-  left: 0;
   border-radius: var(--radius-default);
   background: var(--color-frame-bg);
   backdrop-filter: var(--blur-app-bg);


### PR DESCRIPTION
### Pull Request Description

Fixes #14604

This was broken in https://github.com/enso-org/enso/pull/13726 and the simpler fix is to set overflow: visible; on .TopBar in TobBar.vue. But that then breaks the hiding that menu when too narrow.

This solution is more complex but seems to keep both functionalities

https://github.com/user-attachments/assets/f3aede45-d2dc-4b50-b24f-38afd950d930


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
