### PR TITLE
Make test ignore order

### DIFF
--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -368,7 +368,7 @@ add_filter_specs suite_builder setup =
             t.filter "A" (Filter_Condition.Is_In (Column_Ref.Name "B")) . should_fail_with Illegal_Argument
 
             # If the user really wants this, they pass it as a raw column:
-            t.filter "A" (Filter_Condition.Is_In (t.at "B")) . at "A" . to_vector . should_equal [2, 3]
+            t.filter "A" (Filter_Condition.Is_In (t.at "B")) . at "A" . to_vector . should_equal_ignoring_order [2, 3]
 
         group_builder.specify "by a boolean mask" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["b", [True, False, Nothing, True, True]]]


### PR DESCRIPTION
### Pull Request Description

Make this test ignore order for databases that have non-deterministic order like Snowflake.

This won't be the only test that will have this issue, but going through all of them will be a big effort and I want to think more about a general approach. At least now I can fix this one test from failing again.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
