### PR TITLE
Ignore order when using `is_in` across tables.

### DIFF
--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -187,9 +187,9 @@ add_derived_columns_specs suite_builder setup =
             t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In []) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "FF"]
 
             # Passing a column does not work row-by-row, but looks at whole column contents.
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t2.at "B")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "TT"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t2.at "B")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal_ignoring_order ["FF", "TT"]
             t3 = table_builder [["x", ["e", "e", "a"]]]
-            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t3.at "x")) "TT" "FF")) "Z" . sort "C" . at "Z" . to_vector . should_equal ["TT", "FF"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t3.at "x")) "TT" "FF")) "Z" . sort "C" . at "Z" . to_vector . should_equal_ignoring_order ["TT", "FF"]
 
             # Thus, passing a Column_Ref into Is_In is not allowed as it would be confusing.
             t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (Column_Ref.Name "B")) "TT" "FF")) . should_fail_with Illegal_Argument


### PR DESCRIPTION
### Pull Request Description

Fix for ordering in snowflake tests.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
