### PR TITLE
Test DateTimeStorage off-heap data transfer

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -122,6 +122,7 @@ public interface Builder {
             case TextType type ->
                 StringBuilder.fromAddress(size, data, validity, type).seal(storage, type);
             case DateType _ -> DateBuilder.fromAddress(size, data, validity).seal(storage);
+            case DateTimeType _ -> DateTimeBuilder.fromAddress(size, data, validity).seal(storage);
             case TimeOfDayType type ->
                 TimeOfDayBuilder.fromAddress(size, data, validity).seal(storage, type);
             default -> storage;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -1,5 +1,8 @@
 package org.enso.table.data.column.builder;
 
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -20,6 +23,29 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
     super(DateTimeType.INSTANCE, new ZonedDateTime[size]);
     this.allowDateToDateTimeConversion = allowDateToDateTimeConversion;
     this.wasLocalDate = allowDateToDateTimeConversion ? new BitSet(size) : null;
+  }
+
+  static DateTimeBuilder fromAddress(int size, long data, long validity) {
+    var validityBuffer =
+        MemorySegment.ofAddress(validity).reinterpret((size + 7) / 8).asByteBuffer();
+    var bits = BitSet.valueOf(validityBuffer);
+    var buf =
+        MemorySegment.ofAddress(data)
+            .reinterpret(Long.BYTES * size)
+            .asByteBuffer()
+            .order(ByteOrder.LITTLE_ENDIAN);
+
+    var b = new DateTimeBuilder(size, false);
+    for (var i = 0; i < size; i++) {
+      var stamp = buf.getLong();
+      if (bits.get(i)) {
+        var instant = Instant.ofEpochSecond(stamp);
+        b.append(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()));
+      } else {
+        b.appendNulls(1);
+      }
+    }
+    return b;
   }
 
   /**
@@ -73,7 +99,11 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
 
   @Override
   protected ColumnStorage<ZonedDateTime> doSeal() {
-    return new TypedStorage<>(DateTimeType.INSTANCE, data);
+    return seal(null);
+  }
+
+  final ColumnStorage<ZonedDateTime> seal(ColumnStorage<?> other) {
+    return new TypedStorage<>(DateTimeType.INSTANCE, data, other);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -39,7 +39,7 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
     for (var i = 0; i < size; i++) {
       var stamp = buf.getLong();
       if (bits.get(i)) {
-        var instant = Instant.ofEpochSecond(stamp);
+        var instant = Instant.ofEpochMilli(stamp);
         b.append(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()));
       } else {
         b.appendNulls(1);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -12,6 +12,7 @@ import org.enso.table.data.column.storage.ColumnStorage;
 import org.enso.table.data.column.storage.TypedStorage;
 import org.enso.table.data.column.storage.type.DateTimeType;
 import org.enso.table.data.column.storage.type.DateType;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.error.ValueTypeMismatchException;
 
 /** A builder for ZonedDateTime columns. */
@@ -35,12 +36,17 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
             .asByteBuffer()
             .order(ByteOrder.LITTLE_ENDIAN);
 
