### PR TITLE
`YdocServerTest` - setting the timeout to one minute

### DIFF
--- a/lib/java/ydoc-server/src/test/java/org/enso/ydoc/server/YdocTest.java
+++ b/lib/java/ydoc-server/src/test/java/org/enso/ydoc/server/YdocTest.java
@@ -2,12 +2,12 @@ package org.enso.ydoc.server;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Status;
-import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.websocket.WsClient;
 import io.helidon.websocket.WsListener;
 import io.helidon.websocket.WsSession;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -118,8 +118,10 @@ public class YdocTest {
     Assert.assertTrue(
         "Binary onConnect callback should be called after client connects", binaryOnConnectCalled);
 
-    WebClient http = WebClient.create();
-    HttpClientResponse healthcheckResponse = http.get(HEALTHCHECK_URL).request();
+    var waitMinute = Duration.ofMinutes(1);
+    var http = WebClient.create();
+    var healthcheckResponse =
+        http.get(HEALTHCHECK_URL).readContinueTimeout(waitMinute).readTimeout(waitMinute).request();
     Assert.assertEquals(Status.OK_200, healthcheckResponse.status());
   }
 


### PR DESCRIPTION
### Pull Request Description

- timeout adjustments after #14438 got integrated
- [YdocTest:122](https://github.com/enso-org/enso/actions/runs/23328248524/job/67857039027#step:14:2803) fails with `SocketTimeoutException`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [ ] Engine nightly tests are OK - [1st run](https://github.com/enso-org/enso/actions/runs/23344423101) 
