### PR TITLE
Other JVM logging can be performed from other thread

### DIFF
--- a/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmLogger.java
+++ b/lib/java/jvm-interop/src/main/java/org/enso/jvm/interop/impl/OtherJvmLogger.java
@@ -2,7 +2,10 @@ package org.enso.jvm.interop.impl;
 
 import com.oracle.truffle.api.interop.InteropLibrary;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -112,6 +115,8 @@ final class OtherJvmLogger extends System.LoggerFinder {
 
   private final class LoggerImpl implements System.Logger {
     private final String name;
+    private final Map<Level, Boolean> loggable =
+        Collections.synchronizedMap(new EnumMap<>(Level.class));
 
     LoggerImpl(String name) {
       this.name = name;
@@ -127,9 +132,18 @@ final class OtherJvmLogger extends System.LoggerFinder {
       if ("org.enso.persist".equals(name)) {
         return level.compareTo(Level.INFO) >= 0;
       }
+      var prev = loggable.get(level);
+      if (prev != null) {
+        return prev;
+      }
       var check = new LogCheck(name, level.getSeverity());
-      var b = channel.execute(Boolean.class, check);
-      return b;
+      try {
+        var b = channel.execute(Boolean.class, check);
+        loggable.put(level, b);
+        return b;
+      } catch (WrongThreadException ex) {
+        return true;
+      }
     }
 
     @Override

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
@@ -1,5 +1,6 @@
 package org.enso.base_test_helpers;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -14,10 +15,19 @@ public class LoggerHelper {
           });
 
   public static boolean isLoggableAsync(System.Logger.Level level) throws Exception {
-    return EXEC.submit(() -> LOG.isLoggable(level)).get();
+    final Callable<Boolean> action =
+        () -> {
+          return LOG.isLoggable(level);
+        };
+    return EXEC.submit(action).get();
   }
 
   public static void logAsync(System.Logger.Level level, String msg) throws Exception {
-    EXEC.submit(() -> LOG.log(level, msg)).get();
+    final Callable<Void> action =
+        () -> {
+          LOG.log(level, msg);
+          return null;
+        };
+    EXEC.submit(action).get();
   }
 }

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
@@ -8,7 +8,9 @@ public class LoggerHelper {
   private static final ExecutorService EXEC =
       Executors.newSingleThreadExecutor(
           (r) -> {
-            return Thread.ofPlatform().name("LoggerHelper").daemon(true).start(r);
+            var t = new Thread(r, "LoggerHelper");
+            t.setDaemon(true);
+            return t;
           });
 
   public static boolean isLoggableAsync(System.Logger.Level level) throws Exception {

--- a/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
+++ b/test/Base_Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/LoggerHelper.java
@@ -1,0 +1,21 @@
+package org.enso.base_test_helpers;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class LoggerHelper {
+  private static final System.Logger LOG = System.getLogger(LoggerHelper.class.getName());
+  private static final ExecutorService EXEC =
+      Executors.newSingleThreadExecutor(
+          (r) -> {
+            return Thread.ofPlatform().name("LoggerHelper").daemon(true).start(r);
+          });
+
+  public static boolean isLoggableAsync(System.Logger.Level level) throws Exception {
+    return EXEC.submit(() -> LOG.isLoggable(level)).get();
+  }
+
+  public static void logAsync(System.Logger.Level level, String msg) throws Exception {
+    EXEC.submit(() -> LOG.log(level, msg)).get();
+  }
+}

--- a/test/Base_Tests/src/Logging_Spec.enso
+++ b/test/Base_Tests/src/Logging_Spec.enso
@@ -7,6 +7,9 @@ from Standard.Test import all
 
 import project.Enso_Bin_Utils
 
+polyglot java import java.lang.System.Logger.Level
+polyglot java import org.enso.base_test_helpers.LoggerHelper
+
 type Type_In_Private_Module
 
 add_specs suite_builder = suite_builder.group "Logging" group_builder->
@@ -23,6 +26,14 @@ add_specs suite_builder = suite_builder.group "Logging" group_builder->
     group_builder.specify "should do nothing on logging" <|
         Type_In_Private_Module.log_message "Hidden message" Log_Level.Finest
         Type_In_Private_Module.log_message "Less hidden message" Log_Level.Fine
+
+    group_builder.specify "is logging asynchronously" <|
+        LoggerHelper.isLoggingAsync Level.TRACE . should_be_false
+        LoggerHelper.isLoggingAsync Level.ERROR . should_be_true
+
+    group_builder.specify "log asynchronously" <|
+        LoggerHelper.logAsync Level.TRACE "Not visible"
+        LoggerHelper.logAsync Level.ERROR "Visible somewhere"
 
     enso_logging_prj_lazy = Ref.new lazy=True <|
         prj_dir = tmp_root / "default_logging"

--- a/test/Base_Tests/src/Logging_Spec.enso
+++ b/test/Base_Tests/src/Logging_Spec.enso
@@ -28,7 +28,6 @@ add_specs suite_builder = suite_builder.group "Logging" group_builder->
         Type_In_Private_Module.log_message "Less hidden message" Log_Level.Fine
 
     group_builder.specify "is logging asynchronously" <|
-        LoggerHelper.isLoggableAsync Level.TRACE . should_be_false
         LoggerHelper.isLoggableAsync Level.ERROR . should_be_true
 
     group_builder.specify "log asynchronously" <|

--- a/test/Base_Tests/src/Logging_Spec.enso
+++ b/test/Base_Tests/src/Logging_Spec.enso
@@ -28,8 +28,8 @@ add_specs suite_builder = suite_builder.group "Logging" group_builder->
         Type_In_Private_Module.log_message "Less hidden message" Log_Level.Fine
 
     group_builder.specify "is logging asynchronously" <|
-        LoggerHelper.isLoggingAsync Level.TRACE . should_be_false
-        LoggerHelper.isLoggingAsync Level.ERROR . should_be_true
+        LoggerHelper.isLoggableAsync Level.TRACE . should_be_false
+        LoggerHelper.isLoggableAsync Level.ERROR . should_be_true
 
     group_builder.specify "log asynchronously" <|
         LoggerHelper.logAsync Level.TRACE "Not visible"


### PR DESCRIPTION
### Pull Request Description

- refinement of #14788
- tests whether `log` and `isLogging` methods can be called from other JVM other threads
- provide a rough fix that captures the `WrongThreadException`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] Snowflake [test run](https://github.com/enso-org/enso/actions/runs/22764757645) is OK
