### PR TITLE
Log when a SoftReference in RuntimeCache is GCed

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/RuntimeCacheImpl.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.instrument;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -13,12 +14,16 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.enso.common.CachePreferences;
 import org.enso.interpreter.service.ExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A storage for computed values. */
 final class RuntimeCacheImpl extends RuntimeCache
     implements RuntimeCache.Immutable,
         RuntimeCache.Mutable,
         java.util.function.Function<String, Object> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeCache.class);
+
   private final Map<UUID, Reference<Object>> cache = new HashMap<>();
   private final Map<UUID, Reference<Object>> expressions = new HashMap<>();
   private final Map<UUID, TypeInfo> types = new HashMap<>();
@@ -54,7 +59,7 @@ final class RuntimeCacheImpl extends RuntimeCache
   public boolean offer(UUID key, Object value) {
     expressions.put(key, new WeakReference<>(value));
     if (preferences.contains(key)) {
-      var ref = new SoftReference<>(value);
+      var ref = new CacheReference<>(value, key);
       cache.put(key, ref);
       return true;
     }
@@ -260,12 +265,36 @@ final class RuntimeCacheImpl extends RuntimeCache
    */
   @Override
   public <V> V runQuery(Consumer<UUID> callback, Function<Immutable, V> scope) {
+    CacheReference.flushQueue();
     var previousCallback = this.observer;
     this.observer = callback;
     try {
       return scope.apply(this);
     } finally {
       this.observer = previousCallback;
+    }
+  }
+
+  private static final class CacheReference<T> extends SoftReference<T> {
+    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+
+    private final UUID key;
+
+    CacheReference(T referent, UUID key) {
+      super(referent, QUEUE);
+      this.key = key;
+    }
+
+    static void flushQueue() {
+      while (true) {
+        var obj = QUEUE.poll();
+        if (obj == null) {
+          return;
+        }
+        if (obj instanceof CacheReference ref) {
+          LOGGER.debug("Cached cleared for {}", ref.key);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Pull Request Description

- values in `RuntimeCache` are hold by `SoftReference`s
- such values may be released when the JVM is about to ask OS for more memory
- that might be true especially when working with huge workflows
- let's detect such release and log it


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually verified that a log happens:

```
$ grep RuntimeCache ~/.local/share/enso/log/enso-language-server-2026-02-12.0.log
[DEBUG] [2026-02-12T09:43:04.070] [org.enso.interpreter.instrument.RuntimeCache] Cached cleared for 42bbc07e-403a-4062-95b2-fb6ffeecc767
[DEBUG] [2026-02-12T09:43:04.070] [org.enso.interpreter.instrument.RuntimeCache] Cached cleared for cdc16553-9fa9-4428-8bcb-b725bbee27ec
[DEBUG] [2026-02-12T09:43:04.070] [org.enso.interpreter.instrument.RuntimeCache] Cached cleared for 115140c3-28d6-4257-a840-2c11a97220e7
```
```