### PR TITLE
Improve fs watcher in project-manager-shim tests to fix failures on Mac

### DIFF
--- a/app/project-manager-shim/src/fs.ts
+++ b/app/project-manager-shim/src/fs.ts
@@ -163,7 +163,7 @@ export function watch(options: WatchOptions): Watcher {
     .on('unlink', handleEvent('unlink'))
     .on('addDir', handleEvent('addDir'))
     .on('unlinkDir', handleEvent('unlinkDir'))
-    .on('ready', function() {
+    .on('ready', () => {
       isReady = true
     })
     .on('error', (error) => {

--- a/app/project-manager-shim/src/fs.ts
+++ b/app/project-manager-shim/src/fs.ts
@@ -3,6 +3,7 @@
  */
 
 import chokidar from 'chokidar'
+import type { Stats } from 'node:fs'
 
 export type WatcherState = 'pending' | 'executed'
 
@@ -30,6 +31,28 @@ export interface Watcher {
   getState: () => WatcherState
 }
 
+interface FileState {
+  exists: boolean
+  mtimeMs?: number
+  size?: number
+}
+
+function toState(exists: boolean, stats?: Stats): FileState {
+  return { exists, ...(stats ? { mtimeMs: stats.mtimeMs, size: stats.size } : {}) }
+}
+
+function isDuplicateState(previous: FileState | undefined, next: FileState): boolean {
+  if (!previous) {
+    return false
+  }
+  // If the file state hasn't materially changed, suppress duplicate events.
+  return (
+    previous.exists === next.exists &&
+    previous.mtimeMs === next.mtimeMs &&
+    previous.size === next.size
+  )
+}
+
 /**
  * Watches a directory for filesystem changes with debouncing and synchronous callback execution.
  * @param options - Configuration options for the watcher
@@ -37,13 +60,16 @@ export interface Watcher {
  */
 export function watch(options: WatchOptions): Watcher {
   const { directory, delay, timeout, callback } = options
+  // Track last observed metadata to dedupe duplicate OS events for the same state.
+  const lastKnownStates = new Map<string, FileState>()
+  let isReady = false
 
   let debounceTimer: NodeJS.Timeout | null = null
   let timeoutTimer: NodeJS.Timeout | null = null
   let isExecuting = false
   let pendingExecution = false
 
-  const executeCallback = async () => {
+  async function executeCallback() {
     // If already executing, mark that we need to execute again and return
     if (isExecuting) {
       pendingExecution = true
@@ -67,7 +93,7 @@ export function watch(options: WatchOptions): Watcher {
     }
   }
 
-  const scheduleCallback = () => {
+  function scheduleCallback() {
     // Cancel any previously scheduled debounce callback
     if (debounceTimer) {
       clearTimeout(debounceTimer)
@@ -97,26 +123,53 @@ export function watch(options: WatchOptions): Watcher {
     }, delay)
   }
 
-  // Create the watcher
   const watcher = chokidar.watch(directory, {
     persistent: true,
-    ignoreInitial: true, // Don't fire events for files that already exist
+    ignoreInitial: false,
     ignorePermissionErrors: true,
+    alwaysStat: true,
   })
+
+  // Derive a normalized file state per event to suppress duplicates and only
+  // trigger callbacks for meaningful state changes after the initial scan.
+  const handleEvent = (event: string) => {
+    return function handleEventEntry(filePath: string, stats?: Stats) {
+      const exists = event !== 'unlink' && event !== 'unlinkDir'
+      const nextState = toState(exists, stats)
+      const previousState = lastKnownStates.get(filePath)
+      const isDuplicate = isDuplicateState(previousState, nextState)
+
+      lastKnownStates.set(filePath, nextState)
+
+      // Ignore initial scan events while still seeding baseline state.
+      if (!isReady && (event === 'add' || event === 'addDir')) {
+        return
+      }
+
+      if (isDuplicate) {
+        return
+      }
+
+      scheduleCallback()
+    }
+  }
 
   // Listen to all change events
   watcher
-    .on('add', scheduleCallback)
-    .on('change', scheduleCallback)
-    .on('unlink', scheduleCallback)
-    .on('addDir', scheduleCallback)
-    .on('unlinkDir', scheduleCallback)
+    .on('add', handleEvent('add'))
+    .on('change', handleEvent('change'))
+    .on('unlink', handleEvent('unlink'))
+    .on('addDir', handleEvent('addDir'))
+    .on('unlinkDir', handleEvent('unlinkDir'))
+    .on('ready', function () {
+      isReady = true
+    })
     .on('error', (error) => {
       console.error('Watcher error:', error)
     })
 
   return {
-    close: async () => {
+    async close() {
       // Check if there's a scheduled callback that hasn't executed yet
       const isDirty = debounceTimer !== null || timeoutTimer !== null
 
@@ -135,7 +188,7 @@ export function watch(options: WatchOptions): Watcher {
 
       return isDirty
     },
-    getState: () => {
+    getState() {
       return debounceTimer !== null || timeoutTimer !== null ? 'pending' : 'executed'
     },
   }

--- a/app/project-manager-shim/src/fs.ts
+++ b/app/project-manager-shim/src/fs.ts
@@ -132,6 +132,8 @@ export function watch(options: WatchOptions): Watcher {
 
   // Derive a normalized file state per event to suppress duplicates and only
   // trigger callbacks for meaningful state changes after the initial scan.
+  //
+  // This is required on Mac to prevent duplicated events emitted for some file operations.
   const handleEvent = (event: string) => {
     return function handleEventEntry(filePath: string, stats?: Stats) {
       const exists = event !== 'unlink' && event !== 'unlinkDir'
@@ -161,7 +163,7 @@ export function watch(options: WatchOptions): Watcher {
     .on('unlink', handleEvent('unlink'))
     .on('addDir', handleEvent('addDir'))
     .on('unlinkDir', handleEvent('unlinkDir'))
-    .on('ready', function () {
+    .on('ready', function() {
       isReady = true
     })
     .on('error', (error) => {


### PR DESCRIPTION
### Pull Request Description

Locally on my Mac, I see consistent test failures in project-manager-shim. This change fixes them by deduplicating "change" events in the fs watcher.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
