### PR TITLE
Add ability to skip scheduling unique jobs

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/ExecuteJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/ExecuteJob.java
@@ -26,7 +26,7 @@ import scala.Option;
  * @see UniqueJob
  */
 @SuppressWarnings("unchecked")
-public class ExecuteJob extends Job<Void> implements UniqueJob<Void> {
+public class ExecuteJob extends Job<Void> implements UniqueJob<Void>, SkipSchedulingUniqueJob<Void> {
 
   private static final Logger logger = LoggerFactory.getLogger(ExecuteJob.class);
   private static final String PENDING_VISUALIZATIONS_TRIGGER_CONTEXT = "pending visualizations";

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/ExecuteJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/ExecuteJob.java
@@ -26,7 +26,7 @@ import scala.Option;
  * @see UniqueJob
  */
 @SuppressWarnings("unchecked")
-public class ExecuteJob extends Job<Void> implements UniqueJob<Void>, SkipSchedulingUniqueJob<Void> {
+public class ExecuteJob extends Job<Void> implements UniqueJob<Void>, SkipSchedulingUniqueJob {
 
   private static final Logger logger = LoggerFactory.getLogger(ExecuteJob.class);
   private static final String PENDING_VISUALIZATIONS_TRIGGER_CONTEXT = "pending visualizations";

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -192,15 +192,16 @@ final class JobExecutionEngine(
     }
 
   /** @inheritdoc */
-  override def run[A](job: Job[A]): Future[A] = {
-    if (handleDuplicateJobs(job, runningJobsRef)) {
-      logger.trace("Skipping duplicate job [{}].", job)
-      return Future.successful(null.asInstanceOf[A])
+  override def run[A](job: Job[A]): Future[A] =
+    synchronized {
+      if (handleDuplicateJobs(job, runningJobsRef)) {
+        logger.trace("Skipping duplicate job [{}].", job)
+        return Future.successful(null.asInstanceOf[A])
+      }
+      val executor =
+        if (job.highPriority) highPriorityJobExecutor else jobExecutor
+      runInternal(job, executor, runningJobsRef, "regular")
     }
-    val executor =
-      if (job.highPriority) highPriorityJobExecutor else jobExecutor
-    runInternal(job, executor, runningJobsRef, "regular")
-  }
 
   /** Returns `true` if the job should be skipped (not scheduled).
     * For [[SkipSchedulingUniqueJob]], checks if a duplicate exists.

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -6,6 +6,7 @@ import org.enso.interpreter.instrument.job.{
   BackgroundJob,
   ExecuteJob,
   Job,
+  SkipSchedulingUniqueJob,
   UniqueJob
 }
 import org.enso.text.Sha3_224VersionCalculator
@@ -164,10 +165,21 @@ final class JobExecutionEngine(
   override def runBackground[A](job: BackgroundJob[A]): Unit =
     synchronized {
       if (isBackgroundJobsStarted) {
-        cancelDuplicateJobs(job, backgroundJobsRef)
+        if (handleDuplicateJobs(job, backgroundJobsRef)) {
+          logger.trace("Skipping duplicate background job [{}].", job)
+          return
+        }
         runInternal(job, backgroundJobExecutor, backgroundJobsRef, "background")
       } else {
         job match {
+          case _: SkipSchedulingUniqueJob[_] =>
+            if (hasDuplicateInDelayedQueue(job.asInstanceOf[UniqueJob[_]])) {
+              logger.trace(
+                "Skipping duplicate delayed background job [{}].",
+                job
+              )
+              return
+            }
           case job: UniqueJob[_] =>
             delayedBackgroundJobsQueue.removeIf {
               case that: UniqueJob[_] => that.equalsTo(job)
@@ -181,10 +193,30 @@ final class JobExecutionEngine(
 
   /** @inheritdoc */
   override def run[A](job: Job[A]): Future[A] = {
-    cancelDuplicateJobs(job, runningJobsRef)
+    if (handleDuplicateJobs(job, runningJobsRef)) {
+      logger.trace("Skipping duplicate job [{}].", job)
+      return Future.successful(null.asInstanceOf[A])
+    }
     val executor =
       if (job.highPriority) highPriorityJobExecutor else jobExecutor
     runInternal(job, executor, runningJobsRef, "regular")
+  }
+
+  /** Returns `true` if the job should be skipped (not scheduled).
+    * For [[SkipSchedulingUniqueJob]], checks if a duplicate exists.
+    * For regular [[UniqueJob]], cancels existing duplicates.
+    */
+  private def handleDuplicateJobs[A](
+    job: Job[A],
+    runningJobsRef: AtomicReference[Vector[RunningJob]]
+  ): Boolean = {
+    job match {
+      case _: SkipSchedulingUniqueJob[_] =>
+        hasDuplicateJob(job.asInstanceOf[UniqueJob[_]], runningJobsRef)
+      case _ =>
+        cancelDuplicateJobs(job, runningJobsRef)
+        false
+    }
   }
 
   private def cancelDuplicateJobs[A](
@@ -210,6 +242,31 @@ final class JobExecutionEngine(
         }
       case _ =>
     }
+  }
+
+  private def hasDuplicateJob(
+    job: UniqueJob[_],
+    runningJobsRef: AtomicReference[Vector[RunningJob]]
+  ): Boolean = {
+    val allJobs =
+      runningJobsRef.updateAndGet(_.filterNot(_.future.isCancelled))
+    allJobs.exists { runningJob =>
+      runningJob.job match {
+        case jobRef: UniqueJob[_] => jobRef.equalsTo(job)
+        case _                    => false
+      }
+    }
+  }
+
+  private def hasDuplicateInDelayedQueue(job: UniqueJob[_]): Boolean = {
+    val iter = delayedBackgroundJobsQueue.iterator()
+    while (iter.hasNext) {
+      iter.next() match {
+        case that: UniqueJob[_] if that.equalsTo(job) => return true
+        case _                                        =>
+      }
+    }
+    false
   }
 
   private def updatePendingCancellations(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -172,7 +172,7 @@ final class JobExecutionEngine(
         runInternal(job, backgroundJobExecutor, backgroundJobsRef, "background")
       } else {
         job match {
-          case _: SkipSchedulingUniqueJob[_] =>
+          case _: SkipSchedulingUniqueJob =>
             if (hasDuplicateInDelayedQueue(job.asInstanceOf[UniqueJob[_]])) {
               logger.trace(
                 "Skipping duplicate delayed background job [{}].",
@@ -211,7 +211,7 @@ final class JobExecutionEngine(
     runningJobsRef: AtomicReference[Vector[RunningJob]]
   ): Boolean = {
     job match {
-      case _: SkipSchedulingUniqueJob[_] =>
+      case _: SkipSchedulingUniqueJob =>
         hasDuplicateJob(job.asInstanceOf[UniqueJob[_]], runningJobsRef)
       case _ =>
         cancelDuplicateJobs(job, runningJobsRef)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
@@ -71,3 +71,10 @@ trait UniqueJob[A] { self: Job[A] =>
     */
   def equalsTo(that: UniqueJob[_]): Boolean
 }
+
+/** A [[UniqueJob]] that skips scheduling if a duplicate job already exists
+  * in the queue, as decided by the `equalsTo` method. Unlike regular
+  * [[UniqueJob]] which cancels previous duplicates, this trait prevents
+  * the new job from being scheduled at all.
+  */
+trait SkipSchedulingUniqueJob[A] { self: UniqueJob[A] => }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
@@ -77,4 +77,4 @@ trait UniqueJob[A] { self: Job[A] =>
   * [[UniqueJob]] which cancels previous duplicates, this trait prevents
   * the new job from being scheduled at all.
   */
-trait SkipSchedulingUniqueJob[A] { self: UniqueJob[A] => }
+trait SkipSchedulingUniqueJob { self: UniqueJob[java.lang.Void] => }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Debugging showed that cancelling jobs that started executing but i.e. waiting for a lock is a costly operation. This PR adds optimization that adds ability to skip scheduling some jobs instead of cancelling and rescheduling them.

Drastically improves the startup performance of large projects.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
