### PR TITLE
Warning.to_text delegates to value

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Warning.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Warning.md
@@ -15,6 +15,8 @@
     - remove_warnings value:Standard.Base.Any.Any warning_type:Standard.Base.Any.Any= -> Standard.Base.Any.Any
     - set value:Standard.Base.Any.Any warnings:(Standard.Base.Data.Vector.Vector Standard.Base.Warning.Warning) -> Standard.Base.Any.Any
     - throw_on_warning value:Standard.Base.Any.Any warning_type:Standard.Base.Any.Any= -> Standard.Base.Any.Any
+    - to_display_text self -> Standard.Base.Any.Any
+    - to_text self -> Standard.Base.Any.Any
     - value self -> Standard.Base.Any.Any
     - with_suspended arg:Standard.Base.Any.Any function:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - attach_with_stacktrace value:Standard.Base.Any.Any warning:Standard.Base.Any.Any origin:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -296,6 +296,10 @@ type Warning
     origin : Vector Stack_Trace_Element
     origin self = @Builtin_Method "Warning.origin"
 
+    to_text self = self.value.to_text
+
+    to_display_text self = self.value.to_display_text
+
 
 ## ---
    private: true

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -16,11 +15,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
-
 
 public class TypeOfNodeValueTest {
   @ClassRule public static final ContextUtils ctxRule = ContextUtils.createDefault();
@@ -86,32 +80,5 @@ public class TypeOfNodeValueTest {
     var allTypes1 = (Type[]) arr1[1];
     assertEquals("Just one type", 1, allTypes1.length);
     assertEquals("Integer", types[0], allTypes1[0]);
-  }
-
-  @Test
-  public void customWarningType() {
-    var ret = ctxRule.evalModule("""
-        from Standard.Base import Warning
-        type My_Warn
-            Value reason
-        main =
-            with_warn = Warning.attach (My_Warn.Value "my_warn") 42
-            warn = Warning.get_all with_warn . first
-            [My_Warn, warn]
-        """);
-    assertThat(ret.hasArrayElements(), is(true));
-    var myWarnTypeExpected = ctxRule.unwrapValue(ret.getArrayElement(0));
-    var myWarn = ctxRule.unwrapValue(ret.getArrayElement(1));
-    var myWarnTypeActual = typeOf(myWarn);
-    assertTrue("is type", myWarnTypeExpected instanceof Type);
-    assertTrue("is type", myWarnTypeActual instanceof Type);
-    var expectedTypeName = ((Type) myWarnTypeExpected).getQualifiedName().toString();
-    assertThat(expectedTypeName, containsString("My_Warn"));
-    var actualTypeName = ((Type) myWarnTypeActual).getQualifiedName().toString();
-    assertThat(actualTypeName, is(expectedTypeName));
-  }
-
-  private Object typeOf(Object value) {
-    return ((Object[]) testTypesCall.call(value, false))[0];
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeValueTest.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -15,6 +16,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
 
 public class TypeOfNodeValueTest {
   @ClassRule public static final ContextUtils ctxRule = ContextUtils.createDefault();
@@ -80,5 +86,32 @@ public class TypeOfNodeValueTest {
     var allTypes1 = (Type[]) arr1[1];
     assertEquals("Just one type", 1, allTypes1.length);
     assertEquals("Integer", types[0], allTypes1[0]);
+  }
+
+  @Test
+  public void customWarningType() {
+    var ret = ctxRule.evalModule("""
+        from Standard.Base import Warning
+        type My_Warn
+            Value reason
+        main =
+            with_warn = Warning.attach (My_Warn.Value "my_warn") 42
+            warn = Warning.get_all with_warn . first
+            [My_Warn, warn]
+        """);
+    assertThat(ret.hasArrayElements(), is(true));
+    var myWarnTypeExpected = ctxRule.unwrapValue(ret.getArrayElement(0));
+    var myWarn = ctxRule.unwrapValue(ret.getArrayElement(1));
+    var myWarnTypeActual = typeOf(myWarn);
+    assertTrue("is type", myWarnTypeExpected instanceof Type);
+    assertTrue("is type", myWarnTypeActual instanceof Type);
+    var expectedTypeName = ((Type) myWarnTypeExpected).getQualifiedName().toString();
+    assertThat(expectedTypeName, containsString("My_Warn"));
+    var actualTypeName = ((Type) myWarnTypeActual).getQualifiedName().toString();
+    assertThat(actualTypeName, is(expectedTypeName));
+  }
+
+  private Object typeOf(Object value) {
+    return ((Object[]) testTypesCall.call(value, false))[0];
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -41,7 +41,7 @@ public final class Warning extends BuiltinObject {
     return value;
   }
 
-  @Builtin.Method(name = "origin", description = "Gets the payload of the warning.")
+  @Builtin.Method(name = "origin", description = "Gets the origin of the warning.")
   @SuppressWarnings("generic-enso-builtin-type")
   public Object getOrigin() {
     return origin;

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -13,6 +13,12 @@ from Standard.Test import all
 type My_Warning
     Value reason
 
+type My_Warning_Method_Override
+    Value reason
+
+    to_text self = "My_Warning_Method_Override (to_text): "+self.reason.to_text
+    to_display_text self = "My_Warning_Method_Override (to_display_text): "+self.reason.to_display_text
+
 type My_Type
     Value a b c
 My_Type.my_method self = self.a + self.b + self.c
@@ -135,6 +141,12 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         r = Long.sum x y
         r.should_equal 3
         Warning.get_all r . map .value . should_equal ['warn!', 'warn!!']
+
+    group_builder.specify "should respect to_text method override" <|
+        with_warn = Warning.attach (My_Warning_Method_Override.Value "custom warn") 42
+        warn = Warning.get_all with_warn . first
+        warn.to_text . should_equal "My_Warning_Method_Override (to_text): custom warn"
+        warn.to_display_text . should_equal "My_Warning_Method_Override (to_display_text): custom warn"
 
     group_builder.specify "should be passed correctly when combined with warnings added in branches" <|
         one = Warning.attach "first" "1"

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -120,6 +120,12 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         z = Warning.attach_multiple ["don't do this", "I'm serious"] x
         Warning.get_all z . map .value . should_equal ["I'm serious", "don't do this"]
 
+    group_builder.specify "warning type is always the builtin Warning type" <|
+        with_warn = Warning.attach (My_Warning.Value "warn") 42
+        warn = Warning.get_all with_warn . first
+        Meta.type_of warn . should_equal Warning
+        Meta.type_of warn.value . should_equal My_Warning
+
     group_builder.specify "should thread warnings through constructor calls" <|
         z = Warning.attach (My_Warning.Value "warn!!!") 3
         y = Warning.attach (My_Warning.Value "warn!!") 2

--- a/test/Base_Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Warnings_Spec.enso
@@ -274,7 +274,7 @@ add_specs suite_builder = suite_builder.group "Dataflow Warnings" group_builder-
         no_error = Warning.remove_warnings warned Unimplemented
         Warning.get_all no_error . map .value . should_equal [1, "Alpha", Nothing]
 
-    group_builder.specify "XX should allow raising warnings as errors, by type" <|
+    group_builder.specify "should allow raising warnings as errors, by type" <|
         warned = Warning.attach 1 <| Warning.attach "Alpha" <| Warning.attach Nothing <| Warning.attach (Unimplemented.Error "An Error Here") "foo"
 
         Warning.throw_on_warning warned . should_fail_with Integer


### PR DESCRIPTION
- Fixes #9741
- Replaces https://github.com/enso-org/enso/pull/14642

### Pull Request Description

`Warning.to_text` and `Warning.to_display_text` delegates to its internal `value`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
