### PR TITLE
Make `DependencyInfo.find` the central point to access dataflow analysis information

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/DependencyInfo.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/DependencyInfo.java
@@ -28,6 +28,18 @@ public record DependencyInfo(DependencyMapping dependents, DependencyMapping dep
   }
 
   /**
+   * Finds dependency info in the provided IR element.
+   *
+   * @return non-{@code null} dependency info
+   * @throws exception or error when the info isn't attached to the element
+   */
+  public static DependencyInfo find(IR ir) {
+    var raw = ir.passData().get(DataflowAnalysis$.MODULE$).get();
+    assert raw != null;
+    return (DependencyInfo) raw;
+  }
+
+  /**
    * Combines two dependency information containers.
    *
    * @param that the other container to combine with `this`

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
@@ -4,7 +4,6 @@ import org.enso.scala.wrapper.ScalaConversions
 import org.enso.compiler.pass.analyse.FrameAnalysisMeta
 import org.enso.compiler.pass.analyse.FramePointer
 import org.enso.compiler.pass.analyse.FrameVariableNames
-import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.compiler.pass.analyse.alias.graph.{
   GraphBuilder,
@@ -39,13 +38,13 @@ class LocalScope(
   final val parentScope: Option[LocalScope],
   final val aliasingGraph: () => AliasGraph,
   final private val scopeProvider: () => AliasGraph.Scope,
-  final private val dataflowInfoProvider: () => DataflowAnalysis.Metadata,
+  final private val dataflowInfoProvider: () => DependencyInfo,
   final private val symbolsProvider: () => FrameAnalysisMeta     = null,
   final val flattenToParent: Boolean                             = false,
   private val parentFrameSlotIdxs: () => Map[AliasGraph.Id, Int] = () => Map()
 ) {
-  lazy val scope: AliasGraph.Scope                 = scopeProvider()
-  lazy val dataflowInfo: DataflowAnalysis.Metadata = dataflowInfoProvider()
+  lazy val scope: AliasGraph.Scope      = scopeProvider()
+  lazy val dataflowInfo: DependencyInfo = dataflowInfoProvider()
 
   /** Computes allSymbols needed by this scope. Either the value is obtained
     * from symbolsProvider or (as a fallback) a computation from aliasingGraph

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/refactoring/IRUtils.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/refactoring/IRUtils.scala
@@ -6,7 +6,6 @@ import org.enso.compiler.core.ir.{Expression, Name}
 import org.enso.compiler.core.ir.expression.Application
 import org.enso.compiler.core.ir.module.scope.definition.Method
 import org.enso.compiler.data.BindingsMap
-import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.compiler.pass.resolve.MethodCalls
 import org.enso.pkg.QualifiedName
@@ -158,7 +157,7 @@ trait IRUtils {
       }.flatten
     }
 
-  /** Find usages of a static dependency in the [[DataflowAnalysis]] metadata.
+  /** Find usages of a static dependency in the `DataflowAnalysis` metadata.
     *
     * @param ir the syntax tree
     * @param literal the name to look for
@@ -168,15 +167,9 @@ trait IRUtils {
     ir: IR,
     literal: Name.Literal
   ): Option[Set[IR]] = {
+    val metadata = DependencyInfo.find(ir)
+    val key      = DependencyInfo.Type.asStatic(literal)
     for {
-      metadata <- ir.getMetadata(
-        DataflowAnalysis,
-        classOf[DataflowAnalysis.Metadata]
-      )
-      key = new DependencyInfo.Type.Static(
-        literal.getId(),
-        literal.getExternalId
-      )
       dependents <- metadata.dependents.get(key)
     } yield {
       dependents
@@ -189,7 +182,7 @@ trait IRUtils {
     }
   }
 
-  /** Find usages of a dynamic dependency in the [[DataflowAnalysis]] metadata.
+  /** Find usages of a dynamic dependency in the `DataflowAnalysis` metadata.
     *
     * @param ir the syntax tree
     * @param name the name to look for
@@ -199,12 +192,9 @@ trait IRUtils {
     ir: IR,
     name: String
   ): Option[Set[IR]] = {
+    val metadata = DependencyInfo.find(ir)
+    val key      = new DependencyInfo.Type.Dynamic(name, None)
     for {
-      metadata <- ir.getMetadata(
-        DataflowAnalysis,
-        classOf[DataflowAnalysis.Metadata]
-      )
-      key = new DependencyInfo.Type.Dynamic(name, None)
       dependents <- metadata.dependents.get(key)
     } yield {
       dependents

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
@@ -1,7 +1,6 @@
 package org.enso.interpreter.instrument
 
 import com.oracle.truffle.api.source.Source
-import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{
   CallArgument,
   Expression,
@@ -12,7 +11,6 @@ import org.enso.compiler.core.ir.{
 import org.enso.compiler.core.ir.module.scope.definition
 import org.enso.compiler.core._
 import org.enso.compiler.core.ir.expression.Application
-import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.compiler.suggestions.SimpleUpdate
 import org.enso.interpreter.instrument.execution.model.PendingEdit
@@ -126,7 +124,7 @@ final class ChangesetBuilder[A: TextEditor: IndexedSource](
   }
 
   /** Traverses the IR and returns a list of all IR nodes affected by the edit
-    * using the [[DataflowAnalysis]] information.
+    * using the `DataflowAnalysis` information.
     *
     * @param edits the text edits
     * @throws CompilerError if the IR is missing DataflowAnalysis metadata
@@ -134,11 +132,7 @@ final class ChangesetBuilder[A: TextEditor: IndexedSource](
     */
   @throws[CompilerError]
   def compute(edits: Seq[TextEdit]): Set[UUID @ExternalID] = {
-    val metadata = ir
-      .unsafeGetMetadata[DataflowAnalysis.Metadata](
-        DataflowAnalysis,
-        "Empty dataflow analysis metadata during changeset calculation."
-      )
+    val metadata = DependencyInfo.find(ir)
 
     @scala.annotation.tailrec
     def go(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -1,7 +1,5 @@
 package org.enso.interpreter.instrument.command
 
-import org.enso.compiler.core.Implicits.AsMetadata
-import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.compiler.refactoring.IRUtils
 import org.enso.interpreter.instrument.command.RecomputeContextCmd.InvalidateExpressions
@@ -167,8 +165,10 @@ object RecomputeContextCmd {
     ctx.executionService.getContext
       .findModuleByExpressionId(expressionId)
       .ifPresent { module =>
-        module.getIr
-          .getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata])
+        Option(
+          DependencyInfo
+            .find(module.getIr)
+        )
           .foreach { metadata =>
             val dependents =
               IRUtils

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -13,7 +13,6 @@ import org.enso.compiler.core.ir.{expression, Location}
 import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.pass.analyse.{
   CachePreferenceAnalysis,
-  DataflowAnalysis,
   GatherDiagnostics
 }
 import org.enso.compiler.pass.analyse.DependencyInfo
@@ -355,11 +354,7 @@ class EnsureCompiledJob(
     * @return the set of node ids affected by a resolution error in the module
     */
   private def findNodesWithResolutionErrors(ir: IR): Set[UUID @ExternalID] = {
-    val metadata = ir
-      .unsafeGetMetadata[DataflowAnalysis.Metadata](
-        DataflowAnalysis,
-        "Empty dataflow analysis metadata during the interactive compilation."
-      )
+    val metadata = DependencyInfo.find(ir)
 
     val builder = Set.newBuilder[UUID @ExternalID]
     IR.preorder(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -6,10 +6,7 @@ import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Name
 import org.enso.compiler.core.ir.module.scope.{definition, Definition}
 import org.enso.compiler.refactoring.IRUtils
-import org.enso.compiler.pass.analyse.{
-  CachePreferenceAnalysis,
-  DataflowAnalysis
-}
+import org.enso.compiler.pass.analyse.CachePreferenceAnalysis
 import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.interpreter.instrument.execution.{Executable, RuntimeContext}
 import org.enso.interpreter.instrument.job.UpsertVisualizationJob.{
@@ -741,8 +738,10 @@ object UpsertVisualizationJob {
     ctx.executionService.getContext
       .findModuleByExpressionId(expressionId)
       .ifPresent { module =>
-        module.getIr
-          .getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata])
+        Option(
+          DependencyInfo
+            .find(module.getIr)
+        )
           .foreach { metadata =>
             val externalId = expressionId
             IRUtils

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -307,7 +307,7 @@ class DataflowAnalysisTest extends CompilerTest {
         |""".stripMargin.preprocessModule.analyse
 
     val depInfo =
-      ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+      DependencyInfo.find(ir)
 
     // The method and body
     val method =
@@ -1013,7 +1013,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val fn = ir.asInstanceOf[Function.Lambda]
       val fnArgX =
@@ -1078,7 +1078,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val app   = ir.asInstanceOf[Application.Prefix]
       val appFn = app.function.asInstanceOf[errors.Resolution]
@@ -1173,7 +1173,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val lam = ir.asInstanceOf[Function.Lambda]
       val argX =
@@ -1199,7 +1199,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val block     = ir.asInstanceOf[Expression.Block]
       val xBind     = block.expressions.head.asInstanceOf[Expression.Binding]
@@ -1238,7 +1238,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val binding     = ir.asInstanceOf[Expression.Binding]
       val bindingName = binding.name.asInstanceOf[Name.Literal]
@@ -1275,7 +1275,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val binding     = ir.asInstanceOf[Expression.Binding]
       val bindingName = binding.name.asInstanceOf[Name.Literal]
@@ -1348,7 +1348,7 @@ class DataflowAnalysisTest extends CompilerTest {
           .asInstanceOf[Function.Lambda]
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val vector = ir.body
         .asInstanceOf[Application.Sequence]
@@ -1411,7 +1411,7 @@ class DataflowAnalysisTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
 
       val depInfo =
-        ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+        DependencyInfo.find(ir)
 
       val caseBlock = ir.asInstanceOf[Expression.Block]
       val caseBinding =
@@ -1579,7 +1579,7 @@ class DataflowAnalysisTest extends CompilerTest {
       .asInstanceOf[Function.Lambda]
 
     val metadata =
-      ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+      DependencyInfo.find(ir)
     val blockBody = ir.body.asInstanceOf[Expression.Block]
 
     val aBind = blockBody.expressions.head
@@ -1624,7 +1624,7 @@ class DataflowAnalysisTest extends CompilerTest {
         |""".stripMargin.preprocessModule.analyse
 
     val depInfo =
-      ir.getMetadata(DataflowAnalysis, classOf[DataflowAnalysis.Metadata]).get
+      DependencyInfo.find(ir)
 
     // The method and its body
     val conversion = ir.bindings.head.asInstanceOf[definition.Method.Conversion]

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -6,6 +6,7 @@ import org.enso.compiler.common.{
   BuildScopeFromModuleAlgorithm,
   NameResolutionAlgorithm
 }
+import org.enso.compiler.pass.analyse.DependencyInfo
 import org.enso.compiler.pass.analyse.FramePointer
 import org.enso.compiler.pass.analyse.FrameVariableNames
 import org.enso.compiler.context.{CompilerContext, LocalScope}
@@ -47,7 +48,6 @@ import org.enso.compiler.pass.analyse.alias.graph.Graph.{Scope => AliasScope}
 import org.enso.compiler.pass.analyse.{
   AliasAnalysis,
   BindingAnalysis,
-  DataflowAnalysis,
   FramePointerAnalysis,
   TailCall
 }
@@ -251,11 +251,6 @@ private[runtime] class IrToTruffle(
         s"conversion `${conversion.typeName.map(_.name + ".").getOrElse("")}${conversion.methodName.name}`."
       val scopeInfo = rootScopeInfo(where, conversion)
 
-      def dataflowInfo() =
-        conversion.unsafeGetMetadata[DataflowAnalysis.Metadata](
-          DataflowAnalysis,
-          "Method definition missing dataflow information."
-        )
       def frameInfo() =
         conversion.unsafeGetMetadata[FramePointerAnalysis.Metadata](
           FramePointerAnalysis,
@@ -276,7 +271,7 @@ private[runtime] class IrToTruffle(
           toType.getName ++ Constants.SCOPE_SEPARATOR ++ conversion.methodName.name,
           () => scopeInfo().graph,
           () => scopeInfo().graph.rootScope,
-          dataflowInfo,
+          conversion,
           conversion.methodName.name,
           frameInfo
         )
@@ -333,10 +328,6 @@ private[runtime] class IrToTruffle(
       def where() =
         s"`method ${method.typeName.map(_.name + ".").getOrElse("")}${method.methodName.name}`."
       val scopeInfo = rootScopeInfo(where, method)
-      def dataflowInfo() = method.unsafeGetMetadata[DataflowAnalysis.Metadata](
-        DataflowAnalysis,
-        "Method definition missing dataflow information."
-      )
       def frameInfo() = method.unsafeGetMetadata[FramePointerAnalysis.Metadata](
         FramePointerAnalysis,
         "Method definition missing frame information."
@@ -365,7 +356,7 @@ private[runtime] class IrToTruffle(
           fullMethodDefName,
           () => scopeInfo().graph,
           () => scopeInfo().graph.rootScope,
-          dataflowInfo,
+          method,
           fullMethodDefName,
           frameInfo
         )
@@ -445,11 +436,6 @@ private[runtime] class IrToTruffle(
       () => {
         val scopeInfo = rootScopeInfo(() => "atom definition", atomDefn)
 
-        def dataflowInfo() =
-          atomDefn.unsafeGetMetadata[DataflowAnalysis.Metadata](
-            DataflowAnalysis,
-            "No dataflow information associated with an atom."
-          )
         def frameInfo() =
           atomDefn.unsafeGetMetadata[FramePointerAnalysis.Metadata](
             FramePointerAnalysis,
@@ -459,7 +445,7 @@ private[runtime] class IrToTruffle(
           None,
           () => scopeInfo().graph,
           () => scopeInfo().graph.rootScope,
-          dataflowInfo,
+          () => DependencyInfo.find(atomDefn),
           frameInfo
         )
 
@@ -520,7 +506,7 @@ private[runtime] class IrToTruffle(
             scopeName,
             () => scopeInfo().graph,
             () => scopeInfo().graph.rootScope,
-            dataflowInfo,
+            atomDefn,
             atomDefn.name.name,
             frameInfo
           )
@@ -685,14 +671,6 @@ private[runtime] class IrToTruffle(
                   .mkString(Constants.SCOPE_SEPARATOR)}"
               val scopeInfo = rootScopeInfo(where, annotation)
 
-              def dataflowInfo() =
-                annotation.unsafeGetMetadata[DataflowAnalysis.Metadata](
-                  DataflowAnalysis,
-                  "Missing dataflow information for annotation " +
-                  s"${annotation.name} of method " +
-                  scopeElements.init
-                    .mkString(Constants.SCOPE_SEPARATOR)
-                )
               def frameInfo() =
                 annotation.unsafeGetMetadata[FramePointerAnalysis.Metadata](
                   FramePointerAnalysis,
@@ -702,7 +680,7 @@ private[runtime] class IrToTruffle(
                 scopeName,
                 () => scopeInfo().graph,
                 () => scopeInfo().graph.rootScope,
-                dataflowInfo,
+                annotation,
                 methodDef.methodName.name,
                 frameInfo
               )
@@ -1202,12 +1180,18 @@ private[runtime] class IrToTruffle(
       scopeName: String,
       graph: () => AliasGraph,
       scope: () => AliasScope,
-      dataflowInfo: () => DataflowAnalysis.Metadata,
+      dataflowIR: IR,
       initialName: String,
       frameInfo: () => FramePointerAnalysis.Metadata = null
     ) = {
       this(
-        new LocalScope(None, graph, scope, dataflowInfo, frameInfo),
+        new LocalScope(
+          None,
+          graph,
+          scope,
+          () => DependencyInfo.find(dataflowIR),
+          frameInfo
+        ),
         scopeName,
         initialName
       )


### PR DESCRIPTION
### Pull Request Description

- another puzzle for #12919 
- refactoring that uses `DependencyInfo.find(ir)` to extract dataflow analysis information from the `IR`
   - right now it just delegates to `MetadataStorage`
- future changes like #14697 are likely to change the implementation of `DependencyInfo.find` to do something completely different

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
