### PR TITLE
Small fixes: local folders, union with null, Excel read extents

### DIFF
--- a/app/common/src/utilities/file.ts
+++ b/app/common/src/utilities/file.ts
@@ -92,8 +92,9 @@ export function normalizeSlashes(path: string): Path {
   }
 }
 
-/** Split a {@link Path} inito the path of its parent directory, and its file name. */
+/** Split a {@link Path} into the path of its parent directory, and its file name. */
 export function getDirectoryAndName(path: Path) {
-  const [, directoryPath = '', fileName = ''] = path.match(/^(.+)[/]([^/]+)$/) ?? []
+  const normalizedPath = normalizePath(path)
+  const [, directoryPath = '', fileName = ''] = normalizedPath.match(/^(.+)[/]([^/]+)$/) ?? []
   return { directoryPath: Path(directoryPath), fileName }
 }

--- a/app/common/src/utilities/file.ts
+++ b/app/common/src/utilities/file.ts
@@ -94,8 +94,7 @@ export function normalizeSlashes(path: string): Path {
 
 /** Split a {@link Path} into the path of its parent directory, and its file name. */
 export function getDirectoryAndName(path: Path) {
-  const [, directoryPath = '', fileName = ''] = isOnWindows()
-    ? path.match(/^(.+)[\\/]([^\\/]+)$/) ?? []
-    : path.match(/^(.+)[/]([^/]+)$/) ?? []
+  const regex = isOnWindows() ? /^(.+)[\\/]([^\\/]+)$/ : /^(.+)[/]([^/]+)$/
+  const [, directoryPath = '', fileName = ''] = path.match(regex) ?? []
   return { directoryPath: Path(directoryPath), fileName }
 }

--- a/app/common/src/utilities/file.ts
+++ b/app/common/src/utilities/file.ts
@@ -94,7 +94,8 @@ export function normalizeSlashes(path: string): Path {
 
 /** Split a {@link Path} into the path of its parent directory, and its file name. */
 export function getDirectoryAndName(path: Path) {
-  const normalizedPath = normalizePath(path)
-  const [, directoryPath = '', fileName = ''] = normalizedPath.match(/^(.+)[/]([^/]+)$/) ?? []
+  const [, directoryPath = '', fileName = ''] = isOnWindows()
+    ? path.match(/^(.+)[\\/]([^\\/]+)$/) ?? []
+    : path.match(/^(.+)[/]([^/]+)$/) ?? []
   return { directoryPath: Path(directoryPath), fileName }
 }

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Data/Decimal.md
@@ -30,6 +30,7 @@
     - parse text:Standard.Base.Data.Text.Text locale:Standard.Base.Data.Locale.Locale= format:Standard.Base.Data.Text.Text= mc:(Standard.Base.Data.Numeric.Math_Context.Math_Context|Standard.Base.Nothing.Nothing)= -> Standard.Base.Data.Decimal.Decimal!(Standard.Base.Data.Numbers.Number_Parse_Error|Standard.Base.Errors.Illegal_Argument.Illegal_Argument)
     - pow self exp:Standard.Base.Data.Numbers.Integer -> Standard.Base.Data.Decimal.Decimal
     - precision self -> Standard.Base.Data.Numbers.Integer
+    - pretty self -> Standard.Base.Any.Any
     - remainder self that:Standard.Base.Data.Decimal.Decimal -> Standard.Base.Data.Decimal.Decimal
     - round self decimal_places:Standard.Base.Data.Numbers.Integer= rounding_mode:Standard.Base.Data.Numeric.Rounding_Mode.Rounding_Mode= -> Standard.Base.Data.Decimal.Decimal
     - scale self -> Standard.Base.Data.Numbers.Integer

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -90,6 +90,28 @@ type Decimal
        ---
     private From_Float (big_decimal : BigDecimal) (original_value : Float)
 
+    ### ---
+       private: true
+       group: convert
+       icon: enso_logo
+       ---
+       Convert the value to a corresponding Enso code representation.
+
+       ## Examples
+       ### Getting the Enso code of the Decimal with value 12.345
+
+       ```
+           (Decimal.new "12.345").pretty
+       ```
+
+       Returns a Text
+
+           Decimal.parse '12.345'
+    pretty : Text
+    pretty self = case self of
+        _ : Decimal.Value -> "Decimal.parse "+self.big_decimal.toString.pretty
+        _ : Decimal.From_Float -> "Decimal.from_float "+self.original_value.pretty
+
     ## ---
        icon: input_number
        ---

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -109,8 +109,8 @@ type Decimal
            Decimal.parse '12.345'
     pretty : Text
     pretty self = case self of
-        _ : Decimal.Value -> "Decimal.parse "+self.big_decimal.toString.pretty
-        _ : Decimal.From_Float -> "Decimal.from_float "+self.original_value.pretty
+        Decimal.Value _ -> "Decimal.parse "+self.big_decimal.toString.pretty
+        Decimal.From_Float _ _ -> "Decimal.from_float "+self.original_value.pretty + " explicit=False"
 
     ## ---
        icon: input_number

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Connection/Key_Pair_Credentials.md
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/docs/api/Connection/Key_Pair_Credentials.md
@@ -7,7 +7,7 @@
     - to_js_object self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Data.Text.Text
 - type Key_Pair_Credentials
-    - Key_Pair username:Standard.Base.Data.Text.Text= private_key:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.System.File.File|Standard.Base.Enso_Cloud.Enso_File.Enso_File)= passphrase:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Data.Text.Text)=
+    - Key_Pair username:Standard.Base.Data.Text.Text= private_key:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.System.File.File)= passphrase:(Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Data.Text.Text)=
     - generate_key_pair location:Standard.Base.Enso_Cloud.Enso_File.Enso_File= name:Standard.Base.Data.Text.Text if_exists:Standard.Snowflake.Connection.Key_Pair_Credentials.On_Existing_Key_Pair= -> Standard.Snowflake.Connection.Key_Pair_Credentials.Generated_Key_Pair
 - type On_Existing_Key_Pair
     - Error

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Key_Pair_Credentials.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Key_Pair_Credentials.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_State.Illegal_State
+import Standard.Base.Metadata.Widget.Secret_Browse
 import Standard.Base.Runtime.Context
 from Standard.Base.Runtime import assert
 
