### PR TITLE
Remove Standard.Image from native image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3823,7 +3823,6 @@ lazy val `engine-runner` = project
         } else {
           base ++
           databaseCp ++
-          `image-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
           `table-polyglot-root`.listFiles("*.jar").map(_.getAbsolutePath()) ++
           `database-polyglot-root`
             .listFiles("*.jar")
@@ -3952,7 +3951,6 @@ lazy val `engine-runner` = project
               "com.azure",
               "akka.http",
               "org.enso.base",
-              "org.enso.image",
               "org.enso.logging",
               "org.enso.common.ContextLoggingConfigurator",
               "org.enso.table",


### PR DESCRIPTION
- Prerequisite for #14553
- Follow-up of #14607

### Pull Request Description

i.e. run `Standard.Image` in _dual JVM mode_. Since #14553 will remove `Standard.Image` from the release, there is no need to include it in NI.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Unit tests have been written where possible.
