### PR TITLE
Prevent npx prettier from obscuring `[!NOTE]` and `[!WARNING]` elements

### DIFF
--- a/docs/infrastructure/logging.md
+++ b/docs/infrastructure/logging.md
@@ -176,6 +176,10 @@ executing:
 
 #### Project Manager
 
+<!-- prettier-ignore -->
+> [!WARNING] 
+> Project Manager has been Removed. Can this section be updated?
+
 Project manager by default starts a centralized logging server that collects
 logs (as defined in `logging-service.server` config key) and the logs output can
 be overwritten by `ENSO_LOGSERVER_APPENDER` env variable

--- a/docs/libraries/sharing.md
+++ b/docs/libraries/sharing.md
@@ -63,7 +63,9 @@ See:
 
 ## Publishing to library server
 
-> [!WARNING] Works only on local host.
+<!-- prettier-ignore -->
+> [!WARNING]
+> Works only on local host.
 
 To publish a library, first you must obtain the upload URL of the repository, if
 you are hosting the repository locally it will be `http://localhost:8080/upload`

--- a/docs/semantics/errors.md
+++ b/docs/semantics/errors.md
@@ -20,7 +20,9 @@ users to deal with errors at runtime in the language.
 
 ## Asynchronous Exceptions
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Why do we call it asynchronous, when they are synchronous!?
 > - Specify the semantics of Enso's async exceptions.
@@ -31,13 +33,17 @@ There is a special [dynamic dispatch](../types/dynamic-dispatch.md) for `Error`
 values. A dataflow error dispatch first checks if it may call a method on
 `Error` type.
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING] 
+> The actionables for this section are:
 >
 > - Specify the semantics of Enso's broken values.
 
 ## Warnings
 
-> [!WARNING] TODO
+<!-- prettier-ignore -->
+> [!WARNING] 
+> TODO
 >
 > - Values in Enso may have warnings attached
 

--- a/docs/syntax/function-parameters.md
+++ b/docs/syntax/function-parameters.md
@@ -68,7 +68,9 @@ want to customise.
 
 ## Optional Parameters
 
-> [!WARNING] Not implemented.
+<!-- prettier-ignore -->
+> [!WARNING]
+> Not implemented.
 
 There are certain cases where the type information for an parameter may be able
 to be inferred by the compiler. This is best explained by example. Consider the
@@ -110,7 +112,9 @@ read text this? = t.fromText text
 
 ## Splats parameters (Variadics)
 
-> [!WARNING] Not implemented.
+<!-- prettier-ignore -->
+> [!WARNING]
+> Not implemented.
 
 Enso provides users with the ability to define variadic functions, or _splats_
 functions in our terminology. These are very useful for defining expressive APIs
@@ -127,7 +131,9 @@ and flexible code.
 
 ## Type Applications
 
-> [!WARNING] Not implemented.
+<!-- prettier-ignore -->
+> [!WARNING]
+> Not implemented.
 
 There are sometimes cases where the user wants to explicitly refine the type of
 an parameter at the _call_ site of a function. This can be useful for debugging,

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -30,6 +30,7 @@ as well as formal specifications where necessary. It discusses the impact of
 many syntactic language features upon inference and type checking, and is
 instrumental for ensuring that we build the right language.
 
+<!-- prettier-ignore -->
 > [!NOTE]
 >
 > #### A Note on Syntax
@@ -39,7 +40,9 @@ instrumental for ensuring that we build the right language.
 > described in the [syntax](../syntax/README.md) document makes no promises as
 > to whether said syntax will be exposed in the surface language.
 
-> [!WARNING] The specification in this section is very outdated and far from
+<!-- prettier-ignore -->
+> [!WARNING]
+> The specification in this section is very outdated and far from
 > reality. Sections that are known to be _"off"_ are marked as _warning_.
 
 Information on the type system is broken up into the following sections:

--- a/docs/types/access-modifiers.md
+++ b/docs/types/access-modifiers.md
@@ -8,7 +8,9 @@ order: 4
 
 # Access Modifiers
 
-> [!WARNING] Everybody who ever maintained a large system knows
+<!-- prettier-ignore -->
+> [!WARNING] 
+> Everybody who ever maintained a large system knows
 > [encapsulation is essential](../semantics/encapsulation.md).
 >
 > While we don't usually like making things private in a programming language,

--- a/docs/types/contexts.md
+++ b/docs/types/contexts.md
@@ -8,7 +8,9 @@ order: 8
 
 # Monadic Contexts
 
