### PR TITLE
RuntimeCache.onModification to notify when a value is updated

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -49,6 +49,14 @@ public abstract class RuntimeCache {
    */
   public abstract <V> V runQuery(Consumer<UUID> callback, Function<Immutable, V> action);
 
+  /**
+   * Observe changes related to this UUID.
+   *
+   * @param id the identifier to observe
+   * @param callback callback to invoke when change of given UUID happens
+   */
+  public abstract void onModification(UUID id, Consumer<Immutable> callback);
+
   /** Immutable view of the cache. */
   public interface Immutable {
     /**

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -190,5 +190,11 @@ public abstract class RuntimeCache {
      */
     public ExecutionService.FunctionCallInfo putCall(
         UUID key, ExecutionService.FunctionCallInfo call);
+
+    /**
+     * Process pending {@link RuntimeCache#onModification(UUID, Consumer)} callbacks for values that
+     * are currently available in the cache.
+     */
+    public abstract void processOnModification();
   }
 }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -53,6 +53,20 @@ final class RuntimeCacheImpl extends RuntimeCache
     arr.add(callback);
   }
 
+  @Override
+  public void processOnModification() {
+    for (var pendingKey : onModification.keySet()) {
+      if (cache.containsKey(pendingKey)) {
+        var toNotifyPending = onModification.get(pendingKey);
+        if (toNotifyPending != null) {
+          for (var c : toNotifyPending) {
+            c.accept(this);
+          }
+        }
+      }
+    }
+  }
+
   /**
    * Add value to the cache if it is possible.
    *
@@ -80,7 +94,6 @@ final class RuntimeCacheImpl extends RuntimeCache
 
   /** Get the value from the cache. */
   public Object get(UUID key) {
-    System.err.println("  get: " + key);
     var ref = cache.get(key);
     var res = ref != null ? ref.get() : null;
     return res;
@@ -88,7 +101,6 @@ final class RuntimeCacheImpl extends RuntimeCache
 
   /** Get the value from the cache. */
   public Object getAnyValue(UUID key) {
-    System.err.println("  getany: " + key);
     var ref = expressions.get(key);
     var res = ref != null ? ref.get() : null;
     return res;

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -6,9 +6,12 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.enso.common.CachePreferences;
@@ -23,6 +26,7 @@ final class RuntimeCacheImpl extends RuntimeCache
   private final Map<UUID, Reference<Object>> expressions = new HashMap<>();
   private final Map<UUID, TypeInfo> types = new HashMap<>();
   private final Map<UUID, ExecutionService.FunctionCallInfo> calls = new HashMap<>();
+  private final Map<UUID, List<Consumer<Immutable>>> onModification = new ConcurrentHashMap<>();
   private CachePreferences preferences = CachePreferences.empty();
   private Consumer<UUID> observer;
 
@@ -43,6 +47,12 @@ final class RuntimeCacheImpl extends RuntimeCache
     return this;
   }
 
+  @Override
+  public void onModification(UUID id, Consumer<Immutable> callback) {
+    var arr = onModification.computeIfAbsent(id, (_) -> new CopyOnWriteArrayList<>());
+    arr.add(callback);
+  }
+
   /**
    * Add value to the cache if it is possible.
    *
@@ -52,17 +62,25 @@ final class RuntimeCacheImpl extends RuntimeCache
    */
   @CompilerDirectives.TruffleBoundary
   public boolean offer(UUID key, Object value) {
+    var added = false;
     expressions.put(key, new WeakReference<>(value));
     if (preferences.contains(key)) {
       var ref = new SoftReference<>(value);
       cache.put(key, ref);
-      return true;
+      added = true;
     }
-    return false;
+    var toNotify = onModification.get(key);
+    if (toNotify != null) {
+      for (var c : toNotify) {
+        c.accept(this);
+      }
+    }
+    return added;
   }
 
   /** Get the value from the cache. */
   public Object get(UUID key) {
+    System.err.println("  get: " + key);
     var ref = cache.get(key);
     var res = ref != null ? ref.get() : null;
     return res;
@@ -70,6 +88,7 @@ final class RuntimeCacheImpl extends RuntimeCache
 
   /** Get the value from the cache. */
   public Object getAnyValue(UUID key) {
+    System.err.println("  getany: " + key);
     var ref = expressions.get(key);
     var res = ref != null ? ref.get() : null;
     return res;

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -95,6 +95,10 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
       executeOneshotExpressions(nodeId, result, info);
     }
 
+    // Processing pending `onModification` callbacks when entering the node gives better UX because
+    // we can display visualizations before waiting for the current node to compute.
+    cache.processOnModification();
+
     // When executing the call stack we need to capture the FunctionCall of the next (top) stack
     // item in the `functionCallCallback`. We allow to execute the cached `stackTop` value to be
     // able to continue the stack execution, and unwind later from the `onReturnValue` callback.
@@ -181,6 +185,7 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
       cache.putCall(nodeId, call);
     }
     cache.putType(nodeId, resultType);
+    cache.processOnModification();
 
     callOnComputedCallback(expressionValue);
     executeOneshotExpressions(nodeId, result, info);

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
@@ -45,6 +45,7 @@ class AttachVisualizationCmd(
       case None | null => Future.successful(())
       case Some(executable) =>
         ctx.jobProcessor.run(
+          // this then schedules the execution
           ExecuteJob(
             executable,
             "attach/upsert visualization (id=" + request.visualizationId + ")"

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -829,6 +829,12 @@ object ProgramExecutionSupport {
                 )
               )
             )
+        logger.trace(
+          "Visualization data sent [{}]: {}",
+          expressionId,
+          data
+        )
+
           }
         )
     }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -60,18 +60,26 @@ class UpsertVisualizationJob(
     }
 
   /** @inheritdoc */
