### PR TITLE
Avoid unnecessary recalculation when editing a node

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
@@ -155,42 +155,35 @@ final class ChangesetBuilder[A: TextEditor: IndexedSource](
     ): Set[UUID @ExternalID] =
       if (queue.isEmpty) visited.flatMap(_.externalId).toSet
       else {
-        val elem       = queue.dequeue()
-        val transitive = metadata.dependents.get(elem).getOrElse(Set())
-        val dynamic = transitive
-          .flatMap {
-            case s: DependencyInfo.Type.Static =>
-              ChangesetBuilder
-                .getExpressionName(ir, s.id)
-                .map(new DependencyInfo.Type.Dynamic(_, None))
-            case dyn: DependencyInfo.Type.Dynamic =>
-              Some(dyn)
-            case _ =>
-              None
-          }
-          .flatMap(metadata.dependents.get(_))
-          .flatten
-        val combined = transitive
-          .asInstanceOf[scala.collection.Set[
-            org.enso.compiler.pass.analyse.DependencyInfo.Type
-          ]]
-          .union(
-            dynamic.asInstanceOf[scala.collection.Set[
-              org.enso.compiler.pass.analyse.DependencyInfo.Type
-            ]]
-          )
+        val elem = queue.dequeue()
+        val transitive = metadata.dependents
+          .get(elem)
+          .getOrElse(Set.empty[DependencyInfo.Type])
 
         go(
-          queue ++= combined.diff(visited),
-          visited ++= combined
+          queue ++= transitive.diff(visited),
+          visited ++= transitive
         )
       }
 
     val nodeIds = invalidated(edits)
     val direct  = nodeIds.flatMap(ChangesetBuilder.toDataflowDependencyTypes)
+    val dynamic = direct
+      .flatMap {
+        case s: DependencyInfo.Type.Static =>
+          ChangesetBuilder
+            .getExpressionName(ir, s.id)
+            .map(new DependencyInfo.Type.Dynamic(_, None))
+        case dyn: DependencyInfo.Type.Dynamic =>
+          Some(dyn)
+        case _ =>
+          None
+      }
+      .flatMap(metadata.dependents.get(_))
+      .flatten
     val transitive =
       go(
-        mutable.Queue().addAll(direct),
+        mutable.Queue().addAll(direct).addAll(dynamic),
         mutable.Set()
       )
     direct.flatMap(_.externalId) ++ transitive

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
@@ -155,35 +155,42 @@ final class ChangesetBuilder[A: TextEditor: IndexedSource](
     ): Set[UUID @ExternalID] =
       if (queue.isEmpty) visited.flatMap(_.externalId).toSet
       else {
-        val elem = queue.dequeue()
-        val transitive = metadata.dependents
-          .get(elem)
-          .getOrElse(Set.empty[DependencyInfo.Type])
+        val elem       = queue.dequeue()
+        val transitive = metadata.dependents.get(elem).getOrElse(Set())
+        val dynamic = transitive
+          .flatMap {
+            case s: DependencyInfo.Type.Static =>
+              ChangesetBuilder
+                .getExpressionName(ir, s.id)
+                .map(new DependencyInfo.Type.Dynamic(_, None))
+            case dyn: DependencyInfo.Type.Dynamic =>
+              Some(dyn)
+            case _ =>
+              None
+          }
+          .flatMap(metadata.dependents.get(_))
+          .flatten
+        val combined = transitive
+          .asInstanceOf[scala.collection.Set[
+            org.enso.compiler.pass.analyse.DependencyInfo.Type
+          ]]
+          .union(
+            dynamic.asInstanceOf[scala.collection.Set[
+              org.enso.compiler.pass.analyse.DependencyInfo.Type
+            ]]
+          )
 
         go(
-          queue ++= transitive.diff(visited),
-          visited ++= transitive
+          queue ++= combined.diff(visited),
+          visited ++= combined
         )
       }
 
     val nodeIds = invalidated(edits)
     val direct  = nodeIds.flatMap(ChangesetBuilder.toDataflowDependencyTypes)
-    val dynamic = direct
-      .flatMap {
-        case s: DependencyInfo.Type.Static =>
-          ChangesetBuilder
-            .getExpressionName(ir, s.id)
-            .map(new DependencyInfo.Type.Dynamic(_, None))
-        case dyn: DependencyInfo.Type.Dynamic =>
-          Some(dyn)
-        case _ =>
-          None
-      }
-      .flatMap(metadata.dependents.get(_))
-      .flatten
     val transitive =
       go(
-        mutable.Queue().addAll(direct).addAll(dynamic),
+        mutable.Queue().addAll(direct),
         mutable.Set()
       )
     direct.flatMap(_.externalId) ++ transitive
