### PR TITLE
Fix projects corruption when uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - [Components have Expanded/Collapsed modes][14678]. The effect is visible in
   Table.input components.
 - [Text widgets have a fixed maximum size in collapsed mode][14775]
+- [Fixed uploading corrupted projects to the cloud storage][14805]
 
 [14590]: https://github.com/enso-org/enso/pull/14590
 [14678]: https://github.com/enso-org/enso/pull/14678
 [14775]: https://github.com/enso-org/enso/pull/14775
+[14805]: https://github.com/enso-org/enso/pull/14805
 
 #### Enso Standard Library
 

--- a/app/project-manager-shim/src/handler/watcher.ts
+++ b/app/project-manager-shim/src/handler/watcher.ts
@@ -132,9 +132,9 @@ export async function handleWatcherRequest(
           delay: PROJECT_WATCHER_CALLBACK_DELAY,
           timeout: PROJECT_WATCHER_CALLBACK_TIMEOUT,
           callback: async () => {
-            const responseBody = await projectManagement.createBundle(projectDir)
-            const file = new File([responseBody.buffer as ArrayBuffer], fileName)
-            // Overvwite uploads to create one version per session
+            const projectBundle = await projectManagement.createBundle(projectDir)
+            const file = new File([projectBundle], fileName)
+            // Overwrite uploads to create one version per session
             await uploadFile(backend, { ...uploadParams, overwrite: uploadCount > 0 }, file)
             uploadCount += 1
           },


### PR DESCRIPTION
### Pull Request Description

Sometimes GUI uploads corrupted project bundles to S3 which are suspiciously 8KB-long and contain memory-dump-like binary junk.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
