### PR TITLE
Fix stdlib Compile benchmark

### DIFF
--- a/test/Benchmarks/src/Compiler/Compile.enso
+++ b/test/Benchmarks/src/Compiler/Compile.enso
@@ -12,7 +12,8 @@ type Data
     Value ~enso_bin:File ~std_base:File
 
     bench_compile_base self extra_params=[] =
-        self.startup ["--no-compile-dependencies", "--log-level", "debug", "--compile", self.std_base.to_text]+extra_params
+        no_src_archive_opt = "-Dorg.enso.compiler.noSourceArchives=" + self.std_base.to_text
+        self.startup (["--no-compile-dependencies", "--log-level", "debug", "--compile", self.std_base.to_text] + [no_src_archive_opt] + extra_params)
 
     startup self  args =
         cache_dir = self.std_base / ".enso" / "cache"


### PR DESCRIPTION
### Pull Request Description

Recent [failures](https://github.com/enso-org/enso/actions/runs/21014510929/job/60416733441) of stdlib benchmarks reveal that `Compile` benchmark creates source archives, which was introduced in #14589. This PR fixes that by adding an option to not create the source archive for that benchmark.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Stdlib `Compile` benchmark works - https://github.com/enso-org/enso/actions/runs/21026805031
