### PR TITLE
Respect `Warning.to_text` method override

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
@@ -24,7 +24,7 @@
     - to_display_text self -> Standard.Base.Any.Any
 - type Floating_Point_Equality
     - Error location:Standard.Base.Data.Text.Text
-    - Used_As_Dictionary_Key value:Standard.Base.Data.Numbers.Float
+    - Used_As_Dictionary_Key original_value:Standard.Base.Data.Numbers.Float
     - to_display_text self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
 - type Forbidden_Operation
@@ -75,7 +75,7 @@
     - Error target:Standard.Base.Any.Any that:Standard.Base.Any.Any conversion:Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
 - type No_Such_Field
-    - Error value:Standard.Base.Any.Any field_name:Standard.Base.Any.Any
+    - Error target:Standard.Base.Any.Any field_name:Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
 - type No_Such_Method
     - Error target:Standard.Base.Any.Any symbol:Standard.Base.Any.Any
@@ -91,7 +91,7 @@
     - handle_java_exception operation:Standard.Base.Any.Any ~function:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
 - type Out_Of_Range
-    - Error value:Standard.Base.Any.Any message:Standard.Base.Any.Any=
+    - Error original_value:Standard.Base.Any.Any message:Standard.Base.Any.Any=
     - to_display_text self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
 - type Private_Access

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -283,12 +283,12 @@ type No_Such_Field
        private: true
        ---
        The error thrown when the specified symbol does not exist as a field on
-       the value.
+       the target.
 
        ## Arguments
         - `target`: The target on which the field was accessed.
         - `field_name`: The name of the field that was being accessed.
-    Error value field_name
+    Error target field_name
 
     ## ---
        private: true
@@ -296,8 +296,8 @@ type No_Such_Field
        Convert the No_Such_Method error to a human-readable format.
     to_display_text : Text
     to_display_text self =
-        value_type_name = if Meta.is_polyglot self.value then self.value.to_display_text else (Meta.type_of self.value).to_display_text
-        "Field `"+self.field_name+"` of "+value_type_name+" could not be found."
+        target_type_name = if Meta.is_polyglot self.target then self.target.to_display_text else (Meta.type_of self.target).to_display_text
+        "Field `"+self.field_name+"` of "+target_type_name+" could not be found."
 
 @Builtin_Type
 type Module_Not_In_Package_Error
@@ -722,7 +722,7 @@ type Out_Of_Range
     ## ---
        private: true
        ---
-    Error value message=Nothing
+    Error original_value message=Nothing
 
     ## ---
        private: true
@@ -731,7 +731,7 @@ type Out_Of_Range
     to_display_text : Text
     to_display_text self =
         extra = if self.message.is_nothing then "" else ": "+self.message.to_text
-        "Value out of range: "+self.value.to_text+extra
+        "Value out of range: "+self.original_value.to_text+extra
 
     ## ---
        private: true
@@ -739,7 +739,7 @@ type Out_Of_Range
     to_text : Text
     to_text self =
         extra = if self.message.is_nothing then "" else " (message = "+self.message.to_text+")"
-        "(Out_Of_Range (value = "+self.value.to_text+")" + extra + ")"
+        "(Out_Of_Range (original_value = "+self.original_value.to_text+")" + extra + ")"
 
 ## Indicates that the response from a remote endpoint is over the size limit.
 type Response_Too_Large
@@ -786,7 +786,7 @@ type Floating_Point_Equality
        private: true
        ---
        Represents the use of a floating-point value as a `Dictionary` key.
-    Used_As_Dictionary_Key value:Float
+    Used_As_Dictionary_Key original_value:Float
 
     ## ---
        private: true
@@ -796,8 +796,8 @@ type Floating_Point_Equality
     to_display_text self = case self of
         Floating_Point_Equality.Error location ->
             "Relying on equality of floating-point numbers is not recommended (within "+location+")."
-        Floating_Point_Equality.Used_As_Dictionary_Key value ->
-            "Float used as dictionary key: "+value.to_text
+        Floating_Point_Equality.Used_As_Dictionary_Key original_value ->
+            "Float used as dictionary key: "+original_value.to_text
 
     ## ---
        private: true
