### PR TITLE
WidgetText collapsed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - [Add component alignment options][14590].
 - [Components have Expanded/Collapsed modes][14678]. The effect is visible in
   Table.input components.
+- [Text widgets have a fixed maximum size in collapsed mode][14775]
 
 [14590]: https://github.com/enso-org/enso/pull/14590
 [14678]: https://github.com/enso-org/enso/pull/14678
+[14775]: https://github.com/enso-org/enso/pull/14775
 
 #### Enso Standard Library
 

--- a/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
+++ b/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
@@ -9,7 +9,12 @@ import CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
 import VueHostRender, { VueHostInstance } from '@/components/VueHostRender.vue'
 import { Ast } from '@/util/ast'
 import { targetIsOutside } from '@/util/autoBlur'
-import { selectAllOnMouseFocus, useCodeMirror, useStringSync } from '@/util/codemirror'
+import {
+  selectAllOnMouseFocus,
+  singleLineDisplay,
+  useCodeMirror,
+  useStringSync,
+} from '@/util/codemirror'
 import { highlightStyle } from '@/util/codemirror/highlight'
 import { useToast } from '@/util/toast'
 import { type Extension } from '@codemirror/state'
@@ -30,6 +35,7 @@ const props = defineProps<{
   transformUserInput?: (value: string) => Ast.Owned<Ast.MutableTextLiteral> | string
   /** Editor line mode. Single-line mode will not allow entering newline characters. */
   lineMode: 'single' | 'multi' | 'auto' | 'autoMulti'
+  singleLineDisplay?: boolean
   syncAfterAccept?: boolean
   onAccepted?: (value: string) => HandledUpdate
 }>()
