### PR TITLE
Transfer stack trace elements from the other JVM when rethrowing

### DIFF
--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
@@ -294,16 +294,23 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
       var len = handleWithChannel(channel, buf);
       return len;
     } catch (Throwable ex) {
-      channel.printStackTrace(ex, true);
-      var bytes = ex.getMessage() == null ? new byte[0] : ex.getMessage().getBytes();
       var buf = asNativeByteBuffer(data, size);
-      buf.putInt(bytes.length);
-      buf.put(bytes);
+      ChannelExceptions.exceptionSerialize(buf, ex);
       return RET_CODE_EXCEPTION;
     }
   }
 
-  private static long handleWithChannel(Channel channel, ByteBuffer buf) throws IOException {
+  private static long handleWithChannel(Channel channel, ByteBuffer buf) {
+    try {
+      return handleWithChannelThrow(channel, buf);
+    } catch (Throwable ex) {
+      buf.position(0);
+      ChannelExceptions.exceptionSerialize(buf, ex);
+      return RET_CODE_EXCEPTION;
+    }
+  }
+
+  private static long handleWithChannelThrow(Channel channel, ByteBuffer buf) throws Throwable {
     // clean any previous overflow buffer
     keepLastOverflowBuffer.set(null);
 
@@ -430,11 +437,7 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
       if (len == RET_CODE_EXCEPTION) {
         // signals exception
         buffer.position(0);
-        var msgLen = buffer.getInt();
-        var msgBytes = new byte[msgLen];
-        buffer.get(msgBytes);
-        var exceptionMessage = new String(msgBytes);
-        throw new IllegalStateException(exceptionMessage);
+        throw ChannelExceptions.exceptionDeserialize(RuntimeException.class, buffer);
       }
       if (len == RET_CODE_OVERFLOW) {
         buffer.position(0);

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
@@ -289,15 +289,9 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
 
     var channel = ID_TO_CHANNEL.get(id);
     assert channel != null : "There must be a channel " + id + " but " + ID_TO_CHANNEL;
-    try {
-      var buf = asNativeByteBuffer(data, size);
-      var len = handleWithChannel(channel, buf);
-      return len;
-    } catch (Throwable ex) {
-      var buf = asNativeByteBuffer(data, size);
-      ChannelExceptions.exceptionSerialize(buf, ex);
-      return RET_CODE_EXCEPTION;
-    }
+    var buf = asNativeByteBuffer(data, size);
+    var len = handleWithChannel(channel, buf);
+    return len;
   }
 
   private static long handleWithChannel(Channel channel, ByteBuffer buf) {
@@ -305,7 +299,8 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
       return handleWithChannelThrow(channel, buf);
     } catch (Throwable ex) {
       buf.position(0);
-      ChannelExceptions.exceptionSerialize(buf, ex);
+      ChannelExceptions.exceptionSerialize(
+          buf, ex, Channel.class.getName(), "handleWithChannelThrow");
       return RET_CODE_EXCEPTION;
     }
   }

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
@@ -194,7 +194,7 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
       arg.addressOf(2).setLong(CALLBACK_FN.getFunctionPointer().rawValue());
       arg.addressOf(3).setJObject(poolClassInHotSpot);
       var replyOk = fn.getCallStaticBooleanMethodA().call(e, channelClass, createMethod, arg);
-      channel.checkForException(e, false);
+      channel.checkUnexpectedException(e);
       assert replyOk : "Failed to create peer in HotSpot JVM";
 
       ID_TO_CHANNEL.put(id, channel);
@@ -341,7 +341,7 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
     arg.addressOf(2).setLong(address);
     arg.addressOf(3).setLong(size);
     var replySize = fn.getCallStaticLongMethodA().call(env, channelClass, channelHandle, arg);
-    checkForException(env, true);
+    checkUnexpectedException(env);
     return replySize;
   }
 
@@ -366,7 +366,8 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
         return res;
       }
     } catch (Throwable ex) {
-      printStackTrace(ex, false);
+      // unexpected exception
+      ex.printStackTrace();
       return -1L;
     }
   }
@@ -379,15 +380,13 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
     return len;
   }
 
