### PR TITLE
Fix missing ENSO_CLOUD_API_URL for engine and libs

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -1223,6 +1223,7 @@ export interface OpenHybridProjectParameters {
   readonly cloudProjectId: ProjectId
   /** Cloud project session id. */
   readonly cloudProjectSessionId: ProjectSessionId
+  readonly cloudApiUrl: string
 }
 
 /** HTTP request body for the "open project" endpoint. */

--- a/app/common/src/services/ProjectManager/types.ts
+++ b/app/common/src/services/ProjectManager/types.ts
@@ -191,6 +191,7 @@ export interface CloudParams {
   readonly cloudProjectDirectoryPath: string
   readonly cloudProjectId: string
   readonly cloudProjectSessionId: string
+  readonly cloudApiUrl: string
 }
 
 /** Parameters for the "open project" endpoint. */

--- a/app/gui/src/providers/openedProjects/projectStates.ts
+++ b/app/gui/src/providers/openedProjects/projectStates.ts
@@ -348,6 +348,7 @@ export function useProjectStates() {
             cloudProjectDirectoryPath: cloudParentPath,
             cloudProjectId: info.id,
             cloudProjectSessionId: info.hybridSessionId,
+            cloudApiUrl: backends.remoteBackend.baseUrl.toString(),
           },
         },
         info.title,

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -33,6 +33,7 @@ export interface CloudParams {
   readonly cloudProjectDirectoryPath: Path
   readonly cloudProjectId: string
   readonly cloudProjectSessionId: string
+  readonly cloudApiUrl: string
 }
 
 /** Parameters for the "create project" endpoint. */
@@ -171,6 +172,7 @@ export class ProjectService {
       ['ENSO_CLOUD_PROJECT_DIRECTORY_PATH', cloud.cloudProjectDirectoryPath],
       ['ENSO_CLOUD_PROJECT_ID', cloud.cloudProjectId],
       ['ENSO_CLOUD_PROJECT_SESSION_ID', cloud.cloudProjectSessionId],
+      ['ENSO_CLOUD_API_URL', cloud.cloudApiUrl],
     ]
   }
 

--- a/app/project-manager-shim/src/runProjects.ts
+++ b/app/project-manager-shim/src/runProjects.ts
@@ -60,6 +60,7 @@ export async function runHybridProjectByUrl(
       cloudProjectDirectoryPath,
       cloudProjectId: asset.id,
       cloudProjectSessionId,
+      cloudApiUrl: remoteBackend.baseUrl.toString(),
     })
     return exitCode
   } catch (error) {


### PR DESCRIPTION
### Pull Request Description

Fix missing `ENSO_CLOUD_API_URL` for non production environments. Since we always default to prod API this PR fixes missing LS logs and libs integrations for staging.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
