### PR TITLE
Allow to capture output of `Suite.run_with_filter` 

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/docs/api/Suite.md
+++ b/distribution/lib/Standard/Test/0.0.0-dev/docs/api/Suite.md
@@ -3,6 +3,6 @@
 - type Suite
     - group_names self -> Standard.Base.Any.Any
     - print_all self -> Standard.Base.Any.Any
-    - run_with_filter self filter:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)= should_exit:Standard.Base.Data.Boolean.Boolean= -> (Standard.Base.Data.Boolean.Boolean|Standard.Base.Nothing.Nothing)
+    - run_with_filter self filter:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)= should_exit:Standard.Base.Data.Boolean.Boolean= output:(Standard.Base.Data.Text.Text -> Standard.Base.Nothing.Nothing)= -> (Standard.Base.Data.Boolean.Boolean|Standard.Base.Nothing.Nothing)
 - type Suite_Builder
     - group self name:Standard.Base.Data.Text.Text fn:(Standard.Test.Group.Group_Builder -> Standard.Base.Any.Any) ~pending:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -93,10 +93,10 @@ type Suite
                 case group.is_pending of
                     False ->
                         results = Helpers.run_specs_from_group specs group progress_reporter
-                        Test_Reporter.print_report results config junit_sb_builder
+                        Test_Reporter.print_report IO.println results config junit_sb_builder
                         all_results_bldr.append_vector_range results
                     True ->
-                        Test_Reporter.print_pending_group group config junit_sb_builder
+                        Test_Reporter.print_pending_group IO.println group config junit_sb_builder
 
         all_results = all_results_bldr.to_vector
         succ_tests = all_results.filter (r-> r.is_success) . length

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -55,12 +55,16 @@ type Suite
         - `should_exit`: If true, executes `System.exit` at the end, so the
           method does not return. If false, return boolean from the method
           indicating whether some tests failed.
+        - `output`: A function to print out textual info about progress of execution.
+          By default it uses `IO.println` output
 
        ## Returns
        Boolean if `should_exit` is False, otherwise exits the process.
-    run_with_filter self (filter : (Text | Nothing) = Nothing) (should_exit : Boolean = True) -> (Boolean | Nothing) =
+    run_with_filter self (filter : (Text | Nothing) = Nothing) (should_exit : Boolean = True) (output:Text->Nothing=IO.println) -> (Boolean | Nothing) =
         config = Suite_Config.from_environment
+        self.run_impl output config filter should_exit
 
+    private run_impl self println config:Suite_Config (filter : (Text | Nothing) = Nothing) (should_exit : Boolean = True) -> (Boolean | Nothing) =
         # List of pairs of groups and their specs that match the filter
         matching_specs = self.groups.flat_map group->
             group_matches = Helpers.name_matches group.name filter
@@ -93,10 +97,10 @@ type Suite
                 case group.is_pending of
                     False ->
                         results = Helpers.run_specs_from_group specs group progress_reporter
-                        Test_Reporter.print_report IO.println results config junit_sb_builder
+                        Test_Reporter.print_report println results config junit_sb_builder
                         all_results_bldr.append_vector_range results
                     True ->
-                        Test_Reporter.print_pending_group IO.println group config junit_sb_builder
+                        Test_Reporter.print_pending_group println group config junit_sb_builder
 
         all_results = all_results_bldr.to_vector
         succ_tests = all_results.filter (r-> r.is_success) . length
@@ -112,16 +116,16 @@ type Suite
         pending_groups = matching_specs.filter (p-> p.first.is_pending) . length
         case should_exit of
             True ->
-                IO.println ""
-                IO.println <| succ_tests.to_text + " tests succeeded."
-                IO.println <| failed_tests_number.to_text + " tests failed."
-                IO.println <| skipped_tests.to_text + " tests skipped."
-                IO.println <| pending_groups.to_text + " groups skipped."
-                IO.println ""
+                println ""
+                println <| succ_tests.to_text + " tests succeeded."
+                println <| failed_tests_number.to_text + " tests failed."
+                println <| skipped_tests.to_text + " tests skipped."
+                println <| pending_groups.to_text + " groups skipped."
+                println ""
                 if failed_tests_number > 0 then
-                    IO.println <| "Failed tests: '" + failed_tests_names + "'"
+                    println <| "Failed tests: '" + failed_tests_names + "'"
                     if failed_tests_number > 10 then IO.println "(Displaying only first 10 failed tests)"
-                    IO.println ""
+                    println ""
                 exit_code = if failed_tests_number > 0 then 1 else 0
                 System.exit exit_code
             False ->

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -7,7 +7,6 @@ import Standard.Base.Runtime.Ref.Ref
 from Standard.Base.Logging import all
 from Standard.Base.Runtime import assert
 
-import project.Group.Group
 import project.Internal.Stack_Trace_Helpers
 import project.Spec_Result.Spec_Result
 import project.Suite_Config.Suite_Config

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -64,8 +64,7 @@ maybe_grey_text (text : Text) (config : Suite_Config) =
     if config.use_ansi_colors then (grey text) else text
 
 ## Print result for a single Spec run
-print_single_result : Text -> Test_Result -> Suite_Config -> Nothing
-print_single_result (group_name : Text) (test_result : Test_Result) (config : Suite_Config) =
+print_single_result (println:Text->Nothing) (group_name : Text) (test_result : Test_Result) (config : Suite_Config) =
     times_suffix =
         times = test_result.time_taken.total_milliseconds.to_text + "ms"
         "[" + times + "]"