+    var zonesBuf =
+        StringBuilder.fromAddress(size, data + buf.limit(), validity, TextType.VARIABLE_LENGTH);
+    var zonesStorage = zonesBuf.seal(null, TextType.VARIABLE_LENGTH);
+
     var b = new DateTimeBuilder(size, false);
     for (var i = 0; i < size; i++) {
       var stamp = buf.getLong();
       if (bits.get(i)) {
         var instant = Instant.ofEpochMilli(stamp);
-        b.append(ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()));
+        var zone = ZoneId.of(zonesStorage.getItemBoxed(i));
+        b.append(ZonedDateTime.ofInstant(instant, zone));
       } else {
         b.appendNulls(1);
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -44,8 +44,8 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
     for (var i = 0; i < size; i++) {
       var stamp = buf.getLong();
       if (bits.get(i)) {
-        var nanos = stamp % 1_000_000;
-        var epochSeconds = stamp / 1_000_000;
+        var nanos = stamp % 1_000_000_000;
+        var epochSeconds = stamp / 1_000_000_000;
         var instant = Instant.ofEpochSecond(epochSeconds, nanos);
         var zone = ZoneId.of(zonesStorage.getItemBoxed(i));
         b.append(ZonedDateTime.ofInstant(instant, zone));

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DateTimeBuilder.java
@@ -44,7 +44,9 @@ final class DateTimeBuilder extends TypedBuilder<ZonedDateTime> {
     for (var i = 0; i < size; i++) {
       var stamp = buf.getLong();
       if (bits.get(i)) {
-        var instant = Instant.ofEpochMilli(stamp);
+        var nanos = stamp % 1_000_000;
+        var epochSeconds = stamp / 1_000_000;
+        var instant = Instant.ofEpochSecond(epochSeconds, nanos);
         var zone = ZoneId.of(zonesStorage.getItemBoxed(i));
         b.append(ZonedDateTime.ofInstant(instant, zone));
       } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
@@ -2,7 +2,6 @@ package org.enso.table.data.column.storage;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.IntBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
@@ -33,8 +32,19 @@ final class OffHeapStorages {
   }
 
   static ByteBuffer toDateTimeBuffer(Object[] data, BitSet validity) {
-    int fullSize = data.length * Long.BYTES;
-    ByteBuffer buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
+    var zones = new String[data.length];
+    for (var i = 0; i < data.length; i++) {
+      if (data[i] instanceof ZonedDateTime s) {
+        zones[i] = s.getZone().getId();
+      }
+    }
+
+    int zonesSize = textSize(zones);
+    int indexSize = data.length * Integer.BYTES + Integer.BYTES;
+    int dataSize = data.length * Long.BYTES;
+    int fullSize = dataSize + indexSize + zonesSize;
+
+    var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
     int at = 0;
     for (Object value : data) {
       if (value instanceof ZonedDateTime s) {
@@ -46,28 +56,33 @@ final class OffHeapStorages {
       }
       at++;
     }
-    assert buf.limit() == buf.position();
+    assert buf.position() == dataSize;
+
+    var zonesBuf = buf.slice(dataSize, buf.limit() - dataSize).order(ByteOrder.LITTLE_ENDIAN);
+    var zonesFilled = textFillBuffer(zonesBuf, zones, indexSize, validity);
+
     buf.flip();
+    buf.limit(fullSize);
     assert buf.position() == 0;
-    assert buf.limit() == fullSize;
     return buf;
   }
 
   static ByteBuffer toArrowTextBuffer(Object[] data, BitSet validity) {
-    int textSize = 0;
-    for (Object value : data) {
-      if (value instanceof String s) {
-        textSize += s.getBytes(StandardCharsets.UTF_8).length;
-      } else {
-        if (value != null) {
-          return null;
-        }
-      }
+    int textSize = textSize(data);
+    if (textSize == -1) {
+      return null;
     }
     int indexSize = data.length * Integer.BYTES + Integer.BYTES;
     int fullSize = indexSize + textSize;
     ByteBuffer buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
-    IntBuffer index = buf.asIntBuffer().slice(0, data.length + 1);
+    var filledBuf = textFillBuffer(buf, data, indexSize, validity);
+    assert filledBuf.limit() == fullSize;
+    return filledBuf;
+  }
+
+  private static ByteBuffer textFillBuffer(
+      ByteBuffer buf, Object[] data, int indexSize, BitSet validity) {
+    var index = buf.asIntBuffer().slice(0, data.length + 1);
     buf.position(indexSize);
     for (Object value : data) {
       int at = index.position();
@@ -85,7 +100,21 @@ final class OffHeapStorages {
     assert index.position() == index.limit();
     buf.flip();
     assert buf.position() == 0;
-    assert buf.limit() == fullSize;
     return buf;
+  }
+
+  private static int textSize(Object[] data) {
+    int textSize = 0;
+    for (Object value : data) {
+      if (value instanceof String s) {
+        textSize += s.getBytes(StandardCharsets.UTF_8).length;
+      } else {
+        if (value != null) {
+          textSize = -1;
+          break;
+        }
+      }
+    }
+    return textSize;
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
@@ -6,8 +6,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.BitSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class OffHeapStorages {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapStorages.class);
+
   private OffHeapStorages() {}
 
   static ByteBuffer toArrowTimeOfDayBuffer(Object[] data, BitSet validity) {
@@ -48,7 +52,16 @@ final class OffHeapStorages {
     int at = 0;
     for (Object value : data) {
       if (value instanceof ZonedDateTime s) {
-        buf.putLong(s.toInstant().toEpochMilli());
+        var instant = s.toInstant();
+        var epochSeconds = instant.toEpochMilli() / 1000;
+        try {
+          var epochNanoRaw = Math.multiplyExact(epochSeconds, 1_000_000);
+          var epochNano = Math.addExact(epochNanoRaw, instant.getNano());
+          buf.putLong(epochNano);
+        } catch (ArithmeticException ex) {
+          LOGGER.warn("Cannot convert " + s + " to nanoseconds since the epoch");
+          return null;
+        }
         validity.set(at, true);
       } else {
         buf.putLong(0);
@@ -60,6 +73,7 @@ final class OffHeapStorages {
 
     var zonesBuf = buf.slice(dataSize, buf.limit() - dataSize).order(ByteOrder.LITTLE_ENDIAN);
     var zonesFilled = textFillBuffer(zonesBuf, zones, indexSize, validity);
+    assert zonesBuf == zonesFilled;
 
     buf.flip();
     buf.limit(fullSize);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
@@ -1,0 +1,91 @@
+package org.enso.table.data.column.storage;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.BitSet;
+
+final class OffHeapStorages {
+  private OffHeapStorages() {}
+
+  static ByteBuffer toArrowTimeOfDayBuffer(Object[] data, BitSet validity) {
+    int fullSize = data.length * Long.BYTES;
+    ByteBuffer buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
+    int at = 0;
+    for (Object value : data) {
+      if (value instanceof LocalTime s) {
+        buf.putLong(s.toNanoOfDay());
+        validity.set(at, true);
+      } else {
+        buf.putLong(0);
+        validity.set(at, false);
+      }
+      at++;
+    }
+    assert buf.limit() == buf.position();
+    buf.flip();
+    assert buf.position() == 0;
+    assert buf.limit() == fullSize;
+    return buf;
+  }
+
+  static ByteBuffer toDateTimeBuffer(Object[] data, BitSet validity) {
+    int fullSize = data.length * Long.BYTES;
+    ByteBuffer buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
+    int at = 0;
+    for (Object value : data) {
+      if (value instanceof ZonedDateTime s) {
+        buf.putLong(s.toInstant().toEpochMilli());
+        validity.set(at, true);
+      } else {
+        buf.putLong(0);
+        validity.set(at, false);
+      }
+      at++;
+    }
+    assert buf.limit() == buf.position();
+    buf.flip();
+    assert buf.position() == 0;
+    assert buf.limit() == fullSize;
+    return buf;
+  }
+
+  static ByteBuffer toArrowTextBuffer(Object[] data, BitSet validity) {
+    int textSize = 0;
+    for (Object value : data) {
+      if (value instanceof String s) {
+        textSize += s.getBytes(StandardCharsets.UTF_8).length;
+      } else {
+        if (value != null) {
+          return null;
+        }
+      }
+    }
+    int indexSize = data.length * Integer.BYTES + Integer.BYTES;
+    int fullSize = indexSize + textSize;
+    ByteBuffer buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
+    IntBuffer index = buf.asIntBuffer().slice(0, data.length + 1);
+    buf.position(indexSize);
+    for (Object value : data) {
+      int at = index.position();
+      index.put(buf.position() - indexSize);
+      if (value instanceof String s) {
+        validity.set(at, true);
+      } else {
+        validity.set(at, false);
+        continue;
+      }
+      buf.put(s.getBytes(StandardCharsets.UTF_8));
+    }
+    assert buf.limit() == buf.position();
+    index.put(buf.position() - indexSize);
+    assert index.position() == index.limit();
+    buf.flip();
+    assert buf.position() == 0;
+    assert buf.limit() == fullSize;
+    return buf;
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/OffHeapStorages.java
@@ -55,7 +55,7 @@ final class OffHeapStorages {
         var instant = s.toInstant();
         var epochSeconds = instant.toEpochMilli() / 1000;
         try {
-          var epochNanoRaw = Math.multiplyExact(epochSeconds, 1_000_000);
+          var epochNanoRaw = Math.multiplyExact(epochSeconds, 1_000_000_000);
           var epochNano = Math.addExact(epochNanoRaw, instant.getNano());
           buf.putLong(epochNano);
         } catch (ArithmeticException ex) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -42,7 +42,9 @@ public class TypedStorage<T> extends Storage<T> {
     if (offheapBuffer == null && getType() instanceof DateTimeType) {
       var validity = new BitSet();
       offheapBuffer = OffHeapStorages.toDateTimeBuffer(data, validity);
-      validitySet = new ImmutableBitSet(validity, data.length);
+      if (offheapBuffer != null) {
+        validitySet = new ImmutableBitSet(validity, data.length);
+      }
     }
     if (offheapBuffer == null && getType() instanceof TimeOfDayType) {
       var validity = new BitSet();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -4,12 +4,12 @@ import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
-import org.enso.table.data.column.storage.type.DateType;
+import org.enso.table.data.column.storage.type.DateTimeType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
@@ -74,17 +74,17 @@ public class TypedStorage<T> extends Storage<T> {
       offheapBuffer = buf;
       validitySet = new ImmutableBitSet(validity, data.length);
     }
-    if (offheapBuffer == null && getType() instanceof DateType) {
-      var fullSize = data.length * Integer.BYTES;
+    if (offheapBuffer == null && getType() instanceof DateTimeType) {
+      var fullSize = data.length * Long.BYTES;
       var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
       var validity = new BitSet();
       var at = 0;
       for (var value : data) {
-        if (value instanceof LocalDate s) {
-          buf.putInt(Math.toIntExact(s.toEpochDay()));
+        if (value instanceof ZonedDateTime s) {
+          buf.putLong(s.toEpochSecond());
           validity.set(at, true);
         } else {
-          buf.putInt(0);
+          buf.putLong(0);
           validity.set(at, false);
         }
         at++;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -81,7 +81,7 @@ public class TypedStorage<T> extends Storage<T> {
       var at = 0;
       for (var value : data) {
         if (value instanceof ZonedDateTime s) {
-          buf.putLong(s.toEpochSecond());
+          buf.putLong(s.toInstant().toEpochMilli());
           validity.set(at, true);
         } else {
           buf.putLong(0);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/TypedStorage.java
@@ -2,10 +2,6 @@ package org.enso.table.data.column.storage;
 
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
@@ -37,85 +33,20 @@ public class TypedStorage<T> extends Storage<T> {
   @Override
   public long addressOfData() {
     if (offheapBuffer == null && getType() instanceof TextType) {
-      var textSize = 0;
-      for (var value : data) {
-        if (value instanceof String s) {
-          textSize += s.getBytes(StandardCharsets.UTF_8).length;
-        } else {
-          if (value != null) {
-            return 0L;
-          }
-        }
-      }
-
-      var indexSize = data.length * Integer.BYTES + Integer.BYTES;
-      var fullSize = indexSize + textSize;
-      var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
-      var index = buf.asIntBuffer().slice(0, data.length + 1);
-      buf.position(indexSize);
       var validity = new BitSet();
-      for (var value : data) {
-        var at = index.position();
-        index.put(buf.position() - indexSize);
-        if (value instanceof String s) {
-          validity.set(at, true);
-        } else {
-          validity.set(at, false);
-          continue;
-        }
-        buf.put(s.getBytes(StandardCharsets.UTF_8));
+      offheapBuffer = OffHeapStorages.toArrowTextBuffer(data, validity);
+      if (offheapBuffer != null) {
+        validitySet = new ImmutableBitSet(validity, data.length);
       }
-      assert buf.limit() == buf.position();
-      index.put(buf.position() - indexSize);
-      assert index.position() == index.limit();
-      buf.flip();
-      assert buf.position() == 0;
-      assert buf.limit() == fullSize;
-      offheapBuffer = buf;
-      validitySet = new ImmutableBitSet(validity, data.length);
     }
     if (offheapBuffer == null && getType() instanceof DateTimeType) {
-      var fullSize = data.length * Long.BYTES;
-      var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
       var validity = new BitSet();
-      var at = 0;
-      for (var value : data) {
-        if (value instanceof ZonedDateTime s) {
-          buf.putLong(s.toInstant().toEpochMilli());
-          validity.set(at, true);
-        } else {
-          buf.putLong(0);
-          validity.set(at, false);
-        }
-        at++;
-      }
-      assert buf.limit() == buf.position();
-      buf.flip();
-      assert buf.position() == 0;
-      assert buf.limit() == fullSize;
-      offheapBuffer = buf;
+      offheapBuffer = OffHeapStorages.toDateTimeBuffer(data, validity);
       validitySet = new ImmutableBitSet(validity, data.length);
     }
     if (offheapBuffer == null && getType() instanceof TimeOfDayType) {
-      var fullSize = data.length * Long.BYTES;
-      var buf = ByteBuffer.allocateDirect(fullSize).order(ByteOrder.LITTLE_ENDIAN);
       var validity = new BitSet();
-      var at = 0;
-      for (var value : data) {
-        if (value instanceof LocalTime s) {
-          buf.putLong(s.toNanoOfDay());
-          validity.set(at, true);
-        } else {
-          buf.putLong(0);
-          validity.set(at, false);
-        }
-        at++;
-      }
-      assert buf.limit() == buf.position();
-      buf.flip();
-      assert buf.position() == 0;
-      assert buf.limit() == fullSize;
-      offheapBuffer = buf;
+      offheapBuffer = OffHeapStorages.toArrowTimeOfDayBuffer(data, validity);
       validitySet = new ImmutableBitSet(validity, data.length);
     }
     if (offheapBuffer != null) {

--- a/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
+++ b/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.enso.table.data.column.builder.Builder;
@@ -45,6 +46,28 @@ public class DateTimeStorageTest {
     var one = ZonedDateTime.of(LocalDateTime.of(2005, 1, 10, 12, 30), ZoneOffset.of("+01:00"));
     var two = ZonedDateTime.of(LocalDateTime.of(2006, 8, 23, 6, 13), ZoneOffset.of("+02:00"));
     b.append(one).appendNulls(1).append(two);
+    var storage = b.seal();
+    var localStorage = Builder.makeLocal(storage);
+    assertNotSame("local storage is a copy of storage", storage, localStorage);
+    assertEquals("They have the same size", storage.getSize(), localStorage.getSize());
+    assertEquals("They have the same type", storage.getType(), localStorage.getType());
+    for (var i = 0L; i < storage.getSize(); i++) {
+      var elem = storage.getItemBoxed(i);
+      var localElem = localStorage.getItemBoxed(i);
+      assertEquals("At " + i, elem, localElem);
+    }
+  }
+
+  @Test
+  public void makeZonedFromDateTimeStorageWithNanos() {
+    var b = Builder.getForDateTime(3);
+    var one =
+        ZonedDateTime.of(
+            LocalDateTime.of(2005, 1, 10, 12, 30, 43, 691234), ZoneOffset.of("+01:00"));
+    var two =
+        ZonedDateTime.of(LocalDateTime.of(2006, 8, 23, 6, 13, 1, 901430), ZoneOffset.of("+02:00"));
+    var three = ZonedDateTime.of(LocalDateTime.of(2020, 10, 23, 23, 2, 3, 4005), ZoneId.of("UTC"));
+    b.append(one).appendNulls(1).append(two).append(three);
     var storage = b.seal();
     var localStorage = Builder.makeLocal(storage);
     assertNotSame("local storage is a copy of storage", storage, localStorage);

--- a/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
+++ b/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
@@ -1,0 +1,39 @@
+package org.enso.base.polyglot.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.time.LocalDateTime;
+import org.enso.table.data.column.builder.Builder;
+import org.enso.test.utils.ContextUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class DateTimeStorageTest {
+  @ClassRule
+  public static final ContextUtils ctx = ContextUtils.newBuilder("enso").assertGC(false).build();
+
+  @BeforeClass
+  public static void importAll() {
+    ctx.eval("enso", "from Standard.Base import all");
+  }
+
+  @Test
+  public void makeLocalFromDateTimeStorage() {
+    var b = Builder.getForDateTime(3);
+    var one = LocalDateTime.of(2005, 1, 10, 12, 30);
+    var two = LocalDateTime.of(2006, 8, 23, 6, 13);
+    b.append(one).appendNulls(1).append(two);
+    var storage = b.seal();
+    var localStorage = Builder.makeLocal(storage);
+    assertNotSame("local storage is a copy of storage", storage, localStorage);
+    assertEquals("They have the same size", storage.getSize(), localStorage.getSize());
+    assertEquals("They have the same type", storage.getType(), localStorage.getType());
+    for (var i = 0L; i < storage.getSize(); i++) {
+      var elem = storage.getItemBoxed(i);
+      var localElem = localStorage.getItemBoxed(i);
+      assertEquals("At " + i, elem, localElem);
+    }
+  }
+}

--- a/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
+++ b/std-bits/tests/src/test/java/org/enso/base/polyglot/tests/DateTimeStorageTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.enso.table.data.column.builder.Builder;
 import org.enso.test.utils.ContextUtils;
 import org.junit.BeforeClass;
@@ -24,6 +26,24 @@ public class DateTimeStorageTest {
     var b = Builder.getForDateTime(3);
     var one = LocalDateTime.of(2005, 1, 10, 12, 30);
     var two = LocalDateTime.of(2006, 8, 23, 6, 13);
+    b.append(one).appendNulls(1).append(two);
+    var storage = b.seal();
+    var localStorage = Builder.makeLocal(storage);
+    assertNotSame("local storage is a copy of storage", storage, localStorage);
+    assertEquals("They have the same size", storage.getSize(), localStorage.getSize());
+    assertEquals("They have the same type", storage.getType(), localStorage.getType());
+    for (var i = 0L; i < storage.getSize(); i++) {
+      var elem = storage.getItemBoxed(i);
+      var localElem = localStorage.getItemBoxed(i);
+      assertEquals("At " + i, elem, localElem);
+    }
+  }
+
+  @Test
+  public void makeZonedFromDateTimeStorage() {
+    var b = Builder.getForDateTime(3);
+    var one = ZonedDateTime.of(LocalDateTime.of(2005, 1, 10, 12, 30), ZoneOffset.of("+01:00"));
+    var two = ZonedDateTime.of(LocalDateTime.of(2006, 8, 23, 6, 13), ZoneOffset.of("+02:00"));
     b.append(one).appendNulls(1).append(two);
     var storage = b.seal();
     var localStorage = Builder.makeLocal(storage);


### PR DESCRIPTION
### Pull Request Description

- creating off-heap representation for `DateTimeBuilder`
   - in fact there are **two storages**!
   - one is storing instants since the Epoch
   - the other one (appended to the instances) contains _string zone ID names_
   - both storages share the same validity map
- continuation of #14652
- and of #14646

### Important Notes

- the off-heap representation of the storage is currently created/converted to  on the fly
- some future step is to do something like #14652 
- e.g. to store the data off heap to begin with

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