@@ -696,8 +703,6 @@ object ChangesetBuilder {
       { ir =>
         if (ir.getId == id)
           ir match {
-            case name: Name =>
-              return Some(name.name)
             case method: definition.Method =>
               return Some(method.methodName.name)
             case _ =>

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
@@ -1,0 +1,734 @@
+package org.enso.interpreter.instrument;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.UUID;
+import org.enso.compiler.Passes;
+import org.enso.compiler.context.FreshNameSupply;
+import org.enso.compiler.context.ModuleContext;
+import org.enso.compiler.core.EnsoParser;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Location;
+import org.enso.compiler.core.ir.Module;
+import org.enso.compiler.data.CompilerConfig;
+import org.enso.compiler.pass.PassManager;
+import org.enso.compiler.pass.PassManagerTestUtils;
+import org.enso.interpreter.runtime.ModuleTestUtils;
+import org.enso.pkg.QualifiedName;
+import org.enso.text.buffer.Rope;
+import org.enso.text.editing.model.Position;
+import org.enso.text.editing.model.Range;
+import org.enso.text.editing.model.TextEdit;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import scala.Option;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Tests for {@link ChangesetBuilder#compute(scala.collection.immutable.Seq)} which computes the
+ * transitive closure of all affected external IDs using DataflowAnalysis dependency information.
+ */
+public class ChangesetBuilderComputeTest {
+
+  private PassManager passManager;
+
+  @Before
+  public void setUp() {
+    passManager = new Passes(CompilerConfig.createDefault()).passManager();
+  }
+
+  // ===== Helper methods =====
+
+  private ModuleContext freshModuleContext() {
+    var runtimeMod =
+        org.enso.interpreter.runtime.Module.empty(QualifiedName.simpleName("Test_Module"), null);
+    return new ModuleContext(
+        runtimeMod.asCompilerModule(),
+        CompilerConfig.createDefault(),
+        Option.apply(new FreshNameSupply()),
+        Option.empty(),
+        false,
+        Option.empty());
+  }
+
+  /**
+   * Preprocesses code through the compiler pass pipeline. The code should include a METADATA
+   * section (use {@link #addMetadata} to generate one).
+   */
+  private Module preprocessModule(String code) {
+    var moduleContext = freshModuleContext();
+    var ir = EnsoParser.compile(code);
+    var passGroups = PassManagerTestUtils.getPasses(passManager);
+    var runtimeMod = org.enso.interpreter.runtime.Module.fromCompilerModule(moduleContext.module());
+    var curIr = ir;
+    for (int i = 0; i < passGroups.size(); i++) {
+      var group = passGroups.apply(i);
+      ModuleTestUtils.unsafeSetIr(runtimeMod, curIr);
+      curIr = passManager.runPassesOnModule(curIr, moduleContext, group, Option.empty());
+    }
+    return curIr;
+  }
+
+  /**
+   * Generates a METADATA section that assigns UUIDs to all IR nodes with locations and appends it
+   * to the raw code.
+   */
+  private String addMetadata(String rawCode) {
+    var ir = EnsoParser.compile(rawCode);
+    var locations = new LinkedHashMap<Location, UUID>();
+    IR.preorder(
+        ir,
+        node -> {
+          var locOpt = node.location();
+          if (locOpt.isDefined()) {
+            var loc = locOpt.get().location();
+            locations.putIfAbsent(loc, UUID.randomUUID());
+          }
+        });
+    var sb = new StringBuilder();
+    sb.append("[");
+    boolean first = true;
+    for (var entry : locations.entrySet()) {
+      if (!first) sb.append(",");
+      first = false;
+      int start = entry.getKey().start();
+      int size = entry.getKey().end() - start;
+      sb.append("[{\"index\":{\"value\":")
+          .append(start)
+          .append("},\"size\":{\"value\":")
+          .append(size)
+          .append("}},\"")
+          .append(entry.getValue())
+          .append("\"]");
+    }
+    sb.append("]");
+    return rawCode + "\n\n\n#### METADATA ####\n" + sb + "\n[]\n";
+  }
+
+  /** Strips the METADATA section from a code string, returning the raw code portion. */
+  private String rawCode(String code) {
+    int idx = code.indexOf("\n\n\n#### METADATA ####\n");
+    return idx >= 0 ? code.substring(0, idx) : code;
+  }
+
+  /** Calls {@link ChangesetBuilder#compute} and returns the result as a Java set. */
+  @SuppressWarnings("unchecked")
+  private Set<UUID> computeInvalidated(IR ir, String code, TextEdit... edits) {
+    var scalaEdits = CollectionConverters.asScala(Arrays.asList(edits)).toSeq();
+    var rope = Rope.apply(code);
+    var builder =
+        new ChangesetBuilder<>(
+            rope,
+            ir,
+            org.enso.text.editing.RopeTextEditor$.MODULE$,
+            org.enso.text.editing.IndexedSource$.MODULE$.RopeIndexedSource());
+    var result = builder.compute(scalaEdits);
+    return new HashSet<>(CollectionConverters.asJava((scala.collection.Set<UUID>) result));
+  }
+
+  /** Finds the first {@link Expression.Binding} with the given name in the IR tree. */
+  private Expression.Binding findBinding(IR ir, String name) {
+    var result = new ArrayList<Expression.Binding>();
+    IR.preorder(
+        ir,
+        node -> {
+          if (node instanceof Expression.Binding binding) {
+            if (binding.name().name().equals(name)) {
+              result.add(binding);
+            }
+          }
+        });
+    return result.isEmpty() ? null : result.get(0);
+  }
+
+  /** Gets the external ID of a binding found by name. Fails if not found. */
+  private UUID getBindingId(IR ir, String name) {
+    var binding = findBinding(ir, name);
+    assertNotNull("Binding '" + name + "' not found in IR", binding);
+    var extId = binding.getExternalId();
+    assertTrue("No external ID for binding '" + name + "'", extId.isDefined());
+    return extId.get();
+  }
+
+  /**
+   * Finds an IR node whose source text matches the given string and returns its external ID.
+   * Returns null if not found or no external ID.
+   */
+  private UUID findExternalIdBySourceText(IR ir, String raw, String text) {
+    var result = new ArrayList<UUID>();
+    IR.preorder(
+        ir,
+        node -> {
+          var locOpt = node.location();
+          var extIdOpt = node.getExternalId();
+          if (locOpt.isDefined() && extIdOpt.isDefined()) {
+            var loc = locOpt.get().location();
+            if (loc.start() >= 0 && loc.end() <= raw.length()) {
+              var nodeText = raw.substring(loc.start(), loc.end());
+              if (nodeText.equals(text)) {
+                result.add(extIdOpt.get());
+              }
+            }
+          }
+        });
+    return result.isEmpty() ? null : result.get(0);
+  }
+
+  private void assertInvalidated(Set<UUID> result, IR ir, String name) {
+    var id = getBindingId(ir, name);
+    assertTrue("Expected binding '" + name + "' to be invalidated", result.contains(id));
+  }
+
+  private void assertNotInvalidated(Set<UUID> result, IR ir, String name) {
+    var binding = findBinding(ir, name);
+    if (binding != null && binding.getExternalId().isDefined()) {
+      assertFalse(
+          "Expected binding '" + name + "' NOT to be invalidated",
+          result.contains(binding.getExternalId().get()));
+    }
+  }
+
+  // ===== Test cases =====
+
+  @Test
+  public void editLiteralPropagatesToBindingAndDependents() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x + 1
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 42 -> 99
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 10)), "99");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editDoesNotAffectIndependentBindings() {
+    var rawCode =
+        """
+        main =
+            x = 1
+            y = 2
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 3
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "3");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertNotInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void variableReferenceChainPropagatesTransitively() {
+    var rawCode =
+        """
+        main =
+            a = 100
+            b = a
+            c = b
+            c
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 100 -> 200
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 11)), "200");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "c");
+  }
+
+  @Test
+  public void multipleUsagesOfSameVariable() {
+    var rawCode =
+        """
+        main =
+            x = 10
+            y = x + 1
+            z = x + 2
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 10 -> 20
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 10)), "20");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+    assertInvalidated(result, ir, "z");
+  }
+
+  @Test
+  public void diamondDependencyPattern() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a
+            c = a
+            d = b + c
+            d
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 2
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "c");
+    assertInvalidated(result, ir, "d");
+  }
+
+  @Test
+  public void editPropagatesThroughMethodCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.to_text
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 42 -> 99
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 10)), "99");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editBindingNameInvalidatesDependents() {
+    var rawCode =
+        """
+        main =
+            foo = 42
+            bar = foo
+            bar
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: foo -> baz (rename the binding)
+    var edit = new TextEdit(new Range(new Position(1, 4), new Position(1, 7)), "baz");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "foo");
+    assertInvalidated(result, ir, "bar");
+  }
+
+  @Test
+  public void editInNestedExpressionPropagatesOutward() {
+    var rawCode =
+        """
+        main =
+            x = 1 + 2
+            y = x
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 2 -> 5
+    var edit = new TextEdit(new Range(new Position(1, 12), new Position(1, 13)), "5");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editMethodArgumentInvalidatesCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.method 10
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 10 -> 20 (change argument value)
+    var edit = new TextEdit(new Range(new Position(2, 17), new Position(2, 19)), "20");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "x");
+  }
+
+  @Test
+  public void editMethodSelfArgumentInvalidatesCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.method 10
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 42 -> 99 (change self argument definition)
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 10)), "99");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editMethodNameInvalidatesCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.method1 10
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: method1 -> method2
+    var edit = new TextEdit(new Range(new Position(2, 10), new Position(2, 17)), "method2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "x");
+  }
+
+  @Test
+  public void editMethodDefinitionBody() {
+    var rawCode =
+        """
+        helper x = x + 1
+
+        main =
+            y = helper 10
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 2 in helper body
+    var edit = new TextEdit(new Range(new Position(0, 16), new Position(0, 17)), "2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void multipleSimultaneousEdits() {
+    var rawCode =
+        """
+        main =
+            x = 1
+            y = 2
+            z = x + y
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 10 AND 2 -> 20
+    var edit1 = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "10");
+    var edit2 = new TextEdit(new Range(new Position(2, 8), new Position(2, 9)), "20");
+    var result = computeInvalidated(ir, code, edit1, edit2);
+
+    assertInvalidated(result, ir, "x");
+    assertInvalidated(result, ir, "y");
+    assertInvalidated(result, ir, "z");
+  }
+
+  // ===== Negative / non-invalidation test cases =====
+
+  @Test
+  public void editLaterBindingDoesNotAffectEarlierOnes() {
+    var rawCode =
+        """
+        main =
+            x = 1
+            y = 2
+            z = y + 1
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 2 -> 3 (y's literal)
+    var edit = new TextEdit(new Range(new Position(2, 8), new Position(2, 9)), "3");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertInvalidated(result, ir, "z");
+    assertNotInvalidated(result, ir, "x");
+  }
+
+  @Test
+  public void parallelIndependentChainsDoNotAffectEachOther() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a + 1
+            c = 10
+            d = c + 1
+            d
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 2 (a's literal)
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertInvalidated(result, ir, "b");
+    assertNotInvalidated(result, ir, "c");
+    assertNotInvalidated(result, ir, "d");
+  }
+
+  @Test
+  public void editDownstreamDoesNotPropagateUpstream() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a + 1
+            c = b + 1
+            c
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: the literal 1 in "b = a + 1" (line 2, char 12)
+    var edit = new TextEdit(new Range(new Position(2, 12), new Position(2, 13)), "5");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "c");
+    assertNotInvalidated(result, ir, "a");
+  }
+
+  @Test
+  public void diamondWithUnrelatedSiblingNotAffected() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a
+            c = a
+            d = b + c
+            e = 99
+            d
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 2 (a's literal)
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "c");
+    assertInvalidated(result, ir, "d");
+    assertNotInvalidated(result, ir, "e");
+  }
+
+  @Test
+  public void editInOneMethodDoesNotAffectAnotherMethod() {
+    var rawCode =
+        """
+        foo =
+            x = 1
+            x
+
+        bar =
+            y = 2
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 3 in foo
+    var edit = new TextEdit(new Range(new Position(1, 8), new Position(1, 9)), "3");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "x");
+    assertNotInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editSecondChainDoesNotAffectFirstChain() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a + 1
+            c = 10
+            d = c + 1
+            d
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 10 -> 20 (c's literal)
+    var edit = new TextEdit(new Range(new Position(3, 8), new Position(3, 10)), "20");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "c");
+    assertInvalidated(result, ir, "d");
+    assertNotInvalidated(result, ir, "a");
+    assertNotInvalidated(result, ir, "b");
+  }
+
+  @Test
+  public void editMiddleOfChainDoesNotAffectSiblings() {
+    var rawCode =
+        """
+        main =
+            a = 1
+            b = a
+            c = a
+            d = b + 1
+            e = c + 1
+            e
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: the literal 1 in "d = b + 1" (line 4, char 12)
+    var edit = new TextEdit(new Range(new Position(4, 12), new Position(4, 13)), "5");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "d");
+    assertNotInvalidated(result, ir, "a");
+    assertNotInvalidated(result, ir, "b");
+    assertNotInvalidated(result, ir, "c");
+    assertNotInvalidated(result, ir, "e");
+  }
+
+  @Test
+  public void editMethodCallArgumentDoesNotAffectIndependentMethodCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.method 10
+            z = x.method 20
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 10 -> 99 (argument of y's method call)
+    var edit = new TextEdit(new Range(new Position(2, 17), new Position(2, 19)), "99");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "x");
+    assertNotInvalidated(result, ir, "z");
+  }
+
+  @Test
+  public void editMethodNameDoesNotAffectIndependentMethodCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.alpha 10
+            z = x.beta 20
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: alpha -> gamma in y's call (line 2, chars 10-15)
+    var edit = new TextEdit(new Range(new Position(2, 10), new Position(2, 15)), "gamma");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "x");
+    assertNotInvalidated(result, ir, "z");
+  }
+
+  @Test
+  @Ignore
+  public void editMethodNameDoesNotAffectIndependentMethodCallWithSameName() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = x.method1 10
+            z = x.method1 20
+            z
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: method1 -> method2 in y's call (line 2, chars 10-17)
+    var edit = new TextEdit(new Range(new Position(2, 10), new Position(2, 17)), "method2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "x");
+    // The following assertion fails because the ChangesetBuilder looks for dynamic dependency
+    // "method1". Ignored for now because this edit pattern is not used when editing nodes in IDE.
+    assertNotInvalidated(result, ir, "z");
+  }
+
+  @Test
+  public void editMethodCallSelfDoesNotAffectIndependentMethodCall() {
+    var rawCode =
+        """
+        main =
+            x = 42
+            y = 99
+            a = x.method 10
+            b = y.method 20
+            b
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: x -> y in a's call, i.e. "x.method 10" -> "y.method 10" (line 3, char 8)
+    var edit = new TextEdit(new Range(new Position(3, 8), new Position(3, 9)), "y");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertNotInvalidated(result, ir, "x");
+    assertNotInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "b");
+  }
+}

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
@@ -428,7 +428,7 @@ public class ChangesetBuilderComputeTest {
   }
 
   @Test
-  public void editMethodDefinitionBody() {
+  public void editMethodDefinitionBodyInvalidatesCall() {
     var rawCode =
         """
         helper x = x + 1
@@ -445,6 +445,58 @@ public class ChangesetBuilderComputeTest {
     var result = computeInvalidated(ir, code, edit);
 
     assertInvalidated(result, ir, "y");
+  }
+
+  @Test
+  public void editMethodDefinitionBodyInvalidatesBothCalls() {
+    var rawCode =
+        """
+        helper x = x + 1
+
+        main =
+            a = 10
+            b = 20
+            y = helper a
+            z = helper b
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 2 in helper body
+    var edit = new TextEdit(new Range(new Position(0, 16), new Position(0, 17)), "2");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertNotInvalidated(result, ir, "a");
+    assertNotInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "y");
+    assertInvalidated(result, ir, "z");
+  }
+
+  @Test
+  public void editApplicationArgumentInvalidatesSingleCall() {
+    var rawCode =
+        """
+        helper x = x + 1
+
+        main =
+            a = 10
+            b = 20
+            y = helper a
+            z = helper b
+            y
+        """;
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    // Edit: 1 -> 4 in "a = 10"
+    var edit = new TextEdit(new Range(new Position(3, 8), new Position(3, 9)), "4");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertInvalidated(result, ir, "a");
+    assertNotInvalidated(result, ir, "b");
+    assertInvalidated(result, ir, "y");
+    assertNotInvalidated(result, ir, "z");
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -531,7 +531,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The `IO.println` expression
       dependencies.getDirect(printlnExprId) shouldEqual Some(
-        Set(printlnArgIOId, printlnArgBId, printlnFnId)
+        Set(printlnFnId)
       )
       dependencies.getDirect(printlnFnId) shouldEqual Some(Set(printlnSymbol))
       dependencies.getDirect(printlnArgIOId) shouldEqual Some(
@@ -549,7 +549,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       dependencies.getDirect(cBindNameId) shouldEqual None
       dependencies.getDirect(plusExprId) shouldEqual Some(
-        Set(plusExprFnId, plusExprArgAId, plusExprArgBId)
+        Set(plusExprFnId)
       )
       dependencies.getDirect(plusExprFnId) shouldEqual Some(Set(plusSymbol))
       dependencies.getDirect(plusExprArgAId) shouldEqual Some(
@@ -563,7 +563,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The `frobnicate` expression
       dependencies.getDirect(frobExprId) shouldEqual Some(
-        Set(frobFnId, frobArgAId, frobArgCId)
+        Set(frobFnId)
       )
       dependencies.getDirect(frobFnId) shouldEqual Some(Set(frobnicateSymbol))
       dependencies.getDirect(frobArgAId) shouldEqual Some(Set(frobArgAExprId))
@@ -796,68 +796,23 @@ class DataflowAnalysisTest extends CompilerTest {
           fnId,
           fnBodyId,
           frobExprId,
-          frobArgAId,
-          frobArgAExprId,
-          frobArgCId,
-          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol,
-          cBindExprId,
-          cBindNameId,
-          plusExprId,
-          plusExprFnId,
-          plusSymbol,
-          plusExprArgAId,
-          plusExprArgBId,
-          plusExprArgAExprId,
-          plusExprArgBExprId,
-          fnArgAId,
-          fnArgBId
+          frobnicateSymbol
         )
       )
       dependencies.get(fnId) shouldEqual Some(
         Set(
           fnBodyId,
           frobExprId,
-          frobArgAId,
-          frobArgAExprId,
-          frobArgCId,
-          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol,
-          cBindExprId,
-          cBindNameId,
-          plusExprId,
-          plusExprFnId,
-          plusSymbol,
-          plusExprArgAId,
-          plusExprArgBId,
-          plusExprArgAExprId,
-          plusExprArgBExprId,
-          fnArgAId,
-          fnArgBId
+          frobnicateSymbol
         )
       )
       dependencies.get(fnBodyId) shouldEqual Some(
         Set(
           frobExprId,
-          frobArgAId,
-          frobArgAExprId,
-          frobArgCId,
-          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol,
-          cBindExprId,
-          cBindNameId,
-          plusExprId,
-          plusExprFnId,
-          plusSymbol,
-          plusExprArgAId,
-          plusExprArgBId,
-          plusExprArgAExprId,
-          plusExprArgBExprId,
-          fnArgAId,
-          fnArgBId
+          frobnicateSymbol
         )
       )
       dependencies.get(fnArgAId) shouldEqual None
@@ -867,13 +822,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.get(printlnExprId) shouldEqual Some(
         Set(
           printlnFnId,
-          printlnSymbol,
-          printlnArgIOId,
-          printlnArgIOExprId,
-          ioSymbol,
-          printlnArgBId,
-          printlnArgBExprId,
-          fnArgBId
+          printlnSymbol
         )
       )
       dependencies.get(printlnFnId) shouldEqual Some(Set(printlnSymbol))
@@ -891,27 +840,15 @@ class DataflowAnalysisTest extends CompilerTest {
         Set(
           cBindNameId,
           plusExprId,
-          plusExprArgAId,
-          plusExprArgAExprId,
-          fnArgAId,
           plusExprFnId,
-          plusSymbol,
-          plusExprArgBId,
-          plusExprArgBExprId,
-          fnArgBId
+          plusSymbol
         )
       )
       dependencies.get(cBindNameId) shouldEqual None
       dependencies.get(plusExprId) shouldEqual Some(
         Set(
-          plusExprArgAId,
-          plusExprArgAExprId,
-          fnArgAId,
           plusExprFnId,
-          plusSymbol,
-          plusExprArgBId,
-          plusExprArgBExprId,
-          fnArgBId
+          plusSymbol
         )
       )
       dependencies.get(plusExprArgAId) shouldEqual Some(
@@ -928,23 +865,8 @@ class DataflowAnalysisTest extends CompilerTest {
       // The `frobnicate` expression
       dependencies.get(frobExprId) shouldEqual Some(
         Set(
-          frobArgAId,
-          frobArgAExprId,
-          frobArgCId,
-          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol,
-          cBindExprId,
-          cBindNameId,
-          plusExprId,
-          plusExprFnId,
-          plusSymbol,
-          plusExprArgAId,
-          plusExprArgBId,
-          plusExprArgAExprId,
-          plusExprArgBExprId,
-          fnArgAId,
-          fnArgBId
+          frobnicateSymbol
         )
       )
       dependencies.get(frobArgAId) shouldEqual Some(
@@ -953,17 +875,11 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.get(frobArgCId) shouldEqual Some(
         Set(
           frobArgCExprId,
-          cBindExprId,
-          cBindNameId,
           plusExprId,
           plusExprFnId,
           plusSymbol,
-          plusExprArgAId,
-          plusExprArgAExprId,
-          fnArgAId,
-          plusExprArgBId,
-          plusExprArgBExprId,
-          fnArgBId
+          cBindExprId,
+          cBindNameId
         )
       )
     }
@@ -1060,7 +976,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(fnId) shouldEqual Some(Set(fnBodyId))
       dependencies.getDirect(fnArgXId) shouldEqual None
       dependencies.getDirect(fnBodyId) shouldEqual Some(
-        Set(plusFnId, plusArgXId, plusArgYId)
+        Set(plusFnId)
       )
       dependencies.getDirect(plusArgXId) shouldEqual Some(Set(plusArgXExprId))
       dependencies.getDirect(plusArgYId) shouldEqual Some(Set(plusArgYExprId))
@@ -1143,7 +1059,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The tests for dependencies
       dependencies.getDirect(appId) shouldEqual Some(
-        Set(appFnId, appArg10Id, appArgFnId)
+        Set(appFnId)
       )
       dependencies.getDirect(appFnId) shouldEqual Some(Set(fooSym))
       dependencies.getDirect(appArg10Id) shouldEqual Some(
@@ -1155,7 +1071,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(lamId) shouldEqual Some(Set(mulId))
       dependencies.getDirect(lamArgXId) shouldEqual None
       dependencies.getDirect(mulId) shouldEqual Some(
-        Set(mulFnId, mulArg1Id, mulArg2Id)
+        Set(mulFnId)
       )
       dependencies.getDirect(mulArg1Id) shouldEqual Some(Set(mulArg1ExprId))
       dependencies.getDirect(mulArg1ExprId) shouldEqual Some(Set(lamArgXId))
@@ -1325,7 +1241,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       dependencies.getDirect(bindingNameId) shouldEqual None
       dependencies.getDirect(bindingExprId) shouldEqual Some(
-        Set(plusFnId, undefinedArgId, numArgId)
+        Set(plusFnId)
       )
       dependencies.getDirect(numArgId) shouldEqual Some(Set(numArgExprId))
       dependencies.getDirect(plusFnId) shouldEqual Some(Set(plusSym))
@@ -1533,7 +1449,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
 
       dependencies.getDirect(consBranchExpressionId) shouldEqual Some(
-        Set(aArgId, consBranchFnId, bArgId)
+        Set(consBranchFnId)
       )
       dependencies.getDirect(consBranchFnId) shouldEqual Some(Set(plusSym))
       dependencies.getDirect(aArgId) shouldEqual Some(Set(aUseId))
@@ -1698,7 +1614,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(lambdaId) shouldEqual Some(Set(fnBodyId))
       dependencies.getDirect(fnBodyId) shouldEqual Some(Set(fooExprId))
       dependencies.getDirect(fooExprId) shouldEqual Some(
-        Set(fooFunctionId, fooArg1Id, fooArg2Id)
+        Set(fooFunctionId)
       )
       dependencies.getDirect(fooFunctionId) shouldEqual Some(Set(fooSymbol))
       dependencies.getDirect(fooArg1Id) shouldEqual Some(Set(fooArg1ExprId))

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -531,7 +531,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The `IO.println` expression
       dependencies.getDirect(printlnExprId) shouldEqual Some(
-        Set(printlnFnId)
+        Set(printlnArgIOId, printlnArgBId, printlnFnId)
       )
       dependencies.getDirect(printlnFnId) shouldEqual Some(Set(printlnSymbol))
       dependencies.getDirect(printlnArgIOId) shouldEqual Some(
@@ -549,7 +549,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       dependencies.getDirect(cBindNameId) shouldEqual None
       dependencies.getDirect(plusExprId) shouldEqual Some(
-        Set(plusExprFnId)
+        Set(plusExprFnId, plusExprArgAId, plusExprArgBId)
       )
       dependencies.getDirect(plusExprFnId) shouldEqual Some(Set(plusSymbol))
       dependencies.getDirect(plusExprArgAId) shouldEqual Some(
@@ -563,7 +563,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The `frobnicate` expression
       dependencies.getDirect(frobExprId) shouldEqual Some(
-        Set(frobFnId)
+        Set(frobFnId, frobArgAId, frobArgCId)
       )
       dependencies.getDirect(frobFnId) shouldEqual Some(Set(frobnicateSymbol))
       dependencies.getDirect(frobArgAId) shouldEqual Some(Set(frobArgAExprId))
@@ -796,23 +796,68 @@ class DataflowAnalysisTest extends CompilerTest {
           fnId,
           fnBodyId,
           frobExprId,
+          frobArgAId,
+          frobArgAExprId,
+          frobArgCId,
+          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol
+          frobnicateSymbol,
+          cBindExprId,
+          cBindNameId,
+          plusExprId,
+          plusExprFnId,
+          plusSymbol,
+          plusExprArgAId,
+          plusExprArgBId,
+          plusExprArgAExprId,
+          plusExprArgBExprId,
+          fnArgAId,
+          fnArgBId
         )
       )
       dependencies.get(fnId) shouldEqual Some(
         Set(
           fnBodyId,
           frobExprId,
+          frobArgAId,
+          frobArgAExprId,
+          frobArgCId,
+          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol
+          frobnicateSymbol,
+          cBindExprId,
+          cBindNameId,
+          plusExprId,
+          plusExprFnId,
+          plusSymbol,
+          plusExprArgAId,
+          plusExprArgBId,
+          plusExprArgAExprId,
+          plusExprArgBExprId,
+          fnArgAId,
+          fnArgBId
         )
       )
       dependencies.get(fnBodyId) shouldEqual Some(
         Set(
           frobExprId,
+          frobArgAId,
+          frobArgAExprId,
+          frobArgCId,
+          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol
+          frobnicateSymbol,
+          cBindExprId,
+          cBindNameId,
+          plusExprId,
+          plusExprFnId,
+          plusSymbol,
+          plusExprArgAId,
+          plusExprArgBId,
+          plusExprArgAExprId,
+          plusExprArgBExprId,
+          fnArgAId,
+          fnArgBId
         )
       )
       dependencies.get(fnArgAId) shouldEqual None
@@ -822,7 +867,13 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.get(printlnExprId) shouldEqual Some(
         Set(
           printlnFnId,
-          printlnSymbol
+          printlnSymbol,
+          printlnArgIOId,
+          printlnArgIOExprId,
+          ioSymbol,
+          printlnArgBId,
+          printlnArgBExprId,
+          fnArgBId
         )
       )
       dependencies.get(printlnFnId) shouldEqual Some(Set(printlnSymbol))
@@ -840,15 +891,27 @@ class DataflowAnalysisTest extends CompilerTest {
         Set(
           cBindNameId,
           plusExprId,
+          plusExprArgAId,
+          plusExprArgAExprId,
+          fnArgAId,
           plusExprFnId,
-          plusSymbol
+          plusSymbol,
+          plusExprArgBId,
+          plusExprArgBExprId,
+          fnArgBId
         )
       )
       dependencies.get(cBindNameId) shouldEqual None
       dependencies.get(plusExprId) shouldEqual Some(
         Set(
+          plusExprArgAId,
+          plusExprArgAExprId,
+          fnArgAId,
           plusExprFnId,
-          plusSymbol
+          plusSymbol,
+          plusExprArgBId,
+          plusExprArgBExprId,
+          fnArgBId
         )
       )
       dependencies.get(plusExprArgAId) shouldEqual Some(
@@ -865,8 +928,23 @@ class DataflowAnalysisTest extends CompilerTest {
       // The `frobnicate` expression
       dependencies.get(frobExprId) shouldEqual Some(
         Set(
+          frobArgAId,
+          frobArgAExprId,
+          frobArgCId,
+          frobArgCExprId,
           frobFnId,
-          frobnicateSymbol
+          frobnicateSymbol,
+          cBindExprId,
+          cBindNameId,
+          plusExprId,
+          plusExprFnId,
+          plusSymbol,
+          plusExprArgAId,
+          plusExprArgBId,
+          plusExprArgAExprId,
+          plusExprArgBExprId,
+          fnArgAId,
+          fnArgBId
         )
       )
       dependencies.get(frobArgAId) shouldEqual Some(
@@ -875,11 +953,17 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.get(frobArgCId) shouldEqual Some(
         Set(
           frobArgCExprId,
+          cBindExprId,
+          cBindNameId,
           plusExprId,
           plusExprFnId,
           plusSymbol,
-          cBindExprId,
-          cBindNameId
+          plusExprArgAId,
+          plusExprArgAExprId,
+          fnArgAId,
+          plusExprArgBId,
+          plusExprArgBExprId,
+          fnArgBId
         )
       )
     }
@@ -976,7 +1060,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(fnId) shouldEqual Some(Set(fnBodyId))
       dependencies.getDirect(fnArgXId) shouldEqual None
       dependencies.getDirect(fnBodyId) shouldEqual Some(
-        Set(plusFnId)
+        Set(plusFnId, plusArgXId, plusArgYId)
       )
       dependencies.getDirect(plusArgXId) shouldEqual Some(Set(plusArgXExprId))
       dependencies.getDirect(plusArgYId) shouldEqual Some(Set(plusArgYExprId))
@@ -1059,7 +1143,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
       // The tests for dependencies
       dependencies.getDirect(appId) shouldEqual Some(
-        Set(appFnId)
+        Set(appFnId, appArg10Id, appArgFnId)
       )
       dependencies.getDirect(appFnId) shouldEqual Some(Set(fooSym))
       dependencies.getDirect(appArg10Id) shouldEqual Some(
@@ -1071,7 +1155,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(lamId) shouldEqual Some(Set(mulId))
       dependencies.getDirect(lamArgXId) shouldEqual None
       dependencies.getDirect(mulId) shouldEqual Some(
-        Set(mulFnId)
+        Set(mulFnId, mulArg1Id, mulArg2Id)
       )
       dependencies.getDirect(mulArg1Id) shouldEqual Some(Set(mulArg1ExprId))
       dependencies.getDirect(mulArg1ExprId) shouldEqual Some(Set(lamArgXId))
@@ -1241,7 +1325,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
       dependencies.getDirect(bindingNameId) shouldEqual None
       dependencies.getDirect(bindingExprId) shouldEqual Some(
-        Set(plusFnId)
+        Set(plusFnId, undefinedArgId, numArgId)
       )
       dependencies.getDirect(numArgId) shouldEqual Some(Set(numArgExprId))
       dependencies.getDirect(plusFnId) shouldEqual Some(Set(plusSym))
@@ -1449,7 +1533,7 @@ class DataflowAnalysisTest extends CompilerTest {
       )
 
       dependencies.getDirect(consBranchExpressionId) shouldEqual Some(
-        Set(consBranchFnId)
+        Set(aArgId, consBranchFnId, bArgId)
       )
       dependencies.getDirect(consBranchFnId) shouldEqual Some(Set(plusSym))
       dependencies.getDirect(aArgId) shouldEqual Some(Set(aUseId))
@@ -1614,7 +1698,7 @@ class DataflowAnalysisTest extends CompilerTest {
       dependencies.getDirect(lambdaId) shouldEqual Some(Set(fnBodyId))
       dependencies.getDirect(fnBodyId) shouldEqual Some(Set(fooExprId))
       dependencies.getDirect(fooExprId) shouldEqual Some(
-        Set(fooFunctionId)
+        Set(fooFunctionId, fooArg1Id, fooArg2Id)
       )
       dependencies.getDirect(fooFunctionId) shouldEqual Some(Set(fooSymbol))
       dependencies.getDirect(fooArg1Id) shouldEqual Some(Set(fooArg1ExprId))


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- close #14863 

Changelog:
- update: ChangesetBuidler does not query DataflowAnalysis for unnecessary dynamic dependencies

### Important Notes

On develop both `Runtime.sleep` nodes will be recomputed.

https://github.com/user-attachments/assets/545a2117-7fde-45c9-8f9b-1e514b21818a


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
