### PR TITLE
Avoid computing `partsForImport` again and again

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/phase/ImportResolutionForIR.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/phase/ImportResolutionForIR.java
@@ -104,8 +104,8 @@ abstract class ImportResolverForIR
   }
 
   @Override
-  protected final java.util.List<BindingsMap.ResolvedType> definedEntities(Import.Module name) {
-    var parts = partsForImport(name);
+  protected final java.util.List<BindingsMap.ResolvedType> definedEntities(
+      java.util.List<String> parts, Import.Module name) {
     var last = parts.size() - 1;
     var modName = String.join(".", parts.subList(0, last).stream().toList());
     var compiler = this.getCompiler();
@@ -145,8 +145,8 @@ abstract class ImportResolverForIR
    * @return null if the import is not a constructor import.
    */
   @Override
-  protected java.util.List<ResolvedConstructor> definedConstructors(Import.Module imp) {
-    var parts = partsForImport(imp);
+  protected java.util.List<ResolvedConstructor> definedConstructors(
+      java.util.List<String> parts, Import.Module imp) {
     if (parts.size() < 3) {
       return null;
     }
@@ -184,8 +184,8 @@ abstract class ImportResolverForIR
   }
 
   @Override
-  protected java.util.List<ResolvedModuleMethod> definedModuleMethods(Import.Module imp) {
-    var parts = partsForImport(imp);
+  protected java.util.List<ResolvedModuleMethod> definedModuleMethods(
+      java.util.List<String> parts, Import.Module imp) {
     if (parts.size() < 3) {
       return null;
     }
@@ -219,8 +219,8 @@ abstract class ImportResolverForIR
   }
 
   @Override
-  protected java.util.List<ResolvedExtensionMethod> definedExtensionMethods(Import.Module imp) {
-    var parts = partsForImport(imp);
+  protected java.util.List<ResolvedExtensionMethod> definedExtensionMethods(
+      java.util.List<String> parts, Import.Module imp) {
     if (parts.size() < 3) {
       return null;
     }
@@ -254,8 +254,8 @@ abstract class ImportResolverForIR
   }
 
   @Override
-  protected java.util.List<ResolvedConversionMethod> definedConversionMethods(Import.Module imp) {
-    var parts = partsForImport(imp);
+  protected java.util.List<ResolvedConversionMethod> definedConversionMethods(
+      java.util.List<String> parts, Import.Module imp) {
     if (parts.size() < 3) {
       return null;
     }

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/phase/ImportResolverAlgorithm.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/phase/ImportResolverAlgorithm.java
@@ -17,7 +17,6 @@ public abstract class ImportResolverAlgorithm<
     ResolvedModuleMethod,
     ResolvedExtensionMethod,
     ResolvedConversionMethod> {
-  protected ImportResolverAlgorithm() {}
 
   protected abstract String nameForImport(Import imp);
 
@@ -48,15 +47,19 @@ public abstract class ImportResolverAlgorithm<
    */
   protected abstract java.util.List<String> onlyNames(Export ex);
 
-  protected abstract java.util.List<ResolvedType> definedEntities(Import name);
+  protected abstract java.util.List<ResolvedType> definedEntities(List<String> parts, Import name);
 
-  protected abstract java.util.List<ResolvedConstructor> definedConstructors(Import name);
+  protected abstract java.util.List<ResolvedConstructor> definedConstructors(
+      List<String> parts, Import name);
 
-  protected abstract java.util.List<ResolvedModuleMethod> definedModuleMethods(Import imp);
+  protected abstract java.util.List<ResolvedModuleMethod> definedModuleMethods(
+      List<String> parts, Import imp);
 
-  protected abstract java.util.List<ResolvedExtensionMethod> definedExtensionMethods(Import imp);
+  protected abstract java.util.List<ResolvedExtensionMethod> definedExtensionMethods(
+      List<String> parts, Import imp);
 
-  protected abstract java.util.List<ResolvedConversionMethod> definedConversionMethods(Import imp);
+  protected abstract java.util.List<ResolvedConversionMethod> definedConversionMethods(
+      List<String> parts, Import imp);
 
   /**
    * Ensure library is loaded and load a module.
@@ -127,23 +130,23 @@ public abstract class ImportResolverAlgorithm<
       if (m != null) {
         return createResolvedImport(imp, exp, m);
       }
-      var typ = tryResolveAsTypeNew(imp);
+      var typ = tryResolveAsTypeNew(parts, imp);
       if (typ != null) {
         return createResolvedType(imp, exp, typ);
       }
-      var cons = tryResolveAsConstructor(imp);
+      var cons = tryResolveAsConstructor(parts, imp);
       if (cons != null) {
         return createResolvedConstructor(imp, exp, cons);
       }
-      var moduleMethod = tryResolveAsModuleMethod(imp);
+      var moduleMethod = tryResolveAsModuleMethod(parts, imp);
       if (moduleMethod != null) {
         return createResolvedModuleMethod(imp, exp, moduleMethod);
       }
-      var extensionMethods = tryResolveAsExtensionMethods(imp);
+      var extensionMethods = tryResolveAsExtensionMethods(parts, imp);
       if (extensionMethods != null) {
         return createResolvedExtensionMethods(imp, exp, extensionMethods);
       }
-      var conversionMethods = tryResolveAsConversionMethods(imp);
+      var conversionMethods = tryResolveAsConversionMethods(parts, imp);
       if (conversionMethods != null) {
         return createResolvedConversionMethods(imp, exp, conversionMethods);
       }
@@ -153,11 +156,10 @@ public abstract class ImportResolverAlgorithm<
     }
   }
 
-  private ResolvedType tryResolveAsTypeNew(Import name) {
-    var parts = partsForImport(name);
+  private ResolvedType tryResolveAsTypeNew(List<String> parts, Import name) {
     var last = parts.size() - 1;
     var tp = parts.get(last);
-    var entities = definedEntities(name);
+    var entities = definedEntities(parts, name);
     if (entities == null) {
       return null;
     }
@@ -165,12 +167,11 @@ public abstract class ImportResolverAlgorithm<
     return type.orElse(null);
   }
 
-  private ResolvedConstructor tryResolveAsConstructor(Import imp) {
-    var parts = partsForImport(imp);
+  private ResolvedConstructor tryResolveAsConstructor(List<String> parts, Import imp) {
     if (parts.size() < 3) {
       return null;
     }
-    var constructors = definedConstructors(imp);
+    var constructors = definedConstructors(parts, imp);
     if (constructors == null) {
       return null;
     }
@@ -182,12 +183,11 @@ public abstract class ImportResolverAlgorithm<
     return consOpt.orElse(null);
   }
 
-  private ResolvedModuleMethod tryResolveAsModuleMethod(Import imp) {
-    var parts = partsForImport(imp);
+  private ResolvedModuleMethod tryResolveAsModuleMethod(List<String> parts, Import imp) {
     if (parts.size() < 3) {
       return null;
     }
-    var moduleMethods = definedModuleMethods(imp);
+    var moduleMethods = definedModuleMethods(parts, imp);
     if (moduleMethods == null) {
       return null;
     }
@@ -206,12 +206,12 @@ public abstract class ImportResolverAlgorithm<
    * @return List with at least one element. null if there are no static methods in the imported
    *     module scope.
    */
-  private java.util.List<ResolvedExtensionMethod> tryResolveAsExtensionMethods(Import imp) {
-    var parts = partsForImport(imp);
+  private java.util.List<ResolvedExtensionMethod> tryResolveAsExtensionMethods(
+      List<String> parts, Import imp) {
     if (parts.size() < 3) {
       return null;
     }
-    var definedExtensionMethods = definedExtensionMethods(imp);
+    var definedExtensionMethods = definedExtensionMethods(parts, imp);
     if (definedExtensionMethods == null) {
       return null;
     }
@@ -234,12 +234,12 @@ public abstract class ImportResolverAlgorithm<
    * @return List of at least one element. null if there are no conversion methods in the imported
    *     module scope.
    */
-  private java.util.List<ResolvedConversionMethod> tryResolveAsConversionMethods(Import imp) {
-    var parts = partsForImport(imp);
+  private java.util.List<ResolvedConversionMethod> tryResolveAsConversionMethods(
+      List<String> parts, Import imp) {
     if (parts.size() < 3) {
       return null;
     }
-    var definedConvMethods = definedConversionMethods(imp);
+    var definedConvMethods = definedConversionMethods(parts, imp);
     if (definedConvMethods == null) {
       return null;
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -49,15 +49,19 @@ case object Imports extends IRPass {
           .map { newName =>
             val parts = newName.parts
             if (parts.length == 2) {
-              i.copyWithNameAndRename(
-                newName.copyBuilder().parts(parts :+ mainModuleName).build(),
-                computeRename(
-                  i.rename,
-                  i.onlyNames.nonEmpty || i.isAll,
-                  parts(1).asInstanceOf[Name.Literal]
+              i.copyBuilder()
+                .name(
+                  newName.copyBuilder().parts(parts :+ mainModuleName).build()
                 )
-              )
-            } else { i.copyWithName(newName) }
+                .rename(
+                  computeRename(
+                    i.rename,
+                    i.onlyNames.nonEmpty || i.isAll,
+                    parts(1).asInstanceOf[Name.Literal]
+                  )
+                )
+                .build()
+            } else { i.copyBuilder().name(newName).build() }
           }
           .getOrElse(
             errors.ImportExport.create(

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/module/scope/Import.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/module/scope/Import.java
@@ -99,12 +99,8 @@ public interface Import extends Scope {
           null);
     }
 
-    public Module copyWithNameAndRename(Name.Qualified name, Option<Name.Literal> rename) {
-      return new Builder(this).name(name).rename(rename).build();
-    }
-
-    public Module copyWithName(Name.Qualified name) {
-      return new Builder(this).name(name).build();
+    public Builder copyBuilder() {
+      return ImportModuleGen.builder(this);
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodImportResolver.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodImportResolver.java
@@ -95,27 +95,31 @@ final class InvokeMethodImportResolver
   }
 
   @Override
-  protected List<Type> definedEntities(UnresolvedSymbol symbol) {
+  protected List<Type> definedEntities(java.util.List<String> parts, UnresolvedSymbol symbol) {
     return module.getScope().getAllTypes(symbol.getName());
   }
 
   @Override
-  protected List<AtomConstructor> definedConstructors(UnresolvedSymbol symbol) {
+  protected List<AtomConstructor> definedConstructors(
+      java.util.List<String> parts, UnresolvedSymbol symbol) {
     return Collections.emptyList();
   }
 
   @Override
-  protected List<Function> definedModuleMethods(UnresolvedSymbol symbol) {
+  protected List<Function> definedModuleMethods(
+      java.util.List<String> parts, UnresolvedSymbol symbol) {
     return Collections.emptyList();
   }
 
   @Override
-  protected List<Function> definedExtensionMethods(UnresolvedSymbol imp) {
+  protected List<Function> definedExtensionMethods(
+      java.util.List<String> parts, UnresolvedSymbol imp) {
     return null;
   }
 
   @Override
-  protected List<Function> definedConversionMethods(UnresolvedSymbol imp) {
+  protected List<Function> definedConversionMethods(
+      java.util.List<String> parts, UnresolvedSymbol imp) {
     return null;
   }
 


### PR DESCRIPTION
### Pull Request Description

- compute `parts` via calling `partsForImport` once
- then pass the `parts` value around
- small refactoring

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to work
