### PR TITLE
Fix ide_project_opened log for local projects

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -24,6 +24,7 @@ import {
   Path,
   ProjectId,
   SecretId,
+  UUID,
   VirtualParentsPath,
   type Address,
   type AssetId,
@@ -279,6 +280,8 @@ export interface Project extends CreatedProject {
   readonly openedBy?: EmailAddress
   /** On the Remote (Cloud) Backend, this is a S3 url that is valid for only 120 seconds. */
   readonly url?: HttpsUrl
+  /** On Local Backend, this is the internal UUID of the project read from `.enso/project.json` */
+  readonly internalId?: UUID
 }
 
 /** A user/organization's project containing and/or currently executing code. */

--- a/app/common/src/services/LocalBackend.ts
+++ b/app/common/src/services/LocalBackend.ts
@@ -391,6 +391,7 @@ export class LocalBackend extends backend.Backend {
         },
         url: backend.HttpsUrl(this.resolvePath(downloadProjectPath(projectId))),
         ensoPath: backend.EnsoPath(`${directoryPath}/${cachedProject.projectNormalizedName}`),
+        internalId: cachedProject.projectId,
       }
     }
   }

--- a/app/common/src/services/ProjectManager/types.ts
+++ b/app/common/src/services/ProjectManager/types.ts
@@ -138,6 +138,7 @@ export interface CreateProject {
 
 /** The return value of the "open project" endpoint. */
 export interface OpenProject {
+  readonly projectId: UUID
   readonly languageServerJsonAddress: IpWithSocket
   readonly languageServerBinaryAddress: IpWithSocket
   readonly languageServerYdocAddress?: IpWithSocket

--- a/app/gui/src/providers/openedProjects/projectStates.ts
+++ b/app/gui/src/providers/openedProjects/projectStates.ts
@@ -419,7 +419,7 @@ export function useProjectStates() {
       const module = createModuleStore(store, projectNames, suggestionDb)
       const graph = createGraphStore(store, suggestionDb, projectNames, module)
       const widgetRegistry = new WidgetRegistry(graph.db)
-      const logger = eventLogger(project.info.id)
+      const logger = eventLogger(project, runDetails.value)
 
       logger.send('ide_project_opened')
       onScopeDispose(() => logger.send('ide_project_closed'))
@@ -494,17 +494,14 @@ export function useProjectStates() {
   }
 
   /** Create an event logger for given project. */
-  function eventLogger(projectId: ProjectId) {
-    const logProjectId = computed(() => {
-      const prefix = 'project-'
-      const projectUuid =
-        projectId.startsWith(prefix) ? projectId.substring(prefix.length) : projectId
-      return `${prefix}${projectUuid.replace(/-/g, '')}`
-    })
-
+  function eventLogger(project: Opened, runDetails: ProjectDetails) {
+    const logProjectId =
+      project.info.mode === 'local' ?
+        `project-${runDetails.internalId?.replaceAll('-', '')}`
+      : project.info.id
     return {
       async send(message: string) {
-        backends.remoteBackend.logEvent(message, logProjectId.value)
+        backends.remoteBackend.logEvent(message, logProjectId)
       },
     }
   }

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -53,6 +53,7 @@ export interface CreateProject {
 
 /** The return value of the "open project" endpoint. */
 export interface OpenProject {
+  readonly projectId: UUID
   readonly languageServerJsonAddress: Socket
   readonly languageServerBinaryAddress: Socket
   readonly languageServerYdocAddress: Socket
@@ -206,6 +207,7 @@ export class ProjectService {
 
     // Return the OpenProject response
     return {
+      projectId,
       languageServerJsonAddress: sockets.jsonSocket,
       languageServerBinaryAddress: sockets.binarySocket,
       languageServerYdocAddress: sockets.ydocSocket,


### PR DESCRIPTION
### Pull Request Description

Fixes #14137 

Cloud didn't accept our local project id as projectId. So now we use the internal project UUID from project.json instead.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