@@ -55,7 +61,8 @@ const { editorView } = useCodeMirror(editorRoot, {
     syncExt,
     () => (editorRoot.value ? highlightStyle(editorRoot.value.highlightClasses) : []),
     () =>
-      props.lineMode !== 'multi' && props.lineMode !== 'autoMulti' ? [selectAllOnMouseFocus] : [],
+      props.lineMode !== 'multi' && props.lineMode !== 'autoMulti' ? selectAllOnMouseFocus : [],
+    () => (props.singleLineDisplay ? singleLineDisplay() : []),
     () => props.extensions ?? [],
   ],
   readonly: false,

--- a/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
+++ b/app/gui/src/project-view/components/GraphEditor/CodeMirrorWidgetBase.vue
@@ -11,7 +11,7 @@ import { Ast } from '@/util/ast'
 import { targetIsOutside } from '@/util/autoBlur'
 import {
   selectAllOnMouseFocus,
-  singleLineDisplay,
+  singleLineDisplay as singleLineDisplayExt,
   useCodeMirror,
   useStringSync,
 } from '@/util/codemirror'
@@ -62,7 +62,7 @@ const { editorView } = useCodeMirror(editorRoot, {
     () => (editorRoot.value ? highlightStyle(editorRoot.value.highlightClasses) : []),
     () =>
       props.lineMode !== 'multi' && props.lineMode !== 'autoMulti' ? selectAllOnMouseFocus : [],
-    () => (props.singleLineDisplay ? singleLineDisplay() : []),
+    () => (props.singleLineDisplay ? singleLineDisplayExt() : []),
     () => props.extensions ?? [],
   ],
   readonly: false,

--- a/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui/src/project-view/components/GraphEditor/widgets/WidgetText.vue
@@ -9,6 +9,7 @@ import {
 } from '$/providers/openedProjects/widgetRegistry'
 import CodeMirrorWidgetBase from '@/components/GraphEditor/CodeMirrorWidgetBase.vue'
 import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import { injectWidgetTree } from '@/providers/widgetTree'
 import { Ast } from '@/util/ast'
 import { useLanguageSupport } from '@/util/codemirror/language'
 import { Ok } from 'enso-common/src/utilities/data/result'
@@ -17,6 +18,7 @@ import { computed, ref, useTemplateRef } from 'vue'
 const baseEditor = useTemplateRef('baseEditor')
 const props = defineProps(widgetProps(widgetDefinition))
 const { module } = useCurrentProject()
+const tree = injectWidgetTree()
 
 function focusAndSelect() {
   baseEditor.value?.focusAndSelect()
@@ -123,34 +125,54 @@ export const widgetDefinition = defineWidget(
     @pointerdown.stop.prevent="focusAndSelect"
     @click.stop
   >
-    <NodeWidget v-if="openToken" :input="WidgetInput.FromAst(openToken)" class="delimiter open" />
-    <CodeMirrorWidgetBase
-      ref="baseEditor"
-      v-model="textContents"
-      contentTestId="widget-text-content"
-      :placeholder="placeholder"
-      :lineMode="isMultiline ? 'autoMulti' : 'auto'"
-      :extensions="extensions"
-      :widgetTypeId="widgetTypeId"
-      :input="input"
-      :transformUserInput="makeLiteralFromUserInput"
-      :onAccepted="acceptValue"
-      @textEdited="onTextEdited"
-    />
-    <NodeWidget
-      v-if="closeToken"
-      :input="WidgetInput.FromAst(closeToken)"
-      class="delimiter close"
-    />
+    <span class="textValue" :class="{ collapsed: !tree.expanded }">
+      <NodeWidget v-if="openToken" :input="WidgetInput.FromAst(openToken)" class="delimiter open" />
+      <CodeMirrorWidgetBase
+        ref="baseEditor"
+        v-model="textContents"
+        contentTestId="widget-text-content"
+        :placeholder="placeholder"
+        :lineMode="
+          tree.expanded ?
+            isMultiline ? 'autoMulti'
+            : 'auto'
+          : 'single'
+        "
+        :singleLineDisplay="!tree.expanded"
+        :extensions="extensions"
+        :widgetTypeId="widgetTypeId"
+        :input="input"
+        :transformUserInput="makeLiteralFromUserInput"
+        :onAccepted="acceptValue"
+        @textEdited="onTextEdited"
+      />
+      <NodeWidget
+        v-if="closeToken"
+        :input="WidgetInput.FromAst(closeToken)"
+        class="delimiter close"
+      />
+    </span>
   </label>
 </template>
 
 <style scoped>
 .WidgetText {
+}
+
+.textValue {
   display: inline-flex;
-  justify-content: center;
   align-items: center;
   align-self: start;
+  overflow-x: auto;
+  &.collapsed {
+    max-width: 300px;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    &:focus-within {
+      max-width: 400px;
+    }
+  }
 }
 
 .widgetSingleLine :deep(.cm-scroller) {

--- a/app/gui/src/project-view/util/__tests__/singleLineDisplay.test.ts
+++ b/app/gui/src/project-view/util/__tests__/singleLineDisplay.test.ts
@@ -1,0 +1,49 @@
+import { singleLineDisplay } from '@/util/codemirror/singleLineDisplay'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { expect, test } from 'vitest'
+
+function decorations(source: string) {
+  const view = new EditorView({
+    state: EditorState.create({
+      doc: source,
+      extensions: singleLineDisplay(),
+    }),
+  })
+  const decorationSets = view.state.facet(EditorView.decorations)
+  const results = []
+  for (const decorationSet of decorationSets) {
+    const resolvedDecorations =
+      decorationSet instanceof Function ? decorationSet(view) : decorationSet
+    const cursor = resolvedDecorations.iter()
+    while (cursor.value != null) {
+      results.push({ from: cursor.from, to: cursor.to })
+      cursor.next()
+    }
+  }
+  return results
+}
+
+test.each([
+  { source: '', breaks: [] },
+  { source: 'a', breaks: [] },
+  { source: 'a\nb', breaks: [{ from: 1, to: 2 }] },
+  { source: '\nb', breaks: [{ from: 0, to: 1 }] },
+  { source: 'a\n', breaks: [{ from: 1, to: 2 }] },
+  {
+    source: 'a\nb\n',
+    breaks: [
+      { from: 1, to: 2 },
+      { from: 3, to: 4 },
+    ],
+  },
+  {
+    source: 'a\n\n',
+    breaks: [
+      { from: 1, to: 2 },
+      { from: 2, to: 3 },
+    ],
+  },
+])('Line break ranges', ({ source, breaks }) => {
+  expect(decorations(source)).toEqual(breaks)
+})

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -48,6 +48,7 @@ import { assert } from 'ydoc-shared/util/assert'
 import { Range } from 'ydoc-shared/util/data/range'
 import type { LocalUserActionOrigin } from 'ydoc-shared/yjsModel'
 import * as Y from 'yjs'
+export { singleLineDisplay } from '@/util/codemirror/singleLineDisplay'
 
 function disableEditContextApi() {
   ;(EditorView as any).EDIT_CONTEXT = false

--- a/app/gui/src/project-view/util/codemirror/singleLineDisplay.ts
+++ b/app/gui/src/project-view/util/codemirror/singleLineDisplay.ts
@@ -54,6 +54,7 @@ const ext = StateField.define<DecorationSet>({
   provide: (f) => EditorView.decorations.from(f),
 })
 
+/** @internal */
 export function decorateLinebreaks(state: EditorState, decorate: () => Decoration) {
   if (!state.doc.length) return Decoration.none
   const builder = new RangeSetBuilder<Decoration>()
@@ -68,6 +69,7 @@ export function decorateLinebreaks(state: EditorState, decorate: () => Decoratio
   return builder.finish()
 }
 
+/** CodeMirror extension that renders linebreaks as an inline placeholder character. */
 export function singleLineDisplay(): Extension {
   return ext
 }

--- a/app/gui/src/project-view/util/codemirror/singleLineDisplay.ts
+++ b/app/gui/src/project-view/util/codemirror/singleLineDisplay.ts
@@ -1,0 +1,73 @@
+import { RangeSetBuilder, StateField, type EditorState, type Extension } from '@codemirror/state'
+import { Decoration, EditorView, WidgetType, type DecorationSet } from '@codemirror/view'
+
+class PlainTextWidget extends WidgetType {
+  private element: HTMLElement | undefined
+
+  /** Constructor. */
+  constructor(
+    protected readonly className: string,
+    protected readonly text: string,
+  ) {
+    super()
+  }
+
+  /** See {@link WidgetType.estimatedHeight}. */
+  override get estimatedHeight() {
+    return 1
+  }
+
+  /** See {@link WidgetType.toDOM}. */
+  override toDOM(): HTMLElement {
+    if (!this.element) {
+      const container = document.createElement('span')
+      container.className = this.className
+      container.textContent = this.text
+      this.element = container
+    }
+    return this.element
+  }
+
+  /** See {@link WidgetType.destroy}. */
+  override destroy() {
+    this.element = undefined
+  }
+}
+
+const lineBreakPlaceholder = () => new PlainTextWidget('cm-linebreak-placeholder', '\u21B5')
+function makeDecos(state: EditorState) {
+  return decorateLinebreaks(state, () =>
+    Decoration.replace({
+      widget: lineBreakPlaceholder(),
+    }),
+  )
+}
+
+const ext = StateField.define<DecorationSet>({
+  create(state) {
+    return makeDecos(state)
+  },
+  update(prev, tr) {
+    if (!tr.docChanged) return prev
+    return makeDecos(tr.state)
+  },
+  provide: (f) => EditorView.decorations.from(f),
+})
+
+export function decorateLinebreaks(state: EditorState, decorate: () => Decoration) {
+  if (!state.doc.length) return Decoration.none
+  const builder = new RangeSetBuilder<Decoration>()
+  let pos = 0
+  const iter = state.doc.iter()
+  while (!iter.done) {
+    const from = pos
+    pos += iter.value.length
+    if (iter.lineBreak) builder.add(from, pos, decorate())
+    iter.next()
+  }
+  return builder.finish()
+}
+
+export function singleLineDisplay(): Extension {
+  return ext
+}

--- a/app/gui/tsconfig.app.json
+++ b/app/gui/tsconfig.app.json
@@ -806,6 +806,7 @@
     "./src/project-view/util/codemirror/persistence/persistableStatePlugin.ts",
     "./src/project-view/util/codemirror/persistence/scroll.ts",
     "./src/project-view/util/codemirror/reactivity.ts",
+    "./src/project-view/util/codemirror/singleLineDisplay.ts",
     "./src/project-view/util/codemirror/stateEffect.ts",
     "./src/project-view/util/codemirror/testSupport.ts",
     "./src/project-view/util/codemirror/text.ts",

--- a/app/gui/tsconfig.app.vitest.json
+++ b/app/gui/tsconfig.app.vitest.json
@@ -69,6 +69,7 @@
     "./src/project-view/util/__tests__/qualifiedName.test.ts",
     "./src/project-view/util/__tests__/range.test.ts",
     "./src/project-view/util/__tests__/shortcuts.test.ts",
+    "./src/project-view/util/__tests__/singleLineDisplay.test.ts",
     "./src/project-view/util/__tests__/url.test.ts",
     "./src/project-view/util/ast/__tests__/abstract.test.ts",
     "./src/project-view/util/ast/__tests__/abstractFileIo.test.ts",


### PR DESCRIPTION
### Pull Request Description

When a component is collapsed, any contained text widget:
- has a fixed maximum width
  - this width is increased when the widget is focused
  - long text can be scrolled with the cursor
- is displayed in a single line, with newline characters shown as a placeholder character
  - copying from the text will copy the real newlines, not the placeholder

https://github.com/user-attachments/assets/d8a20226-8c7f-4bfc-a619-ec407546443a

Fixes #14625.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
