### PR TITLE
Revert changes that enable multithreaded access to EnsoPolyglotJava

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -208,5 +208,45 @@ class RuntimeManagementTest extends InterpreterTest {
       def all                         = 0.to(4).map(mkAccessStr) ++ List(1, 3).map(mkFreeStr)
       totalOut should contain theSameElementsAs all
     }
+
+    "Allow for multithreaded polyglot class loading" ignore {
+      val langCtx = interpreterContext
+        .ctx()
+        .getBindings(LanguageInfo.ID)
+        .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
+        .asHostObject[EnsoContext]()
+
+      val code =
+        """import Standard.Base.Data.Numbers
+          |polyglot java import org.enso.example.TestClass
+          |main =
+          |    instance = TestClass.new (x -> x * 2)
+          |    instance.callFunctionAndIncrement 10
+          |""".stripMargin
+
+      val main = getMain(code)
+
+      def runMain()
+        : java.util.concurrent.CompletableFuture[org.graalvm.polyglot.Value] =
+        langCtx.getThreadManager.submit(() => {
+          main.execute()
+        })
+
+      def runTest(): Unit = {
+        val futures = 0.until(parallelism).map(_ => runMain())
+        val combinedFuture = java.util.concurrent.CompletableFuture
+          .allOf(futures: _*)
+          .thenApply(_ => {
+            futures
+              .map(_.get(10, java.util.concurrent.TimeUnit.SECONDS).asInt())
+          })
+        val result =
+          combinedFuture.get(20, java.util.concurrent.TimeUnit.SECONDS)
+        result should equal(List(21, 21, 21, 21, 21))
+        futures.forall(_.isDone) shouldBe true
+      }
+
+      runTest()
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -208,45 +208,5 @@ class RuntimeManagementTest extends InterpreterTest {
       def all                         = 0.to(4).map(mkAccessStr) ++ List(1, 3).map(mkFreeStr)
       totalOut should contain theSameElementsAs all
     }
-
-    "Allow for multithreaded polyglot class loading" in {
-      val langCtx = interpreterContext
-        .ctx()
-        .getBindings(LanguageInfo.ID)
-        .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
-        .asHostObject[EnsoContext]()
-
-      val code =
-        """import Standard.Base.Data.Numbers
-          |polyglot java import org.enso.example.TestClass
-          |main =
-          |    instance = TestClass.new (x -> x * 2)
-          |    instance.callFunctionAndIncrement 10
-          |""".stripMargin
-
-      val main = getMain(code)
-
-      def runMain()
-        : java.util.concurrent.CompletableFuture[org.graalvm.polyglot.Value] =
-        langCtx.getThreadManager.submit(() => {
-          main.execute()
-        })
-
-      def runTest(): Unit = {
-        val futures = 0.until(parallelism).map(_ => runMain())
-        val combinedFuture = java.util.concurrent.CompletableFuture
-          .allOf(futures: _*)
-          .thenApply(_ => {
-            futures
-              .map(_.get(10, java.util.concurrent.TimeUnit.SECONDS).asInt())
-          })
-        val result =
-          combinedFuture.get(20, java.util.concurrent.TimeUnit.SECONDS)
-        result should equal(List(21, 21, 21, 21, 21))
-        futures.forall(_.isDone) shouldBe true
-      }
-
-      runTest()
-    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
@@ -30,7 +30,7 @@ public abstract class AddToClassPathNode extends Node {
     var file = ctx.getTruffleFile(new File(expectStringNode.execute(path)));
     if (getRootNode() instanceof ClosureRootNode crn) {
       var pkg = crn.getModuleScope().getModule().getPackage();
-      ctx.addToClassPath(pkg, file, true);
+      ctx.addToClassPath(pkg, file);
     } else {
       throw ctx.raiseAssertionPanic(this, "Cannot find package", null);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -998,14 +998,16 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      if (index >= extraValues.length) {
-        extraValues = Arrays.copyOf(extraValues, index + 1);
+      synchronized (REFERENCE) {
+        if (index >= extraValues.length) {
+          extraValues = Arrays.copyOf(extraValues, index + 1);
+        }
+        extraValues[index] = init.apply(this);
+        assert extraValues[index] != null;
       }
-      extraValues[index] = init.apply(this);
-      assert extraValues[index] != null;
     }
     return extraValues[index];
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -100,9 +100,6 @@ public final class EnsoContext {
   private final LockManager lockManager;
   private final AtomicLong clock = new AtomicLong();
 
-  /**
-   * @GuardedBy("REFERENCE") - need some private lock
-   */
   @CompilationFinal(dimensions = 1)
   private Object[] extraValues = new Object[0];
 
@@ -1002,16 +999,14 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      synchronized (REFERENCE) {
-        if (index >= extraValues.length) {
-          extraValues = Arrays.copyOf(extraValues, index + 1);
-        }
-        extraValues[index] = init.apply(this);
-        assert extraValues[index] != null;
+      if (index >= extraValues.length) {
+        extraValues = Arrays.copyOf(extraValues, index + 1);
       }
+      extraValues[index] = init.apply(this);
+      assert extraValues[index] != null;
     }
     return extraValues[index];
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -513,17 +513,16 @@ public final class EnsoContext {
    *
    * @param who who requests the addition
    * @param file the file to register
-   * @param polyglotContextEntered true if a polyglot context has been entered, false otherwise
    */
   @TruffleBoundary
-  public void addToClassPath(Package<?> who, TruffleFile file, boolean polyglotContextEntered) {
+  public void addToClassPath(Package<?> who, TruffleFile file) {
     assert who != null;
     var path = new File(file.toUri()).getAbsoluteFile();
     if (!path.exists()) {
       throw new IllegalStateException("File not found " + path);
     }
     try {
-      EnsoPolyglotJava.addToClassPath(this, who, path, polyglotContextEntered);
+      EnsoPolyglotJava.addToClassPath(this, who, path);
     } catch (InteropException ex) {
       throw raiseAssertionPanic(null, "Cannot add " + file + " to classpath", ex);
     }
@@ -999,12 +998,10 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      if (index >= extraValues.length) {
-        extraValues = Arrays.copyOf(extraValues, index + 1);
-      }
+      extraValues = Arrays.copyOf(extraValues, Extra.COUNTER.get());
       extraValues[index] = init.apply(this);
       assert extraValues[index] != null;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -998,10 +998,12 @@ public final class EnsoContext {
     return singleStateProfile.profile(language.currentState());
   }
 
-  private Object extraValues(int index, Function<EnsoContext, ?> init) {
+  private synchronized Object extraValues(int index, Function<EnsoContext, ?> init) {
     if (index >= extraValues.length || extraValues[index] == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      extraValues = Arrays.copyOf(extraValues, Extra.COUNTER.get());
+      if (index >= extraValues.length) {
+        extraValues = Arrays.copyOf(extraValues, index + 1);
+      }
       extraValues[index] = init.apply(this);
       assert extraValues[index] != null;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -17,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Semaphore;
 import org.enso.common.HostEnsoUtils;
 import org.enso.common.RuntimeOptions;
 import org.enso.interpreter.runtime.util.TruffleFileSystem;
@@ -40,24 +42,12 @@ final class EnsoPolyglotJava {
 
   /**
    * the amount of elements from {@link #classPath} already added to {@link
-   * #polyglotJava}. @GuardedBy("classPath")
+   * #polyglotJava}. @GuardedBy("lock")
    */
   private int classPathSize;
 
-  /**
-   * Few state object encapsulating communication with the Java {@link TruffleObject} to communicate
-   * with.
-   *
-   * <ul>
-   *   <li>{@code this} - not yet initialized
-   *   <li>some {@code Throwable} - there was an error initializing
-   *   <li>non-{@code null} value - the actual object to talk with
-   *   <li>{@code null} - the runtime is (being) closed
-   * </ul>
-   *
-   * @GuardedBy("this")
-   */
   private Object polyglotJava = this;
+  private Semaphore lock = new Semaphore(1, true);
 
   /**
    * @param ctx associated conext
@@ -181,60 +171,42 @@ final class EnsoPolyglotJava {
 
   @CompilerDirectives.TruffleBoundary
   private Object findPolyglotJava() throws InteropException {
-    while (true) {
-      Object pj;
-      synchronized (this) {
-        pj = polyglotJava;
-      }
-      if (pj instanceof Throwable t) {
+    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+    try {
+      if (polyglotJava instanceof Throwable t) {
         throw ctx.raiseAssertionPanic(null, t.getMessage(), t);
       }
-      if (pj != this) {
-        adjustClassPath(pj);
-        return pj;
+      if (polyglotJava != this) {
+        return polyglotJava;
       }
-      pj = createPolyglotJava(ctx);
-      assert pj != null;
-      try {
-        InteropLibrary.getUncached().invokeMember(pj, "findLibraries", new LibraryResolver());
-      } catch (InteropException ex) {
-        logger.warn("Cannot register findLibraries", ex);
-      }
-      synchronized (this) {
-        if (polyglotJava == this) {
-          polyglotJava = pj;
+      if (polyglotJava == this) {
+        polyglotJava = createPolyglotJava(ctx);
+        try {
+          InteropLibrary.getUncached()
+              .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
+        } catch (InteropException ex) {
+          logger.warn("Cannot register findLibraries", ex);
         }
       }
+      adjustClassPath();
+      return polyglotJava;
+    } finally {
+      lock.release();
     }
   }
 
-  private void adjustClassPath(Object pj)
+  private void adjustClassPath()
       throws UnknownIdentifierException,
           ArityException,
           UnsupportedMessageException,
           UnsupportedTypeException {
+    var size = classPath.size();
     var iop = InteropLibrary.getUncached();
-    while (true) {
-      int indexToAdd;
-      synchronized (classPath) {
-        indexToAdd = classPathSize;
-        if (indexToAdd >= classPath.size()) {
-          break;
-        }
-      }
-
-      File elem = classPath.get(indexToAdd);
-      // multiple concurrent threads can add the same classpath element
-      // that's OK, classpath elements can be duplicated
-      iop.invokeMember(pj, "addPath", elem.toString());
-
-      synchronized (classPath) {
-        // only after an indexToAdd element is added
-        // we make sure the classPathSize is at least one higher than the index
-        if (classPathSize <= indexToAdd) {
-          classPathSize = indexToAdd + 1;
-        }
-      }
+    while (classPathSize < size) {
+      // we are the thread to add this classpath element
+      var elem = classPath.get(classPathSize);
+      iop.invokeMember(polyglotJava, "addPath", elem.toString());
+      classPathSize++;
     }
   }
 
@@ -251,23 +223,20 @@ final class EnsoPolyglotJava {
 
   @CompilerDirectives.TruffleBoundary
   private final void close() {
-    TruffleObject toClose = null;
-    synchronized (this) {
-      if (polyglotJava == null) {
-        return;
-      }
+    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+    try {
       if (polyglotJava instanceof TruffleObject closeJava) {
-        toClose = closeJava;
+        polyglotJava = null;
+        try {
+          InteropLibrary.getUncached().invokeMember(closeJava, "close");
+        } catch (InteropException ex) {
+          logger.warn("Cannot close " + closeJava, ex);
+        }
+      } else {
+        polyglotJava = null;
       }
-      polyglotJava = null;
-    }
-    // one thread is selected {@code toClose}
-    if (toClose != null) {
-      try {
-        InteropLibrary.getUncached().invokeMember(toClose, "close");
-      } catch (InteropException ex) {
-        logger.warn("Cannot close " + toClose, ex);
-      }
+    } finally {
+      lock.release();
     }
   }
 
@@ -279,7 +248,10 @@ final class EnsoPolyglotJava {
     } else {
       var envJava = System.getenv("ENSO_JAVA");
       if (envJava == null) {
-        return initOtherJvm(ctx);
+        logger.info("Initializing OtherJvm support!");
+        var src = Source.newBuilder("epb", "java:0#guest", "<Bindings>").build();
+        var target = ctx.parseInternal(src);
+        return target.call();
       }
       if ("espresso".equals(envJava)) {
         var src = Source.newBuilder("java", "<Bindings>", "getbindings.java").build();
@@ -294,7 +266,6 @@ final class EnsoPolyglotJava {
                 new Object[] {envJava, ex.getMessage()});
             logger.error("Copy missing libraries to components directory");
             logger.error("Continuing in regular Java mode");
-            return initOtherJvm(ctx);
           } else {
             var ise = new IllegalStateException(ex.getMessage());
             ise.setStackTrace(ex.getStackTrace());
@@ -306,13 +277,7 @@ final class EnsoPolyglotJava {
             "Specify ENSO_JAVA=espresso to use Espresso. Was: " + envJava);
       }
     }
-  }
-
-  private Object initOtherJvm(EnsoContext ctx1) {
-    logger.info("Initializing OtherJvm support!");
-    var src = Source.newBuilder("epb", "java:0#guest", "<Bindings>").build();
-    com.oracle.truffle.api.CallTarget target = ctx1.parseInternal(src);
-    return target.call();
+    return null;
   }
 
   private final TruffleObject loadClass(String fqn, Package<?> requestedBy)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -6,18 +6,17 @@ import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.source.Source;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Semaphore;
 import org.enso.common.HostEnsoUtils;
 import org.enso.common.RuntimeOptions;
@@ -38,27 +37,17 @@ final class EnsoPolyglotJava {
 
   private final EnsoContext ctx;
   private final boolean isHostClassLoading;
-  private final List<File> classPath;
-
-  /**
-   * the amount of elements from {@link #classPath} already added to {@link
-   * #polyglotJava}. @GuardedBy("lock")
-   */
-  private int classPathSize;
-
+  private final List<File> pendingPath = new ArrayList<>();
   private Object polyglotJava = this;
   private Semaphore lock = new Semaphore(1, true);
 
   /**
    * @param ctx associated conext
    * @param isHostClassLoading do host classloading
-   * @param growingPath classpath that may receive new entries incrementally - just make sure the
-   *     list is find with multi threaded access
    */
-  private EnsoPolyglotJava(EnsoContext ctx, boolean isHostClassLoading, List<File> growingPath) {
+  private EnsoPolyglotJava(EnsoContext ctx, boolean isHostClassLoading) {
     this.ctx = ctx;
     this.isHostClassLoading = isHostClassLoading;
-    this.classPath = growingPath;
   }
 
   /**
@@ -179,34 +168,20 @@ final class EnsoPolyglotJava {
       if (polyglotJava != this) {
         return polyglotJava;
       }
-      if (polyglotJava == this) {
-        polyglotJava = createPolyglotJava(ctx);
-        try {
-          InteropLibrary.getUncached()
-              .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
-        } catch (InteropException ex) {
-          logger.warn("Cannot register findLibraries", ex);
-        }
+      polyglotJava = createPolyglotJava(ctx);
+      while (!pendingPath.isEmpty()) {
+        InteropLibrary.getUncached()
+            .invokeMember(polyglotJava, "addPath", pendingPath.remove(0).toString());
       }
-      adjustClassPath();
+      try {
+        InteropLibrary.getUncached()
+            .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
+      } catch (InteropException ex) {
+        logger.log(Level.WARNING, "Cannot register findLibraries", ex);
+      }
       return polyglotJava;
     } finally {
       lock.release();
-    }
-  }
-
-  private void adjustClassPath()
-      throws UnknownIdentifierException,
-          ArityException,
-          UnsupportedMessageException,
-          UnsupportedTypeException {
-    var size = classPath.size();
-    var iop = InteropLibrary.getUncached();
-    while (classPathSize < size) {
-      // we are the thread to add this classpath element
-      var elem = classPath.get(classPathSize);
-      iop.invokeMember(polyglotJava, "addPath", elem.toString());
-      classPathSize++;
     }
   }
 
@@ -218,10 +193,40 @@ final class EnsoPolyglotJava {
       EnsoContext ctx, Object whoIsIgnored, File path, boolean polyglotContextEntered)
       throws InteropException {
     var data = KEY.get(ctx);
-    data.classPath.add(path);
+    data.hosted.addToClassPath(path, polyglotContextEntered);
+    data.guest.addToClassPath(path, polyglotContextEntered);
   }
 
+  /**
+   * Modifies the classpath to use to lookup {@code polyglot java} imports.
+   *
+   * @param file the file to register
+   * @param polyglotContextEntered if true, any lock acquisition will be interruptable for Truffle's
+   *     Safepoints purposes
+   */
   @CompilerDirectives.TruffleBoundary
+  private final void addToClassPath(File file, boolean polyglotContextEntered)
+      throws InteropException {
+    if (polyglotContextEntered) {
+      TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+    } else {
+      try {
+        lock.acquire();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    try {
+      if (polyglotJava == this) {
+        pendingPath.add(file);
+      } else {
+        InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
+      }
+    } finally {
+      lock.release();
+    }
+  }
+
   private final void close() {
     TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
     try {
@@ -320,15 +325,13 @@ final class EnsoPolyglotJava {
   }
 
   private static final class CtxData {
-    private final List<File> classPath;
     private final EnsoPolyglotJava hosted;
     private final EnsoPolyglotJava guest;
     private final Map<String, String> hostClassLoading;
 
     CtxData(EnsoContext ctx) {
-      this.classPath = new CopyOnWriteArrayList<>();
-      this.hosted = new EnsoPolyglotJava(ctx, true, classPath);
-      this.guest = new EnsoPolyglotJava(ctx, false, classPath);
+      this.hosted = new EnsoPolyglotJava(ctx, true);
+      this.guest = new EnsoPolyglotJava(ctx, false);
       this.hostClassLoading = new LinkedHashMap<>();
       for (var entry : ctx.getHostClassLoading().split(",")) {
         var libState = entry.split(":");

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -222,10 +222,7 @@ final class EnsoPolyglotJava {
     } else {
       var envJava = System.getenv("ENSO_JAVA");
       if (envJava == null) {
-        logger.info("Initializing OtherJvm support!");
-        var src = Source.newBuilder("epb", "java:0#guest", "<Bindings>").build();
-        var target = ctx.parseInternal(src);
-        return target.call();
+        return initOtherJvm(ctx);
       }
       if ("espresso".equals(envJava)) {
         var src = Source.newBuilder("java", "<Bindings>", "getbindings.java").build();
@@ -240,6 +237,7 @@ final class EnsoPolyglotJava {
                 new Object[] {envJava, ex.getMessage()});
             logger.error("Copy missing libraries to components directory");
             logger.error("Continuing in regular Java mode");
+            return initOtherJvm(ctx);
           } else {
             var ise = new IllegalStateException(ex.getMessage());
             ise.setStackTrace(ex.getStackTrace());
@@ -251,11 +249,16 @@ final class EnsoPolyglotJava {
             "Specify ENSO_JAVA=espresso to use Espresso. Was: " + envJava);
       }
     }
-    return null;
   }
 
-  private final TruffleObject loadClass(String fqn, Package<?> requestedBy)
-      throws InteropException {
+  private Object initOtherJvm(EnsoContext ctx1) {
+    logger.info("Initializing OtherJvm support!");
+    var src = Source.newBuilder("epb", "java:0#guest", "<Bindings>").build();
+    com.oracle.truffle.api.CallTarget target = ctx1.parseInternal(src);
+    return target.call();
+  }
+
+  private TruffleObject loadClass(String fqn, Package<?> requestedBy) throws InteropException {
     var raw = InteropLibrary.getUncached().readMember(findPolyglotJava(), fqn);
     logger.debug(
         "Classloading of {} as {} requested by {}",

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoPolyglotJava.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -17,7 +16,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
 import org.enso.common.HostEnsoUtils;
 import org.enso.common.RuntimeOptions;
 import org.enso.interpreter.runtime.util.TruffleFileSystem;
@@ -39,7 +37,6 @@ final class EnsoPolyglotJava {
   private final boolean isHostClassLoading;
   private final List<File> pendingPath = new ArrayList<>();
   private Object polyglotJava = this;
-  private Semaphore lock = new Semaphore(1, true);
 
   /**
    * @param ctx associated conext
@@ -159,89 +156,61 @@ final class EnsoPolyglotJava {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private Object findPolyglotJava() throws InteropException {
-    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
-    try {
-      if (polyglotJava instanceof Throwable t) {
-        throw ctx.raiseAssertionPanic(null, t.getMessage(), t);
-      }
-      if (polyglotJava != this) {
-        return polyglotJava;
-      }
-      polyglotJava = createPolyglotJava(ctx);
-      while (!pendingPath.isEmpty()) {
-        InteropLibrary.getUncached()
-            .invokeMember(polyglotJava, "addPath", pendingPath.remove(0).toString());
-      }
-      try {
-        InteropLibrary.getUncached()
-            .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
-      } catch (InteropException ex) {
-        logger.log(Level.WARNING, "Cannot register findLibraries", ex);
-      }
-      return polyglotJava;
-    } finally {
-      lock.release();
+  private synchronized Object findPolyglotJava() throws InteropException {
+    if (polyglotJava instanceof Throwable t) {
+      throw ctx.raiseAssertionPanic(null, t.getMessage(), t);
     }
+    if (polyglotJava != this) {
+      return polyglotJava;
+    }
+    polyglotJava = createPolyglotJava(ctx);
+    while (!pendingPath.isEmpty()) {
+      addToClassPath(pendingPath.remove(0));
+    }
+    try {
+      InteropLibrary.getUncached()
+          .invokeMember(polyglotJava, "findLibraries", new LibraryResolver());
+    } catch (InteropException ex) {
+      logger.warn("Cannot register findLibraries", ex);
+    }
+    return polyglotJava;
   }
 
   /**
    * This method ensure that hosted as well as guest classpath is the same. This is necessary until
    * real isolation between libraries is implemented.
    */
-  static void addToClassPath(
-      EnsoContext ctx, Object whoIsIgnored, File path, boolean polyglotContextEntered)
+  static void addToClassPath(EnsoContext ctx, Object whoIsIgnored, File path)
       throws InteropException {
     var data = KEY.get(ctx);
-    data.hosted.addToClassPath(path, polyglotContextEntered);
-    data.guest.addToClassPath(path, polyglotContextEntered);
+    data.hosted.addToClassPath(path);
+    data.guest.addToClassPath(path);
   }
 
   /**
    * Modifies the classpath to use to lookup {@code polyglot java} imports.
    *
    * @param file the file to register
-   * @param polyglotContextEntered if true, any lock acquisition will be interruptable for Truffle's
-   *     Safepoints purposes
    */
   @CompilerDirectives.TruffleBoundary
-  private final void addToClassPath(File file, boolean polyglotContextEntered)
-      throws InteropException {
-    if (polyglotContextEntered) {
-      TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
+  private final synchronized void addToClassPath(File file) throws InteropException {
+    if (polyglotJava == this) {
+      pendingPath.add(file);
     } else {
-      try {
-        lock.acquire();
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    try {
-      if (polyglotJava == this) {
-        pendingPath.add(file);
-      } else {
-        InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
-      }
-    } finally {
-      lock.release();
+      InteropLibrary.getUncached().invokeMember(polyglotJava, "addPath", file.toString());
     }
   }
 
-  private final void close() {
-    TruffleSafepoint.setBlockedThreadInterruptible(null, Semaphore::acquire, lock);
-    try {
-      if (polyglotJava instanceof TruffleObject closeJava) {
-        polyglotJava = null;
-        try {
-          InteropLibrary.getUncached().invokeMember(closeJava, "close");
-        } catch (InteropException ex) {
-          logger.warn("Cannot close " + closeJava, ex);
-        }
-      } else {
-        polyglotJava = null;
+  private final synchronized void close() {
+    if (polyglotJava instanceof TruffleObject closeJava) {
+      polyglotJava = null;
+      try {
+        InteropLibrary.getUncached().invokeMember(closeJava, "close");
+      } catch (InteropException ex) {
+        logger.warn("Cannot close " + closeJava, ex);
       }
-    } finally {
-      lock.release();
+    } else {
+      polyglotJava = null;
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
@@ -41,8 +41,7 @@ final class ThreadExecutors {
   }
 
   ScheduledExecutorService newScheduledThreadPool(int cnt, String name, boolean systemThread) {
-    var s = new ScheduledThreadPoolExecutor(cnt, new Factory(name, systemThread));
-    s.allowCoreThreadTimeOut(true);
+    var s = Executors.newScheduledThreadPool(cnt, new Factory(name, systemThread));
     pools.put(s, name);
     return s;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
@@ -41,7 +41,8 @@ final class ThreadExecutors {
   }
 
   ScheduledExecutorService newScheduledThreadPool(int cnt, String name, boolean systemThread) {
-    var s = Executors.newScheduledThreadPool(cnt, new Factory(name, systemThread));
+    var s = new ScheduledThreadPoolExecutor(cnt, new Factory(name, systemThread));
+    s.allowCoreThreadTimeOut(true);
     pools.put(s, name);
     return s;
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -214,7 +214,7 @@ private class DefaultPackageRepository(
     isLibrary: Boolean
   ): Unit = {
     val extensions = pkg.listPolyglotExtensions("java")
-    extensions.foreach(context.addToClassPath(pkg, _, false))
+    extensions.foreach(context.addToClassPath(pkg, _))
 
     val (regularModules, syntheticModulesMetadata) = pkg
       .listSources()


### PR DESCRIPTION
### Pull Request Description

This change reverts changes that enabled multithreaded access to EnsoPolyglotJava.
The belief is that the modifications are behind segfaults in Native Image on Windows.
Due to the lack of additional information we've decided it is safer to revert.
A similar revert [happened](https://github.com/enso-org/enso/pull/14516) for the release branch and segfaults stopped happening.

This change reverts:
- https://github.com/enso-org/enso/pull/14521
- https://github.com/enso-org/enso/pull/14238
- https://github.com/enso-org/enso/pull/13907 (partial)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