-  private void checkForException(JNI.JNIEnv e, boolean userCode) {
+  private void checkUnexpectedException(JNI.JNIEnv e) {
     var fn = e.getFunctions();
     var hasException = fn.getExceptionCheck().call(e);
     if (hasException) {
       var throwable = fn.getExceptionOccurred().call(e);
       assert throwable.isNonNull() : "There must be a throwable";
-      if (printStackTrace(null, userCode)) {
-        fn.getExceptionDescribe().call(e);
-      }
+      fn.getExceptionDescribe().call(e);
       fn.getExceptionClear().call(e);
       try (var throwableInC = CTypeConversion.toCString("java/lang/Throwable");
           var messageInC = CTypeConversion.toCString("getMessage");
@@ -484,21 +483,6 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
   public void close() throws Exception {
     ID_TO_CHANNEL.remove(id, this);
     // TBD remove on the peer as well
-  }
-
-  /**
-   * @param ex exception to print stack trace for or {@code null}
-   * @param userCode is the exception from user code or is it unexpected
-   * @return {@code true} if the exception was printed and further details should be printed
-   */
-  private boolean printStackTrace(Throwable ex, boolean userCode) {
-    if (!userCode) {
-      if (ex != null) {
-        ex.printStackTrace();
-      }
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/Channel.java
@@ -299,11 +299,12 @@ public final class Channel<Data extends Channel.Config> implements AutoCloseable
       return handleWithChannelThrow(channel, buf);
     } catch (Throwable ex) {
       buf.position(0);
-      ChannelExceptions.exceptionSerialize(
-          buf, ex, Channel.class.getName(), "handleWithChannelThrow");
+      ChannelExceptions.exceptionSerialize(buf, ex, Channel.class.getName(), STOP_METHOD_NAME);
       return RET_CODE_EXCEPTION;
     }
   }
+
+  private static final String STOP_METHOD_NAME = "handleWithChannelThrow";
 
   private static long handleWithChannelThrow(Channel channel, ByteBuffer buf) throws Throwable {
     // clean any previous overflow buffer

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/ChannelExceptions.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/ChannelExceptions.java
@@ -27,7 +27,6 @@ final class ChannelExceptions {
     byte[] bytes = txt == null ? null : txt.getBytes(StandardCharsets.UTF_8);
     int wholeLen = bytes == null ? Integer.BYTES : bytes.length + Integer.BYTES;
     if (wholeLen > buf.remaining()) {
-      buf.putInt(EOS);
       return false;
     } else {
       if (bytes == null) {
@@ -40,18 +39,26 @@ final class ChannelExceptions {
     }
   }
 
-  static void exceptionSerialize(ByteBuffer buf, Throwable ex) {
+  static void exceptionSerialize(
+      ByteBuffer buf, Throwable ex, String stopClass, String stopMethod) {
     boolean okClass = putUTF(buf, ex.getClass().getName());
     boolean okMsg = putUTF(buf, ex.getMessage());
     assert okClass && okMsg;
+    int lastGood = 0;
     for (StackTraceElement elem : ex.getStackTrace()) {
-      int lastGood = buf.position();
+      lastGood = buf.position();
+      if (stopMethod.equals(elem.getMethodName()) && stopClass.equals(elem.getClassName())) {
+        break;
+      }
       boolean ok =
           putUTF(buf, elem.getClassName())
               && putUTF(buf, elem.getMethodName())
               && putUTF(buf, elem.getFileName());
       if (ok && buf.remaining() >= Integer.BYTES) {
         buf.putInt(elem.getLineNumber());
+        if (buf.remaining() < Integer.BYTES) {
+          break;
+        }
       } else {
         buf.putInt(lastGood, EOS);
         return;

--- a/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/ChannelExceptions.java
+++ b/lib/java/jvm-channel/src/main/java/org/enso/jvm/channel/ChannelExceptions.java
@@ -1,0 +1,92 @@
+package org.enso.jvm.channel;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+final class ChannelExceptions {
+  private static final int EOS = -1;
+  private static final int NULL = -2;
+
+  private ChannelExceptions() {}
+
+  private static String readUTF(ByteBuffer buf) {
+    int len = buf.getInt();
+    assert len != EOS : "Unexpected end of stream in the buffer!";
+    if (len == NULL) {
+      return null;
+    } else {
+      byte[] bytes = new byte[len];
+      buf.get(bytes);
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  private static boolean putUTF(ByteBuffer buf, String txt) {
+    byte[] bytes = txt == null ? null : txt.getBytes(StandardCharsets.UTF_8);
+    int wholeLen = bytes == null ? Integer.BYTES : bytes.length + Integer.BYTES;
+    if (wholeLen > buf.remaining()) {
+      buf.putInt(EOS);
+      return false;
+    } else {
+      if (bytes == null) {
+        buf.putInt(NULL);
+      } else {
+        buf.putInt(bytes.length);
+        buf.put(bytes);
+      }
+      return true;
+    }
+  }
+
+  static void exceptionSerialize(ByteBuffer buf, Throwable ex) {
+    boolean okClass = putUTF(buf, ex.getClass().getName());
+    boolean okMsg = putUTF(buf, ex.getMessage());
+    assert okClass && okMsg;
+    for (StackTraceElement elem : ex.getStackTrace()) {
+      int lastGood = buf.position();
+      boolean ok =
+          putUTF(buf, elem.getClassName())
+              && putUTF(buf, elem.getMethodName())
+              && putUTF(buf, elem.getFileName());
+      if (ok && buf.remaining() >= Integer.BYTES) {
+        buf.putInt(elem.getLineNumber());
+      } else {
+        buf.putInt(lastGood, EOS);
+        return;
+      }
+    }
+    buf.putInt(EOS);
+  }
+
+  @SuppressWarnings(value = "unchecked")
+  static <E extends Throwable> E exceptionDeserialize(Class<E> type, ByteBuffer buf) throws E {
+    var clazz = readUTF(buf);
+    var msg = readUTF(buf);
+    var stack = new ArrayList<StackTraceElement>();
+    while (true) {
+      int peekLen = buf.getInt(buf.position());
+      if (peekLen == EOS) {
+        break;
+      }
+      String className = readUTF(buf);
+      String methodName = readUTF(buf);
+      String fileName = readUTF(buf);
+      int lineNo = buf.getInt();
+      StackTraceElement ste = new StackTraceElement(className, methodName, fileName, lineNo);
+      stack.add(ste);
+    }
+    var ex =
+        switch (clazz) {
+          case "java.lang.NullPointerException" -> new NullPointerException(msg);
+          case "java.lang.IllegalArgumentException" -> new IllegalArgumentException(msg);
+          case "java.lang.IllegalStateException" -> new IllegalStateException(msg);
+          case "java.lang.ClassCastException" -> new ClassCastException(msg);
+          default -> new IllegalStateException(clazz + ":" + msg);
+        };
+    stack.addAll(List.of(ex.getStackTrace()));
+    ex.setStackTrace(stack.toArray(StackTraceElement[]::new));
+    throw (E) ex;
+  }
+}

--- a/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
+++ b/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
@@ -2,6 +2,7 @@ package org.enso.jvm.channel;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -93,6 +94,57 @@ public class ChannelInSingleJvmTest {
     }
   }
 
+  @Test
+  public void throwFactorialOne() throws Exception {
+    assertException("1", new CountDownAndThrow(1, 1));
+  }
+
+  @Test
+  public void throwFactorialTwo() throws Exception {
+    assertException("2", new CountDownAndThrow(2, 1));
+  }
+
+  @Test
+  public void throwFactorialThree() throws Exception {
+    assertException("6", new CountDownAndThrow(3, 1));
+  }
+
+  @Test
+  public void throwFactorialFour() throws Exception {
+    assertException("24", new CountDownAndThrow(4, 1));
+  }
+
+  @Test
+  public void throwFactorialFive() throws Exception {
+    assertException("120", new CountDownAndThrow(5, 1));
+  }
+
+  private void assertException(String msg, CountDownAndThrow action) {
+    var channel = Channel.create(null, PrivateData.class);
+    try {
+      channel.execute(Void.class, action);
+      fail("Expecting an exception to be thrown for " + msg);
+    } catch (IllegalStateException ex) {
+      assertEquals(msg, ex.getMessage());
+      var countDecrementAndSendMessage = 0;
+      for (var elem : ex.getStackTrace()) {
+        if ("decrementAndSendMessage".equals(elem.getMethodName())) {
+          assertEquals("ChannelInSingleJvmTest.java", elem.getFileName());
+          assertNotEquals(-1, elem.getLineNumber());
+          assertEquals(action.getClass().getName(), elem.getClassName());
+          countDecrementAndSendMessage++;
+        }
+      }
+      if (action.value() != countDecrementAndSendMessage) {
+        ex.printStackTrace();
+        assertEquals(
+            "There is exactly right amount of invocations",
+            action.value(),
+            countDecrementAndSendMessage);
+      }
+    }
+  }
+
   @Persistable(id = 8341)
   static final class Increment implements Function<Channel<?>, Increment> {
     int valueToIncrement;
@@ -143,6 +195,23 @@ public class ChannelInSingleJvmTest {
   static record LongString(String text) {
     private LongString(int len) {
       this("Hello".repeat(len / 5) + "!!!!!".substring(5 - len % 5));
+    }
+  }
+
+  @Persistable(id = 8345)
+  record CountDownAndThrow(long value, long acc) implements Function<Channel<?>, Void> {
+    @Override
+    public Void apply(Channel<?> otherVM) {
+      decrementAndSendMessage(value, acc, otherVM);
+      return null;
+    }
+
+    private static void decrementAndSendMessage(long n, long sum, Channel<?> otherVM) {
+      if (n <= 1) {
+        throw new IllegalStateException("" + sum);
+      } else {
+        otherVM.execute(Void.class, new CountDownAndThrow(n - 1, sum * n));
+      }
     }
   }
 }

--- a/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
+++ b/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.function.Function;
 import org.enso.persist.Persistable;
@@ -76,6 +77,22 @@ public class ChannelInSingleJvmTest {
     assertEquals(newMsg.text(), 32632, newMsg.text().length());
   }
 
+  @Test
+  public void exceptionIsThrows() {
+    var ch = Channel.create(null, PrivateData.class);
+
+    var msg = new GenerateString(-73);
+    try {
+      var newMsg = ch.execute(LongString.class, msg);
+      fail("Not expecting a return value: " + newMsg);
+    } catch (IllegalArgumentException ex) {
+      assertEquals("Length must be positive. Was: -73", ex.getMessage());
+      var stackTop = ex.getStackTrace()[0];
+      assertEquals(GenerateString.class.getName(), stackTop.getClassName());
+      assertEquals("handleGenerationOfStrings", stackTop.getMethodName());
+    }
+  }
+
   @Persistable(id = 8341)
   static final class Increment implements Function<Channel<?>, Increment> {
     int valueToIncrement;
@@ -111,7 +128,14 @@ public class ChannelInSingleJvmTest {
       implements Function<Channel<PrivateData>, LongString> {
     @Override
     public LongString apply(Channel<PrivateData> t) {
-      return new LongString(lengthToGenerate);
+      return handleGenerationOfStrings(lengthToGenerate);
+    }
+
+    private static LongString handleGenerationOfStrings(int len) {
+      if (len < 0) {
+        throw new IllegalArgumentException("Length must be positive. Was: " + len);
+      }
+      return new LongString(len);
     }
   }
 

--- a/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
+++ b/lib/java/jvm-channel/src/test/java/org/enso/jvm/channel/ChannelInSingleJvmTest.java
@@ -145,6 +145,19 @@ public class ChannelInSingleJvmTest {
     }
   }
 
+  @Test
+  public void verifyStopMethodNameReferencesRealMethodName() throws Exception {
+    var stopMethodField = Channel.class.getDeclaredField("STOP_METHOD_NAME");
+    stopMethodField.setAccessible(true);
+    var stopMethodValue = stopMethodField.get(null);
+    for (var m : Channel.class.getDeclaredMethods()) {
+      if (m.getName().equals(stopMethodValue)) {
+        return;
+      }
+    }
+    fail("STOP_METHOD_NAME field value should be consistent with method name");
+  }
+
   @Persistable(id = 8341)
   static final class Increment implements Function<Channel<?>, Increment> {
     int valueToIncrement;

--- a/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
+++ b/lib/java/jvm-interop/src/test/java/org/enso/jvm/interop/impl/OtherJvmObjectTest.java
@@ -19,6 +19,8 @@ import java.lang.foreign.MemorySegment;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.jvm.channel.Channel;
@@ -137,6 +139,7 @@ public class OtherJvmObjectTest {
 
   @Test
   public void parsingException() throws Exception {
+    List<StackTraceElement> singleStack = null;
     var shortClass1 = ctx.asValue(java.lang.Short.class).getMember("static");
     try {
       var value1 = shortClass1.invokeMember("valueOf", "not-a-number");
@@ -145,7 +148,9 @@ public class OtherJvmObjectTest {
       MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("not-a-number"));
       assertTrue("This is host exception", e.isHostException());
       assertNotNull("Host exception found", e.asHostException());
+      singleStack = takeFew(5, e.getStackTrace());
     }
+    assertNotNull("Stacktraces captured", singleStack);
     var shortClass2 = loadOtherJvmClass("java.lang.Short");
     try {
       var value2 = shortClass2.invokeMember("valueOf", "not-a-number");
@@ -153,7 +158,16 @@ public class OtherJvmObjectTest {
     } catch (PolyglotException e) {
       MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("not-a-number"));
       assertFalse("Alas this cannot be host exception", e.isHostException());
+      var stack = e.getGuestObject().invokeMember("getStackTrace");
+      for (var i = 0; i < 5; i++) {
+        var elem = stack.getArrayElement(i);
+        assertEquals(singleStack.get(i).toString(), elem.toString());
+      }
     }
+  }
+
+  private static List<StackTraceElement> takeFew(int n, StackTraceElement[] arr) {
+    return Arrays.asList(arr).subList(0, n);
   }
 
   @Test

--- a/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
+++ b/lib/java/os-environment/src/main/java/org/enso/os/environment/jni/TestMain.java
@@ -80,10 +80,15 @@ final class TestMain {
   record CountDownAndThrow(long value, long acc) implements Function<Channel<?>, Void> {
     @Override
     public Void apply(Channel<?> otherVM) {
-      if (value <= 1) {
-        throw new IllegalStateException("" + acc);
+      decrementAndSendMessage(value, acc, otherVM);
+      return null;
+    }
+
+    private static void decrementAndSendMessage(long n, long sum, Channel<?> otherVM) {
+      if (n <= 1) {
+        throw new IllegalStateException("" + sum);
       } else {
-        return otherVM.execute(Void.class, new CountDownAndThrow(value - 1, acc * value));
+        otherVM.execute(Void.class, new CountDownAndThrow(n - 1, sum * n));
       }
     }
   }

--- a/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
+++ b/lib/java/os-environment/src/test/java/org/enso/os/environment/jni/LoadClassTest.java
@@ -1,6 +1,7 @@
 package org.enso.os.environment.jni;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -223,6 +224,22 @@ public class LoadClassTest {
       fail("Expecting an exception to be thrown for " + msg);
     } catch (IllegalStateException ex) {
       assertEquals(msg, ex.getMessage());
+      var countDecrementAndSendMessage = 0;
+      for (var elem : ex.getStackTrace()) {
+        if ("decrementAndSendMessage".equals(elem.getMethodName())) {
+          assertEquals("TestMain.java", elem.getFileName());
+          assertNotEquals(-1, elem.getLineNumber());
+          assertEquals(action.getClass().getName(), elem.getClassName());
+          countDecrementAndSendMessage++;
+        }
+      }
+      if (action.value() != countDecrementAndSendMessage) {
+        ex.printStackTrace();
+        assertEquals(
+            "There is exactly right amount of invocations",
+            action.value(),
+            countDecrementAndSendMessage);
+      }
     }
   }
 }


### PR DESCRIPTION
### Pull Request Description

- @4e6 has troubles to obtain exceptions from _dual JVM mode_
- in his #14438
- this PR intends to make stacktraces of exceptions more useful

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
