### PR TITLE
More informative type error message for intersection types

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -216,7 +216,8 @@ public class ExecStrictCompilerTest {
       assertThat(
           ex.getMessage(),
           AllOf.allOf(
-              containsString("expected `b` to be Text"), containsString("but got Integer")));
+              containsString("expected `b` to be Text | Nothing"),
+              containsString("but got Integer")));
     }
     assertTrue("Default value is Nothing. Returns Nothing.", def.execute(3).isNull());
     assertTrue("Passing null is OK.", def.execute(4, null).isNull());

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -1441,9 +1441,7 @@ public class SignatureTest {
       var res = foo.execute(".");
       fail("Expecting an exception, not: " + res);
     } catch (PolyglotException e) {
-      assertContains(
-          "expected the result of `foo` to be (Integer | Text) & Clazz, but got Text",
-          e.getMessage());
+      assertContains("expected the result of `foo` to be Clazz, but got Text", e.getMessage());
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AbstractTypeCheckNode.java
@@ -27,7 +27,8 @@ abstract sealed class AbstractTypeCheckNode extends Node
 
   abstract Object findDirectMatch(VirtualFrame frame, Object value);
 
-  abstract Object executeConversion(VirtualFrame frame, Object value);
+  abstract Object executeConversion(
+      VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck);
 
   abstract String expectedTypeMessage();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/AllOfTypesCheckNode.java
@@ -49,7 +49,7 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeConversion(VirtualFrame frame, Object value) {
+  Object executeConversion(VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck) {
     if (checks.length == 0) {
       assert isAllTypes() : "Can only happen with : Any check";
       assert allowThru : "Such a check must allow other types thru";
@@ -61,7 +61,7 @@ final class AllOfTypesCheckNode extends AbstractTypeCheckNode {
     var integers = 0;
     var floats = 0;
     for (var n : checks) {
-      var result = n.executeConversion(frame, value);
+      var result = n.executeConversion(frame, value, failingCheck);
       if (result == null) {
         return null;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/FailCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/FailCheckNode.java
@@ -13,7 +13,8 @@ final class FailCheckNode extends AbstractTypeCheckNode {
   }
 
   @Override
-  Object executeConversion(VirtualFrame frame, Object value) {
+  Object executeConversion(
+      VirtualFrame frame, Object value, AbstractTypeCheckNode[] noFailingCheck) {
     return null;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/MetaTypeCheckNode.java
@@ -22,7 +22,8 @@ final class MetaTypeCheckNode extends AbstractTypeCheckNode {
   }
 
   @Override
-  Object executeConversion(VirtualFrame frame, Object value) {
+  Object executeConversion(
+      VirtualFrame frame, Object value, AbstractTypeCheckNode[] noFailingCheck) {
     return null;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -30,12 +30,11 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
   @ExplodeLoop
   Object executeConversion(VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck) {
     for (var n : checks) {
-      var result = n.executeConversion(frame, value, failingCheck);
+      var result = n.executeConversion(frame, value, null);
       if (result != null) {
         return result;
       }
     }
-    failingCheck[0] = null;
     return null;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -35,6 +35,7 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
         return result;
       }
     }
+    failingCheck[0] = null;
     return null;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/OneOfTypesCheckNode.java
@@ -28,9 +28,9 @@ final class OneOfTypesCheckNode extends AbstractTypeCheckNode {
 
   @Override
   @ExplodeLoop
-  Object executeConversion(VirtualFrame frame, Object value) {
+  Object executeConversion(VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck) {
     for (var n : checks) {
-      var result = n.executeConversion(frame, value);
+      var result = n.executeConversion(frame, value, failingCheck);
       if (result != null) {
         return result;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -34,12 +34,19 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
     this.expectedType = expectedType;
   }
 
-  abstract Object executeConversion(
-      VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck);
+  final Object executeConversion(
+      VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck) {
+    var res = executeHandleConversion(frame, value);
+    if (res == null && failingCheck != null) {
+      failingCheck[0] = this;
+    }
+    return res;
+  }
+
+  abstract Object executeHandleConversion(VirtualFrame frame, Object value);
 
   @Specialization
-  Object doPanicSentinel(
-      VirtualFrame frame, PanicSentinel panicSentinel, AbstractTypeCheckNode[] noFailingCheck) {
+  Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel) {
     throw panicSentinel;
   }
 
@@ -47,14 +54,9 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doUnresolvedConstructor(
       VirtualFrame frame,
       UnresolvedConstructor unresolved,
-      AbstractTypeCheckNode[] failingCheck,
       @Cached UnresolvedConstructor.ConstructNode construct) {
     var state = EnsoContext.get(this).currentState();
-    var res = construct.execute(frame, state, expectedType, unresolved);
-    if (res == null && failingCheck != null) {
-      failingCheck[0] = this;
-    }
-    return res;
+    return construct.execute(frame, state, expectedType, unresolved);
   }
 
   @Specialization(
@@ -63,29 +65,17 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doWithConversionCached(
       VirtualFrame frame,
       Object v,
-      AbstractTypeCheckNode[] failingCheck,
       @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
       @Cached(value = "findType(typeOfNode, v)", dimensions = 1) Type[] cachedType,
       @Cached("findConversionNode(cachedType)") TypeToConvertNode node) {
-    var res = handleWithConversion(frame, v, node);
-    if (res == null && failingCheck != null) {
-      failingCheck[0] = this;
-    }
-    return res;
+    return handleWithConversion(frame, v, node);
   }
 
   @Specialization(replaces = "doWithConversionCached")
   Object doWithConversionUncached(
-      VirtualFrame frame,
-      Object v,
-      AbstractTypeCheckNode[] failingCheck,
-      @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode) {
+      VirtualFrame frame, Object v, @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode) {
     var type = findType(typeOfNode, v);
-    var res = doWithConversionUncachedBoundary(frame == null ? null : frame.materialize(), v, type);
-    if (res == null && failingCheck != null) {
-      failingCheck[0] = this;
-    }
-    return res;
+    return doWithConversionUncachedBoundary(frame == null ? null : frame.materialize(), v, type);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/SingleTypeCheckNode.java
@@ -34,10 +34,12 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
     this.expectedType = expectedType;
   }
 
-  abstract Object executeConversion(VirtualFrame frame, Object value);
+  abstract Object executeConversion(
+      VirtualFrame frame, Object value, AbstractTypeCheckNode[] failingCheck);
 
   @Specialization
-  Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel) {
+  Object doPanicSentinel(
+      VirtualFrame frame, PanicSentinel panicSentinel, AbstractTypeCheckNode[] noFailingCheck) {
     throw panicSentinel;
   }
 
@@ -45,9 +47,14 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doUnresolvedConstructor(
       VirtualFrame frame,
       UnresolvedConstructor unresolved,
+      AbstractTypeCheckNode[] failingCheck,
       @Cached UnresolvedConstructor.ConstructNode construct) {
     var state = EnsoContext.get(this).currentState();
-    return construct.execute(frame, state, expectedType, unresolved);
+    var res = construct.execute(frame, state, expectedType, unresolved);
+    if (res == null && failingCheck != null) {
+      failingCheck[0] = this;
+    }
+    return res;
   }
 
   @Specialization(
@@ -56,17 +63,29 @@ abstract non-sealed class SingleTypeCheckNode extends AbstractTypeCheckNode {
   Object doWithConversionCached(
       VirtualFrame frame,
       Object v,
+      AbstractTypeCheckNode[] failingCheck,
       @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
       @Cached(value = "findType(typeOfNode, v)", dimensions = 1) Type[] cachedType,
       @Cached("findConversionNode(cachedType)") TypeToConvertNode node) {
-    return handleWithConversion(frame, v, node);
+    var res = handleWithConversion(frame, v, node);
+    if (res == null && failingCheck != null) {
+      failingCheck[0] = this;
+    }
+    return res;
   }
 
   @Specialization(replaces = "doWithConversionCached")
   Object doWithConversionUncached(
-      VirtualFrame frame, Object v, @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode) {
+      VirtualFrame frame,
+      Object v,
+      AbstractTypeCheckNode[] failingCheck,
+      @Cached.Shared("typeOfNode") @Cached TypeOfNode typeOfNode) {
     var type = findType(typeOfNode, v);
-    return doWithConversionUncachedBoundary(frame == null ? null : frame.materialize(), v, type);
+    var res = doWithConversionUncachedBoundary(frame == null ? null : frame.materialize(), v, type);
+    if (res == null && failingCheck != null) {
+      failingCheck[0] = this;
+    }
+    return res;
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/typecheck/TypeCheckValueNode.java
@@ -107,9 +107,10 @@ public final class TypeCheckValueNode extends Node {
     if (direct != null) {
       return direct;
     }
-    var result = check.executeConversion(frame, value);
+    var failingCheck = new AbstractTypeCheckNode[1];
+    var result = check.executeConversion(frame, value, failingCheck);
     if (result == null) {
-      throw panicAtTheEnd(value);
+      throw panicAtTheEnd(value, failingCheck[0]);
     }
     return result;
   }
@@ -246,14 +247,17 @@ public final class TypeCheckValueNode extends Node {
     return false;
   }
 
-  private final PanicException panicAtTheEnd(Object v) {
-    var expectedTypeMessage = check.getExpectedTypeMessage();
+  private final PanicException panicAtTheEnd(Object v, AbstractTypeCheckNode failedCheck) {
+    if (failedCheck == null) {
+      failedCheck = check;
+    }
+    var expectedTypeMessage = failedCheck.getExpectedTypeMessage();
     var ctx = EnsoContext.get(this);
     Text msg;
     if (v instanceof UnresolvedConstructor) {
       msg = Text.create("Cannot find constructor {got} among {exp}");
     } else {
-      msg = check.getComment();
+      msg = failedCheck.getComment();
     }
     var err = ctx.getBuiltins().error().makeTypeErrorOfComment(expectedTypeMessage, v, msg);
     return new PanicException(err, this);

--- a/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Multi_Value_Spec.enso
@@ -178,6 +178,20 @@ add_specs suite_builder =
             Test.expect_panic Type_Error <|
                 a : C
 
+    suite_builder.group "MultiValue type error" group_builder->
+        group_builder.specify "Conversion to B & X is OK" <|
+            a = A
+            x = (a : B & X)
+            x.is_nothing . should_be_false 
+            
+        group_builder.specify "Missing conversion to C error" <|
+            a = A
+            extract_err_msg caught_panic =
+                caught_panic.payload.to_text
+            err = Panic.catch Type_Error handler=extract_err_msg <|
+                (a : B & X & C)
+            err . should_equal 'Type error: expected expression to be C, but got A.'
+
     suite_builder.group "MultiValue with warnings" group_builder->
         group_builder.specify "warning is propagated to the outer MultiValue" <|
             field_with_warn = Warning.attach "warn" 42


### PR DESCRIPTION
### Pull Request Description

- fixes #13106 
- by creating the error message for _exactly the type check_ that fails in case of _intersection type_
- the _union type_ type check continues to list all alternatives: `Text | Nothing`, etc.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] [engine benchmarks](https://github.com/enso-org/enso/actions/runs/22571775861) are fine
- [x] [library benchmarks](https://github.com/enso-org/enso/actions/runs/22571782105) are fine
