### PR TITLE
Require opt-in to prefer local libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [Flush system caches via `Runtime.gc`][14557]
 - [Removing `catch_primitive` from the API][14676]
 - [`polyglot java import` loads classes from HotSpot JVM][14798]
+- [Require opt-in to prefer local libraries][14885]
 
 [14480]: https://github.com/enso-org/enso/pull/14480
 [14490]: https://github.com/enso-org/enso/pull/14490
@@ -72,6 +73,7 @@
 [14557]: https://github.com/enso-org/enso/pull/14557
 [14676]: https://github.com/enso-org/enso/pull/14676
 [14798]: https://github.com/enso-org/enso/pull/14798
+[14885]: https://github.com/enso-org/enso/pull/14885
 
 # Enso 2025.3
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ProjectSettingsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ProjectSettingsManagerTest.scala
@@ -42,7 +42,7 @@ class ProjectSettingsManagerTest
             "id": 0,
             "result": {
               "parentEdition": ${BuildVersion.currentEdition},
-              "preferLocalLibraries": true
+              "preferLocalLibraries": false
             }
           }
           """)

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -653,6 +653,7 @@ public class Main {
             Option$.MODULE$.empty(),
             nil(),
             Option$.MODULE$.empty(),
+            false,
             false);
     throw exitSuccess();
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeProgressTest.java
@@ -245,7 +245,7 @@ public class RuntimeProgressTest {
     private Context _context;
 
     TestContext(String packageName) {
-      super(packageName);
+      super(packageName, false);
     }
 
     @Override

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/InstrumentTestContext.scala
@@ -15,7 +15,10 @@ import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-abstract class InstrumentTestContext(packageName: String) {
+abstract class InstrumentTestContext(
+  packageName: String,
+  preferLocalLibraries: Boolean = false
+) {
   protected val messageQueue: LinkedBlockingQueue[Api.Response] =
     new LinkedBlockingQueue()
 
@@ -29,7 +32,12 @@ abstract class InstrumentTestContext(packageName: String) {
   )
 
   val pkg: Package[File] =
-    PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
+    PackageManager.Default.create(
+      tmpDir.toFile,
+      packageName,
+      "Enso_Test",
+      preferLocalLibraries = preferLocalLibraries
+    )
 
   protected def context(): Context
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -28,7 +28,7 @@ import scala.collection.immutable.ListSet
 class RuntimeSuggestionUpdatesTest extends AnyFlatSpec with Matchers {
 
   class TestContext(packageName: String, enableGlobalSuggestions: Boolean)
-      extends InstrumentTestContext(packageName) {
+      extends InstrumentTestContext(packageName, preferLocalLibraries = true) {
 
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
     val context =

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -338,7 +338,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
       license              = license,
       authors              = authors,
       edition              = edition,
-      preferLocalLibraries = true,
+      preferLocalLibraries = false,
       maintainers          = maintainers,
       componentGroups      = componentGroups,
       services             = services,

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -312,6 +312,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
     *                will be used
     * @param jvm should JVM mode be set for the package
     * @param keepDevVersion true if default dev versions should be stored
+    * @param preferLocalLibraries by default `false`
     * @return a package object representing the newly created package.
     */
   def create(
@@ -328,7 +329,8 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
     componentGroups: Option[ComponentGroups] = None,
     services: List[ProvidesWith]             = List(),
     jvm: Option[Boolean]                     = None,
-    keepDevVersions: Boolean                 = false
+    keepDevVersions: Boolean                 = false,
+    preferLocalLibraries: Boolean            = false
   ): Package[F] = {
     val config = Config(
       name                 = name,
@@ -338,7 +340,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
       license              = license,
       authors              = authors,
       edition              = edition,
-      preferLocalLibraries = false,
+      preferLocalLibraries = preferLocalLibraries,
       maintainers          = maintainers,
       componentGroups      = componentGroups,
       services             = services,


### PR DESCRIPTION
### Pull Request Description

- newly created projects will not have `prefer-local-libraries` set
- to _"prefer local libraries"_ **opt-in** by manually editing `package.yaml` in project root directory
   - add following line
   - `prefer-local-libraries: 'true'` into `package.yaml`
- modifies the behavior set by #1797 
   - using `preferLocalLibraries` is dangerous!
   - it creates projects that are not easy to transfer between computers
   - it is dangerous to have it on by default
- based on [this comment](https://github.com/enso-org/enso/issues/14823#issuecomment-4022561893) in #14823

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Unit tests have been updated