-  override def runImpl(implicit ctx: RuntimeContext): Option[Executable] =
+  override def runImpl(implicit ctx: RuntimeContext): Option[Executable] = {
+    System.err.println(
+      "UpsertVisualizationJob.runImpl before withReadContextLock"
+    )
     ctx.locking.withReadContextLock(
       ctx.locking.getOrCreateContextLock(config.executionContextId),
       classOf[UpsertVisualizationJob],
       () => {
+        System.err.println("UpsertVisualizationJob.runImpl withReadContextLock")
         val (needsRetryWithWriteLock, maybeResult) =
           ctx.locking.withReadCompilationLock(
             classOf[UpsertVisualizationJob],
-            () =>
+            () => {
+              System.err.println(
+                "UpsertVisualizationJob.runImpl withReadCompilationLock"
+              )
               evaluateAndExecuteVisualization(
                 hasWriteLock = false
               )
+            }
           )
         if (needsRetryWithWriteLock) {
           UpsertVisualizationJob.logger.trace(
@@ -91,6 +99,7 @@ class UpsertVisualizationJob(
         }
       }
     )
+  }
 
   /** Attempts to evaluate the visualization expression associated with this job.
     *
@@ -168,10 +177,46 @@ class UpsertVisualizationJob(
       )
     val stack =
       ctx.contextManager.getStack(config.executionContextId)
+
+    // attach callable to runtimeCache
+    // here
+    System.err.println("Attach to value of " + expressionId)
+
     val runtimeCache = stack.headOption
       .flatMap(frame => Option(frame.cache))
     val cachedValue = runtimeCache
-      .flatMap(c => Option(c.runQuery(null, _.get(expressionId))))
+      .flatMap(c => {
+        c.onModification(
+          expressionId,
+          immutable => {
+            val data = immutable.get(expressionId)
+            System.err.println(
+              "Modified value of " + expressionId + " to " + data
+            );
+            if (data != null) {
+              val contextId = config.executionContextId
+              ctx.endpoint.sendToClient(
+                Api.Response(
+                  Api.VisualizationUpdate(
+                    Api.VisualizationContext(
+                      visualizationId,
+                      contextId,
+                      expressionId
+                    ),
+                    VisualizationResult.visualizationResultToBytes(
+                      data.toString()
+                    )
+                  )
+                )
+              )
+            }
+          }
+        )
+        val v = c.runQuery(null, _.get(expressionId))
+        System.err.println("Checked value of " + expressionId + " was: " + v)
+        Option(v)
+      })
+
     UpsertVisualizationJob.requireVisualizationSynchronization(
       stack,
       visualizationId

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -61,79 +61,44 @@ class UpsertVisualizationJob(
 
   /** @inheritdoc */
   override def runImpl(implicit ctx: RuntimeContext): Option[Executable] = {
+    System.err.println("runImpl for " + expressionId);
     val stack =
       ctx.contextManager.getStack(config.executionContextId)
     val runtimeCache = stack.headOption
       .flatMap(frame => Option(frame.cache))
-    runtimeCache.map(c =>
+    runtimeCache.flatMap { c =>
       c.onModification(
         expressionId,
         immutable => {
           val data = immutable.get(expressionId)
           System.err.println(
-            "Modified value of " + expressionId + " to " + data
+            "runImpl Modified value of " + expressionId + " to " + data
           );
           if (data != null) {
-            val contextId = config.executionContextId
-            ctx.endpoint.sendToClient(
-              Api.Response(
-                Api.VisualizationUpdate(
-                  Api.VisualizationContext(
-                    visualizationId,
-                    contextId,
-                    expressionId
-                  ),
-                  VisualizationResult.visualizationResultToBytes(
-                    data.toString()
-                  )
-                )
-              )
+            evaluateAndExecuteVisualization2(
+              data,
+              hasWriteLock = true
             )
           }
         }
       )
-    )
-    /*
-    System.err.println(
-      "UpsertVisualizationJob.runImpl before withReadContextLock"
-    )
-    ctx.locking.withReadContextLock(
-      ctx.locking.getOrCreateContextLock(config.executionContextId),
-      classOf[UpsertVisualizationJob],
-      () => {
-        System.err.println("UpsertVisualizationJob.runImpl withReadContextLock")
-        val (needsRetryWithWriteLock, maybeResult) =
-          ctx.locking.withReadCompilationLock(
-            classOf[UpsertVisualizationJob],
-            () => {
-              System.err.println(
-                "UpsertVisualizationJob.runImpl withReadCompilationLock"
-              )
-              evaluateAndExecuteVisualization(
-                hasWriteLock = false
-              )
-            }
-          )
-        if (needsRetryWithWriteLock) {
-          UpsertVisualizationJob.logger.trace(
-            "Retrying visualization {} evaluation with write lock to compile necessary modules",
-            visualizationId
-          )
-          ctx.locking.withWriteCompilationLock(
-            classOf[UpsertVisualizationJob],
-            "visualizationId=" + visualizationId + ",expressionId=" + expressionId,
-            () =>
-              evaluateAndExecuteVisualization(
-                hasWriteLock = true
-              )._2
-          )
-        } else {
-          maybeResult
-        }
+      val previous = c.runQuery(null, immutable => immutable.get(expressionId))
+      if (previous == null) {
+        System.err.println("  no value for " + expressionId)
+        // empty
+        Some(Executable(config.executionContextId, stack))
+      } else {
+        System.err.println(
+          "  some value for " + expressionId + " = " + previous
+        )
+        // value is present
+        evaluateAndExecuteVisualization2(
+          previous,
+          hasWriteLock = false
+        )
+        None
       }
-    )
-     */
-    None
+    }
   }
 
   /** Attempts to evaluate the visualization expression associated with this job.
@@ -188,6 +153,62 @@ class UpsertVisualizationJob(
         (!hasWriteLock, None)
       case Right(evaluatedExpression) =>
         (false, executeVisualization(evaluatedExpression))
+    }
+  }
+
+  /** Attempts to evaluate the visualization expression associated with this job.
+    *
+    * @param value computed value to be visualized
+    * @param runtimeCache an instance of runtime cache associated with this frame
+    * @param stack current stackframe
+    * @param hasWriteLock true if necessary module loading/compilation can be performed, if needed. False otherwise
+    * @param ctx an instance of current `RuntimeContext`
+    * @return true if failed due to required compilation and lack of required lock, false if successful
+    */
+  def evaluateAndExecuteVisualization2(
+    value: Object,
+    hasWriteLock: Boolean
+  )(implicit ctx: RuntimeContext): (Boolean, Option[Executable]) = {
+    UpsertVisualizationJob.logger.trace(
+      "Evaluating expression {} in observer",
+      expressionId
+    )
+    val maybeCallable = UpsertVisualizationJob.evaluateVisualizationExpression(
+      config.visualizationModule,
+      config.expression,
+      hasWriteLock
+    )
+
+    maybeCallable match {
+      case Left(ModuleNotFound(moduleName)) =>
+        UpsertVisualizationJob.logger.trace(
+          "Evaluation of visualization {} in observer for expression {} failed. Module not found",
+          visualizationId,
+          expressionId
+        )
+        ctx.endpoint.sendToClient(
+          Api.Response(Api.ModuleNotFound(moduleName))
+        )
+        (false, None)
+      case Left(EvaluationFailed(message, result)) =>
+        UpsertVisualizationJob.logger.trace(
+          "Evaluation of visualization {} in observer for expression {} failed.",
+          visualizationId,
+          expressionId
+        )
+        replyWithExpressionFailedError(
+          config.executionContextId,
+          visualizationId,
+          expressionId,
+          message,
+          result
+        )
+        (false, None)
+      case Left(RequiresCompilation) =>
+        // todo reply with expr failed
+        (!hasWriteLock, None)
+      case Right(evaluatedExpression) =>
+        (false, executeVisualization2(value, evaluatedExpression))
     }
   }
 
@@ -274,6 +295,51 @@ class UpsertVisualizationJob(
         )
         Some(Executable(config.executionContextId, stack))
     }
+  }
+
+  private def executeVisualization2(
+    value: Object,
+    evaluatedVisualization: EvaluationResult
+  )(implicit ctx: RuntimeContext): Option[Executable] = {
+    val EvaluationResult(module, callable, arguments) = evaluatedVisualization
+    UpsertVisualizationJob.logger.trace(
+      "Executing visualization {} for expression {}",
+      visualizationId,
+      expressionId
+    )
+
+    val visualization =
+      UpsertVisualizationJob.updateAttachedVisualization(
+        visualizationId,
+        expressionId,
+        module,
+        config,
+        callable,
+        arguments
+      )
+    val stack =
+      ctx.contextManager.getStack(config.executionContextId)
+
+    // attach callable to runtimeCache
+    // here
+    System.err.println("Attach to value of " + expressionId)
+
+    val runtimeCache = stack.headOption
+      .flatMap(frame => Option(frame.cache))
+
+    UpsertVisualizationJob.requireVisualizationSynchronization(
+      stack,
+      visualizationId
+    )
+    ProgramExecutionSupport.executeAndSendVisualizationUpdate(
+      config.executionContextId,
+      runtimeCache.getOrElse(RuntimeCache.create.cache),
+      stack.headOption.get.syncState,
+      visualization,
+      expressionId,
+      value
+    )
+    None
   }
 
   private def replyWithExpressionFailedError(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -61,12 +61,12 @@ class UpsertVisualizationJob(
 
   /** @inheritdoc */
   override def runImpl(implicit ctx: RuntimeContext): Option[Executable] = {
-    System.err.println("runImpl for " + expressionId);
     val stack =
       ctx.contextManager.getStack(config.executionContextId)
     val runtimeCache = stack.headOption
       .flatMap(frame => Option(frame.cache))
     runtimeCache.flatMap { c =>
+      System.err.println("runImpl for " + expressionId + " attaching to " + c);
       c.onModification(
         expressionId,
         immutable => {
@@ -165,12 +165,12 @@ class UpsertVisualizationJob(
     * @param ctx an instance of current `RuntimeContext`
     * @return true if failed due to required compilation and lack of required lock, false if successful
     */
-  def evaluateAndExecuteVisualization2(
+  private def evaluateAndExecuteVisualization2(
     value: Object,
     hasWriteLock: Boolean
   )(implicit ctx: RuntimeContext): (Boolean, Option[Executable]) = {
     UpsertVisualizationJob.logger.trace(
-      "Evaluating expression {} in observer",
+      "Evaluating2 expression {} in observer",
       expressionId
     )
     val maybeCallable = UpsertVisualizationJob.evaluateVisualizationExpression(
@@ -234,40 +234,10 @@ class UpsertVisualizationJob(
     val stack =
       ctx.contextManager.getStack(config.executionContextId)
 
-    // attach callable to runtimeCache
-    // here
-    System.err.println("Attach to value of " + expressionId)
-
     val runtimeCache = stack.headOption
       .flatMap(frame => Option(frame.cache))
     val cachedValue = runtimeCache
       .flatMap(c => {
-        c.onModification(
-          expressionId,
-          immutable => {
-            val data = immutable.get(expressionId)
-            System.err.println(
-              "Modified value of " + expressionId + " to " + data
-            );
-            if (data != null) {
-              val contextId = config.executionContextId
-              ctx.endpoint.sendToClient(
-                Api.Response(
-                  Api.VisualizationUpdate(
-                    Api.VisualizationContext(
-                      visualizationId,
-                      contextId,
-                      expressionId
-                    ),
-                    VisualizationResult.visualizationResultToBytes(
-                      data.toString()
-                    )
-                  )
-                )
-              )
-            }
-          }
-        )
         val v = c.runQuery(null, _.get(expressionId))
         System.err.println("Checked value of " + expressionId + " was: " + v)
         Option(v)
@@ -303,9 +273,10 @@ class UpsertVisualizationJob(
   )(implicit ctx: RuntimeContext): Option[Executable] = {
     val EvaluationResult(module, callable, arguments) = evaluatedVisualization
     UpsertVisualizationJob.logger.trace(
-      "Executing visualization {} for expression {}",
+      "Executing2 visualization {} for expression {} and value {}",
       visualizationId,
-      expressionId
+      expressionId,
+      value
     )
 
     val visualization =
@@ -336,6 +307,12 @@ class UpsertVisualizationJob(
       runtimeCache.getOrElse(RuntimeCache.create.cache),
       stack.headOption.get.syncState,
       visualization,
+      expressionId,
+      value
+    )
+    UpsertVisualizationJob.logger.trace(
+      "Executing2 finished visualization {} for expression {} and value {}",
+      visualizationId,
       expressionId,
       value
     )

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -92,67 +92,8 @@ class UpsertVisualizationJob(
           "  some value for " + expressionId + " = " + previous
         )
         // value is present
-        evaluateAndExecuteVisualization2(
-          previous,
-          hasWriteLock = false
-        )
         None
       }
-    }
-  }
-
-  /** Attempts to evaluate the visualization expression associated with this job.
-    *
-    * @param value computed value to be visualized
-    * @param runtimeCache an instance of runtime cache associated with this frame
-    * @param stack current stackframe
-    * @param hasWriteLock true if necessary module loading/compilation can be performed, if needed. False otherwise
-    * @param ctx an instance of current `RuntimeContext`
-    * @return true if failed due to required compilation and lack of required lock, false if successful
-    */
-  def evaluateAndExecuteVisualization(
-    hasWriteLock: Boolean
-  )(implicit ctx: RuntimeContext): (Boolean, Option[Executable]) = {
-    UpsertVisualizationJob.logger.trace(
-      "Evaluating expression {} in observer",
-      expressionId
-    )
-    val maybeCallable = UpsertVisualizationJob.evaluateVisualizationExpression(
-      config.visualizationModule,
-      config.expression,
-      hasWriteLock
-    )
-
-    maybeCallable match {
-      case Left(ModuleNotFound(moduleName)) =>
-        UpsertVisualizationJob.logger.trace(
-          "Evaluation of visualization {} in observer for expression {} failed. Module not found",
-          visualizationId,
-          expressionId
-        )
-        ctx.endpoint.sendToClient(
-          Api.Response(Api.ModuleNotFound(moduleName))
-        )
-        (false, None)
-      case Left(EvaluationFailed(message, result)) =>
-        UpsertVisualizationJob.logger.trace(
-          "Evaluation of visualization {} in observer for expression {} failed.",
-          visualizationId,
-          expressionId
-        )
-        replyWithExpressionFailedError(
-          config.executionContextId,
-          visualizationId,
-          expressionId,
-          message,
-          result
-        )
-        (false, None)
-      case Left(RequiresCompilation) =>
-        // todo reply with expr failed
-        (!hasWriteLock, None)
-      case Right(evaluatedExpression) =>
-        (false, executeVisualization(evaluatedExpression))
     }
   }
 
@@ -169,8 +110,9 @@ class UpsertVisualizationJob(
     value: Object,
     hasWriteLock: Boolean
   )(implicit ctx: RuntimeContext): (Boolean, Option[Executable]) = {
-    UpsertVisualizationJob.logger.trace(
-      "Evaluating2 expression {} in observer",
+    UpsertVisualizationJob.logger.debug(
+      "Evaluating visualization {} for expression {} in observer",
+      visualizationId,
       expressionId
     )
     val maybeCallable = UpsertVisualizationJob.evaluateVisualizationExpression(
@@ -181,7 +123,7 @@ class UpsertVisualizationJob(
 
     maybeCallable match {
       case Left(ModuleNotFound(moduleName)) =>
-        UpsertVisualizationJob.logger.trace(
+        UpsertVisualizationJob.logger.debug(
           "Evaluation of visualization {} in observer for expression {} failed. Module not found",
           visualizationId,
           expressionId
@@ -191,7 +133,7 @@ class UpsertVisualizationJob(
         )
         (false, None)
       case Left(EvaluationFailed(message, result)) =>
-        UpsertVisualizationJob.logger.trace(
+        UpsertVisualizationJob.logger.debug(
           "Evaluation of visualization {} in observer for expression {} failed.",
           visualizationId,
           expressionId
@@ -212,68 +154,13 @@ class UpsertVisualizationJob(
     }
   }
 
-  private def executeVisualization(
-    evaluatedVisualization: EvaluationResult
-  )(implicit ctx: RuntimeContext): Option[Executable] = {
-    val EvaluationResult(module, callable, arguments) = evaluatedVisualization
-    UpsertVisualizationJob.logger.trace(
-      "Executing visualization {} for expression {}",
-      visualizationId,
-      expressionId
-    )
-
-    val visualization =
-      UpsertVisualizationJob.updateAttachedVisualization(
-        visualizationId,
-        expressionId,
-        module,
-        config,
-        callable,
-        arguments
-      )
-    val stack =
-      ctx.contextManager.getStack(config.executionContextId)
-
-    val runtimeCache = stack.headOption
-      .flatMap(frame => Option(frame.cache))
-    val cachedValue = runtimeCache
-      .flatMap(c => {
-        val v = c.runQuery(null, _.get(expressionId))
-        System.err.println("Checked value of " + expressionId + " was: " + v)
-        Option(v)
-      })
-
-    UpsertVisualizationJob.requireVisualizationSynchronization(
-      stack,
-      visualizationId
-    )
-    cachedValue match {
-      case Some(value) =>
-        ProgramExecutionSupport.executeAndSendVisualizationUpdate(
-          config.executionContextId,
-          runtimeCache.getOrElse(RuntimeCache.create.cache),
-          stack.headOption.get.syncState,
-          visualization,
-          expressionId,
-          value
-        )
-        None
-      case None =>
-        UpsertVisualizationJob.logger.trace(
-          "Cached value for expresion {}: missing",
-          expressionId
-        )
-        Some(Executable(config.executionContextId, stack))
-    }
-  }
-
   private def executeVisualization2(
     value: Object,
     evaluatedVisualization: EvaluationResult
   )(implicit ctx: RuntimeContext): Option[Executable] = {
     val EvaluationResult(module, callable, arguments) = evaluatedVisualization
-    UpsertVisualizationJob.logger.trace(
-      "Executing2 visualization {} for expression {} and value {}",
+    UpsertVisualizationJob.logger.debug(
+      "Executing visualization {} for expression {} and value {}",
       visualizationId,
       expressionId,
       value
@@ -310,8 +197,8 @@ class UpsertVisualizationJob(
       expressionId,
       value
     )
-    UpsertVisualizationJob.logger.trace(
-      "Executing2 finished visualization {} for expression {} and value {}",
+    UpsertVisualizationJob.logger.debug(
+      "Finished executing visualization {} for expression {} and value {}",
       visualizationId,
       expressionId,
       value

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -61,6 +61,39 @@ class UpsertVisualizationJob(
 
   /** @inheritdoc */
   override def runImpl(implicit ctx: RuntimeContext): Option[Executable] = {
+    val stack =
+      ctx.contextManager.getStack(config.executionContextId)
+    val runtimeCache = stack.headOption
+      .flatMap(frame => Option(frame.cache))
+    runtimeCache.map(c =>
+      c.onModification(
+        expressionId,
+        immutable => {
+          val data = immutable.get(expressionId)
+          System.err.println(
+            "Modified value of " + expressionId + " to " + data
+          );
+          if (data != null) {
+            val contextId = config.executionContextId
+            ctx.endpoint.sendToClient(
+              Api.Response(
+                Api.VisualizationUpdate(
+                  Api.VisualizationContext(
+                    visualizationId,
+                    contextId,
+                    expressionId
+                  ),
+                  VisualizationResult.visualizationResultToBytes(
+                    data.toString()
+                  )
+                )
+              )
+            )
+          }
+        }
+      )
+    )
+    /*
     System.err.println(
       "UpsertVisualizationJob.runImpl before withReadContextLock"
     )
@@ -99,6 +132,8 @@ class UpsertVisualizationJob(
         }
       }
     )
+     */
+    None
   }
 
   /** Attempts to evaluate the visualization expression associated with this job.
@@ -110,7 +145,7 @@ class UpsertVisualizationJob(
     * @param ctx an instance of current `RuntimeContext`
     * @return true if failed due to required compilation and lack of required lock, false if successful
     */
-  private def evaluateAndExecuteVisualization(
+  def evaluateAndExecuteVisualization(
     hasWriteLock: Boolean
   )(implicit ctx: RuntimeContext): (Boolean, Option[Executable]) = {
     UpsertVisualizationJob.logger.trace(

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/RuntimeCacheTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/RuntimeCacheTest.java
@@ -151,6 +151,28 @@ public class RuntimeCacheTest {
     assertTrue("Two queries to the cache: " + queried, queried.contains(key2));
   }
 
+  @Test
+  public void observeCachedItems() {
+    var cache = new RuntimeCacheImpl();
+    var key = UUID.randomUUID();
+    var obj = 42;
+    var changeCounter = new int[1];
+    cache.onModification(
+        key,
+        (c) -> {
+          changeCounter[0]++;
+        });
+
+    assertFalse(cache.offer(key, obj));
+    assertNull(cache.get(key));
+    assertEquals("One change reported", 1, changeCounter[0]);
+
+    cache.setPreferences(of(key, CachePreferences.Kind.BINDING_EXPRESSION));
+    assertTrue(cache.offer(key, obj));
+    assertEquals(obj, cache.get(key));
+    assertEquals("Second change reported", 2, changeCounter[0]);
+  }
+
   private static void assertGC(String msg, boolean expectGC, Reference<?> ref) {
     for (var i = 1; i < Integer.MAX_VALUE / 2; i *= 2) {
       if (ref.get() == null) {


### PR DESCRIPTION
### Pull Request Description

- an attempt to address #14732 by providing `RuntimeCache.onModification`
- and (hopefully) registering the callback to UUID as soon as request arrives

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