-> [!WARNING] Reword for people without Haskell background who don't know what
+<!-- prettier-ignore -->
+> [!WARNING]
+> Reword for people without Haskell background who don't know what
 > _lifting_ is.
 >
 > Coming from a Haskell background, we have found that Monads provide a great
@@ -44,7 +46,9 @@ in the compiler, and hence can be automatically lifted to aid usability.
 
 ## Context Syntax
 
-> [!WARNING] There used to be three main notes about the syntax of contexts:
+<!-- prettier-ignore -->
+> [!WARNING]
+> There used to be three main notes about the syntax of contexts:
 >
 > 1. Monadic contexts are defined using the `in` keyword (e.g. `Int in IO`).
 > 2. We have a symbol `!`, which is short-hand for putting something into the
@@ -71,7 +75,9 @@ There is still the `!` symbol signaling [presence of errors](./errors.md)
 
 ## Monadic Bind
 
-> [!WARNING] Who knows what `<-` means in Haskell?
+> <!-- prettier-ignore -->
+> [!WARNING] 
+> Who knows what `<-` means in Haskell?
 >
 > It is also important to note that Enso has no equivalent to `<-` in Haskell.
 > Instead, pure computations are implicitly placed in the `Pure` monadic

--- a/docs/types/dynamic-dispatch.md
+++ b/docs/types/dynamic-dispatch.md
@@ -34,7 +34,9 @@ one to select, the compiler needs to have a notion of _specificity_, which is
 effectively an algorithm for determining which candidate is more specific than
 another.
 
-> [!WARNING] Static compiler selects nothing. The right method to invoke is
+<!-- prettier-ignore -->
+> [!WARNING]
+> Static compiler selects nothing. The right method to invoke is
 > _selected in the runtime_.
 >
 > - Always prefer a member function for both `x.f y` and `f y x` notations.
@@ -72,7 +74,9 @@ Multiple dispatch is currently used for
 Multiple dispatch is also used on `from` conversions, because in expression
 `T.from x` the function to use is based on both `T` and `x`.
 
-> [!WARNING] Supporting general _multiple dispatch is unlikely_
+<!-- prettier-ignore -->
+> [!WARNING]
+> Supporting general _multiple dispatch is unlikely_
 >
 > Supporting it for general functions remains an open question as to whether we
 > want to support proper multiple dispatch in Enso. Multiple dispatch refers to

--- a/docs/types/errors.md
+++ b/docs/types/errors.md
@@ -13,7 +13,9 @@ around `Panic.throw` and related methods), while the other is a theory of
 _broken values_ that propagate through computations (represented by `Error` and
 created by `Error.throw` method).
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Greatly expand on the reasoning and theory behind the two exception models.
 > - Explain why broken values serve the GUI well.
@@ -28,7 +30,9 @@ created by `Error.throw` method).
 
 ## Exceptions/Panics
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING] 
+> The actionables for this section are:
 >
 > - Formalise the model of `Panic.throw` as implemented.
 

--- a/docs/types/evaluation.md
+++ b/docs/types/evaluation.md
@@ -14,7 +14,9 @@ design of certain APIs.
 
 To that end, Enso provides a mechanism for this through the type system.
 
-> [!WARNING] Enso is using `~` and `...` to defer computations and perform them
+<!-- prettier-ignore -->
+> [!WARNING]
+> Enso is using `~` and `...` to defer computations and perform them
 > lazily when needed.
 >
 > The standard library defines a `Suspend a` type which, when used in explicit
@@ -49,7 +51,9 @@ use the already evaluated value.
 
 ## Specifying Suspension in the Type System
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Actually specify how the type system interacts with eager and lazy
 >   evaluation.

--- a/docs/types/function-types.md
+++ b/docs/types/function-types.md
@@ -11,7 +11,9 @@ order: 3
 As a functional programming language, the type of functions in Enso (`->`) is
 key. There are a few things that should be noted about functions in Enso.
 
-> [!NOTE] The actionables for this section:
+<!-- prettier-ignore -->
+> [!NOTE]
+> The actionables for this section:
 >
 > - Work out a full specification for function typing and behaviour.
 > - Calling a function with an upper-case letter instantiates all of its type
