### PR TITLE
Make sure interop `null` behaves as Enso `Nothing` in case of statements

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ObjectEqualityBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ObjectEqualityBranchNode.java
@@ -4,11 +4,11 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 import org.enso.interpreter.node.ExpressionNode;
-import org.enso.interpreter.node.expression.builtin.meta.IsSameObjectNode;
+import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 
 public class ObjectEqualityBranchNode extends BranchNode {
   private @Child ExpressionNode expected;
-  private @Child IsSameObjectNode isSameObject = IsSameObjectNode.build();
+  private @Child EqualsNode matchesNode = EqualsNode.create();
   private final CountingConditionProfile profile = CountingConditionProfile.create();
 
   private ObjectEqualityBranchNode(
@@ -25,7 +25,7 @@ public class ObjectEqualityBranchNode extends BranchNode {
   @Override
   public void execute(VirtualFrame frame, Object state, Object target) {
     var exp = expected.executeGeneric(frame);
-    if (profile.profile(isSameObject.execute(target, exp))) {
+    if (profile.profile(matchesNode.execute(frame, target, exp).isTrue())) {
       accept(frame, state, new Object[0]);
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.nodes.Node;
+import java.util.NoSuchElementException;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.node.callable.InteropConversionCallNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
@@ -159,7 +160,13 @@ public final class EqualsNode extends Node {
     private static boolean findConversionImpl(
         EnsoContext ctx, Type selfType, Type thatType, Object self, Object that) {
       var selfScope = selfType.getDefinitionScope();
-      var comparableType = ctx.getBuiltins().comparableType();
+      Type comparableType;
+      try {
+        comparableType = ctx.getBuiltins().comparableType();
+      } catch (NoSuchElementException e) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        return false;
+      }
 
       var fromSelfType =
           UnresolvedConversion.build(selfScope).resolveFor(ctx, comparableType, selfType);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime.builtin;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.IOException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.enso.common.MethodNames;
@@ -448,7 +449,9 @@ public final class Builtins {
       context.getPackageRepository().ensurePackageIsLoaded(stdBase);
       moduleOpt = context.getTopScope().getModule(moduleName);
     }
-    assert moduleOpt.isPresent() : moduleName;
+    if (!moduleOpt.isPresent()) {
+      throw new NoSuchElementException(moduleName);
+    }
     var module = moduleOpt.get();
     var scope = module.compileScope(context);
     return scope;

--- a/std-bits/base/src/main/java/org/enso/base/polyglot/EnsoMeta.java
+++ b/std-bits/base/src/main/java/org/enso/base/polyglot/EnsoMeta.java
@@ -90,8 +90,6 @@ public final class EnsoMeta {
       throw new IllegalStateException("Constructor " + constructorName + " is not instantiable.");
     }
 
-    args = java.util.Arrays.stream(args).map(arg -> arg == null ? getNothing() : arg).toArray();
-
     return constructor.newInstance(args);
   }
 

--- a/std-bits/tests/src/test/java/org/enso/table/data/column/operation/cast/CastOperationTest.java
+++ b/std-bits/tests/src/test/java/org/enso/table/data/column/operation/cast/CastOperationTest.java
@@ -1,0 +1,49 @@
+package org.enso.table.data.column.operation.unary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.enso.table.data.column.operation.cast.ConversionFailure;
+import org.enso.table.data.column.operation.cast.ConversionFailureType;
+import org.enso.table.data.column.storage.type.TextType;
+import org.enso.test.utils.ContextUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class CastOperationTest {
+  @ClassRule public static final ContextUtils ctx = ContextUtils.createDefault();
+
+  @BeforeClass
+  public static void importTable() {
+    var m =
+        ctx.evalModule(
+            """
+            from Standard.Table import all
+
+            main = Table
+            """);
+    assertFalse("Make sure Standard.Table is imported", m.isNull());
+  }
+
+  @Test
+  public void caseOfOnConversionFailureRelatedColumn() {
+    var cf =
+        new ConversionFailure(
+            ConversionFailureType.FAILED_CONVERSION, TextType.VARIABLE_LENGTH, null, 0, null);
+    var v = cf.asEnsoValue();
+
+    var matchNull =
+        ctx.evalModule(
+            """
+            from Standard.Base import all
+            match_null v = case v.related_column of
+              Nothing -> "Good"
+              _ -> "Bad"
+            """,
+            "match_null");
+
+    var res = matchNull.execute(v);
+    assertEquals("Good", res.asString());
+  }
+}

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/Constants.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/Constants.java
@@ -8,4 +8,5 @@ public class Constants {
   public static final long SMALL_LONG = 2L;
   public static final long BIG_LONG = 20_000L;
   public static final String STRING = "string";
+  public static final Object NULL = null;
 }

--- a/test/Base_Tests/src/Semantic/Case_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Case_Spec.enso
@@ -348,6 +348,16 @@ add_specs suite_builder = suite_builder.group "Pattern Matches" group_builder->
             _ : Function -> Nothing
             _ -> Test.fail "Expected to match on Function type."
 
+    group_builder.specify "null matches Nothing" <|
+        case Java_Constants.NULL of
+            Nothing -> Nothing
+            _ -> Test.fail "Expected to match on Nothing type."
+
+    group_builder.specify "null matches Nothing type" <|
+        case Java_Constants.NULL of
+            _ : Nothing -> Nothing
+            _ -> Test.fail "Expected to match on Nothing type."
+
     group_builder.specify "should pattern match on Java constant fields" <|
         case 1 of
             Java_Constants.SMALL_INT -> Nothing
@@ -364,6 +374,9 @@ add_specs suite_builder = suite_builder.group "Pattern Matches" group_builder->
         case 2020 of
             Java_Constants.BIG_INT -> Nothing
             _ -> Test.fail "Expected to match on BIG_INT."
+        case Nothing of
+            Java_Constants.NULL -> Nothing
+            _ -> Test.fail "Expected to match on NULL."
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

- `case null of` should match on `Nothing`
- discovered in https://github.com/enso-org/enso/pull/14711#discussion_r2763184862

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] Engine benchmarks are fine [1st run](https://github.com/enso-org/enso/actions/runs/21707414524)
- [x] Library benchmarks are fine [1st run](https://github.com/enso-org/enso/actions/runs/21707420450)
