### PR TITLE
Separating `RuntimeCache` API from implementation

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -1,11 +1,6 @@
 package org.enso.interpreter.instrument;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import java.lang.ref.Reference;
-import java.lang.ref.SoftReference;
-import java.lang.ref.WeakReference;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -13,199 +8,56 @@ import java.util.function.Supplier;
 import org.enso.common.CachePreferences;
 import org.enso.interpreter.service.ExecutionService;
 
-/** A storage for computed values. */
-public final class RuntimeCache implements java.util.function.Function<String, Object> {
-  private final Map<UUID, Reference<Object>> cache = new HashMap<>();
-  private final Map<UUID, Reference<Object>> expressions = new HashMap<>();
-  private final Map<UUID, TypeInfo> types = new HashMap<>();
-  private final Map<UUID, ExecutionService.FunctionCallInfo> calls = new HashMap<>();
-  private CachePreferences preferences = CachePreferences.empty();
-  private Consumer<UUID> observer;
+/**
+ * Immutable API facade for Enso runtime cache. It contains only "query" methods. See {@link
+ * Mutable} for operations that can modify the cache.
+ *
+ * <p>Implementation is provided by original implementation in {@link RuntimeCacheImpl}.
+ */
+public abstract class RuntimeCache {
+  /** the only implementation is in the same package */
+  RuntimeCache() {}
+
+  /** Factory method to create new runtime cache. */
+  public static RuntimeCache create() {
+    return new RuntimeCacheImpl();
+  }
 
   /**
-   * Add value to the cache if it is possible.
+   * Reads a cached value from the cache for given key. Cached values are hold be "soft reference" -
+   * e.g. they are kept until the system runs out of memory or until the value for given key is
+   * replacd
    *
-   * @param key the key of an entry.
-   * @param value the added value.
-   * @return {@code true} if the value was added to the cache.
+   * @param key the UUID of the key
+   * @return cached value associated with the {@code key} or {@code null}
    */
-  @CompilerDirectives.TruffleBoundary
-  public boolean offer(UUID key, Object value) {
-    expressions.put(key, new WeakReference<>(value));
-    if (preferences.contains(key)) {
-      var ref = new SoftReference<>(value);
-      cache.put(key, ref);
-      return true;
-    }
-    return false;
-  }
-
-  /** Get the value from the cache. */
-  public Object get(UUID key) {
-    var ref = cache.get(key);
-    var res = ref != null ? ref.get() : null;
-    return res;
-  }
-
-  /** Get the value from the cache. */
-  public Object getAnyValue(UUID key) {
-    var ref = expressions.get(key);
-    var res = ref != null ? ref.get() : null;
-    return res;
-  }
-
-  // Accessed in InstrumentorBuiltin
-  @Override
-  public Object apply(String uuid) {
-    Object res;
-    try {
-      var key = UUID.fromString(uuid);
-      var ref = expressions.get(key);
-      res = ref != null ? ref.get() : null;
-      var callback = observer;
-      if (callback != null) {
-        callback.accept(key);
-      }
-    } catch (IllegalArgumentException ex) {
-      res = null;
-    }
-    return res;
-  }
-
-  /** Remove the value from the cache. */
-  public Object remove(UUID key) {
-    var ref = cache.remove(key);
-    return ref == null ? null : ref.get();
-  }
+  public abstract Object get(UUID key);
 
   /**
-   * @return all cache keys.
-   */
-  public Set<UUID> getKeys() {
-    return cache.keySet();
-  }
-
-  /** Clear the cached values. */
-  public void clear() {
-    cache.clear();
-  }
-
-  /**
-   * Clear cached values of the provided kind.
+   * Reads a value that was notified to the cache (which may or may not be subject to caching). A
+   * non-cached values include values of expression which are only available while the computation
+   * is running.
    *
-   * @param kind the kind of cached value to clear
-   * @return the set of cleared keys
+   * @param key the UUID of the key
+   * @return available value or {@code null}
    */
-  public Set<UUID> clear(CachePreferences.Kind kind) {
-    var keys = preferences.get(kind);
-    for (var key : keys) {
-      cache.remove(key);
-    }
-    return keys;
-  }
+  public abstract Object getAnyValue(UUID key);
 
   /**
-   * Cache the type of expression.
+   * Obtains info about a type of expression identify by UUID.
    *
-   * @return the previously cached type.
+   * @param key the UUID of the key
+   * @return the cached type of the expression or {@code null}
    */
-  @CompilerDirectives.TruffleBoundary
-  public TypeInfo putType(UUID key, TypeInfo typeInfo) {
-    return types.put(key, typeInfo);
-  }
+  public abstract TypeInfo getType(UUID key);
 
   /**
-   * @return the cached type of the expression
-   */
-  @CompilerDirectives.TruffleBoundary
-  public TypeInfo getType(UUID key) {
-    return types.get(key);
-  }
-
-  /**
-   * Cache the function call
+   * Obtains function call for given UUID.
    *
-   * @param key the expression associated with the function call.
-   * @param call the function call.
-   * @return the function call that was previously associated with this expression.
+   * @param key the UUID of the key
+   * @return the cached function call associated with the expression or {@code null}
    */
-  @CompilerDirectives.TruffleBoundary
-  public ExecutionService.FunctionCallInfo putCall(
-      UUID key, ExecutionService.FunctionCallInfo call) {
-    if (call == null) {
-      return calls.remove(key);
-    }
-    return calls.put(key, call);
-  }
-
-  /**
-   * @return the cached function call associated with the expression.
-   */
-  @CompilerDirectives.TruffleBoundary
-  public ExecutionService.FunctionCallInfo getCall(UUID key) {
-    return calls.get(key);
-  }
-
-  /**
-   * @return the cached method calls.
-   */
-  public Set<UUID> getCalls() {
-    return calls.keySet();
-  }
-
-  /**
-   * Remove the function call from the cache.
-   *
-   * @param key the expression associated with the function call.
-   */
-  public void removeCall(UUID key) {
-    calls.remove(key);
-  }
-
-  /** Clear the cached calls. */
-  public void clearCalls() {
-    calls.clear();
-  }
-
-  /** Remove the type associated with the provided key. */
-  public void removeType(UUID key) {
-    types.remove(key);
-  }
-
-  /** Clear the cached types. */
-  public void clearTypes() {
-    types.clear();
-  }
-
-  /**
-   * @return the preferences of this cache.
-   */
-  public CachePreferences getPreferences() {
-    return preferences;
-  }
-
-  /**
-   * Set the new cache preferences.
-   *
-   * @param preferences the new cache preferences
-   */
-  public void setPreferences(CachePreferences preferences) {
-    this.preferences = preferences;
-  }
-
-  /**
-   * Remove the cache preference associated with the provided key.
-   *
-   * @param key the preference to remove
-   */
-  public void removePreference(UUID key) {
-    preferences.remove(key);
-  }
-
-  /** Clear the cache preferences. */
-  public void clearPreferences() {
-    preferences.clear();
-  }
+  public abstract ExecutionService.FunctionCallInfo getCall(UUID key);
 
   /**
    * Executes a query while tracking access to the cache by {@code callback} observer.
@@ -215,13 +67,66 @@ public final class RuntimeCache implements java.util.function.Function<String, O
    * @return value computed by the {@code scope}
    * @param <V> type of the returned value
    */
-  public <V> V runQuery(Consumer<UUID> callback, Supplier<V> scope) {
-    var previousCallback = this.observer;
-    this.observer = callback;
-    try {
-      return scope.get();
-    } finally {
-      this.observer = previousCallback;
+  public abstract <V> V runQuery(Consumer<UUID> callback, Supplier<V> scope);
+
+  /**
+   * Obtains a list of UUIDs known to the cache.
+   *
+   * @param calls collect UUIDs of the calls
+   * @param preferences collect UUIDs of the preferences
+   * @return
+   */
+  public final Set<UUID> findUUIDs(boolean calls, boolean preferences) {
+    var impl = (RuntimeCacheImpl) this;
+    var set = new HashSet<UUID>();
+    if (calls) {
+      set.addAll(impl.getCalls());
     }
+    if (preferences) {
+      set.addAll(impl.getPreferences().preferences().keySet());
+    }
+    return set;
+  }
+
+  /**
+   * Checks whether this key is associated with a binding expression.
+   *
+   * @param uuid the key to check
+   * @return {@code true} or {@code false}
+   */
+  public final boolean isBindingExpression(UUID uuid) {
+    var impl = (RuntimeCacheImpl) this;
+    return impl.getPreferences().get(uuid) == CachePreferences.Kind.BINDING_EXPRESSION;
+  }
+
+  /** */
+  public interface Mutable {
+    public abstract void clear();
+
+    /**
+     * Add value to the cache if it is possible.
+     *
+     * @param key the key of an entry.
+     * @param value the added value.
+     * @return {@code true} if the value was added to the cache.
+     */
+    public boolean offer(UUID key, Object value);
+
+    /**
+     * Cache the type of expression.
+     *
+     * @return the previously cached type.
+     */
+    public TypeInfo putType(UUID key, TypeInfo typeInfo);
+
+    /**
+     * Cache the function call
+     *
+     * @param key the expression associated with the function call.
+     * @param call the function call.
+     * @return the function call that was previously associated with this expression.
+     */
+    public ExecutionService.FunctionCallInfo putCall(
+        UUID key, ExecutionService.FunctionCallInfo call);
   }
 }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -102,14 +102,6 @@ public abstract class RuntimeCache {
      * @return
      */
     public abstract Set<UUID> findUUIDs(boolean calls, boolean preferences);
-
-    /**
-     * Checks whether this key is associated with a binding expression.
-     *
-     * @param uuid the key to check
-     * @return {@code true} or {@code false}
-     */
-    public abstract boolean isBindingExpression(UUID uuid);
   }
 
   /**
@@ -132,6 +124,24 @@ public abstract class RuntimeCache {
     public abstract void clear();
 
     /**
+     * Checks whether this key is associated with a binding expression.
+     *
+     * @param uuid the key to check
+     * @return {@code true} or {@code false}
+     */
+    public abstract boolean isBindingExpression(UUID uuid);
+
+    /**
+     * Reads a cached value from the cache for given key. Cached values are hold be "soft reference"
+     * - e.g. they are kept until the system runs out of memory or until the value for given key is
+     * replacd
+     *
+     * @param key the UUID of the key
+     * @return cached value associated with the {@code key} or {@code null}
+     */
+    public abstract Object get(UUID key);
+
+    /**
      * Add value to the cache if it is possible.
      *
      * @param key the key of an entry.
@@ -146,6 +156,22 @@ public abstract class RuntimeCache {
      * @return the previously cached type.
      */
     public TypeInfo putType(UUID key, TypeInfo typeInfo);
+
+    /**
+     * Obtains info about a type of expression identify by UUID.
+     *
+     * @param key the UUID of the key
+     * @return the cached type of the expression or {@code null}
+     */
+    public abstract TypeInfo getType(UUID key);
+
+    /**
+     * Obtains function call for given UUID.
+     *
+     * @param key the UUID of the key
+     * @return the cached function call associated with the expression or {@code null}
+     */
+    public abstract ExecutionService.FunctionCallInfo getCall(UUID key);
 
     /**
      * Cache the function call

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -1,11 +1,9 @@
 package org.enso.interpreter.instrument;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
-import org.enso.common.CachePreferences;
+import java.util.function.Function;
 import org.enso.interpreter.service.ExecutionService;
 
 /**
@@ -24,79 +22,69 @@ public abstract class RuntimeCache {
   }
 
   /**
-   * Reads a cached value from the cache for given key. Cached values are hold be "soft reference" -
-   * e.g. they are kept until the system runs out of memory or until the value for given key is
-   * replacd
-   *
-   * @param key the UUID of the key
-   * @return cached value associated with the {@code key} or {@code null}
-   */
-  public abstract Object get(UUID key);
-
-  /**
-   * Reads a value that was notified to the cache (which may or may not be subject to caching). A
-   * non-cached values include values of expression which are only available while the computation
-   * is running.
-   *
-   * @param key the UUID of the key
-   * @return available value or {@code null}
-   */
-  public abstract Object getAnyValue(UUID key);
-
-  /**
-   * Obtains info about a type of expression identify by UUID.
-   *
-   * @param key the UUID of the key
-   * @return the cached type of the expression or {@code null}
-   */
-  public abstract TypeInfo getType(UUID key);
-
-  /**
-   * Obtains function call for given UUID.
-   *
-   * @param key the UUID of the key
-   * @return the cached function call associated with the expression or {@code null}
-   */
-  public abstract ExecutionService.FunctionCallInfo getCall(UUID key);
-
-  /**
    * Executes a query while tracking access to the cache by {@code callback} observer.
    *
    * @param callback call with accessed UUIDs
-   * @param scope the code to execute
+   * @param action the code to execute
    * @return value computed by the {@code scope}
    * @param <V> type of the returned value
    */
-  public abstract <V> V runQuery(Consumer<UUID> callback, Supplier<V> scope);
+  public abstract <V> V runQuery(Consumer<UUID> callback, Function<Immutable, V> action);
 
-  /**
-   * Obtains a list of UUIDs known to the cache.
-   *
-   * @param calls collect UUIDs of the calls
-   * @param preferences collect UUIDs of the preferences
-   * @return
-   */
-  public final Set<UUID> findUUIDs(boolean calls, boolean preferences) {
-    var impl = (RuntimeCacheImpl) this;
-    var set = new HashSet<UUID>();
-    if (calls) {
-      set.addAll(impl.getCalls());
-    }
-    if (preferences) {
-      set.addAll(impl.getPreferences().preferences().keySet());
-    }
-    return set;
-  }
+  /** Immutable view of the cache. */
+  public interface Immutable {
+    /**
+     * Reads a cached value from the cache for given key. Cached values are hold be "soft reference"
+     * - e.g. they are kept until the system runs out of memory or until the value for given key is
+     * replacd
+     *
+     * @param key the UUID of the key
+     * @return cached value associated with the {@code key} or {@code null}
+     */
+    public abstract Object get(UUID key);
 
-  /**
-   * Checks whether this key is associated with a binding expression.
-   *
-   * @param uuid the key to check
-   * @return {@code true} or {@code false}
-   */
-  public final boolean isBindingExpression(UUID uuid) {
-    var impl = (RuntimeCacheImpl) this;
-    return impl.getPreferences().get(uuid) == CachePreferences.Kind.BINDING_EXPRESSION;
+    /**
+     * Reads a value that was notified to the cache (which may or may not be subject to caching). A
+     * non-cached values include values of expression which are only available while the computation
+     * is running.
+     *
+     * @param key the UUID of the key
+     * @return available value or {@code null}
+     */
+    public abstract Object getAnyValue(UUID key);
+
+    /**
+     * Obtains info about a type of expression identify by UUID.
+     *
+     * @param key the UUID of the key
+     * @return the cached type of the expression or {@code null}
+     */
+    public abstract TypeInfo getType(UUID key);
+
+    /**
+     * Obtains function call for given UUID.
+     *
+     * @param key the UUID of the key
+     * @return the cached function call associated with the expression or {@code null}
+     */
+    public abstract ExecutionService.FunctionCallInfo getCall(UUID key);
+
+    /**
+     * Obtains a list of UUIDs known to the cache.
+     *
+     * @param calls collect UUIDs of the calls
+     * @param preferences collect UUIDs of the preferences
+     * @return
+     */
+    public abstract Set<UUID> findUUIDs(boolean calls, boolean preferences);
+
+    /**
+     * Checks whether this key is associated with a binding expression.
+     *
+     * @param uuid the key to check
+     * @return {@code true} or {@code false}
+     */
+    public abstract boolean isBindingExpression(UUID uuid);
   }
 
   /** */

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -10,14 +10,32 @@ import org.enso.interpreter.service.ExecutionService;
  * Immutable API facade for Enso runtime cache. It contains only "query" methods. See {@link
  * Mutable} for operations that can modify the cache.
  *
+ * <h3>Threading</h3>
+ *
+ * The methods provided by the {@code RuntimeCache} object are <em>thread safe</em> - e.g. they can
+ * be called from any thread at any moment. However these methods serve only as
+ * <strong>entrypoints</strong> for accessing the cache:
+ *
+ * <ul>
+ *   <li><em>read only view</em> - there is {@link Immutable} interface providing read only view of
+ *       the cache - it can only be used inside of the {@link #runQuery} method when provided as a
+ *       callback interface
+ *   <li><em>mutable view</em> - there is {@link Mutable} interface allowing to perform
+ *       modifications to the cache. It follows its own threading rules ... TBD
+ * </ul>
+ *
  * <p>Implementation is provided by original implementation in {@link RuntimeCacheImpl}.
  */
 public abstract class RuntimeCache {
   /** the only implementation is in the same package */
   RuntimeCache() {}
 
-  /** Factory method to create new runtime cache. */
-  public static RuntimeCache create() {
+  /**
+   * Factory method to create new runtime cache.
+   *
+   * @return mutable (e.g. priviledged) interface to the cache
+   */
+  public static RuntimeCache.Mutable create() {
     return new RuntimeCacheImpl();
   }
 
@@ -33,6 +51,13 @@ public abstract class RuntimeCache {
 
   /** Immutable view of the cache. */
   public interface Immutable {
+    /**
+     * Accessor to the generic interface of the cache.
+     *
+     * @return associated instance of {@link RuntimeCache}
+     */
+    public abstract RuntimeCache cache();
+
     /**
      * Reads a cached value from the cache for given key. Cached values are hold be "soft reference"
      * - e.g. they are kept until the system runs out of memory or until the value for given key is
@@ -87,8 +112,23 @@ public abstract class RuntimeCache {
     public abstract boolean isBindingExpression(UUID uuid);
   }
 
-  /** */
+  /**
+   * Mutable (e.g. priviledged) view of the {@link RuntimeCache}. Created by {@link
+   * RuntimeCache#create} method and held by those who perform execution and update the state of the
+   * cache.
+   *
+   * <p>All other parties in the system that need just to observe the cache shall hold on {@link
+   * RuntimeCache} only.
+   */
   public interface Mutable {
+    /**
+     * Accessor to the generic interface of the cache.
+     *
+     * @return associated instance of {@link RuntimeCache}
+     */
+    public abstract RuntimeCache cache();
+
+    /** Clears the content of the cache. */
     public abstract void clear();
 
     /**

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -5,17 +5,20 @@ import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import org.enso.common.CachePreferences;
 import org.enso.interpreter.service.ExecutionService;
 
 /** A storage for computed values. */
 final class RuntimeCacheImpl extends RuntimeCache
-    implements RuntimeCache.Mutable, java.util.function.Function<String, Object> {
+    implements RuntimeCache.Immutable,
+        RuntimeCache.Mutable,
+        java.util.function.Function<String, Object> {
   private final Map<UUID, Reference<Object>> cache = new HashMap<>();
   private final Map<UUID, Reference<Object>> expressions = new HashMap<>();
   private final Map<UUID, TypeInfo> types = new HashMap<>();
@@ -77,6 +80,18 @@ final class RuntimeCacheImpl extends RuntimeCache
   public Object remove(UUID key) {
     var ref = cache.remove(key);
     return ref == null ? null : ref.get();
+  }
+
+  public final Set<UUID> findUUIDs(boolean calls, boolean preferences) {
+    var impl = (RuntimeCacheImpl) this;
+    var set = new HashSet<UUID>();
+    if (calls) {
+      set.addAll(impl.getCalls());
+    }
+    if (preferences) {
+      set.addAll(impl.getPreferences().preferences().keySet());
+    }
+    return set;
   }
 
   /**
@@ -179,6 +194,16 @@ final class RuntimeCacheImpl extends RuntimeCache
   }
 
   /**
+   * Checks whether this key is associated with a binding expression.
+   *
+   * @param uuid the key to check
+   * @return {@code true} or {@code false}
+   */
+  public final boolean isBindingExpression(UUID uuid) {
+    return getPreferences().get(uuid) == CachePreferences.Kind.BINDING_EXPRESSION;
+  }
+
+  /**
    * @return the preferences of this cache.
    */
   public CachePreferences getPreferences() {
@@ -216,11 +241,12 @@ final class RuntimeCacheImpl extends RuntimeCache
    * @return value computed by the {@code scope}
    * @param <V> type of the returned value
    */
-  public <V> V runQuery(Consumer<UUID> callback, Supplier<V> scope) {
+  @Override
+  public <V> V runQuery(Consumer<UUID> callback, Function<Immutable, V> scope) {
     var previousCallback = this.observer;
     this.observer = callback;
     try {
-      return scope.get();
+      return scope.apply(this);
     } finally {
       this.observer = previousCallback;
     }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -1,0 +1,228 @@
+package org.enso.interpreter.instrument;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import java.lang.ref.Reference;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.enso.common.CachePreferences;
+import org.enso.interpreter.service.ExecutionService;
+
+/** A storage for computed values. */
+final class RuntimeCacheImpl extends RuntimeCache
+    implements RuntimeCache.Mutable, java.util.function.Function<String, Object> {
+  private final Map<UUID, Reference<Object>> cache = new HashMap<>();
+  private final Map<UUID, Reference<Object>> expressions = new HashMap<>();
+  private final Map<UUID, TypeInfo> types = new HashMap<>();
+  private final Map<UUID, ExecutionService.FunctionCallInfo> calls = new HashMap<>();
+  private CachePreferences preferences = CachePreferences.empty();
+  private Consumer<UUID> observer;
+
+  /**
+   * Add value to the cache if it is possible.
+   *
+   * @param key the key of an entry.
+   * @param value the added value.
+   * @return {@code true} if the value was added to the cache.
+   */
+  @CompilerDirectives.TruffleBoundary
+  public boolean offer(UUID key, Object value) {
+    expressions.put(key, new WeakReference<>(value));
+    if (preferences.contains(key)) {
+      var ref = new SoftReference<>(value);
+      cache.put(key, ref);
+      return true;
+    }
+    return false;
+  }
+
+  /** Get the value from the cache. */
+  public Object get(UUID key) {
+    var ref = cache.get(key);
+    var res = ref != null ? ref.get() : null;
+    return res;
+  }
+
+  /** Get the value from the cache. */
+  public Object getAnyValue(UUID key) {
+    var ref = expressions.get(key);
+    var res = ref != null ? ref.get() : null;
+    return res;
+  }
+
+  // Accessed in InstrumentorBuiltin
+  @Override
+  public Object apply(String uuid) {
+    Object res;
+    try {
+      var key = UUID.fromString(uuid);
+      var ref = expressions.get(key);
+      res = ref != null ? ref.get() : null;
+      var callback = observer;
+      if (callback != null) {
+        callback.accept(key);
+      }
+    } catch (IllegalArgumentException ex) {
+      res = null;
+    }
+    return res;
+  }
+
+  /** Remove the value from the cache. */
+  public Object remove(UUID key) {
+    var ref = cache.remove(key);
+    return ref == null ? null : ref.get();
+  }
+
+  /**
+   * @return all cache keys.
+   */
+  public Set<UUID> getKeys() {
+    return cache.keySet();
+  }
+
+  /** Clear the cached values. */
+  public void clear() {
+    cache.clear();
+  }
+
+  /**
+   * Clear cached values of the provided kind.
+   *
+   * @param kind the kind of cached value to clear
+   * @return the set of cleared keys
+   */
+  public Set<UUID> clear(CachePreferences.Kind kind) {
+    var keys = preferences.get(kind);
+    for (var key : keys) {
+      cache.remove(key);
+    }
+    return keys;
+  }
+
+  /**
+   * Cache the type of expression.
+   *
+   * @return the previously cached type.
+   */
+  @CompilerDirectives.TruffleBoundary
+  public TypeInfo putType(UUID key, TypeInfo typeInfo) {
+    return types.put(key, typeInfo);
+  }
+
+  /**
+   * @return the cached type of the expression
+   */
+  @CompilerDirectives.TruffleBoundary
+  public TypeInfo getType(UUID key) {
+    return types.get(key);
+  }
+
+  /**
+   * Cache the function call
+   *
+   * @param key the expression associated with the function call.
+   * @param call the function call.
+   * @return the function call that was previously associated with this expression.
+   */
+  @CompilerDirectives.TruffleBoundary
+  public ExecutionService.FunctionCallInfo putCall(
+      UUID key, ExecutionService.FunctionCallInfo call) {
+    if (call == null) {
+      return calls.remove(key);
+    }
+    return calls.put(key, call);
+  }
+
+  /**
+   * @return the cached function call associated with the expression.
+   */
+  @CompilerDirectives.TruffleBoundary
+  public ExecutionService.FunctionCallInfo getCall(UUID key) {
+    return calls.get(key);
+  }
+
+  /**
+   * @return the cached method calls.
+   */
+  public Set<UUID> getCalls() {
+    return calls.keySet();
+  }
+
+  /**
+   * Remove the function call from the cache.
+   *
+   * @param key the expression associated with the function call.
+   */
+  public void removeCall(UUID key) {
+    calls.remove(key);
+  }
+
+  /** Clear the cached calls. */
+  public void clearCalls() {
+    calls.clear();
+  }
+
+  /** Remove the type associated with the provided key. */
+  public void removeType(UUID key) {
+    types.remove(key);
+  }
+
+  /** Clear the cached types. */
+  public void clearTypes() {
+    types.clear();
+  }
+
+  /**
+   * @return the preferences of this cache.
+   */
+  public CachePreferences getPreferences() {
+    return preferences;
+  }
+
+  /**
+   * Set the new cache preferences.
+   *
+   * @param preferences the new cache preferences
+   */
+  public void setPreferences(CachePreferences preferences) {
+    this.preferences = preferences;
+  }
+
+  /**
+   * Remove the cache preference associated with the provided key.
+   *
+   * @param key the preference to remove
+   */
+  public void removePreference(UUID key) {
+    preferences.remove(key);
+  }
+
+  /** Clear the cache preferences. */
+  public void clearPreferences() {
+    preferences.clear();
+  }
+
+  /**
+   * Executes a query while tracking access to the cache by {@code callback} observer.
+   *
+   * @param callback call with accessed UUIDs
+   * @param scope the code to execute
+   * @return value computed by the {@code scope}
+   * @param <V> type of the returned value
+   */
+  public <V> V runQuery(Consumer<UUID> callback, Supplier<V> scope) {
+    var previousCallback = this.observer;
+    this.observer = callback;
+    try {
+      return scope.get();
+    } finally {
+      this.observer = previousCallback;
+    }
+  }
+}

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -27,6 +27,23 @@ final class RuntimeCacheImpl extends RuntimeCache
   private Consumer<UUID> observer;
 
   /**
+   * To keep compatibility with previous implementations {@code this} object implements all three
+   * interfaces:
+   *
+   * <ul>
+   *   <li>{@link RuntimeCache}
+   *   <li>{@link Immutable}
+   *   <li>{@link Mutable}
+   * </ul>
+   *
+   * Hence it is possible to return just {@code this} in this method.
+   */
+  @Override
+  public RuntimeCache cache() {
+    return this;
+  }
+
+  /**
    * Add value to the cache if it is possible.
    *
    * @param key the key of an entry.

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.enso.common.CachePreferences;
 import org.enso.interpreter.instrument.ExpressionExecutionState;
 import org.enso.interpreter.instrument.MethodCallsCache;
 import org.enso.interpreter.instrument.OneshotExpression;
@@ -113,7 +112,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   @CompilerDirectives.TruffleBoundary
   private void reportEvaluationProgress(UUID nodeId) {
-    if (cache.getPreferences().get(nodeId) == CachePreferences.Kind.BINDING_EXPRESSION) {
+    if (cache.isBindingExpression(nodeId)) {
       var newObserver =
           ExecutionProgressObserver.startComputation(
               nodeId,
@@ -178,11 +177,12 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
     // Panics are not cached because a panic can be fixed by changing seemingly unrelated code,
     // like imports, and the invalidation mechanism can not always track those changes and
     // appropriately invalidate all dependent expressions.
+    var mutable = (RuntimeCache.Mutable) cache;
     if (!isPanic) {
-      cache.offer(nodeId, result);
-      cache.putCall(nodeId, call);
+      mutable.offer(nodeId, result);
+      mutable.putCall(nodeId, call);
     }
-    cache.putType(nodeId, resultType);
+    mutable.putType(nodeId, resultType);
 
     callOnComputedCallback(expressionValue);
     executeOneshotExpressions(nodeId, result, info);

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -112,7 +112,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   @CompilerDirectives.TruffleBoundary
   private void reportEvaluationProgress(UUID nodeId) {
-    if (cache.isBindingExpression(nodeId)) {
+    if (cache.runQuery(null, query -> query.isBindingExpression(nodeId))) {
       var newObserver =
           ExecutionProgressObserver.startComputation(
               nodeId,
@@ -147,32 +147,38 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
       refreshObserver(null);
     }
 
-    TypeInfo cachedType = cache.getType(nodeId);
-    FunctionCallInfo call = functionCallInfoById(nodeId);
-    FunctionCallInfo cachedCall = cache.getCall(nodeId);
-    ProfilingInfo[] profilingInfo = new ProfilingInfo[] {new ExecutionTime(info.getElapsedTime())};
+    var call = functionCallInfoById(nodeId);
+    var expressionValue =
+        cache.runQuery(
+            null,
+            (query) -> {
+              TypeInfo cachedType = query.getType(nodeId);
+              FunctionCallInfo cachedCall = query.getCall(nodeId);
+              ProfilingInfo[] profilingInfo =
+                  new ProfilingInfo[] {new ExecutionTime(info.getElapsedTime())};
 
-    ExpressionValue expressionValue =
-        new ExpressionValue(
-            nodeId,
-            result,
-            resultType,
-            cachedType,
-            call,
-            cachedCall,
-            profilingInfo,
-            false,
-            -1.0,
-            null);
-    syncState.setExpressionUnsync(nodeId);
-    visualizationHolder
-        .find(nodeId)
-        .foreach(
-            visualization -> {
-              syncState.setVisualizationUnsync(visualization.id());
-              return null;
+              ExpressionValue ev =
+                  new ExpressionValue(
+                      nodeId,
+                      result,
+                      resultType,
+                      cachedType,
+                      call,
+                      cachedCall,
+                      profilingInfo,
+                      false,
+                      -1.0,
+                      null);
+              syncState.setExpressionUnsync(nodeId);
+              visualizationHolder
+                  .find(nodeId)
+                  .foreach(
+                      visualization -> {
+                        syncState.setVisualizationUnsync(visualization.id());
+                        return null;
+                      });
+              return ev;
             });
-
     boolean isPanic = info.isPanic();
     // Panics are not cached because a panic can be fixed by changing seemingly unrelated code,
     // like imports, and the invalidation mechanism can not always track those changes and
@@ -203,7 +209,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
     calls.put(nodeId, FunctionCallInfo.fromFunctionCall(fnCall));
     functionCallCallback.accept(new ExpressionCall(nodeId, fnCall));
     // Return cached value after capturing the enterable function call in `functionCallCallback`
-    Object cachedResult = cache.get(nodeId);
+    Object cachedResult = cache.runQuery(null, query -> query.get(nodeId));
     if (cachedResult != null) {
       return cachedResult;
     }
@@ -240,17 +246,20 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
   @CompilerDirectives.TruffleBoundary
   private void callOnCachedCallback(UUID nodeId, Object result) {
     ExpressionValue expressionValue =
-        new ExpressionValue(
-            nodeId,
-            result,
-            cache.getType(nodeId),
-            typeOf(result),
-            calls.get(nodeId),
-            cache.getCall(nodeId),
-            new ProfilingInfo[] {ExecutionTime.empty()},
-            true,
-            -1.0,
-            null);
+        cache.runQuery(
+            null,
+            query ->
+                new ExpressionValue(
+                    nodeId,
+                    result,
+                    query.getType(nodeId),
+                    typeOf(result),
+                    calls.get(nodeId),
+                    query.getCall(nodeId),
+                    new ProfilingInfo[] {ExecutionTime.empty()},
+                    true,
+                    -1.0,
+                    null));
 
     onCachedCallback.accept(expressionValue);
   }
@@ -281,7 +290,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   @CompilerDirectives.TruffleBoundary
   private Object getCachedResult(UUID nodeId) {
-    return cache.get(nodeId);
+    return cache.runQuery(null, query -> query.get(nodeId));
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -32,7 +32,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   private final VisualizationHolder visualizationHolder;
   private final UUID nextExecutionItem;
-  private final RuntimeCache cache;
+  private final RuntimeCache.Mutable cache;
   private final MethodCallsCache methodCallsCache;
   private final UpdatesSynchronizationState syncState;
   private final Map<UUID, FunctionCallInfo> calls = new HashMap<>();
@@ -63,7 +63,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
   ExecutionCallbacks(
       VisualizationHolder visualizationHolder,
       UUID nextExecutionItem,
-      RuntimeCache cache,
+      RuntimeCache.Mutable cache,
       MethodCallsCache methodCallsCache,
       UpdatesSynchronizationState syncState,
       ExpressionExecutionState expressionExecutionState,
@@ -112,7 +112,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   @CompilerDirectives.TruffleBoundary
   private void reportEvaluationProgress(UUID nodeId) {
-    if (cache.runQuery(null, query -> query.isBindingExpression(nodeId))) {
+    if (cache.isBindingExpression(nodeId)) {
       var newObserver =
           ExecutionProgressObserver.startComputation(
               nodeId,
@@ -148,47 +148,39 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
     }
 
     var call = functionCallInfoById(nodeId);
-    var expressionValue =
-        cache.runQuery(
-            null,
-            (query) -> {
-              TypeInfo cachedType = query.getType(nodeId);
-              FunctionCallInfo cachedCall = query.getCall(nodeId);
-              ProfilingInfo[] profilingInfo =
-                  new ProfilingInfo[] {new ExecutionTime(info.getElapsedTime())};
+    TypeInfo cachedType = cache.getType(nodeId);
+    FunctionCallInfo cachedCall = cache.getCall(nodeId);
+    ProfilingInfo[] profilingInfo = new ProfilingInfo[] {new ExecutionTime(info.getElapsedTime())};
 
-              ExpressionValue ev =
-                  new ExpressionValue(
-                      nodeId,
-                      result,
-                      resultType,
-                      cachedType,
-                      call,
-                      cachedCall,
-                      profilingInfo,
-                      false,
-                      -1.0,
-                      null);
-              syncState.setExpressionUnsync(nodeId);
-              visualizationHolder
-                  .find(nodeId)
-                  .foreach(
-                      visualization -> {
-                        syncState.setVisualizationUnsync(visualization.id());
-                        return null;
-                      });
-              return ev;
+    var expressionValue =
+        new ExpressionValue(
+            nodeId,
+            result,
+            resultType,
+            cachedType,
+            call,
+            cachedCall,
+            profilingInfo,
+            false,
+            -1.0,
+            null);
+    syncState.setExpressionUnsync(nodeId);
+    visualizationHolder
+        .find(nodeId)
+        .foreach(
+            visualization -> {
+              syncState.setVisualizationUnsync(visualization.id());
+              return null;
             });
     boolean isPanic = info.isPanic();
     // Panics are not cached because a panic can be fixed by changing seemingly unrelated code,
     // like imports, and the invalidation mechanism can not always track those changes and
     // appropriately invalidate all dependent expressions.
-    var mutable = (RuntimeCache.Mutable) cache;
     if (!isPanic) {
-      mutable.offer(nodeId, result);
-      mutable.putCall(nodeId, call);
+      cache.offer(nodeId, result);
+      cache.putCall(nodeId, call);
     }
-    mutable.putType(nodeId, resultType);
+    cache.putType(nodeId, resultType);
 
     callOnComputedCallback(expressionValue);
     executeOneshotExpressions(nodeId, result, info);
@@ -209,7 +201,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
     calls.put(nodeId, FunctionCallInfo.fromFunctionCall(fnCall));
     functionCallCallback.accept(new ExpressionCall(nodeId, fnCall));
     // Return cached value after capturing the enterable function call in `functionCallCallback`
-    Object cachedResult = cache.runQuery(null, query -> query.get(nodeId));
+    Object cachedResult = cache.get(nodeId);
     if (cachedResult != null) {
       return cachedResult;
     }
@@ -246,20 +238,17 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
   @CompilerDirectives.TruffleBoundary
   private void callOnCachedCallback(UUID nodeId, Object result) {
     ExpressionValue expressionValue =
-        cache.runQuery(
-            null,
-            query ->
-                new ExpressionValue(
-                    nodeId,
-                    result,
-                    query.getType(nodeId),
-                    typeOf(result),
-                    calls.get(nodeId),
-                    query.getCall(nodeId),
-                    new ProfilingInfo[] {ExecutionTime.empty()},
-                    true,
-                    -1.0,
-                    null));
+        new ExpressionValue(
+            nodeId,
+            result,
+            cache.getType(nodeId),
+            typeOf(result),
+            calls.get(nodeId),
+            cache.getCall(nodeId),
+            new ProfilingInfo[] {ExecutionTime.empty()},
+            true,
+            -1.0,
+            null);
 
     onCachedCallback.accept(expressionValue);
   }
@@ -290,7 +279,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
 
   @CompilerDirectives.TruffleBoundary
   private Object getCachedResult(UUID nodeId) {
-    return cache.runQuery(null, query -> query.get(nodeId));
+    return cache.get(nodeId);
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -186,13 +186,14 @@ public final class ExecutionService {
       Consumer<ExecutionService.ExpressionValue> onComputedCallback,
       Consumer<ExecutionService.ExpressionValue> onCachedCallback,
       Consumer<ExecutedVisualization> onExecutedVisualizationCallback) {
-    return submitExecution(
-        () -> {
+    return submitExecutionWithCacheAccess(
+        cache,
+        (cacheMut) -> {
           var callbacks =
               new ExecutionCallbacks(
                   visualizationHolder,
                   nextExecutionItem,
-                  cache,
+                  cacheMut,
                   methodCallsCache,
                   syncState,
                   expressionExecutionState,
@@ -370,8 +371,9 @@ public final class ExecutionService {
       Object function,
       Object... arguments) {
 
-    return submitExecution(
-        () -> {
+    return submitExecutionWithCacheAccess(
+        cache,
+        (cacheMut) -> {
           var fn = function;
           UUID nextExecutionItem = null;
           CallTarget entryCallTarget =
@@ -392,7 +394,7 @@ public final class ExecutionService {
               new ExecutionCallbacks(
                   visualizationHolder,
                   nextExecutionItem,
-                  cache,
+                  cacheMut,
                   methodCallsCache,
                   syncState,
                   expressionExecutionState,
@@ -651,8 +653,15 @@ public final class ExecutionService {
     throw (E) ex;
   }
 
-  private <T> CompletionStage<T> submitExecution(Supplier<T> c) {
-    return context.getThreadManager().submit(c);
+  private <T> CompletionStage<T> submitExecutionWithCacheAccess(
+      RuntimeCache cache, java.util.function.Function<RuntimeCache.Mutable, T> action) {
+    // let's assume the submitException knows how to "upgrade" access to cache to a mutable one
+    var cacheMut = (RuntimeCache.Mutable) cache;
+    return submitExecution(() -> action.apply(cacheMut));
+  }
+
+  private <T> CompletionStage<T> submitExecution(Supplier<T> action) {
+    return context.getThreadManager().submit(action);
   }
 
   private static final class ExecuteRootNode extends RootNode {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
@@ -208,17 +208,18 @@ object CacheInvalidation {
 
   /** Run cache invalidation of a single instrument frame.
     *
-    * @param cache the cache to invalidate
+    * @param cacheApi the cache to invalidate
     * @param syncState the synchronization state of runtime updates
     * @param command the invalidation instruction
     * @param indexes the list of indexes to invalidate
     */
   private def run(
-    cache: RuntimeCache,
+    cacheApi: RuntimeCache,
     syncState: Option[UpdatesSynchronizationState],
     command: Command,
     indexes: Set[IndexSelector]
-  ): Unit =
+  ): Unit = {
+    val cache = cacheApi.asInstanceOf[RuntimeCacheImpl]
     command match {
       case Command.InvalidateAll =>
         logger.trace("Cache - clear all")
@@ -249,13 +250,17 @@ object CacheInvalidation {
       case Command.SetMetadata(metadata) =>
         cache.setPreferences(metadata.preferences)
     }
+  }
 
   /** Clear the selected index.
     *
     * @param selector the selected index
     * @param cache the cache to invalidate
     */
-  private def clearIndex(selector: IndexSelector, cache: RuntimeCache): Unit =
+  private def clearIndex(
+    selector: IndexSelector,
+    cache: RuntimeCacheImpl
+  ): Unit =
     selector match {
       case IndexSelector.All =>
         cache.clearTypes()
@@ -278,7 +283,7 @@ object CacheInvalidation {
   private def clearIndexKey(
     key: UUID,
     selector: IndexSelector,
-    cache: RuntimeCache
+    cache: RuntimeCacheImpl
   ): Unit =
     selector match {
       case IndexSelector.All =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ExecutionContextState.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ExecutionContextState.scala
@@ -49,7 +49,7 @@ case object InstrumentFrame {
   def apply(item: StackItem): InstrumentFrame =
     new InstrumentFrame(
       item,
-      RuntimeCache.create,
+      RuntimeCache.create.cache,
       new UpdatesSynchronizationState
     )
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ExecutionContextState.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ExecutionContextState.scala
@@ -15,7 +15,7 @@ case class ExecutionContextState(
   visualizations: VisualizationHolder
 ) {
   def close(): Unit = {
-    stack.foreach(_.cache.clear())
+    stack.foreach(_.cache.asInstanceOf[RuntimeCache.Mutable].clear())
   }
 }
 
@@ -47,5 +47,9 @@ case object InstrumentFrame {
     * @return an instance of [[InstrumentFrame]]
     */
   def apply(item: StackItem): InstrumentFrame =
-    new InstrumentFrame(item, new RuntimeCache, new UpdatesSynchronizationState)
+    new InstrumentFrame(
+      item,
+      RuntimeCache.create,
+      new UpdatesSynchronizationState
+    )
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -203,8 +203,8 @@ object RecomputeContextCmd {
       case CacheInvalidation.Command.InvalidateAll =>
         stack.headOption
           .map { frame =>
-            frame.cache.getPreferences.preferences
-              .keySet()
+            frame.cache
+              .findUUIDs(false, true)
               .forEach(builder.addOne)
           }
       case CacheInvalidation.Command.InvalidateKeys(expressionIds, _) =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -203,9 +203,11 @@ object RecomputeContextCmd {
       case CacheInvalidation.Command.InvalidateAll =>
         stack.headOption
           .map { frame =>
-            frame.cache
-              .findUUIDs(false, true)
-              .forEach(builder.addOne)
+            frame.cache.runQuery(
+              null,
+              _.findUUIDs(false, true)
+                .forEach(builder.addOne)
+            )
           }
       case CacheInvalidation.Command.InvalidateKeys(expressionIds, _) =>
         builder ++= expressionIds

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -208,28 +208,33 @@ object ProgramExecutionSupport {
     pendingResult.toCompletableFuture.get()
     callStack match {
       case Nil =>
-        val notExecuted =
-          methodCallsCache.getNotExecuted(
-            executionFrame.cache.findUUIDs(true, false)
-          )
-        notExecuted.forEach { expressionId =>
-          val expressionTypes = executionFrame.cache.getType(expressionId)
-          val expressionCall  = executionFrame.cache.getCall(expressionId)
-          onCachedMethodCallCallback.accept(
-            new ExpressionValue(
-              expressionId,
-              null,
-              expressionTypes,
-              expressionTypes,
-              expressionCall,
-              expressionCall,
-              Array(ExecutionTime.empty()),
-              true,
-              -1.0,
-              null
-            )
-          )
-        }
+        executionFrame.cache.runQuery(
+          null,
+          cache => {
+            val notExecuted =
+              methodCallsCache.getNotExecuted(
+                cache.findUUIDs(true, false)
+              )
+            notExecuted.forEach { expressionId =>
+              val expressionTypes = cache.getType(expressionId)
+              val expressionCall  = cache.getCall(expressionId)
+              onCachedMethodCallCallback.accept(
+                new ExpressionValue(
+                  expressionId,
+                  null,
+                  expressionTypes,
+                  expressionTypes,
+                  expressionCall,
+                  expressionCall,
+                  Array(ExecutionTime.empty()),
+                  true,
+                  -1.0,
+                  null
+                )
+              )
+            }
+          }
+        )
       case item :: tail =>
         enterables.get(item.expressionId) match {
           case Some(call) =>
@@ -655,7 +660,7 @@ object ProgramExecutionSupport {
         val v = if (visualization.expressionId == value.getExpressionId) {
           value.getValue
         } else {
-          runtimeCache.getAnyValue(visualization.expressionId)
+          runtimeCache.runQuery(null, _.getAnyValue(visualization.expressionId))
         }
         if (v != null && !VisualizationResult.isInterruptedException(v)) {
           executeAndSendVisualizationUpdate(
@@ -712,7 +717,7 @@ object ProgramExecutionSupport {
             holder.upsert(visualization, id)
           }
         }
-        runtimeCache.runQuery(processUUID, makeCall)
+        runtimeCache.runQuery(processUUID, _ => makeCall.get())
       } else {
         makeCall.get()
       }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -209,7 +209,9 @@ object ProgramExecutionSupport {
     callStack match {
       case Nil =>
         val notExecuted =
-          methodCallsCache.getNotExecuted(executionFrame.cache.getCalls)
+          methodCallsCache.getNotExecuted(
+            executionFrame.cache.findUUIDs(true, false)
+          )
         notExecuted.forEach { expressionId =>
           val expressionTypes = executionFrame.cache.getType(expressionId)
           val expressionCall  = executionFrame.cache.getCall(expressionId)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -180,7 +180,7 @@ class UpsertVisualizationJob(
       case Some(value) =>
         ProgramExecutionSupport.executeAndSendVisualizationUpdate(
           config.executionContextId,
-          runtimeCache.getOrElse(new RuntimeCache),
+          runtimeCache.getOrElse(RuntimeCache.create),
           stack.headOption.get.syncState,
           visualization,
           expressionId,
@@ -613,7 +613,7 @@ object UpsertVisualizationJob {
       Visualization(
         visualizationId,
         expressionId,
-        new RuntimeCache(),
+        RuntimeCache.create(),
         module,
         visualizationConfig,
         visualizationExpressionId,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -171,7 +171,7 @@ class UpsertVisualizationJob(
     val runtimeCache = stack.headOption
       .flatMap(frame => Option(frame.cache))
     val cachedValue = runtimeCache
-      .flatMap(c => Option(c.get(expressionId)))
+      .flatMap(c => Option(c.runQuery(null, _.get(expressionId))))
     UpsertVisualizationJob.requireVisualizationSynchronization(
       stack,
       visualizationId
@@ -706,7 +706,7 @@ object UpsertVisualizationJob {
     stack: Iterable[InstrumentFrame]
   ): Boolean = {
     stack.headOption.exists { frame =>
-      frame.cache.get(expressionId) ne null
+      frame.cache.runQuery(null, _.get(expressionId) ne null)
     }
   }
 
@@ -757,7 +757,9 @@ object UpsertVisualizationJob {
                 stacks.foreach { stack =>
                   stack.headOption.foreach { frame =>
                     dependents
-                      .find { id => frame.cache.get(id) ne null }
+                      .find { id =>
+                        frame.cache.runQuery(null, _.get(id) ne null)
+                      }
                       .foreach { firstDependent =>
                         CacheInvalidation.run(
                           stack,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -180,7 +180,7 @@ class UpsertVisualizationJob(
       case Some(value) =>
         ProgramExecutionSupport.executeAndSendVisualizationUpdate(
           config.executionContextId,
-          runtimeCache.getOrElse(RuntimeCache.create),
+          runtimeCache.getOrElse(RuntimeCache.create.cache),
           stack.headOption.get.syncState,
           visualization,
           expressionId,
@@ -613,7 +613,7 @@ object UpsertVisualizationJob {
       Visualization(
         visualizationId,
         expressionId,
-        RuntimeCache.create(),
+        RuntimeCache.create().cache(),
         module,
         visualizationConfig,
         visualizationExpressionId,

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/RuntimeCacheTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/RuntimeCacheTest.java
@@ -18,7 +18,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void cacheItems() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var obj = 42;
 
@@ -32,7 +32,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void removeItems() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var obj = new Object();
 
@@ -44,7 +44,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void cacheTypes() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var obj = TypeInfo.ofType("Number");
 
@@ -57,7 +57,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void cacheAllExpressions() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var exprKey = UUID.randomUUID();
     var obj = new Object();
@@ -79,7 +79,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void cleanupOfCachedExpressions() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var exprKey = UUID.randomUUID();
     var obj = new Object();
@@ -109,7 +109,7 @@ public class RuntimeCacheTest {
 
   @Test
   public void cleanupOfNotCachedExpressions() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var exprKey = UUID.randomUUID();
     var obj = new Object();
@@ -129,7 +129,7 @@ public class RuntimeCacheTest {
   /** */
   @Test
   public void runQueryWithCallback() {
-    var cache = new RuntimeCache();
+    var cache = new RuntimeCacheImpl();
     var key = UUID.randomUUID();
     var key2 = UUID.randomUUID();
     var obj = new Object();
@@ -139,7 +139,7 @@ public class RuntimeCacheTest {
     var result =
         cache.runQuery(
             queried::add,
-            () -> {
+            (query) -> {
               cache.apply(key.toString());
               cache.apply(key2.toString());
               return obj;


### PR DESCRIPTION
### Pull Request Description

- refactoring to change the API facade, but keep current implementation
  - making `RuntimeCache` an abstract class
   - splitting the "query API" from "modification API"
   - providing query API in `Immutable` interface
   - moving modification API to its own interface `Mutable`
- moving original implementation to `RuntimeCacheImpl`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests update to new API
