### PR TITLE
Investigate issue with dragging files

### DIFF
--- a/app/project-manager-shim/src/projectManagement.ts
+++ b/app/project-manager-shim/src/projectManagement.ts
@@ -369,8 +369,9 @@ function getCommonPrefix(a: string, b: string): string {
  * for the name.
  */
 function generateDirectoryName(name: string, directory = getProjectsDirectory()): string {
-  // Use only the last path component.
-  let baseName = pathModule.parse(name).name
+  // Use only the last path component (but with the extension as we don't want to remove that).
+  const parsedPath = pathModule.parse(name)
+  let baseName = parsedPath.name + (parsedPath.ext ? parsedPath.ext : '')
   logger.log(`Generating directory name for '${name}' in '${directory}'. Base name: '${baseName}'.`)
 
   // If the name already consists a suffix, reuse it.
@@ -383,9 +384,7 @@ function generateDirectoryName(name: string, directory = getProjectsDirectory())
     logger.log(`Base name after stripping suffix: '${baseName}'.`)
   }
 
-  const result = pathModule.join(directory, baseName)
-  logger.log(`Target '${result}'.`)
-  return result
+  return pathModule.join(directory, baseName)
 }
 
 /**

--- a/app/project-manager-shim/src/projectManagement.ts
+++ b/app/project-manager-shim/src/projectManagement.ts
@@ -370,8 +370,7 @@ function getCommonPrefix(a: string, b: string): string {
  */
 function generateDirectoryName(name: string, directory = getProjectsDirectory()): string {
   // Use only the last path component (but with the extension as we don't want to remove that).
-  const parsedPath = pathModule.parse(name)
-  let baseName = parsedPath.name + (parsedPath.ext ? parsedPath.ext : '')
+  let baseName = pathModule.basename(name)
   logger.log(`Generating directory name for '${name}' in '${directory}'. Base name: '${baseName}'.`)
 
   // If the name already consists a suffix, reuse it.

--- a/app/project-manager-shim/src/projectManagement.ts
+++ b/app/project-manager-shim/src/projectManagement.ts
@@ -172,6 +172,7 @@ export async function uploadBundle(
   logger.log(`Uploading project from bundle${name != null ? ` as '${name}'` : ''}.`)
 
   const targetPath = generateDirectoryName(name ?? 'Project', directory)
+  logger.log(`Importing project as '${targetPath}'.`)
   fs.mkdirSync(targetPath, { recursive: true })
   await new Promise<void>((resolve) => {
     bundle.pipe(tar.extract({ cwd: targetPath })).on('finish', resolve)
@@ -370,6 +371,7 @@ function getCommonPrefix(a: string, b: string): string {
 function generateDirectoryName(name: string, directory = getProjectsDirectory()): string {
   // Use only the last path component.
   let baseName = pathModule.parse(name).name
+  logger.log(`Generating directory name for '${name}' in '${directory}'. Base name: '${baseName}'.`)
 
   // If the name already consists a suffix, reuse it.
   const matches = baseName.match(/^(.*)_(\d+)$/)
@@ -378,9 +380,12 @@ function generateDirectoryName(name: string, directory = getProjectsDirectory())
 
   if (typeof matchedName !== 'undefined' && typeof matchedSuffix !== 'undefined') {
     baseName = matchedName
+    logger.log(`Base name after stripping suffix: '${baseName}'.`)
   }
 
-  return pathModule.join(directory, baseName)
+  const result = pathModule.join(directory, baseName)
+  logger.log(`Target '${result}'.`)
+  return result
 }
 
 /**


### PR DESCRIPTION
### Pull Request Description

We are stripping "extensions" off the project name when computing where to import a project.
This was leading to 2 projects extracting to same place.
Small change adding the extension on if present.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