@@ -806,8 +806,8 @@ type Floating_Point_Equality
     to_text self = case self of
         Floating_Point_Equality.Error location ->
             "(Error  (location = "+location+"))"
-        Floating_Point_Equality.Used_As_Dictionary_Key value ->
-            "(Used_As_Dictionary_Key (value = "+value.to_text+"))"
+        Floating_Point_Equality.Used_As_Dictionary_Key original_value ->
+            "(Used_As_Dictionary_Key (original_value = "+original_value.to_text+"))"
 
 ## A warning indicating that a file failed to be loaded.
 type Failed_To_Load

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Warning_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Warning_Helpers.enso
@@ -1,0 +1,3 @@
+private
+
+type Placeholder

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -12,6 +12,7 @@ import project.Runtime.Stack_Trace_Element
 from project.Data.Boolean import Boolean, False
 from project.Error import all
 from project.Function import flip
+from project.Internal.Warning_Helpers import Placeholder
 from project.Nothing import all
 
 ## A representation of a dataflow warning attached to a value.
@@ -400,6 +401,3 @@ Any.remove_warnings self warning_type=Any =
 Any.throw_on_warning self warning_type=Any =
     _ = warning_type
     self
-
-
-type Placeholder

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -72,8 +72,8 @@ type Warning
     throw_on_warning : Any -> Any -> Any
     throw_on_warning value warning_type=Any =
         warnings = Warning.get_all value
-        first = warnings.find (w-> w.value.is_a warning_type) if_missing=Nothing
-        if first.is_nothing then value else Error.throw first.value
+        first = warnings.find (w-> w.value.is_a warning_type) if_missing=Placeholder
+        if first == Placeholder then value else Error.throw first.value
 
     ## ---
        private: true
@@ -400,3 +400,6 @@ Any.remove_warnings self warning_type=Any =
 Any.throw_on_warning self warning_type=Any =
     _ = warning_type
     self
