### PR TITLE
Implement meaningful `PanicException.getStackTrace()`

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
@@ -1,12 +1,10 @@
 package org.enso.interpreter.instrument
 
 import java.nio.ByteBuffer
-import com.oracle.truffle.api.TruffleStackTrace
 import com.typesafe.scalalogging.Logger
 import org.enso.polyglot.debugger._
 import org.graalvm.polyglot.io.MessageEndpoint
-
-import scala.jdk.CollectionConverters._
+import org.enso.interpreter.runtime.error.PanicException
 
 /** Helper class that handles communication with Debugger client and delegates
   * request to the execution event node of the ReplDebuggerInstrument.
@@ -130,32 +128,17 @@ object DebuggerMessageHandler {
   private def fillInTruffleStackTraceForSerialization(
     exception: Exception
   ): Exception = {
-    val truffleTrace =
-      Option(TruffleStackTrace.getStackTrace(exception))
-        .map(_.asScala)
-        .getOrElse(Nil)
-
-    val javaTrace = truffleTrace.map { elem =>
-      val rootNode = elem.getTarget.getRootNode
-      val language =
-        Option(rootNode.getLanguageInfo).map(_.getId).getOrElse("unknown")
-      val declaringClass = s"<$language>"
-      val methodName = Option(rootNode.getQualifiedName)
-        .getOrElse("?")
-      val sourceLocation = for {
-        sourceSection <- Option(rootNode.getSourceSection)
-        source        <- Option(sourceSection.getSource)
-      } yield (source.getName, sourceSection.getStartLine)
-      val (fileName, lineNumber) = sourceLocation.getOrElse((null, -1))
-      new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
-    }
+    val javaTrace = PanicException.toJavaStackTrace(exception, true)
 
     if (javaTrace.nonEmpty) {
       var lastException: Throwable = exception
       while (lastException.getCause != null) {
         lastException = lastException.getCause
       }
-      if (lastException.getStackTrace.isEmpty) {
+      if (
+        lastException.getStackTrace.isEmpty || lastException
+          .isInstanceOf[PanicException]
+      ) {
         lastException.setStackTrace(javaTrace.toArray)
       }
     }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.error;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
@@ -9,6 +10,7 @@ import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.test.utils.ContextUtils;
 import org.enso.test.utils.TestRootNode;
+import org.graalvm.polyglot.PolyglotException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -46,5 +48,34 @@ public class PanicExceptionTest {
     assertEquals(text.toString(), ex.getMessage());
     var msg = InteropLibrary.getUncached().getExceptionMessage(ex);
     assertEquals(text, msg);
+  }
+
+  @Test
+  public void panicExceptionGetStackTrace() throws UnsupportedMessageException {
+    var fn =
+        ctxRule.evalModule(
+            """
+            from Standard.Base import all
+
+            throw n =
+                if n == 0 then
+                    Panic.throw "now"
+                else
+                    throw n-1
+            """,
+            "throw.enso",
+            "throw");
+
+    try {
+      var none = fn.execute(10);
+      fail("Not expecting any result: " + none);
+    } catch (PolyglotException ex) {
+      var panic = (PanicException) ctxRule.unwrapValue(ex.getGuestObject());
+      for (var i = 0; i < 10; i++) {
+        var polyElem = ex.getStackTrace()[i];
+        var truffleElem = panic.getStackTrace()[i];
+        assertEquals(polyElem, truffleElem);
+      }
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/error/PanicExceptionTest.java
@@ -71,11 +71,15 @@ public class PanicExceptionTest {
       fail("Not expecting any result: " + none);
     } catch (PolyglotException ex) {
       var panic = (PanicException) ctxRule.unwrapValue(ex.getGuestObject());
-      for (var i = 0; i < 10; i++) {
-        var polyElem = ex.getStackTrace()[i];
-        var truffleElem = panic.getStackTrace()[i];
-        assertEquals(polyElem, truffleElem);
-      }
+      assertStackTraces(10, ex, panic);
+    }
+  }
+
+  private void assertStackTraces(int depth, Exception first, Exception other) {
+    for (var i = 0; i < depth; i++) {
+      var polyElem = first.getStackTrace()[i];
+      var truffleElem = other.getStackTrace()[i];
+      assertEquals(polyElem, truffleElem);
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/DebugServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/DebugServerTest.scala
@@ -181,7 +181,7 @@ class DebugServerTest
 
       val traceMethodNames = lastException.getStackTrace.map(_.getMethodName)
       traceMethodNames should contain("Panic.throw")
-      traceMethodNames should contain("Test::Test::main")
+      traceMethodNames should contain("Test.main")
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/DebugServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/DebugServerTest.scala
@@ -181,7 +181,7 @@ class DebugServerTest
 
       val traceMethodNames = lastException.getStackTrace.map(_.getMethodName)
       traceMethodNames should contain("Panic.throw")
-      traceMethodNames should contain("Test.main")
+      traceMethodNames should contain("Test::Test::main")
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -14,6 +14,7 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -113,11 +114,15 @@ public final class PanicException extends AbstractTruffleException {
    * Extracts Truffle stack from provided exception and converts it into Java stack.
    *
    * @param t throwable to process
-   * @param useFqn
-   * @return
+   * @param useFqn should the method call {@link RootNode#getQualifiedName()} or just {@link
+   *     RootNode#getName()}?
+   * @return non-{@code null} array of Java stack trace elements representing the Truffle stack
    */
   public static StackTraceElement[] toJavaStackTrace(Throwable t, boolean useFqn) {
     var trace = TruffleStackTrace.getStackTrace(t);
+    if (trace == null) {
+      return new StackTraceElement[0];
+    }
     var collect = new ArrayList<StackTraceElement>();
     for (var elem : trace) {
       var node = elem.getInstrumentableLocation();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -103,31 +103,42 @@ public final class PanicException extends AbstractTruffleException {
   public StackTraceElement[] getStackTrace() {
     var arr = super.getStackTrace();
     if (arr.length == 0) {
-      var trace = TruffleStackTrace.getStackTrace(this);
-      var collect = new ArrayList<StackTraceElement>();
-      for (var elem : trace) {
-        var node = elem.getInstrumentableLocation();
-        if (node == null) {
-          continue;
-        }
-        var root = node.getRootNode();
-        if (root == null) {
-          continue;
-        }
-        var name = root.getName();
-        if (name == null) {
-          continue;
-        }
-        var info = root.getLanguageInfo();
-        var lang = info == null ? "" : "<" + info.getId() + ">";
-        var ss = node.getEncapsulatingSourceSection();
-        var java = new StackTraceElement(lang, name, fileName(ss), fileLine(ss));
-        collect.add(java);
-      }
-      arr = collect.toArray(StackTraceElement[]::new);
+      arr = toJavaStackTrace(this, false);
       setStackTrace(arr);
     }
     return arr;
+  }
+
+  /**
+   * Extracts Truffle stack from provided exception and converts it into Java stack.
+   *
+   * @param t throwable to process
+   * @param useFqn
+   * @return
+   */
+  public static StackTraceElement[] toJavaStackTrace(Throwable t, boolean useFqn) {
+    var trace = TruffleStackTrace.getStackTrace(t);
+    var collect = new ArrayList<StackTraceElement>();
+    for (var elem : trace) {
+      var node = elem.getInstrumentableLocation();
+      if (node == null) {
+        continue;
+      }
+      var root = node.getRootNode();
+      if (root == null) {
+        continue;
+      }
+      var name = useFqn ? root.getQualifiedName() : root.getName();
+      if (name == null) {
+        continue;
+      }
+      var info = root.getLanguageInfo();
+      var lang = info == null ? "" : "<" + info.getId() + ">";
+      var ss = node.getEncapsulatingSourceSection();
+      var java = new StackTraceElement(lang, name, fileName(ss), fileLine(ss));
+      collect.add(java);
+    }
+    return collect.toArray(StackTraceElement[]::new);
   }
 
   private static int fileLine(SourceSection ss) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -14,7 +14,6 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -112,20 +111,17 @@ public final class PanicException extends AbstractTruffleException {
           continue;
         }
         var root = node.getRootNode();
-        if (root == null || root.getName() == null) {
+        if (root == null) {
+          continue;
+        }
+        var name = root.getName();
+        if (name == null) {
           continue;
         }
         var info = root.getLanguageInfo();
         var lang = info == null ? "" : "<" + info.getId() + ">";
-        var java = new StackTraceElement(lang, root.getName(), "Unknown", -1);
-
         var ss = node.getEncapsulatingSourceSection();
-        if (ss != null) {
-          var src = ss.getSource();
-          java =
-              new StackTraceElement(
-                  lang, node.getRootNode().getName(), fileName(src), ss.getStartLine());
-        }
+        var java = new StackTraceElement(lang, name, fileName(ss), fileLine(ss));
         collect.add(java);
       }
       arr = collect.toArray(StackTraceElement[]::new);
@@ -134,7 +130,15 @@ public final class PanicException extends AbstractTruffleException {
     return arr;
   }
 
-  private static String fileName(Source src) {
+  private static int fileLine(SourceSection ss) {
+    return ss == null ? -1 : ss.getStartLine();
+  }
+
+  private static String fileName(SourceSection ss) {
+    if (ss == null) {
+      return "Unknown";
+    }
+    var src = ss.getSource();
     if (src.getPath() != null) {
       return src.getPath();
     } else {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -14,7 +14,10 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -95,6 +98,60 @@ public final class PanicException extends AbstractTruffleException {
       return computeMessage();
     }
     return cacheMessage;
+  }
+
+  @Override
+  public StackTraceElement[] getStackTrace() {
+    var arr = super.getStackTrace();
+    if (arr.length == 0) {
+      var trace = TruffleStackTrace.getStackTrace(this);
+      var collect = new ArrayList<StackTraceElement>();
+      for (var elem : trace) {
+        var node = elem.getInstrumentableLocation();
+        if (node == null) {
+          continue;
+        }
+        var root = node.getRootNode();
+        if (root == null || root.getName() == null) {
+          continue;
+        }
+        var info = root.getLanguageInfo();
+        var lang = info == null ? "" : "<" + info.getId() + ">";
+        var java = new StackTraceElement(lang, root.getName(), "Unknown", -1);
+
+        var ss = node.getEncapsulatingSourceSection();
+        if (ss != null) {
+          var src = ss.getSource();
+          java =
+              new StackTraceElement(
+                  lang, node.getRootNode().getName(), fileName(src), ss.getStartLine());
+        }
+        collect.add(java);
+      }
+      arr = collect.toArray(StackTraceElement[]::new);
+      setStackTrace(arr);
+    }
+    return arr;
+  }
+
+  private static String fileName(Source src) {
+    if (src.getPath() != null) {
+      return src.getPath();
+    } else {
+      return src.getName();
+    }
+  }
+
+  @Override
+  public void printStackTrace(PrintStream s) {
+    getStackTrace();
+    super.printStackTrace(s);
+  }
+
+  @Override
+  public void printStackTrace(PrintWriter s) {
+    getStackTrace();
+    super.printStackTrace(s);
   }
 
   /**


### PR DESCRIPTION
### Pull Request Description

- #14745 fixed error in table visualization
- before that there was `PanicException`, but without printed stacktrace
- this change makes sure the stacktrace in this failure is properly printed

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
