### PR TITLE
Fix minimal log level for logs sent remotely

### DIFF
--- a/lib/scala/logging-config/src/main/java/org/enso/logging/config/OpenSearchAppender.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logging/config/OpenSearchAppender.java
@@ -35,7 +35,7 @@ public final class OpenSearchAppender extends Appender {
 
   @Override
   public boolean setup(Level logLevel, LoggerSetup loggerSetup) {
-    var maxLogLevelInt = Math.max(logLevel.toInt(), maxLogLevel.toInt());
+    var maxLogLevelInt = Math.min(logLevel.toInt(), maxLogLevel.toInt());
     return enabled
         && loggerSetup.setupOpenSearchAppender(
             Level.intToLevel(maxLogLevelInt), URI.create(logsUri), logConnectionFailures);


### PR DESCRIPTION
### Pull Request Description

If the default level is `WARN` and OpenSearch (i.e. remote endpoint) level is `DEBUG` then taking a max gives `WARN`. Should be taking minimal value instead.

After the change, sessions logs are now showing logs up to DEBUG.

Closes #14613.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

~~- [ ] The documentation has been updated, if necessary.~~
~~- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
~~- [ ] Unit tests have been written where possible.~~
~~- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-~~org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
~~  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