@@ -47,6 +49,7 @@ Scope lookup proceeds from the function body outwards, as is standard for
 lexical scoping. For a detailed discussion of scoping, please see
 [the scoping documentation](../semantics/scoping.md).
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > PLEASE NOTE. THIS IS OUT OF DATE.
@@ -114,7 +117,9 @@ all arguments have been applied. This operator is `>>` (and its backwards cousin
 arguments, and the result consumes `n` arguments, applies them to `f`, and then
 applies the result of that plus any additional arguments to `g`.
 
-> [!WARNING] Enso does support `>>` as well as `<<` operators, but
+<!-- prettier-ignore -->
+> [!WARNING]
+> Enso does support `>>` as well as `<<` operators, but
 >
 > ```ruby
 > computeCoeff = (+) >> (*5)
@@ -132,7 +137,9 @@ applies the result of that plus any additional arguments to `g`.
 In addition, we have the operator `.`, which acts as standard forward function
 chaining in Enso, and its backwards chaining cousin `<|`.
 
-> [!NOTE] The actionables from this section are:
+<!-- prettier-ignore -->
+> [!NOTE]
+> The actionables from this section are:
 >
 > - Examples for the more advanced use-cases of `>>` to decide if the type
 >   complexity is worth it.

--- a/docs/types/goals.md
+++ b/docs/types/goals.md
@@ -23,7 +23,9 @@ needs to be as unobtrusive as possible.
 
 The high-level goals for the Enso type system are as follows:
 
-> [!WARNING] _Not a goal anymore_: Enso is a dynamic language. Static type
+<!-- prettier-ignore -->
+> [!WARNING]
+> _Not a goal anymore_: Enso is a dynamic language. Static type
 > inference is _not needed for execution_. As such _static typing_ is an
 > optional component - more a _linter_ than essential part of the system.
 >

--- a/docs/types/hierarchy.md
+++ b/docs/types/hierarchy.md
@@ -33,7 +33,9 @@ Enso is **conversion and** (structured) **equality oriented language**. That
 fact is stressed by the shape of its root type `Any`. It exposes just `.to`,
 `==` and `!=` operations.
 
-> [!WARNING] _Typeset theory is far from current state of affairs_:
+<!-- prettier-ignore -->
+> [!WARNING]
+> _Typeset theory is far from current state of affairs_:
 >
 > Enso is a statically typed language based upon a theory of set-based typing,
 > what we call `typesets`. This is a novel approach, and it is key to our intent
@@ -58,7 +60,9 @@ called [intersection types](./intersection-types.md). It is possible to
 query/inspect these types during runtime and thus decide what operations are
 available for a particular value at hand.
 
-> [!WARNING] > _Probably not true in current system at all_
+<!-- prettier-ignore -->
+> [!WARNING]
+> _Probably not true in current system at all_
 >
 > A brief note on naming (for more, please see the
 > [naming syntax](../syntax/naming.md)):
@@ -105,7 +109,9 @@ v:Maybe
 v.value:Text
 ```
 
-> [!WARNING] There are no _Typesets_ in Enso anymore
+<!-- prettier-ignore -->
+> [!WARNING]
+> There are no _Typesets_ in Enso anymore
 >
 > Typesets in Enso are an entity unique to Enso's type system. They are a
 > fundamental recognition of types as 'sets of values' in Enso, and while they
@@ -161,7 +167,9 @@ They are as follows:
 - **Intersection - `&`:** This operator creates a typeset that contains the
   members in the [intersection of its operands](./intersection-types.md).
 
-> [!WARNING] These operators _don't seem to be supported_. There is no plan to
+<!-- prettier-ignore -->
+> [!WARNING]
+> These operators _don't seem to be supported_. There is no plan to
 > support following operators now:
 >
 > - **Subsumption - `<:`:** This operator asserts that the left hand operand is
@@ -176,7 +184,9 @@ For information on the syntactic usage of these operators, please see the
 section on [type operators](#../syntax/types.md#type-operators) in the syntax
 design documentation.
 
-> [!NOTE] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!NOTE]
+> The actionables for this section are:
 >
 > - When necessary, we need to _explicitly formalise_ the semantics of all of
 >   these operators.
@@ -184,7 +194,9 @@ design documentation.
 >   generative) types?
 > - Are `<:` and `:` equivalent in the surface syntax?
 
-> [!WARNING] > _Typeset Subsumption_ isn't relevant
+<!-- prettier-ignore -->
+> [!WARNING]
+> _Typeset Subsumption_ isn't relevant
 >
 > For two typesets `a` and `b`, `a` is said to be subsumed by `b` (written using
 > the notation `a <: b`) if the following hold recursively. This can be thought
