### PR TITLE
Fix warnings about inactive effectscope

### DIFF
--- a/app/gui/src/project-view/util/database/reactiveDb.ts
+++ b/app/gui/src/project-view/util/database/reactiveDb.ts
@@ -356,12 +356,15 @@ export class ReactiveMapping<K, V, M> {
       const handler = db.on('entryAdded', (key, value, onDelete) => {
         const scope = effectScope()
         const mappedValue = scope.run(() =>
-          computed(() => scope.run(() => indexer(key, value)), debugOptions),
+          computed(
+            () => (scope.active ? scope.run(() => indexer(key, value)) : undefined),
+            debugOptions,
+          ),
         )! // This non-null assertion is SAFE, as the scope is initially active.
         this.computed.set(key, mappedValue)
         onDelete(() => {
-          scope.stop()
           this.computed.delete(key)
+          scope.stop()
         })
       })
       onScopeDispose(() => db.off('entryAdded', handler))

--- a/app/gui/src/router/dataLoader.ts
+++ b/app/gui/src/router/dataLoader.ts
@@ -133,7 +133,7 @@ export function withDataLoader<
         DEV: assert(scope != null)
         return scope?.run(() => dataLoader.beforeRouteUpdate?.(to, from, data))
       },
-      unmounted() {
+      beforeRouteLeave() {
         scope?.stop()
       },
       render() {


### PR DESCRIPTION
### Pull Request Description

They were appearing when switching tabs (sometimes) and closing project.

### Important Notes

Changed `unmounted` to `beforeRouteLeave`, because it happens that the component is unmounted and then mounted immediately again (probably due to some veaury shenanigans)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
