### PR TITLE
Remove references to ENSO_JVM_OPTS

### DIFF
--- a/docs/distribution/launcher-cli.md
+++ b/docs/distribution/launcher-cli.md
@@ -292,7 +292,7 @@ be passed after a double dash (`--`), i.e. `enso repl -- --someUnknownFlag`.
 
 ## JVM Options
 
-It is possible to pass parameters to the JVM that is used to launch
-these components, which may be helpful with debugging. A parameter of the form
+It is possible to pass parameters to the JVM that is used to launch these
+components, which may be helpful with debugging. A parameter of the form
 `--jvm.argumentName=argumentValue` will be passed to the JVM as
 `-DargumentName=argumentValue`.

--- a/docs/distribution/launcher-cli.md
+++ b/docs/distribution/launcher-cli.md
@@ -292,14 +292,7 @@ be passed after a double dash (`--`), i.e. `enso repl -- --someUnknownFlag`.
 
 ## JVM Options
 
-If an environment variable `ENSO_JVM_OPTS` is defined, JVM options defined there
-are passed to the launcher JVM.
-
-> Note: Currently the `ENSO_JVM_OPTS` are parsed by splitting on the space
-> character, so individual options listed in this environment variable should
-> not contain spaces or they may be interpreted incorrectly.
-
-Moreover, it is possible to pass parameters to the JVM that is used to launch
+It is possible to pass parameters to the JVM that is used to launch
 these components, which may be helpful with debugging. A parameter of the form
 `--jvm.argumentName=argumentValue` will be passed to the JVM as
 `-DargumentName=argumentValue`.

--- a/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/components/LauncherRunnerSpec.scala
@@ -58,9 +58,7 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
 
   "Runner" should {
     "create a command from settings" in {
-      val envOptions = "-Xfrom-env -Denv=env"
-      val runner =
-        makeFakeRunner(extraEnv = Map("ENSO_JVM_OPTS" -> envOptions))
+      val runner = makeFakeRunner()
 
       val runSettings = RunSettings(
         SemVer.of(0, 0, 0),
@@ -76,9 +74,6 @@ class LauncherRunnerSpec extends RuntimeVersionManagerTest with FlakySpec {
         val arguments     = command.command.tail
         val javaArguments = arguments.takeWhile(_ != "-jar")
         val appArguments  = arguments.dropWhile(_ != runnerEntryPoint).tail
-        javaArguments should contain("-Xfrom-env")
-        javaArguments should contain("-Denv=env")
-        javaArguments should contain("-Dlocally-added-options=value1")
         javaArguments should contain("-Dlocally-added-options=value1")
         javaArguments should contain("-Doptions-added-from-manifest=42")
         javaArguments should contain("-Xanother-one")

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -4,7 +4,6 @@ import org.enso.semver.SemVer
 import org.enso.distribution.{DistributionManager, Environment}
 import org.enso.editions.updater.EditionManager
 import org.enso.editions.{DefaultEnsoVersion, SemVerEnsoVersion}
-import org.enso.logger.masking.MaskedString
 import org.slf4j.event.Level
 
 import java.net.URI
@@ -161,8 +160,7 @@ class Runner(
       )
     }
 
-  final private val JVM_PATH_ENV_VAR    = "ENSO_JVM_PATH"
-  final private val JVM_OPTIONS_ENV_VAR = "ENSO_JVM_OPTS"
+  final private val JVM_PATH_ENV_VAR = "ENSO_JVM_PATH"
 
   /** Runs an action giving it a command that can be used to launch the
     * component.
@@ -178,20 +176,7 @@ class Runner(
     action: RawCommand => R
   ): R = {
     def prepareAndRunCommand(engine: Engine, cmd: ExecCommand): R = {
-      val jvmOptsFromEnvironment = environment.getEnvVar(JVM_OPTIONS_ENV_VAR)
-      jvmOptsFromEnvironment.foreach { opts =>
-        logger.info(
-          "Additional JVM options [{}] from the {} environment variable.",
-          MaskedString(opts),
-          JVM_OPTIONS_ENV_VAR
-        )
-      }
-
-      val environmentOptions =
-        jvmOptsFromEnvironment.map(_.split(' ').toIndexedSeq).getOrElse(Seq())
-
-      val jvmArguments =
-        environmentOptions ++ cmd.cmdArguments(engine, jvmSettings)
+      val jvmArguments = cmd.cmdArguments(engine, jvmSettings)
 
       val loggingConnectionArguments =
         if (runSettings.connectLoggerIfAvailable)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- close #14509 

Cleanup references to `ENSO_JVM_OPTS`

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
