### PR TITLE
Fix clicking enso links with Ctrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
   Table.input components.
 - [Text widgets have a fixed maximum size in collapsed mode][14775]
 - [Fixed uploading corrupted projects to the cloud storage][14805]
+- [Fixed <kbd>Ctrl</kbd>-clicking enso:// links][14820]
 
 [14590]: https://github.com/enso-org/enso/pull/14590
 [14678]: https://github.com/enso-org/enso/pull/14678
 [14775]: https://github.com/enso-org/enso/pull/14775
 [14805]: https://github.com/enso-org/enso/pull/14805
+[14820]: https://github.com/enso-org/enso/pull/14820
 
 #### Enso Standard Library
 

--- a/app/gui/integration-test/mock/lsHandler.ts
+++ b/app/gui/integration-test/mock/lsHandler.ts
@@ -73,6 +73,8 @@ func2 a =
 
    Here is a link: <https://example.com>
 
+   [A reference to another project](enso://Users/user%20name/MockProject)
+
    Nested lists:
     - List element
       - Nested list element

--- a/app/gui/integration-test/project-view/editorPanels.spec.ts
+++ b/app/gui/integration-test/project-view/editorPanels.spec.ts
@@ -56,12 +56,11 @@ test.describe('Main method documentation rendering', () => {
 
   test('Link (rendered and interactive)', async ({ editorPage, page, context }) => {
     const { docsContent } = await goToGraphAndGetDocs(editorPage)
-    await expect(docsContent.locator('a')).toHaveAccessibleDescription(
-      /Click to edit.*Click to open link/,
-    )
+    const link = docsContent.locator('a').first()
+    await expect(link).toHaveAccessibleDescription(/Click to edit.*Click to open link/)
 
-    await expect(docsContent.locator('a')).toHaveText('https://example.com')
-    await docsContent.locator('a').click()
+    await expect(link).toHaveText('https://example.com')
+    await link.click()
     await expect(page.locator('.LinkEditPopup')).toBeVisible()
     await locate.graphEditor(page).click()
     await expect(page.locator('.LinkEditPopup')).toBeHidden()
@@ -69,8 +68,24 @@ test.describe('Main method documentation rendering', () => {
       route.fulfill({ status: 200, body: 'YAY' }),
     )
     const newPagePromise = context.waitForEvent('page', { timeout: 10000 })
-    await docsContent.locator('a').click({ modifiers: ['ControlOrMeta'] })
+    await link.click({ modifiers: ['ControlOrMeta'] })
     await expect(newPagePromise).resolves.toHaveURL('https://example.com')
+  })
+
+  test.use({
+    setupApi: {
+      cloud: (cloudApi) => {
+        cloudApi.addProject({ title: 'MockProject' })
+      },
+    },
+  })
+
+  test('Enso links', async ({ drivePage, editorPage }) => {
+    const { docsContent } = await goToGraphAndGetDocs(editorPage)
+    const link = docsContent.locator('a').nth(1)
+    await expect(link).toHaveText('A reference to another project')
+    await link.click({ modifiers: ['ControlOrMeta'] })
+    await drivePage.expectProjectEditorOpened('MockProject')
   })
 })
 

--- a/app/gui/src/project-view/components/LinkEditPopup.vue
+++ b/app/gui/src/project-view/components/LinkEditPopup.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import { useNavigateLink } from '$/utils/links'
 import { textEditorsBindings } from '@/bindings'
 import { autoUpdate, flip, useFloating } from '@floating-ui/vue'
-import { computed, ref, toRef, useTemplateRef } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { ref, toRef, useTemplateRef } from 'vue'
 
 const props = defineProps<{
   referenceElement: HTMLElement
@@ -10,21 +10,12 @@ const props = defineProps<{
   popOut: boolean
 }>()
 
-const route = useRoute()
-const router = useRouter()
+const navigateLink = useNavigateLink()
 const navigating = ref(false)
 
-const navigationType = computed(() => {
-  const url = URL.parse(props.href)
-  const isEnsoLink = url?.protocol === 'enso:'
-  return isEnsoLink ? ('internal' as const) : ('external' as const)
-})
-
-function navigateInternally() {
+function onClick() {
   navigating.value = true
-  router
-    .push({ params: { path: props.href.split('/') }, query: route.query })
-    .finally(() => (navigating.value = false))
+  navigateLink(props.href).finally(() => (navigating.value = false))
 }
 
 const floatingElement = useTemplateRef<HTMLElement>('floating')
@@ -40,15 +31,7 @@ const { floatingStyles } = useFloating(toRef(props, 'referenceElement'), floatin
 <template>
   <teleport to="#floatingLayer">
     <div ref="floating" class="LinkEditPopup" :style="floatingStyles" @pointerdown.stop.prevent>
-      <a
-        v-if="navigationType === 'internal' && !navigating"
-        class="link"
-        @click="navigateInternally"
-        >Follow link</a
-      >
-      <a v-else-if="!navigating" class="link" :href="href" target="_blank" rel="noopener,noreferrer"
-        >Follow link</a
-      >
+      <a v-if="!navigating" class="link" @click="onClick">Follow link</a>
       ({{ textEditorsBindings.bindings.openLink.humanReadable }})
     </div>
   </teleport>

--- a/app/gui/src/project-view/util/codemirror/index.ts
+++ b/app/gui/src/project-view/util/codemirror/index.ts
@@ -1,4 +1,5 @@
 import { LINE_BOUNDARIES } from '$/utils/data/string'
+import { useNavigateLink } from '$/utils/links'
 import type { ToValue } from '$/utils/reactivity'
 import { textEditorsBindings } from '@/bindings'
 import type CodeMirrorRoot from '@/components/CodeMirrorRoot.vue'
@@ -217,6 +218,7 @@ const NULL_EXTENSION: Extension = readonly([])
 
 function useBindings() {
   const keyboard = injectKeyboard(true)
+  const navigateLink = useNavigateLink()
 
   function openLink(event: CmEventExt<AnyHandlerEvent>) {
     const parents = elementHierarchy(event.target)
@@ -226,7 +228,7 @@ function useBindings() {
 
     event.preventDefault()
     event.stopPropagation()
-    window.open(linkElement.href, '_blank', 'noopener,noreferrer')
+    navigateLink(linkElement.href)
     return true
   }
 

--- a/app/gui/src/project-view/util/codemirror/links.ts
+++ b/app/gui/src/project-view/util/codemirror/links.ts
@@ -12,13 +12,19 @@ export function useLinkTitles(
   { readonly }: { readonly: ToValue<boolean> },
 ) {
   const keyboard = injectKeyboard(true)
-  useStateEffect(editorView, setLinkAttributesFactory, () =>
-    linkAttributeFactory(
+  useStateEffect(editorView, setLinkAttributesFactory, () => {
+    const title =
       toValue(readonly) ? 'Click to open link in a new window.'
       : keyboard?.mod ? `${textEditorsBindings.bindings.openLink.humanReadable} to open link.`
-      : `Click to edit; ${textEditorsBindings.bindings.openLink.humanReadable} to open link.`,
-    ),
-  )
+      : `Click to edit; ${textEditorsBindings.bindings.openLink.humanReadable} to open link.`
+    return (href: string) => {
+      return {
+        href,
+        title,
+        target: '_blank',
+      }
+    }
+  })
 }
 
 export type LinkAttributesFactory = (url: string) => Record<string, string>
@@ -28,11 +34,3 @@ export const {
   changed: linkAttributesFactoryChanged,
   extension: linkDecoratorStateExt,
 } = valueExt<LinkAttributesFactory>((href) => ({ href }))
-
-function linkAttributeFactory(title: string) {
-  return (href: string) => ({
-    href,
-    title,
-    target: '_blank',
-  })
-}

--- a/app/gui/src/utils/links.ts
+++ b/app/gui/src/utils/links.ts
@@ -1,0 +1,18 @@
+import { useRoute, useRouter, type RouteLocationNormalizedLoaded, type Router } from 'vue-router'
+
+export function isEnsoLink(href: string) {
+  return URL.parse(href)?.protocol === 'enso:'
+}
+
+export function useNavigateLink(
+  router: Pick<Router, 'push'> = useRouter(),
+  route: Pick<RouteLocationNormalizedLoaded, 'query'> = useRoute(),
+) {
+  return async (href: string) => {
+    if (isEnsoLink(href)) {
+      await router.push({ params: { path: href.split('/') }, query: route.query })
+    } else {
+      window.open(href, '_blank', 'noopener,noreferrer')
+    }
+  }
+}

--- a/app/gui/src/utils/links.ts
+++ b/app/gui/src/utils/links.ts
@@ -1,9 +1,14 @@
 import { useRoute, useRouter, type RouteLocationNormalizedLoaded, type Router } from 'vue-router'
 
+/** Check if given link is an enso:// link. */
 export function isEnsoLink(href: string) {
   return URL.parse(href)?.protocol === 'enso:'
 }
 
+/**
+ * Composable returning a method for navigation to links, including proper handling of enso://
+ * links.
+ */
 export function useNavigateLink(
   router: Pick<Router, 'push'> = useRouter(),
   route: Pick<RouteLocationNormalizedLoaded, 'query'> = useRoute(),

--- a/app/gui/tsconfig.app.json
+++ b/app/gui/tsconfig.app.json
@@ -934,6 +934,7 @@
     "./src/utils/data/set.ts",
     "./src/utils/data/string.ts",
     "./src/utils/dom.ts",
+    "./src/utils/links.ts",
     "./src/utils/load.ts",
     "./src/utils/queryClient.ts",
     "./src/utils/reactivity.ts",


### PR DESCRIPTION
### Pull Request Description

The ctrl+click at enso:// link didn't work.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
- ~~[] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