@@ -16,7 +17,9 @@ type Key_Pair_Credentials
           located on the local machine.
         - `passphrase`: The passphrase for the private key file. Only applicable
           if the private key is a file.
-    Key_Pair username:Text=(Missing_Argument.throw "username") private_key:Enso_Secret|File|Enso_File=(Missing_Argument.throw "private_key") passphrase:Enso_Secret|Text=""
+    @private_key Secret_Browse
+    @passphrase Secret_Browse
+    Key_Pair username:Text=(Missing_Argument.throw "username") private_key:Enso_Secret|File=(Missing_Argument.throw "private_key") passphrase:Enso_Secret|Text=""
 
     ## ---
        group: Standard.Base.Database

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelHeaders.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelHeaders.java
@@ -3,7 +3,6 @@ package org.enso.table.excel;
 import org.apache.poi.ss.util.CellReference;
 import org.enso.table.problems.ProblemAggregator;
 import org.enso.table.util.NameDeduplicator;
-import org.graalvm.polyglot.Context;
 
 public class ExcelHeaders {
   private final NameDeduplicator deduplicator;
@@ -52,7 +51,6 @@ public class ExcelHeaders {
 
   private static String[] readRowAsHeaders(
       ExcelRow row, int startCol, int endCol, NameDeduplicator deduplicator) {
-    Context context = Context.getCurrent();
     if (row == null) {
       return null;
     }
@@ -65,16 +63,14 @@ public class ExcelHeaders {
       String name = cellText.isEmpty() ? "" : deduplicator.makeUnique(cellText);
 
       output[col - startCol] = name;
-
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
 
     for (int i = 0; i < output.length; i++) {
       if (output[i] == null || output[i].isEmpty()) {
         output[i] = CellReference.convertNumToColString(i + startCol - 1);
       }
-
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
 
     return output;

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelRange.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelRange.java
@@ -6,7 +6,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellReference;
-import org.graalvm.polyglot.Context;
 
 public class ExcelRange {
   private static final Pattern FULL_ADDRESS = Pattern.compile("^('.+'|[^'!]+)!(.+)$");
@@ -196,13 +195,12 @@ public class ExcelRange {
     int bottomRow = excelRange.getTopRow();
     int rightColumn = excelRange.getLeftColumn();
 
-    Context context = Context.getCurrent();
     while (currentRow != null && !currentRow.isEmpty(excelRange.getLeftColumn(), rightColumn)) {
       rightColumn = findEndRight(currentRow, rightColumn);
       bottomRow++;
       currentRow = sheet.get(bottomRow);
 
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
 
     return new ExcelRange(
@@ -214,11 +212,10 @@ public class ExcelRange {
   }
 
   private static int findEndRight(ExcelRow row, int start) {
-    Context context = Context.getCurrent();
     int column = start;
     while (!row.isEmpty(column + 1)) {
       column++;
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
     return column;
   }
@@ -342,11 +339,10 @@ public class ExcelRange {
     int lastRow =
         Math.min(sheet.getLastRow(), isWholeColumn() ? sheet.getLastRow() : bottomRow) + 1;
 
-    Context context = Context.getCurrent();
     while (lastRow > topRow
         && sheet.get(lastRow - 1).isEmpty(leftColumn, isWholeRow() ? -1 : rightColumn)) {
       lastRow--;
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
 
     return lastRow - 1;

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelRow.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelRow.java
@@ -9,7 +9,6 @@ import org.apache.poi.ss.usermodel.ExcelNumberFormat;
 import org.apache.poi.ss.usermodel.FormulaError;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.graalvm.polyglot.Context;
 
 /** Wrapper class to handle Excel rows. */
 public interface ExcelRow {
@@ -47,7 +46,6 @@ public interface ExcelRow {
   }
 
   static boolean isEmptyHelper(ExcelRow row, int start, int end) {
-    Context context = Context.getCurrent();
     int currentEnd = end == -1 ? row.getLastColumn() : end;
     for (int column = Math.max(row.getFirstColumn(), start);
         column <= Math.min(row.getLastColumn(), currentEnd);
@@ -56,7 +54,7 @@ public interface ExcelRow {
         return false;
       }
 
-      context.safepoint();
+      ExcelUtils.safepoint();
     }
     return true;
   }
@@ -134,7 +132,6 @@ public interface ExcelRow {
     }
 
     public String[] getCellsAsText(int startCol, int endCol) {
-      Context context = Context.getCurrent();
       int currentEndCol = endCol == -1 ? getLastColumn() : endCol;
 
       String[] output = new String[currentEndCol - startCol + 1];
@@ -146,7 +143,7 @@ public interface ExcelRow {
         }
         output[col - startCol] =
             type == CellType.STRING && cell != null ? cell.getStringCellValue() : "";
-        context.safepoint();
+        ExcelUtils.safepoint();
       }
 
       return output;

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelUtils.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelUtils.java
@@ -11,8 +11,30 @@ import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.ExcelNumberFormat;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.graalvm.polyglot.Context;
 
-public class ExcelUtils {
+public final class ExcelUtils {
+  private static Boolean noContext = false;
+  private static Context context;
+
+  static void safepoint() {
+    if (noContext) {
+      return;
+    }
+
+    if (context != null) {
+      context.safepoint();
+      return;
+    }
+
+    try {
+      context = Context.getCurrent();
+      context.safepoint();
+    } catch (IllegalStateException e) {
+      noContext = true;
+    }
+  }
+
   // The epoch for Excel date-time values. Due to 1900-02-29 being a valid date
   // in Excel, it is actually 1899-12-30. Excel dates are counted from 1 being
   // 1900-01-01.

--- a/std-bits/table/src/main/java/org/enso/table/excel/XlsbExcelRow.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/XlsbExcelRow.java
@@ -3,7 +3,6 @@ package org.enso.table.excel;
 import java.util.List;
 import org.apache.poi.ss.usermodel.Cell;
 import org.enso.table.excel.XlsbExcelWorkbookReader.XlsbSheetContentsHandler.RowData;
-import org.graalvm.polyglot.Context;
 
 /** Simple row wrapper backed by the parsed XLSB cell values. */
 public final class XlsbExcelRow implements ExcelRow {
@@ -69,9 +68,8 @@ public final class XlsbExcelRow implements ExcelRow {
     }
 
     String[] output = new String[effectiveLastColumn - startCol + 1];
-    var context = Context.getCurrent();
     for (int column = startCol; column <= effectiveLastColumn; column++) {
-      context.safepoint();
+      ExcelUtils.safepoint();
 
       if (!isWithinBounds(column)) {
         output[column - startCol] = "";

--- a/std-bits/table/src/main/java/org/enso/table/excel/internal/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/internal/ExcelConnectionPool.java
@@ -54,7 +54,13 @@ public class ExcelConnectionPool implements ReloadDetector.HasClearableCache {
       ExcelFileFormat format,
       FunctionWithException<ExcelWorkbookReader, R, InterruptedException> action)
       throws IOException, InterruptedException {
-    ReloadDetector.clearOnReload(this);
+
+    // Catch and ignore IllegalStateException to allow JUnit tests to run without the full context.
+    try {
+      ReloadDetector.clearOnReload(this);
+    } catch (IllegalStateException _) {
+    }
+
     var workbook = openCachedConnection(file, format);
     return action.apply(workbook);
   }

--- a/std-bits/table/src/main/java/org/enso/table/excel/xssfreader/XSSFReaderRow.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/xssfreader/XSSFReaderRow.java
@@ -10,10 +10,14 @@ public class XSSFReaderRow implements ExcelRow {
   private static final DataFormatter formatter = new DataFormatter();
   private final SortedMap<Short, XSSFReaderSheetXMLHandler.CellValue> data;
   private final boolean use1904Dates;
+  private final int lastCol;
 
   public XSSFReaderRow(
-      SortedMap<Short, XSSFReaderSheetXMLHandler.CellValue> data, boolean use1904Dates) {
+      SortedMap<Short, XSSFReaderSheetXMLHandler.CellValue> data,
+      boolean use1904Dates,
+      short lastCol) {
     this.data = data;
+    this.lastCol = Math.min(lastCol, data.lastKey());
     this.use1904Dates = use1904Dates;
   }
 
@@ -24,7 +28,7 @@ public class XSSFReaderRow implements ExcelRow {
 
   @Override
   public int getLastColumn() {
-    return data.lastKey();
+    return lastCol;
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/excel/xssfreader/XSSFReaderSheet.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/xssfreader/XSSFReaderSheet.java
@@ -25,6 +25,7 @@ public class XSSFReaderSheet implements ExcelSheetReader {
   private String dimensions;
   private int firstRow;
   private int lastRow;
+  private short lastCol;
   private Map<Integer, SortedMap<Short, XSSFReaderSheetXMLHandler.CellValue>> rowData;
 
   public XSSFReaderSheet(int sheetIdx, String sheetName, String relId, XSSFReaderWorkbook parent) {
@@ -81,33 +82,10 @@ public class XSSFReaderSheet implements ExcelSheetReader {
         throw new RuntimeException(e);
       }
 
-      lastRow = findLastNonEmptyRow();
       hasReadSheetData = true;
     } catch (SAXException | ParserConfigurationException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private int findLastNonEmptyRow() {
-    // Walk backwards to find the first row with actual data
-    for (int i = lastRow; i >= 0; i--) {
-      if (!isRowEmpty(rowData.get(i))) {
-        return i; // Found the last row with data
-      }
-    }
-    return lastRow; // Fallback case (shouldn't happen)
-  }
-
-  private boolean isRowEmpty(SortedMap<Short, XSSFReaderSheetXMLHandler.CellValue> cells) {
-    if (cells == null || cells.isEmpty()) {
-      return true;
-    }
-    for (XSSFReaderSheetXMLHandler.CellValue value : cells.values()) {
-      if (value != null && !value.strValue().isEmpty()) {
-        return false; // Found a non-empty cell
-      }
-    }
-    return true; // No non-empty cells found
   }
 
   @Override
@@ -145,7 +123,7 @@ public class XSSFReaderSheet implements ExcelSheetReader {
       return null;
     }
 
-    return new XSSFReaderRow(rowData.get(row), parent.use1904Format());
+    return new XSSFReaderRow(rowData.get(row), parent.use1904Format(), lastCol);
   }
 
   @Override
@@ -163,14 +141,19 @@ public class XSSFReaderSheet implements ExcelSheetReader {
     if (firstRow == 0 || rowNum < firstRow) {
       firstRow = rowNum;
     }
-
-    if (lastRow == 0 || rowNum > lastRow) {
-      lastRow = rowNum;
-    }
   }
 
   private void handleOnCell(
       int rowNumber, short columnNumber, XSSFReaderSheetXMLHandler.CellValue value) {
+    if (value.dataType() != XSSFReaderSheetXMLHandler.XSSDataType.BLANK) {
+      if (rowNumber > lastRow) {
+        lastRow = rowNumber;
+      }
+
+      if (columnNumber > lastCol) {
+        lastCol = columnNumber;
+      }
+    }
     rowData.computeIfAbsent(rowNumber, k -> new TreeMap<>()).put(columnNumber, value);
   }
 }

--- a/test/Base_Tests/src/Data/Decimal_Spec.enso
+++ b/test/Base_Tests/src/Data/Decimal_Spec.enso
@@ -766,6 +766,11 @@ add_specs suite_builder =
             Decimal.new "10" . pow 99999999999 . should_fail_with Arithmetic_Error
 
     suite_builder.group "(Decimal_Spec) text conversion" group_builder->
+        group_builder.specify "should convert to Enso code correctly" <|
+            Decimal.new "34.56" . pretty . should_equal "Decimal.parse '34.56'"
+            Decimal.from_float 123.45 . pretty . should_equal "Decimal.parse '123.45'"
+            123.45 . to Decimal . pretty . should_equal "Decimal.from_float 123.45 explicit=False"
+
         group_builder.specify "should convert to text correctly" <|
             Decimal.new "34.56" . to_text . should_equal "34.56"
             Decimal.new "34.56" . to_display_text . should_equal "34.56"


### PR DESCRIPTION
### Pull Request Description

- Allow both `\` and `/` when getting directory and name in Windows (sometimes not normalised).
- Fix for `Decimal.pretty` since the constructors are now private.
- Limit Excel reading to extent of the data.
  - Small adjustment so Context is read in a helper method allowing JUnit debugging.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