@@ -78,29 +77,29 @@ print_single_result (group_name : Text) (test_result : Test_Result) (config : Su
         Spec_Result.Success ->
             if config.print_only_failures.not then
                 txt = "    - " + test_result.spec_name + " " + times_suffix
-                IO.println (maybe_green_text txt config)
+                println (maybe_green_text txt config)
         Spec_Result.Failure msg details ->
-            report_github_error_message group_name+": "+test_result.spec_name msg
-            IO.println ""
+            report_github_error_message println group_name+": "+test_result.spec_name msg
+            println ""
             txt = "    - [FAILED] " + test_result.spec_name + " " + times_suffix
-            IO.println (maybe_red_text txt config)
-            IO.println ("        Reason: " + msg)
+            println (maybe_red_text txt config)
+            println ("        Reason: " + msg)
             if details.is_nothing.not then
-                IO.println (decorate_stack_trace details)
-            IO.println ""
+                println (decorate_stack_trace details)
+            println ""
         Spec_Result.Pending reason ->
-            IO.println (maybe_grey_text ("    - [PENDING] " + test_result.spec_name) config)
-            IO.println ("        Reason: " + reason)
+            println (maybe_grey_text ("    - [PENDING] " + test_result.spec_name) config)
+            println ("        Reason: " + reason)
 
 ## ---
    private: true
    ---
    Reports an error message to show up as a note in GitHub Actions, only if
    running in the GitHub Actions environment.
-report_github_error_message (~title : Text) (~message : Text) =
+private report_github_error_message println (~title : Text) (~message : Text) =
     is_enabled = Environment.get "GITHUB_ACTIONS" == "true"
     if is_enabled then
-        IO.println (generate_github_error_annotation title message)
+        println (generate_github_error_annotation title message)
 
 ## ---
    private: true
@@ -142,8 +141,7 @@ generate_github_error_annotation (title : Text) (message : Text) =
       from multiple groups.
     - `builder`: StringBuilder or Nothing. If StringBuilder, then a jUnit XML
       format is appended to that StringBuilder.
-print_report : Vector Test_Result -> Suite_Config -> (StringBuilder | Nothing) -> Nothing
-print_report (test_results : Vector Test_Result) (config : Suite_Config) (builder : (StringBuilder | Nothing)) =
+private print_report (println:Text->Nothing) (test_results : Vector Test_Result) (config : Suite_Config) (builder : (StringBuilder | Nothing)) =
     distinct_group_names = test_results.map (_.group_name) . distinct
     results_per_group = distinct_group_names.fold Dictionary.empty acc-> group_name->
         group_results = test_results.filter res->
@@ -151,11 +149,10 @@ print_report (test_results : Vector Test_Result) (config : Suite_Config) (builde
         assert (group_results.length > 0)
         acc.insert group_name group_results
     results_per_group.each_with_key group_name-> group_results->
-        print_group_report group_name group_results config builder
+        print_group_report println group_name group_results config builder
 
 ## Prints a pending group, optionally writing it to a jUnit XML output.
-print_pending_group : Group -> Suite_Config -> (StringBuilder | Nothing) -> Nothing
-print_pending_group group config builder =
+private print_pending_group println group config builder =
     assert group.pending.is_nothing.not "Group in print_pending_group should be pending"
     if config.should_output_junit then
         assert builder.is_nothing.not "Builder must be specified when JUnit output is enabled"
@@ -165,15 +162,14 @@ print_pending_group group config builder =
         builder.append ('            <skipped message="Reason: '+(escape_xml group.pending inside_attribute=True)+'"/>\n')
         builder.append ('        </testcase>\n')
         builder.append '    </testsuite>\n'
-    IO.println <| maybe_grey_text ("[PENDING] " + group.name) config
-    IO.println ("    Reason: " + group.pending)
+    println <| maybe_grey_text ("[PENDING] " + group.name) config
+    println ("    Reason: " + group.pending)
 
 ## Prints report for test_results from a single group.
 
    ## Arguments
     - `test_results`: Test test_results from a single group
-print_group_report : Text -> Vector Test_Result -> Suite_Config -> (StringBuilder|Nothing) -> Nothing
-print_group_report group_name test_results config builder =
+private print_group_report (println:Text->Nothing) group_name test_results config builder =
     distinct_groups = test_results.distinct (res-> res.group_name)
     assert (distinct_groups.length == 1)
     total_time = test_results.fold Duration.zero acc-> res->
@@ -216,11 +212,11 @@ print_group_report group_name test_results config builder =
             counts = tests_succeeded.to_text + "/" + tests_executed.to_text
             times = total_time.total_milliseconds.to_text + "ms"
             group_name + ": " + "[" + counts + ", " + times + "]"
-        IO.println <| case some_test_failed of
+        println <| case some_test_failed of
             True -> maybe_red_text ("[FAILED] " + group_description) config
             False -> maybe_green_text group_description config
         test_results.each result->
-            print_single_result group_name result config
+            print_single_result println group_name result config
 
 ## ---
    private: true

--- a/test/Test_Tests/src/Teardown_Spec.enso
+++ b/test/Test_Tests/src/Teardown_Spec.enso
@@ -34,7 +34,7 @@ add_specs suite_builder =
             messages = Vector.build builder->
                 test_suite = Test.build suite_builder->
                     failing_teardown_suite builder.append suite_builder
-                result = test_suite.run_with_filter should_exit=False
+                result = test_suite.run_with_filter should_exit=False output=(\_->Nothing)
                 # tear down fails, but doesn't crash
                 result:Boolean . should_be_false
 


### PR DESCRIPTION
### Pull Request Description

- adds `output` argument to `Suite.run_with_filter`
- uses that to suppress output in `Teardown_Spec`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      style guides. 
- [x] Manually verified by running `runEngineDistribution --run test/Test_Tests` and observing output is suppressed
