### PR TITLE
Fixes in remote backend error handling

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1729,11 +1729,11 @@ export abstract class Backend {
     }
 
     const error =
-      response == null || response.headers.get('Content-Type') !== 'application/json' ?
+      response == null || !response.headers.get('Content-Type')?.startsWith('application/json') ?
         { message: 'unknown error' }
       : await ((): Promise<Error> => response.json())()
 
-    const message = `${this.getText(textId, ...replacements)}: ${error.message}.`
+    const message = `${this.getText(textId, ...replacements)}: ${error.message}`
     console.error(message)
 
     const status = response?.status

--- a/app/common/src/services/RemoteBackend.ts
+++ b/app/common/src/services/RemoteBackend.ts
@@ -268,7 +268,7 @@ export class RemoteBackend extends backend.Backend {
 
   /**
    * Return details for the current organization.
-   * @returns `null` if a non-successful status code (not 200-299) was received.
+   * @returns `null` if a organization was not found or user has no permissions to view it.
    */
   override async getOrganization(): Promise<backend.OrganizationInfo | null> {
     const path = remoteBackendPaths.GET_ORGANIZATION_PATH
@@ -331,7 +331,7 @@ export class RemoteBackend extends backend.Backend {
 
   /**
    * Return details for the current user.
-   * @returns `null` if a non-successful status code (not 200-299) was received.
+   * @returns `null` if the user was not found.
    */
   override async usersMe(): Promise<backend.User | null> {
     const response = await this.get<backend.User>(remoteBackendPaths.USERS_ME_PATH)
@@ -732,7 +732,7 @@ export class RemoteBackend extends backend.Backend {
     const path = remoteBackendPaths.deleteProjectExecutionPath(executionId)
     const response = await this.delete<backend.ProjectExecution>(path)
     if (!response.ok) {
-      return await this.throw(response, 'createProjectExecutionBackendError', projectTitle)
+      return await this.throw(response, 'deleteProjectExecutionBackendError', projectTitle)
     } else {
       return
     }
@@ -1548,6 +1548,9 @@ export class RemoteBackend extends backend.Backend {
     const { assetIds, filePath } = params
     const path = remoteBackendPaths.EXPORT_ARCHIVE_PATH
     const response = await this.post<{ readonly jobId: backend.ZipAssetsJobId }>(path, { assetIds })
+    if (!response.ok) {
+      return await this.throw(response, 'exportArchiveBackendError')
+    }
     const { jobId } = await response.json()
     const statusPath = remoteBackendPaths.getExportArchiveJobStatusPath(jobId)
     while (true) {

--- a/app/common/src/services/RemoteBackend.ts
+++ b/app/common/src/services/RemoteBackend.ts
@@ -18,10 +18,8 @@ import * as remoteBackendPaths from './Backend/remoteBackendPaths.js'
 import type { HttpClient } from './HttpClient.js'
 import { organizationIdToDirectoryId } from './RemoteBackend/ids.js'
 
-/** HTTP status indicating that the resource does not exist. */
-const STATUS_NOT_FOUND = 404
-/** HTTP status indicating that authorized user doesn't have access to the given resource */
-const STATUS_NOT_ALLOWED = 403
+const HTTP_STATUS_NOT_FOUND = 404
+const HTTP_STATUS_NOT_ALLOWED = 403
 /** The interval between checks for the export status. */
 const EXPORT_STATUS_INTERVAL_MS = 5_000
 /** The interval between checks for the import status. */
@@ -111,7 +109,7 @@ export class RemoteBackend extends backend.Backend {
   override async listUsers(): Promise<readonly Omit<backend.User, 'groups'>[]> {
     const path = remoteBackendPaths.LIST_USERS_PATH
     const response = await this.get<backend.ListUsersResponseBody>(path)
-    if (response.status === STATUS_NOT_ALLOWED) {
+    if (response.status === HTTP_STATUS_NOT_ALLOWED) {
       return []
     } else if (!response.ok) {
       return await this.throw(response, 'listUsersBackendError')
@@ -137,7 +135,7 @@ export class RemoteBackend extends backend.Backend {
     const response = await this.put(path, body)
     if (!response.ok) {
       return body.username != null ?
-          await this.throw(response, 'updateUsernameBackendError')
+        await this.throw(response, 'updateUsernameBackendError')
         : await this.throw(response, 'updateUserBackendError')
     } else {
       if (this.user != null && body.username != null) {
@@ -276,9 +274,8 @@ export class RemoteBackend extends backend.Backend {
     const path = remoteBackendPaths.GET_ORGANIZATION_PATH
     const response = await this.get<backend.OrganizationInfo>(path)
 
-    if ([STATUS_NOT_ALLOWED, STATUS_NOT_FOUND].includes(response.status)) {
-      // Organization info has not yet been created.
-      // or the user is not eligible to create an organization.
+    if ([HTTP_STATUS_NOT_ALLOWED, HTTP_STATUS_NOT_FOUND].includes(response.status)) {
+      // Organization not found or the user is not allowed to get its info.
       return null
     }
 
@@ -292,14 +289,11 @@ export class RemoteBackend extends backend.Backend {
   /** Update details for the current organization. */
   override async updateOrganization(
     body: backend.UpdateOrganizationRequestBody,
-  ): Promise<backend.OrganizationInfo | null> {
+  ): Promise<backend.OrganizationInfo> {
     const path = remoteBackendPaths.UPDATE_ORGANIZATION_PATH
     const response = await this.patch<backend.OrganizationInfo>(path, body)
 
-    if (response.status === STATUS_NOT_FOUND) {
-      // Organization info has not yet been created.
-      return null
-    } else if (!response.ok) {
+    if (!response.ok) {
       return await this.throw(response, 'updateOrganizationBackendError')
     } else {
       return await response.json()
@@ -342,7 +336,7 @@ export class RemoteBackend extends backend.Backend {
   override async usersMe(): Promise<backend.User | null> {
     const response = await this.get<backend.User>(remoteBackendPaths.USERS_ME_PATH)
 
-    if (response.status === STATUS_NOT_FOUND) {
+    if (response.status === HTTP_STATUS_NOT_FOUND) {
       // User info has not yet been created, we should redirect to the onboarding page.
       return null
     }
@@ -390,7 +384,7 @@ export class RemoteBackend extends backend.Backend {
     const paramsString = new URLSearchParams(
       query.recentProjects === true ?
         [['recent_projects', String(true)]]
-      : [
+        : [
           ...(query.parentId != null ? [['parent_id', query.parentId]] : []),
           ...(query.filterBy != null ? [['filter_by', query.filterBy]] : []),
           ...(query.from != null ? [['from', query.from]] : []),
@@ -818,7 +812,7 @@ export class RemoteBackend extends backend.Backend {
     const response = await this.get<backend.AssetDetailsResponse<Id>>(path)
 
     if (!response.ok) {
-      if (response.status === STATUS_NOT_FOUND) {
+      if (response.status === HTTP_STATUS_NOT_FOUND) {
         if (backend.isDirectoryId(assetId)) {
           throw new backend.DirectoryDoesNotExistError()
         }
@@ -1220,7 +1214,7 @@ export class RemoteBackend extends backend.Backend {
   override async listUserGroups(): Promise<backend.UserGroupInfo[]> {
     const path = remoteBackendPaths.LIST_USER_GROUPS_PATH
     const response = await this.get<backend.UserGroupInfo[]>(path)
-    if (response.status === STATUS_NOT_ALLOWED) {
+    if (response.status === HTTP_STATUS_NOT_ALLOWED) {
       return [] as const
     } else if (!response.ok) {
       return this.throw(response, 'listUserGroupsBackendError')

--- a/app/common/src/services/RemoteBackend.ts
+++ b/app/common/src/services/RemoteBackend.ts
@@ -135,7 +135,7 @@ export class RemoteBackend extends backend.Backend {
     const response = await this.put(path, body)
     if (!response.ok) {
       return body.username != null ?
-        await this.throw(response, 'updateUsernameBackendError')
+          await this.throw(response, 'updateUsernameBackendError')
         : await this.throw(response, 'updateUserBackendError')
     } else {
       if (this.user != null && body.username != null) {
@@ -384,7 +384,7 @@ export class RemoteBackend extends backend.Backend {
     const paramsString = new URLSearchParams(
       query.recentProjects === true ?
         [['recent_projects', String(true)]]
-        : [
+      : [
           ...(query.parentId != null ? [['parent_id', query.parentId]] : []),
           ...(query.filterBy != null ? [['filter_by', query.filterBy]] : []),
           ...(query.from != null ? [['from', query.from]] : []),

--- a/app/gui/src/dashboard/components/Form/components/FormError.tsx
+++ b/app/gui/src/dashboard/components/Form/components/FormError.tsx
@@ -33,7 +33,13 @@ export function FormError(props: FormErrorProps) {
             icon={icon}
             {...alertProps}
           >
-            <Text variant="body" truncate="3" color="primary" testId={testId}>
+            <Text
+              disableLineHeightCompensation
+              variant="body"
+              truncate="3"
+              color="primary"
+              testId={testId}
+            >
               {error.message}
             </Text>
           </Alert>


### PR DESCRIPTION
### Pull Request Description

I noticed that editing organization can return a cryptic error message:

<img width="516" height="126" alt="CleanShot 2026-02-13 at 15 53 08" src="https://github.com/user-attachments/assets/feb2d072-cdf2-4f48-8d22-0b898b1ffd2f" />

Now it is fixed:

<img width="532" height="141" alt="CleanShot 2026-02-13 at 15 53 33" src="https://github.com/user-attachments/assets/2d82fcbc-039e-4489-b5f1-daa744062f2a" />

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
