### PR TITLE
Fix closing duplicated project

### DIFF
--- a/app/common/src/services/ProjectManager/types.ts
+++ b/app/common/src/services/ProjectManager/types.ts
@@ -204,6 +204,7 @@ export interface OpenProjectParams {
 /** Parameters for the "close project" endpoint. */
 export interface CloseProjectParams {
   readonly projectId: UUID
+  readonly projectsDirectory: Path
 }
 
 /** Parameters for the "create project" endpoint. */

--- a/app/gui/integration-test/mock/localApi.ts
+++ b/app/gui/integration-test/mock/localApi.ts
@@ -306,6 +306,7 @@ export async function mockLocalApi(page: Page) {
       }
       unsafeMutable(project.entry.metadata).lastOpened = toRfc3339(new Date())
       const result: OpenProject = {
+        projectId: UUID(crypto.randomUUID()),
         languageServerBinaryAddress,
         languageServerJsonAddress,
         languageServerYdocAddress,

--- a/app/project-manager-shim/src/handler/projectService.ts
+++ b/app/project-manager-shim/src/handler/projectService.ts
@@ -66,11 +66,12 @@ export async function handleProjectServiceRequest(
     case 'POST /api/project-service/project/close': {
       interface Body {
         readonly projectId: UUID
+        readonly projectsDirectory: Path
       }
       bodyJson<Body>(request)
         .then(async (body) => {
           const projectService = await getProjectService()
-          return projectService.closeProject(body.projectId)
+          return projectService.closeProject(body.projectId, body.projectsDirectory)
         })
         .then(() => {
           response.writeHead(HTTP_STATUS_OK, headers).end(toJSONRPCResult(null))

--- a/app/project-manager-shim/src/projectService/__tests__/ProjectService.test.ts
+++ b/app/project-manager-shim/src/projectService/__tests__/ProjectService.test.ts
@@ -247,7 +247,7 @@ describe('ProjectService', () => {
         expect(openResult.languageServerBinaryAddress.port).toBeGreaterThan(0)
 
         // Close the project to clean up
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
       },
       LANGUAGE_SERVER_TEST_TIMEOUT,
     )
@@ -283,7 +283,7 @@ describe('ProjectService', () => {
         expect(metadata.lastOpened).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/)
 
         // Clean up
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
       },
       LANGUAGE_SERVER_TEST_TIMEOUT,
     )
@@ -356,8 +356,8 @@ describe('ProjectService', () => {
         expect(project2Running).toBe(true)
 
         // Clean up - close both projects
-        await projectService.closeProject(project1.projectId)
-        await projectService.closeProject(project2.projectId)
+        await projectService.closeProject(project1.projectId, projectsDirectory)
+        await projectService.closeProject(project2.projectId, projectsDirectory)
       },
       LANGUAGE_SERVER_TEST_TIMEOUT * 2,
     )
@@ -373,7 +373,9 @@ describe('ProjectService', () => {
         await projectService.openProject(createResult.projectId, projectsDirectory)
 
         // Close the project - should not throw
-        await expect(projectService.closeProject(createResult.projectId)).resolves.not.toThrow()
+        await expect(
+          projectService.closeProject(createResult.projectId, projectsDirectory),
+        ).resolves.not.toThrow()
       },
       LANGUAGE_SERVER_TEST_TIMEOUT,
     )
@@ -390,10 +392,12 @@ describe('ProjectService', () => {
         await projectService.openProject(createResult.projectId, projectsDirectory)
 
         // Close the project once
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
 
         // Attempt to close again - should handle gracefully
-        await expect(projectService.closeProject(createResult.projectId)).resolves.not.toThrow()
+        await expect(
+          projectService.closeProject(createResult.projectId, projectsDirectory),
+        ).resolves.not.toThrow()
       },
       LANGUAGE_SERVER_TEST_TIMEOUT,
     )
@@ -406,7 +410,9 @@ describe('ProjectService', () => {
       )
 
       // Attempt to close - should handle gracefully
-      await expect(projectService.closeProject(createResult.projectId)).resolves.not.toThrow()
+      await expect(
+        projectService.closeProject(createResult.projectId, projectsDirectory),
+      ).resolves.not.toThrow()
     })
 
     test(
@@ -441,7 +447,7 @@ describe('ProjectService', () => {
         expect(isRunningBefore).toBe(true)
 
         // Close the project
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
 
         // Wait a bit for the process to fully terminate
         await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -834,7 +840,7 @@ describe('ProjectService', () => {
         expect(oldDirExists).toBe(true)
 
         // Close the project to trigger the deferred rename
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
 
         // Now verify the directory was renamed after closing
         const newDirectoryPath = path.join(path.dirname(createResult.projectPath), newName)
@@ -1008,7 +1014,7 @@ describe('ProjectService', () => {
         expect(packageContent3).not.contain(secondName)
 
         // Close the project to trigger the final deferred rename
-        await projectService.closeProject(createResult.projectId)
+        await projectService.closeProject(createResult.projectId, projectsDirectory)
 
         // Verify the directory was renamed to the final name
         const finalDirectoryPath = path.join(path.dirname(createResult.projectPath), thirdName)
@@ -1075,8 +1081,8 @@ describe('ProjectService', () => {
         expect(package2Content).contain('RenamedRunning2')
 
         // Close both projects
-        await projectService.closeProject(project1.projectId)
-        await projectService.closeProject(project2.projectId)
+        await projectService.closeProject(project1.projectId, projectsDirectory)
+        await projectService.closeProject(project2.projectId, projectsDirectory)
 
         // Verify both directories were renamed
         const newPath1 = path.join(path.dirname(project1.projectPath), 'RenamedRunning1')

--- a/app/project-manager-shim/src/projectService/ensoRunner.ts
+++ b/app/project-manager-shim/src/projectService/ensoRunner.ts
@@ -18,16 +18,16 @@ export interface Runner {
     extraArgs?: readonly string[],
     extraEnv?: readonly (readonly [string, string])[],
   ): Promise<LanguageServerSockets>
-  closeProject(projectId: string): Promise<void>
-  isProjectRunning(projectId: string): Promise<boolean>
+  closeProject(projectPath: Path): Promise<void>
+  isProjectRunning(projectPath: Path): Promise<boolean>
   renameProject(
-    projectId: string,
+    projectPath: Path,
     namespace: string,
     oldPackage: string,
     newPackage: string,
   ): Promise<void>
   registerShutdownHook(
-    projectId: string,
+    projectPath: Path,
     hookType: ShutdownHookType,
     hook: () => Promise<void>,
   ): Promise<void>
@@ -77,8 +77,8 @@ const LANGUAGE_SERVER_STARTUP_TIMEOUT = 30000
 
 /** Implementation of Runner that uses the Enso executable. */
 export class EnsoRunner implements Runner {
-  private runningProjects = new Map<string, RunningProject>()
-  private loadingProjects = new Map<string, Promise<LanguageServerSockets>>()
+  private runningProjects = new Map<Path, RunningProject>()
+  private loadingProjects = new Map<Path, Promise<LanguageServerSockets>>()
 
   /** Creates a new EnsoRunner with the path to the Enso executable. */
   constructor(private ensoPath: Path) {}
@@ -167,11 +167,11 @@ export class EnsoRunner implements Runner {
     extraEnv?: readonly (readonly [string, string])[],
   ): Promise<LanguageServerSockets> {
     // Check if the project is already running
-    const runningProject = this.runningProjects.get(projectId)
+    const runningProject = this.runningProjects.get(projectPath)
     if (runningProject) {
       return runningProject.sockets
     }
-    const loadingProject = this.loadingProjects.get(projectId)
+    const loadingProject = this.loadingProjects.get(projectPath)
     if (loadingProject) {
       return loadingProject
     }
@@ -247,7 +247,7 @@ export class EnsoRunner implements Runner {
                   binarySocket: { host: '127.0.0.1', port: binaryPort },
                   ydocSocket: { host: '127.0.0.1', port: ydocPort },
                 }
-                this.runningProjects.set(projectId, {
+                this.runningProjects.set(projectPath, {
                   process: serverProcess,
                   sockets: sockets,
                   shutdownHooks: new Map(),
@@ -269,7 +269,7 @@ export class EnsoRunner implements Runner {
 
           serverProcess.on('close', async (code) => {
             // Execute shutdown hooks if the process exits unexpectedly
-            const runningProject = this.runningProjects.get(projectId)
+            const runningProject = this.runningProjects.get(projectPath)
             if (runningProject && runningProject.shutdownHooks) {
               for (const [hookType, hook] of runningProject.shutdownHooks) {
                 try {
@@ -277,7 +277,7 @@ export class EnsoRunner implements Runner {
                   await hook()
                 } catch (error) {
                   console.error(
-                    `Error executing shutdown hook '${hookType}' for project ${projectId}:`,
+                    `Error executing shutdown hook '${hookType}' for project ${projectPath}:`,
                     error,
                   )
                 }
@@ -285,7 +285,7 @@ export class EnsoRunner implements Runner {
             }
 
             // Remove from running projects when it closes
-            this.runningProjects.delete(projectId)
+            this.runningProjects.delete(projectPath)
             if (!resolved) {
               reject(new Error(`Language server process exited with code ${code}.`))
             }
@@ -305,16 +305,16 @@ export class EnsoRunner implements Runner {
         })
       },
     )
-    this.loadingProjects.set(projectId, promise)
-    promise.finally(() => this.loadingProjects.delete(projectId))
+    this.loadingProjects.set(projectPath, promise)
+    promise.finally(() => this.loadingProjects.delete(projectPath))
     return promise
   }
 
   /** Closes a project and stops its language server. */
-  async closeProject(projectId: string): Promise<void> {
+  async closeProject(projectPath: Path): Promise<void> {
     // First wait for potential initialization end.
-    await this.loadingProjects.get(projectId)
-    const runningProject = this.runningProjects.get(projectId)
+    await this.loadingProjects.get(projectPath)
+    const runningProject = this.runningProjects.get(projectPath)
 
     if (!runningProject) {
       // Project is not running or already closed
@@ -332,7 +332,7 @@ export class EnsoRunner implements Runner {
             await hook()
           } catch (error) {
             console.error(
-              `Error executing shutdown hook '${hookType}' for project ${projectId}:`,
+              `Error executing shutdown hook '${hookType}' for project ${projectPath}:`,
               error,
             )
           }
@@ -345,7 +345,7 @@ export class EnsoRunner implements Runner {
           process.kill('SIGKILL')
         }
         await executeShutdownHooks()
-        this.runningProjects.delete(projectId)
+        this.runningProjects.delete(projectPath)
         resolve()
       }, 10000)
 
@@ -353,7 +353,7 @@ export class EnsoRunner implements Runner {
       process.on('exit', async () => {
         clearTimeout(timeout)
         await executeShutdownHooks()
-        this.runningProjects.delete(projectId)
+        this.runningProjects.delete(projectPath)
         resolve()
       })
 
@@ -367,17 +367,17 @@ export class EnsoRunner implements Runner {
   }
 
   /** Checks if a project's language server is currently running. */
-  async isProjectRunning(projectId: string): Promise<boolean> {
-    return this.runningProjects.has(projectId)
+  async isProjectRunning(projectPath: Path): Promise<boolean> {
+    return this.runningProjects.has(projectPath)
   }
 
   /** Registers an action to be executed when the project is closed. */
   async registerShutdownHook(
-    projectId: string,
+    projectPath: Path,
     hookType: ShutdownHookType,
     hook: () => void | Promise<void>,
   ): Promise<void> {
-    const runningProject = this.runningProjects.get(projectId)
+    const runningProject = this.runningProjects.get(projectPath)
 
     if (!runningProject) {
       // If project is not running, execute the hook immediately
@@ -388,16 +388,20 @@ export class EnsoRunner implements Runner {
     runningProject.shutdownHooks.set(hookType, hook)
   }
 
-  /** Renames the running language server project. */
+  /**
+   * Renames the running language server project.
+   *
+   * It does _not_ rename it's directory.
+   */
   async renameProject(
-    projectId: string,
+    projectPath: Path,
     namespace: string,
     oldPackage: string,
     newPackage: string,
   ): Promise<void> {
-    const runningProject = this.runningProjects.get(projectId)
+    const runningProject = this.runningProjects.get(projectPath)
     if (!runningProject) {
-      throw new Error(`Project ${projectId} is not running`)
+      throw new Error(`Project ${projectPath} is not running`)
     }
 
     const { sockets } = runningProject

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -219,9 +219,14 @@ export class ProjectService {
   }
 
   /** Closes a project and stops its language server. */
-  async closeProject(projectId: UUID): Promise<void> {
-    this.logger.debug('Closing project', projectId)
-    await this.runner.closeProject(projectId)
+  async closeProject(projectId: UUID, projectsDirectory: Path): Promise<void> {
+    const repo = this.getProjectRepository(projectsDirectory)
+    const project = await repo.findById(projectId)
+    if (!project) {
+      throw new Error(`Project '${projectId}' not found`)
+    }
+    this.logger.debug('Closing project', projectId, projectsDirectory)
+    await this.runner.closeProject(project.path)
   }
 
   /** Deletes a user project. */
@@ -301,10 +306,10 @@ export class ProjectService {
     // Rename in the repository (updates metadata)
     await repo.rename(projectId, newName)
     // Check if language server is running for this project
-    const isRunning = await this.runner.isProjectRunning(projectId)
+    const isRunning = await this.runner.isProjectRunning(project.path)
     if (isRunning) {
       // Register a shutdown hook to rename the directory after the server stops
-      await this.runner.registerShutdownHook(projectId, 'rename-project-directory', async () => {
+      await this.runner.registerShutdownHook(project.path, 'rename-project-directory', async () => {
         this.logger.info(`Executing deferred directory rename for project ${projectId}`)
         try {
           await repo.renameProjectDirectory(project.path, newNormalizedName)
@@ -314,7 +319,7 @@ export class ProjectService {
         }
       })
       // Send rename command to the running server
-      await this.runner.renameProject(projectId, namespace, oldNormalizedName, newNormalizedName)
+      await this.runner.renameProject(project.path, namespace, oldNormalizedName, newNormalizedName)
     } else {
       // If server is not running, rename the directory immediately
       await repo.renameProjectDirectory(project.path, newNormalizedName)

--- a/app/project-manager-shim/src/runProjects.ts
+++ b/app/project-manager-shim/src/runProjects.ts
@@ -84,7 +84,7 @@ export async function runLocalProjectByUuid(
     return exitCode
   } catch (error) {
     console.error(`Error starting local project '${projectId}':`, error)
-    await projectService.closeProject(projectId)
+    await projectService.closeProject(projectId, projectsDirectory)
     throw error
   }
 }


### PR DESCRIPTION
### Pull Request Description

Part of #14803

Cached projects in runner are stored by path, not by UUID

Closing projects requires projectsDirectory (we remove duplicated ids, but only in projects in the same dir).

Still not working: AST still is not loaded in the project opened as second.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- `~[] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
