### PR TITLE
Add explicit TextEncoder and TextDecoder call for passing paths from Electron backend to frontend

### DIFF
--- a/app/electron-client/src/server.ts
+++ b/app/electron-client/src/server.ts
@@ -388,13 +388,14 @@ export class Server {
 
   /** Send a HTTP response with a JSON payload. */
   httpOkText(response: http.ServerResponse, content: string) {
+    var bytes = new TextEncoder().encode(content)
     return response
       .writeHead(HTTP_STATUS_OK, [
-        ['Content-Length', `${content.length}`],
+        ['Content-Length', `${bytes.length}`],
         ['Content-Type', 'text/plain'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(content, 'binary')
+      .end(bytes, 'utf-8')
   }
 
   /** Send a HTTP error with a text payload. */

--- a/app/electron-client/src/server.ts
+++ b/app/electron-client/src/server.ts
@@ -394,7 +394,7 @@ export class Server {
         ['Content-Type', 'text/plain'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(content)
+      .end(content, 'binary')
   }
 
   /** Send a HTTP error with a text payload. */

--- a/app/electron-client/src/server.ts
+++ b/app/electron-client/src/server.ts
@@ -388,7 +388,7 @@ export class Server {
 
   /** Send a HTTP response with a JSON payload. */
   httpOkText(response: http.ServerResponse, content: string) {
-    var bytes = new TextEncoder().encode(content)
+    const bytes = new TextEncoder().encode(content)
     return response
       .writeHead(HTTP_STATUS_OK, [
         ['Content-Length', `${bytes.length}`],

--- a/app/electron-client/src/server.ts
+++ b/app/electron-client/src/server.ts
@@ -325,13 +325,14 @@ export class Server {
             type: 'error',
             error: `Unknown endpoint '${route.pathname}'`,
           })
+          const bytes = new TextEncoder().encode(content)
           response
             .writeHead(HTTP_STATUS_NOT_FOUND, [
-              ['Content-Length', String(content.length)],
+              ['Content-Length', String(bytes.length)],
               ['Content-Type', 'application/json'],
               ...COOP_COEP_CORP_HEADERS,
             ])
-            .end(content)
+            .end(bytes)
           break
         }
       }
@@ -377,13 +378,14 @@ export class Server {
   /** Send a HTTP response with a JSON payload. */
   httpOkJson<T = never>(response: http.ServerResponse, body: NoInfer<T>) {
     const content = JSON.stringify(body)
+    const bytes = new TextEncoder().encode(content)
     return response
       .writeHead(HTTP_STATUS_OK, [
-        ['Content-Length', `${content.length}`],
+        ['Content-Length', `${bytes.length}`],
         ['Content-Type', 'application/json'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(content)
+      .end(bytes)
   }
 
   /** Send a HTTP response with a JSON payload. */
@@ -400,13 +402,14 @@ export class Server {
 
   /** Send a HTTP error with a text payload. */
   httpError(response: http.ServerResponse, message: string) {
+    const bytes = new TextEncoder().encode(message)
     return response
       .writeHead(HTTP_STATUS_BAD_REQUEST, [
-        ['Content-Length', `${message.length}`],
+        ['Content-Length', `${bytes.length}`],
         ['Content-Type', 'text/plain'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(message)
+      .end(bytes)
   }
 
   /** The root directory path. */
@@ -836,13 +839,14 @@ export class Server {
       const error = await archive.promise
       if (error) {
         const content = JSON.stringify({ error: `Asset '${error.id}' not found` })
+        const bytes = new TextEncoder().encode(content)
         response
           .writeHead(HTTP_STATUS_NOT_FOUND, [
-            ['Content-Length', String(content.length)],
+            ['Content-Length', String(bytes.length)],
             ['Content-Type', 'application/json'],
             ...COOP_COEP_CORP_HEADERS,
           ])
-          .end(content)
+          .end(bytes)
       }
       await promise
       this.httpOkJson<ExportedArchive>(response, {

--- a/app/electron-client/src/server.ts
+++ b/app/electron-client/src/server.ts
@@ -395,7 +395,7 @@ export class Server {
         ['Content-Type', 'text/plain'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(bytes, 'utf-8')
+      .end(bytes)
   }
 
   /** Send a HTTP error with a text payload. */

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -257,13 +257,14 @@ export class ProjectManagerShimMiddleware {
           break
         }
         case 'GET /api/root-directory-path': {
+          console.log(PROJECTS_ROOT_DIRECTORY)
           response
             .writeHead(HTTP_STATUS_OK, {
               'Content-Length': String(PROJECTS_ROOT_DIRECTORY.length),
               'Content-Type': 'text/plain',
               ...COMMON_HEADERS,
             })
-            .end(PROJECTS_ROOT_DIRECTORY)
+            .end(PROJECTS_ROOT_DIRECTORY, 'binary')
           break
         }
         default: {

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -257,7 +257,7 @@ export class ProjectManagerShimMiddleware {
           break
         }
         case 'GET /api/root-directory-path': {
-          var bytes = new TextEncoder().encode(PROJECTS_ROOT_DIRECTORY)
+          const bytes = new TextEncoder().encode(PROJECTS_ROOT_DIRECTORY)
           response
             .writeHead(HTTP_STATUS_OK, {
               'Content-Length': String(bytes.length),

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -264,7 +264,7 @@ export class ProjectManagerShimMiddleware {
               'Content-Type': 'text/plain',
               ...COMMON_HEADERS,
             })
-            .end(bytes, 'utf-8')
+            .end(bytes)
           break
         }
         default: {

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -257,14 +257,14 @@ export class ProjectManagerShimMiddleware {
           break
         }
         case 'GET /api/root-directory-path': {
-          console.log(PROJECTS_ROOT_DIRECTORY)
+          var bytes = new TextEncoder().encode(PROJECTS_ROOT_DIRECTORY)
           response
             .writeHead(HTTP_STATUS_OK, {
-              'Content-Length': String(PROJECTS_ROOT_DIRECTORY.length),
+              'Content-Length': String(bytes.length),
               'Content-Type': 'text/plain',
               ...COMMON_HEADERS,
             })
-            .end(PROJECTS_ROOT_DIRECTORY, 'binary')
+            .end(bytes, 'utf-8')
           break
         }
         default: {

--- a/app/gui/project-manager-shim-middleware/index.ts
+++ b/app/gui/project-manager-shim-middleware/index.ts
@@ -317,24 +317,26 @@ async function fileExists(path: string) {
 /** Send a HTTP response with a JSON payload. */
 function httpOkJson<T = never>(response: http.ServerResponse, body: NoInfer<T>) {
   const content = JSON.stringify(body)
+  const bytes = new TextEncoder().encode(content)
   return response
     .writeHead(HTTP_STATUS_OK, [
-      ['Content-Length', `${content.length}`],
+      ['Content-Length', `${bytes.length}`],
       ['Content-Type', 'application/json'],
       ...COOP_COEP_CORP_HEADERS,
     ])
-    .end(content)
+    .end(bytes)
 }
 
 /** Send a HTTP response with a JSON payload. */
 function httpOkText(response: http.ServerResponse, content: string) {
+  const bytes = new TextEncoder().encode(content)
   return response
     .writeHead(HTTP_STATUS_OK, [
-      ['Content-Length', `${content.length}`],
+      ['Content-Length', `${bytes.length}`],
       ['Content-Type', 'text/plain'],
       ...COOP_COEP_CORP_HEADERS,
     ])
-    .end(content)
+    .end(bytes)
 }
 
 /** Get details for an asset by its path. */
@@ -541,13 +543,14 @@ async function httpDownloadArchive(
   const error = await archive.promise
   if (error) {
     const content = JSON.stringify({ error: `Asset '${error.id}' not found` })
+    const bytes = new TextEncoder().encode(content)
     response
       .writeHead(HTTP_STATUS_NOT_FOUND, [
-        ['Content-Length', String(content.length)],
+        ['Content-Length', String(bytes.length)],
         ['Content-Type', 'application/json'],
         ...COOP_COEP_CORP_HEADERS,
       ])
-      .end(content)
+      .end(bytes)
   }
   await promise
   httpOkJson<ExportedArchive>(response, {

--- a/app/gui/src/entrypoint.ts
+++ b/app/gui/src/entrypoint.ts
@@ -111,7 +111,9 @@ async function getRootDirPath() {
     window.overrideFeatureFlags?.enableLocalBackend ?? $config.CLOUD_BUILD !== 'true'
   if (!supportsLocalBackend) return undefined
   const rootDirRequest = await fetch(`/api/root-directory-path`)
-  return await rootDirRequest.text()
+  const rootDirBytes = await rootDirRequest.bytes()
+  const rootDirText = new TextDecoder('utf-8').decode(rootDirBytes)
+  return rootDirText
 }
 
 main()

--- a/app/gui/src/entrypoint.ts
+++ b/app/gui/src/entrypoint.ts
@@ -111,9 +111,7 @@ async function getRootDirPath() {
     window.overrideFeatureFlags?.enableLocalBackend ?? $config.CLOUD_BUILD !== 'true'
   if (!supportsLocalBackend) return undefined
   const rootDirRequest = await fetch(`/api/root-directory-path`)
-  const rootDirBytes = await rootDirRequest.bytes()
-  const rootDirText = new TextDecoder('utf-8').decode(rootDirBytes)
-  return rootDirText
+  return await rootDirRequest.text()
 }
 
 main()


### PR DESCRIPTION
### Pull Request Description

- close #14865

Fix for the issue when the root path contains an accent.
Explicit encoding and decoding make it work correctly with these

<img width="1387" height="362" alt="image" src="https://github.com/user-attachments/assets/d9355a84-e57d-4fb9-967e-db05502e7222" />


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
