### PR TITLE
Mistake in the case of Auto for Snowflake bulk load

### DIFF
--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
@@ -61,14 +61,14 @@ type Snowflake_File_Format
                 + (if dt != "" then " DATE_FORMAT = '" + (dt.replace "'" "''") + "'"  else ' DATE_FORMAT = AUTO')
                 + (if tm != "" then " TIME_FORMAT = '" + (tm.replace "'" "''") + "'"  else ' TIME_FORMAT = AUTO')
                 + (if ts != "" then " TIMESTAMP_FORMAT = '" + (ts.replace "'" "''") + "'"  else ' TIMESTAMP_FORMAT = AUTO')
-                + (if compression != Auto_Boolean.AUTO then ' COMPRESSION = ' + compression.to_sql else '')
+                + (if compression != Auto_Boolean.Auto then ' COMPRESSION = ' + compression.to_sql else '')
             output
         Snowflake_File_Format.JSON dt tm ts compression ->
             output = 'TYPE = JSON'
                 + (if dt != "" then " DATE_FORMAT = '" + (dt.replace "'" "''") + "'"  else ' DATE_FORMAT = AUTO')
                 + (if tm != "" then " TIME_FORMAT = '" + (tm.replace "'" "''") + "'"  else ' TIME_FORMAT = AUTO')
                 + (if ts != "" then " TIMESTAMP_FORMAT = '" + (ts.replace "'" "''") + "'"  else ' TIMESTAMP_FORMAT = AUTO')
-                + (if compression != Auto_Boolean.AUTO then ' COMPRESSION = ' + compression.to_sql else '')
+                + (if compression != Auto_Boolean.Auto then ' COMPRESSION = ' + compression.to_sql else '')
             output
         Snowflake_File_Format.Avro -> 'TYPE = AVRO'
         Snowflake_File_Format.ORC -> 'TYPE = ORC'
@@ -95,7 +95,7 @@ Snowflake_File_Format.from (that:Identifier) =
 ## Three-state boolean type for Snowflake options. (avoiding clash with True/False by being all caps)
 type Auto_Boolean
     ## Attempt to use automatic detection.
-    AUTO
+    Auto
 
     ## True value.
     TRUE
@@ -107,7 +107,7 @@ type Auto_Boolean
        private: true
        ---
     private to_sql self = case self of
-        Auto_Boolean.AUTO -> 'AUTO'
+        Auto_Boolean.Auto -> 'AUTO'
         Auto_Boolean.TRUE -> 'TRUE'
         Auto_Boolean.FALSE -> 'FALSE'
 
@@ -116,7 +116,7 @@ Auto_Boolean.from (that:Boolean) =
 
 Auto_Boolean.from (that:Nothing) =
     _ = that
-    Auto_Boolean.AUTO
+    Auto_Boolean.Auto
 
 ## Specified the compression type for the file format.
 type Compression

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/File_Format.enso
@@ -95,7 +95,7 @@ Snowflake_File_Format.from (that:Identifier) =
 ## Three-state boolean type for Snowflake options. (avoiding clash with True/False by being all caps)
 type Auto_Boolean
     ## Attempt to use automatic detection.
-    Auto
+    AUTO
 
     ## True value.
     TRUE
@@ -107,7 +107,7 @@ type Auto_Boolean
        private: true
        ---
     private to_sql self = case self of
-        Auto_Boolean.Auto -> 'AUTO'
+        Auto_Boolean.AUTO -> 'AUTO'
         Auto_Boolean.TRUE -> 'TRUE'
         Auto_Boolean.FALSE -> 'FALSE'
 
@@ -116,7 +116,7 @@ Auto_Boolean.from (that:Boolean) =
 
 Auto_Boolean.from (that:Nothing) =
     _ = that
-    Auto_Boolean.Auto
+    Auto_Boolean.AUTO
 
 ## Specified the compression type for the file format.
 type Compression


### PR DESCRIPTION
### Pull Request Description

Corrects an case error in Snowflake functions.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