+
+
+type Placeholder

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -16,11 +15,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
-
 
 public class TypeOfNodeValueTest {
   @ClassRule public static final ContextUtils ctxRule = ContextUtils.createDefault();
@@ -86,32 +80,5 @@ public class TypeOfNodeValueTest {
     var allTypes1 = (Type[]) arr1[1];
     assertEquals("Just one type", 1, allTypes1.length);
     assertEquals("Integer", types[0], allTypes1[0]);
-  }
-
-  @Test
-  public void customWarningType() {
-    var ret = ctxRule.evalModule("""
-        from Standard.Base import Warning
-        type My_Warn
-            Value reason
-        main =
-            with_warn = Warning.attach (My_Warn.Value "my_warn") 42
-            warn = Warning.get_all with_warn . first
-            [My_Warn, warn]
-        """);
-    assertThat(ret.hasArrayElements(), is(true));
-    var myWarnTypeExpected = ctxRule.unwrapValue(ret.getArrayElement(0));
-    var myWarn = ctxRule.unwrapValue(ret.getArrayElement(1));
-    var myWarnTypeActual = typeOf(myWarn);
-    assertTrue("is type", myWarnTypeExpected instanceof Type);
-    assertTrue("is type", myWarnTypeActual instanceof Type);
-    var expectedTypeName = ((Type) myWarnTypeExpected).getQualifiedName().toString();
-    assertThat(expectedTypeName, containsString("My_Warn"));
-    var actualTypeName = ((Type) myWarnTypeActual).getQualifiedName().toString();
-    assertThat(actualTypeName, is(expectedTypeName));
-  }
-
-  private Object typeOf(Object value) {
-    return ((Object[]) testTypesCall.call(value, false))[0];
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -15,6 +16,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
 
 public class TypeOfNodeValueTest {
   @ClassRule public static final ContextUtils ctxRule = ContextUtils.createDefault();
@@ -80,5 +86,32 @@ public class TypeOfNodeValueTest {
     var allTypes1 = (Type[]) arr1[1];
     assertEquals("Just one type", 1, allTypes1.length);
     assertEquals("Integer", types[0], allTypes1[0]);
+  }
+
+  @Test
+  public void customWarningType() {
+    var ret = ctxRule.evalModule("""
+        from Standard.Base import Warning
+        type My_Warn
+            Value reason
+        main =
+            with_warn = Warning.attach (My_Warn.Value "my_warn") 42
+            warn = Warning.get_all with_warn . first
+            [My_Warn, warn]
+        """);
+    assertThat(ret.hasArrayElements(), is(true));
+    var myWarnTypeExpected = ctxRule.unwrapValue(ret.getArrayElement(0));
+    var myWarn = ctxRule.unwrapValue(ret.getArrayElement(1));
+    var myWarnTypeActual = typeOf(myWarn);
+    assertTrue("is type", myWarnTypeExpected instanceof Type);
+    assertTrue("is type", myWarnTypeActual instanceof Type);
+    var expectedTypeName = ((Type) myWarnTypeExpected).getQualifiedName().toString();
+    assertThat(expectedTypeName, containsString("My_Warn"));
+    var actualTypeName = ((Type) myWarnTypeActual).getQualifiedName().toString();
+    assertThat(actualTypeName, is(expectedTypeName));
+  }
+
+  private Object typeOf(Object value) {
+    return ((Object[]) testTypesCall.call(value, false))[0];
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InstanceInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InstanceInvokeMethodNode.java
@@ -312,6 +312,10 @@ abstract class InstanceInvokeMethodNode extends InvokeMethodNode {
         invokeFunctionNode.getArgumentsExecutionMode());
   }
 
+  Type warningBuiltinType() {
+    return EnsoContext.get(this).getBuiltins().warning();
+  }
+
   @Specialization
   Object doWarning(
       VirtualFrame frame,
@@ -319,22 +323,21 @@ abstract class InstanceInvokeMethodNode extends InvokeMethodNode {
       UnresolvedSymbol symbol,
       Warning self,
       Object[] arguments,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
       @Shared("methodResolverNode") @Cached MethodResolverNode methodResolverNode,
-      @Shared("types") @CachedLibrary(limit = "10") TypesLibrary typesLib
-  ) {
-    var warningBuiltinType = EnsoContext.get(this).getBuiltins().warning();
-    var builtinFunc = resolveFunction(symbol, self, warningBuiltinType, methodResolverNode);
-    var valueType = typesLib.getType(self.getValue());
-    var valueFunc = resolveFunction(symbol, self.getValue(), valueType, methodResolverNode);
-    if (builtinFunc != null && valueFunc != null) {
-      // value type overrides the method - dispatch on the value
+      @Cached("warningBuiltinType()") Type warningBuiltinType,
+      @Cached("resolveFunction(cachedSymbol, self, warningBuiltinType, methodResolverNode)")
+          Function builtinFunc,
+      @Shared("types") @CachedLibrary(limit = "10") TypesLibrary typesLib,
+      @Cached("typesLib.getType(self.getValue())") Type valueType,
+      @Cached("resolveFunction(cachedSymbol, self.getValue(), valueType, methodResolverNode)")
+          Function valueFunc) {
+    if (valueFunc != null) {
+      // value type overrides the method - dispatch on the value function
       arguments[thisArgumentPosition] = self.getValue();
       return invokeFunctionNode.execute(valueFunc, frame, state, arguments);
     } else if (builtinFunc != null) {
       return invokeFunctionNode.execute(builtinFunc, frame, state, arguments);
-    } else if (valueFunc != null) {
-      arguments[thisArgumentPosition] = self.getValue();
-      return invokeFunctionNode.execute(valueFunc, frame, state, arguments);
     } else {
       throw methodNotFound(this, onBoundary, symbol, self);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InstanceInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InstanceInvokeMethodNode.java
@@ -52,6 +52,7 @@ import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.state.State;
 import org.enso.interpreter.runtime.warning.AppendWarningNode;
+import org.enso.interpreter.runtime.warning.Warning;
 import org.enso.interpreter.runtime.warning.WarningsLibrary;
 
 /**
@@ -311,13 +312,41 @@ abstract class InstanceInvokeMethodNode extends InvokeMethodNode {
         invokeFunctionNode.getArgumentsExecutionMode());
   }
 
+  @Specialization
+  Object doWarning(
+      VirtualFrame frame,
+      State state,
+      UnresolvedSymbol symbol,
+      Warning self,
+      Object[] arguments,
+      @Shared("methodResolverNode") @Cached MethodResolverNode methodResolverNode,
+      @Shared("types") @CachedLibrary(limit = "10") TypesLibrary typesLib
+  ) {
+    var warningBuiltinType = EnsoContext.get(this).getBuiltins().warning();
+    var builtinFunc = resolveFunction(symbol, self, warningBuiltinType, methodResolverNode);
+    var valueType = typesLib.getType(self.getValue());
+    var valueFunc = resolveFunction(symbol, self.getValue(), valueType, methodResolverNode);
+    if (builtinFunc != null && valueFunc != null) {
+      // value type overrides the method - dispatch on the value
+      arguments[thisArgumentPosition] = self.getValue();
+      return invokeFunctionNode.execute(valueFunc, frame, state, arguments);
+    } else if (builtinFunc != null) {
+      return invokeFunctionNode.execute(builtinFunc, frame, state, arguments);
+    } else if (valueFunc != null) {
+      arguments[thisArgumentPosition] = self.getValue();
+      return invokeFunctionNode.execute(valueFunc, frame, state, arguments);
+    } else {
+      throw methodNotFound(this, onBoundary, symbol, self);
+    }
+  }
+
   @Specialization(
       guards = {
         "warnings.hasWarnings(self)",
         "resolvedFunction != null",
         "resolvedFunction.getSchema() == cachedSchema"
       })
-  Object doWarningsCustom(
+  Object doWithWarningsCustom(
       VirtualFrame frame,
       State state,
       UnresolvedSymbol symbol,
@@ -339,7 +368,7 @@ abstract class InstanceInvokeMethodNode extends InvokeMethodNode {
   }
 
   @Specialization(guards = "warnings.hasWarnings(self)")
-  Object doWarning(
+  Object doWithWarning(
       VirtualFrame frame,
       State state,
       UnresolvedSymbol symbol,

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -41,7 +41,7 @@ public final class Warning extends BuiltinObject {
     return value;
   }
 
-  @Builtin.Method(name = "origin", description = "Gets the payload of the warning.")
+  @Builtin.Method(name = "origin", description = "Gets the origin of the warning.")
   @SuppressWarnings("generic-enso-builtin-type")
   public Object getOrigin() {
     return origin;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -15,7 +15,6 @@ import org.enso.interpreter.dsl.AcceptsWarning;
 import org.enso.interpreter.dsl.Builtin;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.BuiltinObject;
-import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.hash.EnsoHashMap;
 import org.enso.interpreter.runtime.data.hash.HashMapInsertNode;
@@ -86,21 +85,19 @@ public final class Warning extends BuiltinObject {
   }
 
   @ExportMessage
-  Object getField(int index,
-      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+  Object getField(int index, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
     return structsLib.getField(value, index);
   }
 
   @ExportMessage
   void setField(
-      int index, Object value,
-      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+      int index, Object value, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
     structsLib.setField(this.value, index, value);
   }
 
   @ExportMessage
-  boolean isFieldEvaluated(int index,
-      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+  boolean isFieldEvaluated(
+      int index, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
     return structsLib.isFieldEvaluated(value, index);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime.warning;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.StopIterationException;
@@ -14,11 +15,16 @@ import org.enso.interpreter.dsl.AcceptsWarning;
 import org.enso.interpreter.dsl.Builtin;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.BuiltinObject;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.hash.EnsoHashMap;
 import org.enso.interpreter.runtime.data.hash.HashMapInsertNode;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 @Builtin(pkg = "error", stdlibName = "Standard.Base.Warning.Warning")
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "value")
+@ExportLibrary(value = StructsLibrary.class)
+@ExportLibrary(value = TypesLibrary.class)
 public final class Warning extends BuiltinObject {
   final Object value;
   private final Object origin;
@@ -72,6 +78,30 @@ public final class Warning extends BuiltinObject {
       @Cached AppendWarningNode appendWarningNode) {
     var warn = new Warning(warning, origin, ctx.nextSequenceId());
     return appendWarningNode.executeAppend(frame, value, warn);
+  }
+
+  @ExportMessage
+  boolean hasSpecialDispatch() {
+    return true;
+  }
+
+  @ExportMessage
+  Object getField(int index,
+      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+    return structsLib.getField(value, index);
+  }
+
+  @ExportMessage
+  void setField(
+      int index, Object value,
+      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+    structsLib.setField(this.value, index, value);
+  }
+
+  @ExportMessage
+  boolean isFieldEvaluated(int index,
+      @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
+    return structsLib.isFieldEvaluated(value, index);
   }
 
   /** Slow version of {@link #fromMapToArray(EnsoHashMap, InteropLibrary)}. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.runtime.warning;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.StopIterationException;
@@ -15,14 +14,12 @@ import org.enso.interpreter.dsl.AcceptsWarning;
 import org.enso.interpreter.dsl.Builtin;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.BuiltinObject;
-import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.hash.EnsoHashMap;
 import org.enso.interpreter.runtime.data.hash.HashMapInsertNode;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 @Builtin(pkg = "error", stdlibName = "Standard.Base.Warning.Warning")
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "value")
-@ExportLibrary(value = StructsLibrary.class)
 @ExportLibrary(value = TypesLibrary.class)
 public final class Warning extends BuiltinObject {
   final Object value;
@@ -82,23 +79,6 @@ public final class Warning extends BuiltinObject {
   @ExportMessage
   boolean hasSpecialDispatch() {
     return true;
-  }
-
-  @ExportMessage
-  Object getField(int index, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
-    return structsLib.getField(value, index);
-  }
-
-  @ExportMessage
-  void setField(
-      int index, Object value, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
-    structsLib.setField(this.value, index, value);
-  }
-
-  @ExportMessage
-  boolean isFieldEvaluated(
-      int index, @Shared @CachedLibrary(limit = "3") StructsLibrary structsLib) {
-    return structsLib.isFieldEvaluated(value, index);
   }
 
   /** Slow version of {@link #fromMapToArray(EnsoHashMap, InteropLibrary)}. */

--- a/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/MethodParameter.java
+++ b/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/MethodParameter.java
@@ -133,7 +133,8 @@ public record MethodParameter(int index, String name, String tpe, List<String> a
 
   public boolean isTruffleCachedParam() {
     return tpe.startsWith(CachedLibraryMethodParameter.INTEROP_LIBRARY)
-        || tpe.startsWith(CachedLibraryMethodParameter.WARNINGS_LIBRARY);
+        || tpe.startsWith(CachedLibraryMethodParameter.WARNINGS_LIBRARY)
+        || tpe.startsWith(CachedLibraryMethodParameter.TYPES_LIBRARY);
   }
 
   public boolean needsToInjectValueOfType() {

--- a/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodParameter.java
+++ b/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodParameter.java
@@ -123,6 +123,7 @@ class CachedLibraryMethodParameter extends SpecializedMethodParameter {
   public static final String INTEROP_LIBRARY = "com.oracle.truffle.api.interop.InteropLibrary";
   public static final String WARNINGS_LIBRARY =
       "org.enso.interpreter.runtime.warning.WarningsLibrary";
+  public static final String TYPES_LIBRARY = "org.enso.interpreter.runtime.library.dispatch.TypesLibrary";
 }
 
 class InjectedMethodParameter extends SpecializedMethodParameter {

--- a/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodParameter.java
+++ b/lib/java/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodParameter.java
@@ -123,7 +123,8 @@ class CachedLibraryMethodParameter extends SpecializedMethodParameter {
   public static final String INTEROP_LIBRARY = "com.oracle.truffle.api.interop.InteropLibrary";
   public static final String WARNINGS_LIBRARY =
       "org.enso.interpreter.runtime.warning.WarningsLibrary";
-  public static final String TYPES_LIBRARY = "org.enso.interpreter.runtime.library.dispatch.TypesLibrary";
+  public static final String TYPES_LIBRARY =
+      "org.enso.interpreter.runtime.library.dispatch.TypesLibrary";
 }
 
 class InjectedMethodParameter extends SpecializedMethodParameter {

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -13,6 +13,12 @@ from Standard.Test import all
 type My_Warning
     Value reason
 
+type My_Warning_Method_Override
+    Value reason
+
+    to_text self = "My_Warning_Method_Override (to_text): "+self.reason.to_text
+    to_display_text self = "My_Warning_Method_Override (to_display_text): "+self.reason.to_display_text
+
 type My_Type
     Value a b c
 My_Type.my_method self = self.a + self.b + self.c
@@ -135,6 +141,12 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         r = Long.sum x y
         r.should_equal 3
         Warning.get_all r . map .value . should_equal ['warn!', 'warn!!']
+
+    group_builder.specify "should respect to_text method override" <|
+        with_warn = Warning.attach (My_Warning_Method_Override.Value "custom warn") 42
+        warn = Warning.get_all with_warn . first
+        warn.to_text . should_equal "My_Warning_Method_Override (to_text): custom warn"
+        warn.to_display_text . should_equal "My_Warning_Method_Override (to_display_text): custom warn"
 
     group_builder.specify "should be passed correctly when combined with warnings added in branches" <|
         one = Warning.attach "first" "1"

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -120,6 +120,12 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         z = Warning.attach_multiple ["don't do this", "I'm serious"] x
         Warning.get_all z . map .value . should_equal ["I'm serious", "don't do this"]
 
+    group_builder.specify "warning type is always the builtin Warning type" <|
+        with_warn = Warning.attach (My_Warning.Value "warn") 42
+        warn = Warning.get_all with_warn . first
+        Meta.type_of warn . should_equal Warning
+        Meta.type_of warn.value . should_equal My_Warning
+
     group_builder.specify "should thread warnings through constructor calls" <|
         z = Warning.attach (My_Warning.Value "warn!!!") 3
         y = Warning.attach (My_Warning.Value "warn!!") 2

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -274,7 +274,7 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         no_error = Warning.remove_warnings warned Unimplemented
         Warning.get_all no_error . map .value . should_equal [1, "Alpha", Nothing]
 
-    group_builder.specify "XX should allow raising warnings as errors, by type" <|
+    group_builder.specify "should allow raising warnings as errors, by type" <|
         warned = Warning.attach 1 <| Warning.attach "Alpha" <| Warning.attach Nothing <| Warning.attach (Unimplemented.Error "An Error Here") "foo"
 
         Warning.throw_on_warning warned . should_fail_with Integer


### PR DESCRIPTION
- Fixes #9741

### Pull Request Description

Changes semantics of the `Warning` builtin type to delegate method calls to its `value`.

### Important Notes

- [Warning](https://github.com/enso-org/enso/blob/8e6fba560fd9d944ecb48194f90a547a3967d8d6/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java) builtin type has [special dispatch](https://github.com/enso-org/enso/blob/8e6fba560fd9d944ecb48194f90a547a3967d8d6/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java#L82-L85)
- Which means it has to have a separate specialization in [InstanceInvokeMethodNode](https://github.com/enso-org/enso/blob/7f5ffaaeb213f9927fe0eb480f0e1d36f55449a4/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InstanceInvokeMethodNode.java#L319-L344).
  - This specialization checks whether the given symbol is defined on the Warning's `value`, and if it is, it delegates the method call there.
  - Otherwise, the method from `Warning` builtin is called.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- [X] Unit tests have been written where possible.
