### PR TITLE
Using native engine build in packaged app

### DIFF
--- a/app/electron-client/BUILD.bazel
+++ b/app/electron-client/BUILD.bazel
@@ -114,14 +114,23 @@ alias(
     }),
 )
 
+genrule(
+    name = "enso_bundle_marker",
+    outs = [".enso.bundle"],
+    cmd = "touch $@",
+    cmd_bat = "type NUL > $@",
+    visibility = ["//visibility:public"],
+)
+
 electron_builder_bin.electron_builder(
     name = "dist",
     srcs = npm_link_targets() + [
         "package.json",
         ":electron-builder-config.cjs",
+        ":enso_bundle_marker",
         ":selected_bundle",
         ":selected_gui_dist",
-        "//:sbt_build_engine_distribution",
+        "//:sbt_build_native_engine_distribution",
         "//:sbt_build_small_jdk",
     ],
     args = [

--- a/app/electron-client/electron-builder-config.cjs
+++ b/app/electron-client/electron-builder-config.cjs
@@ -70,7 +70,7 @@ async function patchAppImage(context) {
 
       # TODO[ib]: quick hack to resolve java binary at runtime on Linux
       SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
-      export PATH="$PATH:$SCRIPT_DIR/resources/enso/runtime/graalvm-ce-java24.0.1-24.2.0/bin"
+      export PATH="$PATH:$SCRIPT_DIR/resources/enso/runtime/graalvm-ce-java25.0.1-25.0.1/bin"
       exec "$SCRIPT_DIR/${executableName}.bin" --no-sandbox "$@"
       `
   try {

--- a/app/electron-client/electron-builder-config.cjs
+++ b/app/electron-client/electron-builder-config.cjs
@@ -16,7 +16,7 @@ function engineDistributionSource(version, platform = process.platform, arch = p
   const normalizedPlatform = platformMap[platform] ?? platform
   const normalizedArch = archMapByPlatform[platform]?.[arch] ?? arch
 
-  return `../../built-distribution/enso-engine-${version}-${normalizedPlatform}-${normalizedArch}/enso-${version}/`
+  return `../../built-distribution-native/enso-engine-${version}-${normalizedPlatform}-${normalizedArch}/enso-${version}/`
 }
 
 function engineDistributionTarget(version) {
@@ -149,7 +149,12 @@ module.exports = {
     },
     {
       from: '../../built-small-jdk/',
-      to: 'enso/runtime/graalvm-ce-java24.0.1-24.2.0',
+      // TODO: avoid hardcoding the version here
+      to: 'enso/runtime/graalvm-ce-java25.0.1-25.0.1',
+    },
+    {
+      from: '.enso.bundle',
+      to: 'enso/.enso.bundle',
     },
   ],
   fileAssociations: [

--- a/bazel_scripts/distribution_config.bzl
+++ b/bazel_scripts/distribution_config.bzl
@@ -56,8 +56,8 @@ def get_enso_env(native_image = False):
     unix_env = dict(_COMMON_ENV, PATH = path_unix)
 
     if native_image:
-        windows_env["ENSO_LAUNCHER"] = "native,fast,-ls"
-        unix_env["ENSO_LAUNCHER"] = "native,fast,-ls"
+        windows_env["ENSO_LAUNCHER"] = "native"
+        unix_env["ENSO_LAUNCHER"] = "native"
 
     return select({
         "@platforms//os:windows": windows_env,


### PR DESCRIPTION
### Pull Request Description

Small fixes for the native build to use it in the packaged Electron app. 

- `.enso.bundle` is created at `resources/enso` to make runtime resolution working in the engine (This empty file is usually created by Rust build script)
- Native engine build is used in the app
- Updated JVM directory name to match graalvm version (TBD: avoid hardcoding the version, will be done with other version-related changes)
- Fix `ENSO_LAUNCHER` flags to enable LS

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
