### PR TITLE
cargo-watch is no longer needed for successful build

### DIFF
--- a/build-config.yaml
+++ b/build-config.yaml
@@ -5,4 +5,4 @@ wasm-size-limit: 16.20 MiB
 required-versions:
   # NB. The Rust version is pinned in rust-toolchain.toml.
   # NB. The Node version is pinned in .node-version.
-  cargo-watch: ^8.1.1
+  # We no longer need cargo-watch: ^8.1.1


### PR DESCRIPTION
### Pull Request Description

- when running `./run ide build` on my Mac 
- I get a failure that `cargo-watch` isn't installed
- however when I skip the check with `--skip-version-check` everything works
   - why would we need to _watch a directory for changes_ in Rust?
   - it might have been needed when we were developing UI in Rust
   - but it seems obsolete these days
- let's remove `cargo-watch` requirement!

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] All CI checks pass
