### PR TITLE
Fix Date_Time extended error test failure

### DIFF
--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -437,7 +437,7 @@ snowflake_specific_spec suite_builder default_connection db_name setup =
                     table.update_rows source_table update_action=Update_Action.Insert
                 w.requested_type . should_equal (source_table.at "A" . value_type)
                 w.actual_type . should_equal (table.at "A" . value_type)
-                w.to_display_text . should_equal "The type Date_Time (with timezone) has been coerced to Date_Time (without timezone). Some information may be lost."
+                w.to_display_text . should_equal "The type Date_Time (with timezone) has been coerced to Date_Time (without timezone). Some information may be lost. Consider using .at_time_zone or .set_time_zone to explicitly convert Date_Time values before upload."
 
                 # When uploading we want to just strip the timezone information and treat every timestamp as LocalDateTime.
                 # This is verified by checking the text representation in the DB: it should show the same local time in all 4 cases, regardless of original timezone.


### PR DESCRIPTION
Fixes the [Snowflake test failure](https://github.com/enso-org/enso/actions/runs/21087732186/job/60654585470#step:14:1416) in "should round-trip timestamptz column, preserving instant but converting to UTC":


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