@@ -256,11 +268,15 @@ Historically interfaces used to be defined by _duck typing_. As Enso is a
 dynamic language, having two types with the same operations means they can be
 used interchangingly.
 
-> [!NOTE] A work on
+<!-- prettier-ignore -->
+> [!NOTE]
+> A work on
 > [type classes](https://github.com/orgs/enso-org/discussions/11366) support is
 > under way
 
-> [!WARNING] _Doesn't match reality:_
+<!-- prettier-ignore -->
+> [!WARNING] 
+> _Doesn't match reality:_
 >
 > Because typesets can be matched _structurally_, all typesets implicitly define
 > interfaces. A type `t` conforming to an interface `i` in Enso is as simple as
@@ -317,7 +333,9 @@ _finalizers_.
 An expression `a : b` says that the expression denoted by `a` has the type
 denoted by the expression `b`.
 
-> [!WARNING] No support for Scoping in Type Ascription
+<!-- prettier-ignore -->
+> [!WARNING] 
+> No support for Scoping in Type Ascription
 >
 > Enso intends to support some form of mutual scoping between the left and right
 > sides of the type ascription operator. This introduces some complexity into
@@ -334,7 +352,9 @@ denoted by the expression `b`.
 >   bindings in groups, and the desugaring needs to depend on combinations of
 >   `>>=` and `fix`.
 
-> [!WARNING] There are _no projections_ right now and none are planned
+<!-- prettier-ignore -->
+> [!WARNING]
+> There are _no projections_ right now and none are planned
 >
 > In order to work efficiently with typesets, we need the ability to seamlessly
 > access and modify (immutably) their properties. In the context of our type

--- a/docs/types/inference-and-checking.md
+++ b/docs/types/inference-and-checking.md
@@ -337,6 +337,7 @@ the current relatively simple 'propagation' algorithm.
 
 ## Design Goals
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > The actionables for this section are:
@@ -358,7 +359,9 @@ In order to make Enso's type inference as helpful and friendly as possible to
 our users, we want the ability to infer the _maximal subset_ of the types that
 Enso can express.
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - How do we do inference for higher-rank and impredicative instantiations.
 > - How do we infer contexts, and how do we make that inference granular (e.g.
@@ -373,18 +376,24 @@ Enso can express.
 
 ### Type Inference Algorithm
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING] 
+> The actionables for this section are:
 >
 > - Specify the inference algorithm.
 
 #### Inferring Dependency
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Specify how (if at all) we can infer dependent quantifiers.
 
 ### Type Checking Algorithm
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Specify the type checking algorithm.

--- a/docs/types/intersection-types.md
+++ b/docs/types/intersection-types.md
@@ -52,7 +52,9 @@ Complex.from (that:Float) = Complex.Num that 0
 
 and uses them to create all the values the _intersection type_ represents.
 
-> [!NOTE] Note that if a `Float.from (that:Complex)` conversion were available
+<!-- prettier-ignore -->
+> [!NOTE]
+> Note that if a `Float.from (that:Complex)` conversion were available
 > in the scope, any `Complex` instance would be convertible to `Float`
 > regardless of how it was constructed. To ensure that such mix-ins are only
 > available on values that opt-in to being an intersection type (like in the
@@ -108,7 +110,9 @@ case c of
 Remember to use `f.sqrt` and not `c.sqrt`. `f` in the case branch _has been cast
 to_ `Float` while `c` in the case branch only _can be cast to_.
 
-> [!WARNING] Keep in mind that while both argument type check in method
+<!-- prettier-ignore -->
+> [!WARNING]
+> Keep in mind that while both argument type check in method
 > definitions and a 'type asserting' expression look similarly, they have
 > slightly different behaviour.
 >
@@ -124,7 +128,9 @@ to_ `Float` while `c` in the case branch only _can be cast to_.
 > function `g` will accept the same value and return it as a `Float` value,
 > based on the 'hidden' part of its type.
 
-> [!NOTE] In the **object oriented terminology** we can think of a type
+<!-- prettier-ignore -->
+> [!NOTE]
+> In the **object oriented terminology** we can think of a type
 > `Complex&Float` as being a subclass of `Complex` and subclass of `Float`
 > types. As such a value of type `Complex&Float` may be used wherever `Complex`
 > or `Float` types are used. Let there, for example, be a function:

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -26,7 +26,9 @@ types).
 
 ## Resolving Name Clashes
 
-> [!WARNING] There is no `here` keyword anymore and the clash resultion is
+<!-- prettier-ignore -->
+> [!WARNING]
+> There is no `here` keyword anymore and the clash resultion is
 > probably also not working.
 >
 > Enso modules employ the following rules in order to avoid name clashes:
@@ -39,7 +41,9 @@ types).
 
 ## Scoping and Imports
 
