### PR TITLE
Fix handling of fragmented websocket messages in polyglot ydoc

### DIFF
--- a/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
+++ b/lib/java/ydoc-polyfill/src/main/java/org/enso/ydoc/polyfill/web/WebSocket.java
@@ -15,6 +15,7 @@ import io.helidon.websocket.WsSession;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -270,6 +271,7 @@ final class WebSocket implements ProxyExecutable {
     private final Value handleUpgrade;
 
     private WsSession session;
+    private final List<byte[]> fragments = new ArrayList<>();
 
     private WebSocketConnection(
         ScheduledExecutorService executor,
@@ -300,9 +302,34 @@ final class WebSocket implements ProxyExecutable {
     @Override
     public void onMessage(WsSession session, BufferData buffer, boolean last) {
       log.debug("onMessage\n{}", buffer.debugDataHex(true));
+      var rawBytes = buffer.readBytes();
+
+      if (!last) {
+        fragments.add(rawBytes);
+        return;
+      }
+
+      final byte[] messageBytes;
+      if (fragments.isEmpty()) {
+        messageBytes = rawBytes;
+      } else {
+        fragments.add(rawBytes);
+        var totalLength = 0;
+        for (var fragment : fragments) {
+          totalLength += fragment.length;
+        }
+        messageBytes = new byte[totalLength];
+        var offset = 0;
+        for (var fragment : fragments) {
+          System.arraycopy(fragment, 0, messageBytes, offset, fragment.length);
+          offset += fragment.length;
+        }
+        log.debug("Reassembled {} fragments into {} bytes", fragments.size(), totalLength);
+        fragments.clear();
+      }
 
       // Passing byte sequence to JS requires `HostAccess.allowBufferAccess()`
-      var bytes = ByteSequence.create(buffer.readBytes());
+      var bytes = ByteSequence.create(messageBytes);
       handleCallback(() -> handleMessage.executeVoid(bytes));
     }
 

--- a/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
+++ b/lib/java/ydoc-polyfill/src/test/java/org/enso/ydoc/polyfill/web/WebSocketTest.java
@@ -307,6 +307,57 @@ public class WebSocketTest extends ExecutorSetup {
     Assert.assertTrue(res.get());
   }
 
+  @Test
+  public void reassembleFragmentedBinaryMessage() throws Exception {
+    var fragmentServer =
+        WebServer.builder()
+            .host("localhost")
+            .port(22335)
+            .addRouting(WsRouting.builder().endpoint("/", new FragmentingWsListener()))
+            .build();
+    fragmentServer.start();
+
+    try {
+      var lock = new Semaphore(0);
+      var res = new AtomicReference<>();
+
+      var code =
+          """
+          const ws = new WebSocket('ws://localhost:22335');
+          ws.on('open', () => {
+            ws.send('trigger');
+          });
+          ws.on('message', (data) => {
+            res.set(new Uint8Array(data).toString());
+            lock.release();
+          });
+          """;
+
+      context.getBindings("js").putMember("lock", lock);
+      context.getBindings("js").putMember("res", res);
+
+      CompletableFuture.supplyAsync(() -> context.eval("js", code), executor).get();
+
+      lock.acquire();
+
+      Assert.assertEquals("1,2,3,4,5,6", res.get());
+    } finally {
+      fragmentServer.stop();
+    }
+  }
+
+  private static final class FragmentingWsListener implements WsListener {
+    FragmentingWsListener() {}
+
+    @Override
+    public void onMessage(WsSession session, String text, boolean last) {
+      // Reply with a single logical binary message split across 3 WebSocket frames
+      session.send(BufferData.create(new byte[] {1, 2}), false);
+      session.send(BufferData.create(new byte[] {3, 4}), false);
+      session.send(BufferData.create(new byte[] {5, 6}), true);
+    }
+  }
+
   private static final class TestWsListener implements WsListener {
     TestWsListener() {}
 


### PR DESCRIPTION
### Pull Request Description

Large messages, likely caused by large nodes being moved around or c&p, led to fragmented websocket messages being exchanged with polyglot websocket implementation. That appeared to be problematic as partial messages were being passed over to JS callbacks and the latter are not aware of the possibility of such fragmentation.
This changes collects such partial messages and only passes them whenever the last message in received. 
That appears to fix common problems with #14772.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