-> [!WARNING] Review by an _imports expert_ is needed!
+<!-- prettier-ignore -->
+> [!WARNING]
+> Review by an _imports expert_ is needed!
 
 To use the contents of a module we need a way to bring them into scope. Like
 most languages, Enso provides an _import_ mechanism for this. Enso has four

--- a/docs/types/parallelism.md
+++ b/docs/types/parallelism.md
@@ -21,13 +21,17 @@ by the compiler to automatically parallelise some sections of Enso programs.
 
 ## Supporting Parallelism Analysis with Types
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING] 
+> The actionables for this section are:
 >
 > - Work out how the type checker can support parallelism analysis.
 
 ## Constructs That Can Be Parallelised
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Provide an analysis of the language constructs that could automatically be
 >   parallelised, and the typing predicates that make them so.

--- a/docs/types/pattern-matching.md
+++ b/docs/types/pattern-matching.md
@@ -48,7 +48,9 @@ case v of
   v3:Vector -> print v3.x
 ```
 
-> [!WARNING] > **Unsupported:** Name Matching on Labels
+<!-- prettier-ignore -->
+> [!WARNING]
+> **Unsupported:** Name Matching on Labels
 >
 > Matching on the labels defined within a type for both atoms and typesets, with
 > renaming.

--- a/docs/types/type-directed-programming.md
+++ b/docs/types/type-directed-programming.md
@@ -14,7 +14,9 @@ based on types. This is an _advanced_ feature and is not expected to be used by
 the novice, but it is nonetheless an important feature for working with a
 powerful type system.
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Just _delete it all_!?
 > - Examine what other ways we can exploit type information to aid development.
@@ -30,26 +32,34 @@ powerful type system.
 
 ## Typed Holes
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Determine how we want to support typed holes.
 > - Determine the syntax for typed holes.
 
 ## Case Splitting
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING] 
+> The actionables for this section are:
 >
 > - Determine how we want to support case splitting.
 > - Determine the tooling for case splitting.
 
 ## Row Manipulation
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Determine how we want to support row manipulation.
 
 ## Dependent Sum Manipulation
 
-> [!WARNING] The actionables for this section are:
+<!-- prettier-ignore -->
+> [!WARNING]
+> The actionables for this section are:
 >
 > - Determine how we want to support dependent sum manipulation.

--- a/docs/types/types.md
+++ b/docs/types/types.md
@@ -41,6 +41,7 @@ main = (Foo.One 3.14):(Foo Float Integer Text) # yields (One 3.14)
 
 Arguments to atom constructors can have defaults and explicit type signatures.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > Following seems to be off a bit:
@@ -117,6 +118,7 @@ main =
 
 constructs a two item list and yields `(Cons 3 (Cons 14 Nil))`.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > This is not at all what we currently do:
@@ -139,6 +141,7 @@ constructs a two item list and yields `(Cons 3 (Cons 14 Nil))`.
 
 `List` acts as a container holding its static methods.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > Type constructors aren't really implemented in Enso as of now:
@@ -149,6 +152,7 @@ constructs a two item list and yields `(Cons 3 (Cons 14 Nil))`.
 `List Int` is currently _erased_ to `List` and the additional type element
 information of `Int` is lost during execution.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > Enso supports just static methods
@@ -166,6 +170,7 @@ type Vector a
   from (that : List x): Vector x = MkVec (Array.from that)
 ```
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > This is not how it works:
@@ -203,6 +208,7 @@ Vector.from_polyglot_array [1,2,3] : Vector Int
 where 'Vector' is playing double duty as a type constructor (currently erased
 just to raw type `Vector`) and as the bag of static methods.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > Another example with `.type` that's unlikely valid:
@@ -259,6 +265,7 @@ just to raw type `Vector`) and as the bag of static methods.
 The static methods get attached to the type definition. This means they do not
 have access to any of the type's atom arguments themselves.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 >
 > No plans for `explicit` static methods


### PR DESCRIPTION
### Pull Request Description

- I noticed #11775 attempt got obscured by `npx prettier`
- fixing by adding `<!-- prettier-ignore -->` before every note and warning
   - only then the format follows spec at https://github.com/orgs/community/discussions/16925
- another step towards #11462

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the `npx prettier` style
