### PR TITLE
Fix AWS signed post follow Dual JVM changes

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
@@ -12,6 +12,7 @@ import project.AWS_Region.AWS_Region
 import project.Errors.Invalid_AWS_URI
 
 polyglot java import org.enso.aws.ClientBuilder
+polyglot java import java.net.http.HttpClient
 
 ## Methods for interacting with AWS services.
 type AWS
@@ -151,4 +152,4 @@ type AWS_Region_Service
 
 private _make_client credentials region_service http hash =
     builder = ClientBuilder.new credentials.as_java (AWS_Region.Region region_service.region).as_java
-    builder.createSignedClient region_service.region region_service.service (internal_http_client http "") hash
+    builder.createSignedClient region_service.region region_service.service (internal_http_client http "" HttpClient) hash

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
@@ -5,7 +5,7 @@ import Standard.Base.Network.HTTP.Request_Body.Request_Body
 import Standard.Base.Network.HTTP.Request_Error
 import Standard.Base.Network.HTTP.Response.Response
 from Standard.Base.Metadata.Widget import Text_Input
-from Standard.Base.Network.HTTP import if_fetch_method, if_post_method, internal_http_client, with_hash_and_client
+from Standard.Base.Network.HTTP import if_fetch_method, if_post_method, with_hash_and_client
 
 import project.AWS_Credential.AWS_Credential
 import project.AWS_Region.AWS_Region
@@ -151,5 +151,6 @@ type AWS_Region_Service
     Region_Service region:Text service:Text
 
 private _make_client credentials region_service http hash =
+    _ = http
     builder = ClientBuilder.new credentials.as_java (AWS_Region.Region region_service.region).as_java
-    builder.createSignedClient region_service.region region_service.service (internal_http_client http "" HttpClient) hash
+    builder.createSignedClient region_service.region region_service.service hash

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/AWS.enso
@@ -12,6 +12,7 @@ import project.AWS_Region.AWS_Region
 import project.Errors.Invalid_AWS_URI
 
 polyglot java import org.enso.aws.ClientBuilder
+polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper
 polyglot java import java.net.http.HttpClient
 
 ## Methods for interacting with AWS services.
@@ -46,7 +47,7 @@ type AWS
     signed_fetch : URI -> HTTP_Method -> (Vector (Header | Pair Text Text)) -> File_Format -> AWS_Credential -> AWS_Region_Service -> Any
     signed_fetch (uri:URI=(Missing_Argument.throw "uri")) (method:HTTP_Method=..Get) (headers:(Vector (Header | Pair Text Text))=[]) (format = Auto_Detect) credentials:AWS_Credential=..Default (region_service:AWS_Region_Service=(AWS.resolve_region_and_service uri)) = if_fetch_method method <|
         request = Request.new method uri (Header.unify_vector headers) Request_Body.Empty
-        http = with_hash_and_client HTTP.new hash_method=AWS.hash_bytes make_client=(_make_client credentials region_service)
+        http = with_hash_and_client HTTP.new hash_method=AWS.hash_bytes make_client=(_make_client credentials region_service) enso_secret_helper=EnsoSecretHelper
         raw_response = http.request request
         raw_response.decode format=format if_unsupported=raw_response.with_materialized_body
 
@@ -116,7 +117,7 @@ type AWS
     signed_post : URI -> Request_Body -> HTTP_Method -> Vector (Header | Pair Text Text) -> Any -> AWS_Credential -> AWS_Region_Service -> Response ! Request_Error | HTTP_Error
     signed_post (uri:URI=(Missing_Argument.throw "uri")) (body:Request_Body=..Empty) (method:HTTP_Method=..Post) (headers:(Vector (Header | Pair Text Text))=[]) (response_format = Auto_Detect) credentials:AWS_Credential=..Default (region_service:AWS_Region_Service=(AWS.resolve_region_and_service uri)) = if_post_method method <|
         request = Request.new method uri (Header.unify_vector headers) body
-        http = with_hash_and_client HTTP.new hash_method=AWS.hash_bytes make_client=(_make_client credentials region_service)
+        http = with_hash_and_client HTTP.new hash_method=AWS.hash_bytes make_client=(_make_client credentials region_service) enso_secret_helper=EnsoSecretHelper
         raw_response = http.request request
         raw_response.decode format=response_format if_unsupported=raw_response.with_materialized_body
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Errors/Common.md
@@ -100,7 +100,6 @@
     - to_js_object self -> Standard.Base.Any.Any
 - type Response_Too_Large
     - Error actual_size:(Standard.Base.Data.Numbers.Integer|Standard.Base.Nothing.Nothing) limit:Standard.Base.Data.Numbers.Integer
-    - handle_java_exception ~action:Standard.Base.Any.Any -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
 - type Syntax_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP.md
@@ -11,6 +11,7 @@
     - Error error_type:Standard.Base.Any.Any message:Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
 - type Resolved_Body
+    - Value publisher:Standard.Base.Any.Any boundary:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing) hash:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)
 - _get_follow_redirects http:Standard.Base.Network.HTTP.HTTP -> Standard.Base.Any.Any
 - _get_proxy http:Standard.Base.Network.HTTP.HTTP -> Standard.Base.Any.Any
 - _get_timeout http:Standard.Base.Network.HTTP.HTTP -> Standard.Base.Any.Any
@@ -18,5 +19,4 @@
 - _resolve_headers req:Standard.Base.Any.Any -> Standard.Base.Any.Any
 - if_fetch_method method:Standard.Base.Network.HTTP.HTTP_Method.HTTP_Method ~action:Standard.Base.Any.Any ~if_not:Standard.Base.Any.Any= -> Standard.Base.Any.Any
 - if_post_method method:Standard.Base.Network.HTTP.HTTP_Method.HTTP_Method ~action:Standard.Base.Any.Any ~if_not:Standard.Base.Any.Any= -> Standard.Base.Any.Any
-- internal_http_client http:Standard.Base.Any.Any hash:Standard.Base.Any.Any -> Standard.Base.Any.Any
-- with_hash_and_client http:Standard.Base.Any.Any hash_method:Standard.Base.Any.Any make_client:Standard.Base.Any.Any -> Standard.Base.Any.Any
+- with_hash_and_client http:Standard.Base.Any.Any hash_method:Standard.Base.Any.Any make_client:Standard.Base.Any.Any enso_secret_helper:Standard.Base.Any.Any= -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP/Header.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP/Header.md
@@ -13,11 +13,11 @@
     - content_type value:Standard.Base.Data.Text.Text encoding:(Standard.Base.Data.Text.Encoding.Encoding|Standard.Base.Nothing.Nothing)= -> Standard.Base.Any.Any
     - content_type_header_name -> Standard.Base.Any.Any
     - default_widget display:Standard.Base.Metadata.Display= -> Standard.Base.Metadata.Widget
+    - hideable_value self -> Standard.Base.Any.Any
     - multipart_form_data boundary:Standard.Base.Data.Text.Text= -> Standard.Base.Any.Any
     - new name:Standard.Base.Data.Text.Text value:(Standard.Base.Data.Text.Text|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret|Standard.Base.Enso_Cloud.Enso_Secret.Derived_Secret_Value) -> Standard.Base.Any.Any
     - text_plain -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
-    - to_java_pair self -> Standard.Base.Any.Any
     - unify_vector headers:Standard.Base.Data.Vector.Vector -> Standard.Base.Any.Any
 - type Header_Comparator
     - compare x:Standard.Base.Any.Any y:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP/Request_Body.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/HTTP/Request_Body.md
@@ -7,7 +7,11 @@
     - Form_Data form_data:Standard.Base.Data.Dictionary.Dictionary= url_encoded:Standard.Base.Data.Boolean.Boolean=
     - Json x:Standard.Base.Any.Any=
     - Text text:Standard.Base.Data.Text.Text= encoding:(Standard.Base.Data.Text.Encoding.Encoding|Standard.Base.Nothing.Nothing)= content_type:(Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)=
+    - bytes_value self -> ((Standard.Base.Data.Vector.Vector Standard.Base.Data.Numbers.Integer)|Standard.Base.Nothing.Nothing)
+    - charset self -> Standard.Base.Any.Any
     - default_content_type_header self -> Standard.Base.Any.Any
+    - text_value self -> (Standard.Base.Data.Text.Text|Standard.Base.Nothing.Nothing)
+    - type_name self -> Standard.Base.Data.Text.Text
 - dictionary_widget -> Standard.Base.Metadata.Widget
 - make_all_with_json -> Standard.Base.Any.Any
 - Standard.Base.Network.HTTP.Request_Body.Request_Body.from that:Standard.Base.Data.Text.Text -> Standard.Base.Network.HTTP.Request_Body.Request_Body

--- a/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/URI.md
+++ b/distribution/lib/Standard/Base/0.0.0-dev/docs/api/Network/URI.md
@@ -4,7 +4,7 @@
     - Warning query_string:Standard.Base.Data.Text.Text
     - to_display_text self -> Standard.Base.Any.Any
 - type URI
-    - Value internal_uri:Standard.Base.Network.URI.Java_URI additional_query_parameters:(Standard.Base.Data.Vector.Vector Standard.Base.Any.Any)
+    - Value internal_uri:Standard.Base.Network.URI.Java_URI additional_query_parameters:(Standard.Base.Data.Vector.Vector Standard.Base.Network.HTTP.Header.Header)
     - / self segment:Standard.Base.Data.Text.Text -> Standard.Base.Any.Any
     - add_query_argument self key:Standard.Base.Data.Text.Text value:(Standard.Base.Data.Text.Text|Standard.Base.Enso_Cloud.Enso_Secret.Enso_Secret) -> Standard.Base.Any.Any
     - authority self -> Standard.Base.Any.Any
@@ -24,10 +24,10 @@
     - reset_query_arguments self -> Standard.Base.Any.Any
     - scheme self -> Standard.Base.Any.Any
     - to_display_text self -> Standard.Base.Any.Any
-    - to_java_representation self -> Standard.Base.Any.Any
     - to_java_uri self -> Standard.Base.Any.Any
     - to_js_object self -> Standard.Base.Any.Any
     - to_text self -> Standard.Base.Any.Any
+    - to_uri_string self -> Standard.Base.Data.Text.Text
     - user_info self -> Standard.Base.Any.Any
 - type URI_Comparator
     - compare x:Standard.Base.Any.Any y:Standard.Base.Any.Any -> Standard.Base.Any.Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -18,7 +18,6 @@ from project.Nothing import all
 polyglot java import java.lang.ArithmeticException
 polyglot java import java.lang.ClassCastException
 polyglot java import java.lang.OutOfMemoryError
-polyglot java import org.enso.base.cache.ResponseTooLargeException
 polyglot java import org.enso.base.CompareException
 
 ## An error indicating that no value was found.
@@ -748,13 +747,6 @@ type Response_Too_Large
     to_text : Text
     to_text self =
         "(Response_Too_Large (actual_size = "+self.actual_size.to_text+") (limit = "+self.limit.to_text+"))"
-
-    ## ---
-       private: true
-       ---
-       Convert the Java exception to an Enso dataflow error.
-    handle_java_exception ~action =
-        Panic.catch ResponseTooLargeException action (cause-> Error.throw (Response_Too_Large.Error cause.payload.getActualSize cause.payload.getLimit))
 
 ## Indicates that some operation relies on equality on floating-point values,
    which is not recommended.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -44,6 +44,7 @@ polyglot java import java.net.http.HttpRequest.Builder
 polyglot java import java.net.InetSocketAddress
 polyglot java import java.net.ProxySelector
 polyglot java import javax.net.ssl.SSLContext
+polyglot java import org.enso.base.cache.ResponseTooLargeException
 polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper
 polyglot java import org.enso.base.file_system.File_Utils
 polyglot java import org.enso.base.net.http.MultipartBodyBuilder
@@ -150,40 +151,42 @@ type HTTP
     request : Request -> Boolean -> Cache_Policy -> Response ! Request_Error | HTTP_Error | Illegal_Argument | Response_Too_Large
     request self req error_on_failure_code:Boolean=True (cache_policy:Cache_Policy = ..Default) =
         # Prevent request if the method is a write-like method and output context is disabled.
-        check_output_context ~action =
-            if (if_fetch_method req.method True if_not=Context.Output.is_enabled) then action else
-                Error.throw (Forbidden_Operation.Error ("As writing is disabled, " + req.method.to_text + " request not sent. Press the Write button ▶ to send it."))
+        if (if_fetch_method req.method True if_not=Context.Output.is_enabled).not then
+            Error.throw (Forbidden_Operation.Error ("As writing is disabled, " + req.method.to_text + " request not sent. Press the Write button ▶ to send it."))
+
         # You can only explicitly mention the cache for GET requests.
-        check_cache_policy ~action =
-            cache_policy_value_ok = req.method == HTTP_Method.Get || cache_policy != Cache_Policy.Use_Cache
-            if cache_policy_value_ok then action else
-                Error.throw (Illegal_Argument.Error "Cannot specify cache policy for a "+req.method.to_text+" request")
+        if req.method != HTTP_Method.Get && cache_policy == Cache_Policy.Use_Cache then
+            Error.throw (Illegal_Argument.Error "Cannot specify cache policy for a "+req.method.to_text+" request")
 
         handle_request_error =
             handler caught_panic =
                 exception = caught_panic.payload
                 Error.throw (Request_Error.Error (Meta.type_of exception . to_text) exception.getMessage)
-            Panic.catch IllegalArgumentException handler=handler <| Panic.catch IOException handler=handler
+            too_large_handler caught_panic =
+                Error.throw (Response_Too_Large.Error caught_panic.payload.getActualSize caught_panic.payload.getLimit)
+            Panic.catch IllegalArgumentException handler=handler <| Panic.catch IOException handler=handler <| Panic.catch ResponseTooLargeException handler=too_large_handler
 
-        handle_request_error <| Illegal_Argument.handle_java_exception <| check_output_context <| check_cache_policy <| Response_Too_Large.handle_java_exception <|
+        handle_request_error <|
             headers = _resolve_headers req
-            headers.if_not_error <|
-                resolved_body = _resolve_body req.body self.hash_method
-                resolved_body.if_not_error <|
-                    # Create builder and set method and body
-                    builder = HttpRequest.newBuilder
-                    builder.method req.method.to_http_method_name resolved_body.publisher
+            Error.return_if_error headers
 
-                    # Create Unified Header list
-                    boundary_header_list = if resolved_body.boundary.is_nothing then [] else [Header.multipart_form_data resolved_body.boundary]
-                    all_headers = headers + boundary_header_list
-                    mapped_headers = all_headers.map on_problems=No_Wrap.Value .to_java_pair
+            resolved_body = _resolve_body req.body self.hash_method
+            Error.return_if_error resolved_body
 
-                    response = Response.new (EnsoSecretHelper.makeRequest (self.make_client self resolved_body.hash) builder req.uri.to_java_representation mapped_headers (cache_policy.should_use_cache req))
-                    if error_on_failure_code.not || response.code.is_success then response else
-                        body = response.body.decode_as_text.catch Any _->""
-                        message = if body.is_empty then Nothing else body
-                        Error.throw (HTTP_Error.Status_Error response.code message response.uri)
+            # Create builder and set method and body
+            builder = HttpRequest.newBuilder
+            builder.method req.method.to_http_method_name resolved_body.publisher
+
+            # Create Unified Header list
+            boundary_header_list = if resolved_body.boundary.is_nothing then [] else [Header.multipart_form_data resolved_body.boundary]
+            all_headers = headers + boundary_header_list
+            mapped_headers = all_headers.map on_problems=No_Wrap.Value .to_java_pair
+
+            response = Response.new (EnsoSecretHelper.makeRequest (self.make_client self resolved_body.hash) builder req.uri.to_java_representation mapped_headers (cache_policy.should_use_cache req))
+            if error_on_failure_code.not || response.code.is_success then response else
+                body = response.body.decode_as_text.catch Any _->""
+                message = if body.is_empty then Nothing else body
+                Error.throw (HTTP_Error.Status_Error response.code message response.uri)
 
     ## ---
        aliases: [flush]
@@ -355,8 +358,8 @@ with_hash_and_client http hash_method make_client =
    private: true
    ---
    Build a Java HttpClient with the given settings.
-internal_http_client : HTTP -> Text -> Any -> HttpClient
-internal_http_client http hash http_client_type=HttpClient =
+internal_http_client : HTTP -> Text -> HttpClient
+internal_http_client http hash =
     _ = hash
     builder = HttpClient.newBuilder.connectTimeout http.timeout
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -38,6 +38,8 @@ polyglot java import java.net.InetSocketAddress
 polyglot java import java.net.ProxySelector
 polyglot java import javax.net.ssl.SSLContext
 polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper
+polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoRequestBody
+polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoHeader
 polyglot java import org.enso.base.net.http.MultipartBodyBuilder
 polyglot java import org.enso.base.net.http.UrlencodedBodyBuilder
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -32,19 +32,14 @@ from project.Error import all
 from project.Nothing import all
 
 polyglot java import java.net.http.HttpClient
-polyglot java import java.net.http.HttpClient.Builder as ClientBuilder
+polyglot java import java.net.http.HttpClient.Builder
 polyglot java import java.net.http.HttpClient.Redirect
 polyglot java import java.net.http.HttpClient.Version
 polyglot java import java.net.http.HttpRequest
-polyglot java import java.net.http.HttpRequest.BodyPublisher
-polyglot java import java.net.http.HttpRequest.BodyPublishers
-polyglot java import java.net.http.HttpRequest.Builder
 polyglot java import java.net.InetSocketAddress
 polyglot java import java.net.ProxySelector
 polyglot java import javax.net.ssl.SSLContext
-polyglot java import org.enso.base.cache.ResponseTooLargeException
 polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper
-polyglot java import org.enso.base.file_system.File_Utils
 polyglot java import org.enso.base.net.http.MultipartBodyBuilder
 polyglot java import org.enso.base.net.http.UrlencodedBodyBuilder
 
@@ -165,6 +160,10 @@ type HTTP
         resolved_body = case req.body of
             Request_Body.Form_Data form_data url_encoded ->
                 _resolve_form_body form_data url_encoded self.hash_method
+            Request_Body.Json x ->
+                json = x.to_json
+                Error.return_if_error json
+                EnsoSecretHelper.resolveBody (Request_Body.Text json) self.hash_method
             _ -> EnsoSecretHelper.resolveBody req.body self.hash_method
         Error.return_if_error resolved_body
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -355,8 +355,8 @@ with_hash_and_client http hash_method make_client =
    private: true
    ---
    Build a Java HttpClient with the given settings.
-internal_http_client : HTTP -> Text -> HttpClient
-internal_http_client http hash =
+internal_http_client : HTTP -> Text -> Any -> HttpClient
+internal_http_client http hash http_client_type=HttpClient =
     _ = hash
     builder = HttpClient.newBuilder.connectTimeout http.timeout
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -4,7 +4,6 @@ import project.Data.Pair.Pair
 import project.Data.Text.Encoding.Encoding
 import project.Data.Text.Text
 import project.Data.Time.Duration.Duration
-import project.Data.Vector.No_Wrap
 import project.Data.Vector.Vector
 import project.Errors.Common.Forbidden_Operation
 import project.Errors.Common.Response_Too_Large
@@ -22,7 +21,6 @@ import project.Network.HTTP.Request_Body.Request_Body
 import project.Network.HTTP.Response.Response
 import project.Network.Proxy.Proxy
 import project.Network.URI.URI
-import project.Panic.Panic
 import project.Runtime.Context
 import project.System.File.File
 from project.Data.Boolean import Boolean, False, True
@@ -174,9 +172,7 @@ type HTTP
         # Create HttpClient
         http_client = self.make_client self resolved_body.hash
 
-        java_uri = req.uri.to_java_representation
-        java_response = EnsoSecretHelper.makeRequest http_client req.method.to_http_method_name resolved_body.publisher java_uri all_headers use_cache
-
+        java_response = EnsoSecretHelper.makeRequest http_client req.method.to_http_method_name resolved_body.publisher req.uri.to_uri_string req.uri.additional_query_parameters all_headers use_cache
         response = Response.new java_response
         if error_on_failure_code.not || response.code.is_success then response else
             body = response.body.decode_as_text.catch Any _->""

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -31,8 +31,6 @@ from project.Data.Text.Extensions import all
 from project.Error import all
 from project.Nothing import all
 
-polyglot java import java.io.IOException
-polyglot java import java.lang.IllegalArgumentException
 polyglot java import java.net.http.HttpClient
 polyglot java import java.net.http.HttpClient.Builder as ClientBuilder
 polyglot java import java.net.http.HttpClient.Redirect
@@ -157,36 +155,34 @@ type HTTP
         # You can only explicitly mention the cache for GET requests.
         if req.method != HTTP_Method.Get && cache_policy == Cache_Policy.Use_Cache then
             Error.throw (Illegal_Argument.Error "Cannot specify cache policy for a "+req.method.to_text+" request")
+        use_cache = cache_policy.should_use_cache req
 
-        handle_request_error =
-            handler caught_panic =
-                exception = caught_panic.payload
-                Error.throw (Request_Error.Error (Meta.type_of exception . to_text) exception.getMessage)
-            too_large_handler caught_panic =
-                Error.throw (Response_Too_Large.Error caught_panic.payload.getActualSize caught_panic.payload.getLimit)
-            Panic.catch IllegalArgumentException handler=handler <| Panic.catch IOException handler=handler <| Panic.catch ResponseTooLargeException handler=too_large_handler
+        ## Headers are key (Text) and value (Text or Secret)
+        headers = _resolve_headers req
+        Error.return_if_error headers
 
-        handle_request_error <|
-            headers = _resolve_headers req
-            Error.return_if_error headers
+        ## Can throw a File Not Found
+        resolved_body = case req.body of
+            Request_Body.Form_Data form_data url_encoded ->
+                _resolve_form_body form_data url_encoded self.hash_method
+            _ -> EnsoSecretHelper.resolveBody req.body self.hash_method
+        Error.return_if_error resolved_body
 
-            resolved_body = _resolve_body req.body self.hash_method
-            Error.return_if_error resolved_body
+        # Create Unified Header list
+        boundary_header_list = if resolved_body.boundary.is_nothing then [] else [Header.multipart_form_data resolved_body.boundary]
+        all_headers = headers + boundary_header_list
 
-            # Create builder and set method and body
-            builder = HttpRequest.newBuilder
-            builder.method req.method.to_http_method_name resolved_body.publisher
+        # Create HttpClient
+        http_client = self.make_client self resolved_body.hash
 
-            # Create Unified Header list
-            boundary_header_list = if resolved_body.boundary.is_nothing then [] else [Header.multipart_form_data resolved_body.boundary]
-            all_headers = headers + boundary_header_list
-            mapped_headers = all_headers.map on_problems=No_Wrap.Value .to_java_pair
+        java_uri = req.uri.to_java_representation
+        java_response = EnsoSecretHelper.makeRequest http_client req.method.to_http_method_name resolved_body.publisher java_uri all_headers use_cache
 
-            response = Response.new (EnsoSecretHelper.makeRequest (self.make_client self resolved_body.hash) builder req.uri.to_java_representation mapped_headers (cache_policy.should_use_cache req))
-            if error_on_failure_code.not || response.code.is_success then response else
-                body = response.body.decode_as_text.catch Any _->""
-                message = if body.is_empty then Nothing else body
-                Error.throw (HTTP_Error.Status_Error response.code message response.uri)
+        response = Response.new java_response
+        if error_on_failure_code.not || response.code.is_success then response else
+            body = response.body.decode_as_text.catch Any _->""
+            message = if body.is_empty then Nothing else body
+            Error.throw (HTTP_Error.Status_Error response.code message response.uri)
 
     ## ---
        aliases: [flush]
@@ -266,42 +262,7 @@ _resolve_headers req =
    private: true
    ---
 type Resolved_Body
-    private Value publisher:BodyPublisher boundary:Text|Nothing hash:Text|Nothing
-
-## ---
-   private: true
-   ---
-   Generate body publisher, optional form content boundary and optionally hash
-   from the body
-_resolve_body : Request_Body -> Function | Nothing -> Resolved_Body
-private _resolve_body body:Request_Body hash_function =
-    body_publishers = HttpRequest.BodyPublishers
-    case body of
-        Request_Body.Text text encoding _ ->
-            body_publisher = case encoding of
-                Nothing -> body_publishers.ofString text
-                _ : Encoding ->  body_publishers.ofString text encoding.to_java_charset
-            hash = if hash_function.is_nothing then "" else hash_function (text.bytes (encoding.if_nothing Encoding.utf_8))
-            Resolved_Body.Value body_publisher Nothing hash
-        Request_Body.Json x ->
-            json = x.to_json
-            hash = if hash_function.is_nothing then "" else hash_function json.bytes
-            json.if_not_error <| Resolved_Body.Value (body_publishers.ofString json) Nothing hash
-        Request_Body.Binary file ->
-            path = File_Utils.toPath file.path
-            ## ToDo: Support hashing a file.
-            hash = if hash_function.is_nothing then "" else Unimplemented.throw "Hashing a file body is not yet supported."
-            Resolved_Body.Value (body_publishers.ofFile path) Nothing hash
-        Request_Body.Byte_Array bytes ->
-            hash = if hash_function.is_nothing then "" else hash_function bytes
-            Resolved_Body.Value (body_publishers.ofByteArray bytes) Nothing hash
-        Request_Body.Form_Data form_data url_encoded ->
-            _resolve_form_body form_data url_encoded hash_function
-        Request_Body.Empty ->
-            hash = if hash_function.is_nothing then "" else hash_function []
-            Resolved_Body.Value body_publishers.noBody Nothing hash
-        _ ->
-            Error.throw (Illegal_Argument.Error ("Unsupported POST body: " + body.to_display_text + "; this is a bug library."))
+    Value publisher boundary:Text|Nothing hash:Text|Nothing
 
 ## ---
    private: true
@@ -359,7 +320,7 @@ with_hash_and_client http hash_method make_client =
    ---
    Build a Java HttpClient with the given settings.
 internal_http_client : HTTP -> Text -> HttpClient
-internal_http_client http hash =
+private internal_http_client http hash =
     _ = hash
     builder = HttpClient.newBuilder.connectTimeout http.timeout
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -33,7 +33,6 @@ polyglot java import java.net.http.HttpClient
 polyglot java import java.net.http.HttpClient.Builder
 polyglot java import java.net.http.HttpClient.Redirect
 polyglot java import java.net.http.HttpClient.Version
-polyglot java import java.net.http.HttpRequest
 polyglot java import java.net.InetSocketAddress
 polyglot java import java.net.ProxySelector
 polyglot java import javax.net.ssl.SSLContext

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -37,9 +37,9 @@ polyglot java import java.net.http.HttpRequest
 polyglot java import java.net.InetSocketAddress
 polyglot java import java.net.ProxySelector
 polyglot java import javax.net.ssl.SSLContext
+polyglot java import org.enso.base.enso_cloud.EnsoHeader
+polyglot java import org.enso.base.enso_cloud.EnsoRequestBody
 polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper
-polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoRequestBody
-polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoHeader
 polyglot java import org.enso.base.net.http.MultipartBodyBuilder
 polyglot java import org.enso.base.net.http.UrlencodedBodyBuilder
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -121,7 +121,8 @@ type HTTP
           recommended to use the default.
         - `hash_method`: The hash method to use for body hashing.
         - `make_client`: Creates the Java HTTPClient.
-    private Value timeout follow_redirects:Boolean proxy:Proxy version:HTTP_Version custom_ssl_context hash_method=Nothing make_client=internal_http_client
+        - `enso_secret_helper`: the Java helper for resolving secrets and making requests.
+    private Value timeout follow_redirects:Boolean proxy:Proxy version:HTTP_Version custom_ssl_context hash_method=Nothing make_client=internal_http_client enso_secret_helper=EnsoSecretHelper
 
     ## ---
        advanced: true
@@ -163,8 +164,8 @@ type HTTP
             Request_Body.Json x ->
                 json = x.to_json
                 Error.return_if_error json
-                EnsoSecretHelper.resolveBody (Request_Body.Text json) self.hash_method
-            _ -> EnsoSecretHelper.resolveBody req.body self.hash_method
+                self.enso_secret_helper.resolveBody (Request_Body.Text json) self.hash_method
+            _ -> self.enso_secret_helper.resolveBody req.body self.hash_method
         Error.return_if_error resolved_body
 
         # Create Unified Header list
@@ -174,7 +175,7 @@ type HTTP
         # Create HttpClient
         http_client = self.make_client self resolved_body.hash
 
-        java_response = EnsoSecretHelper.makeRequest http_client req.method.to_http_method_name resolved_body.publisher req.uri.to_uri_string req.uri.additional_query_parameters all_headers use_cache
+        java_response = self.enso_secret_helper.makeRequest http_client req.method.to_http_method_name resolved_body.publisher req.uri.to_uri_string req.uri.additional_query_parameters all_headers use_cache
         response = Response.new java_response
         if error_on_failure_code.not || response.code.is_success then response else
             body = response.body.decode_as_text.catch Any _->""
@@ -308,9 +309,9 @@ if_post_method method:HTTP_Method ~action ~if_not=(Error.throw (Illegal_Argument
    private: true
    ---
    Build a custom HTTP with hash function and make_client function.
-with_hash_and_client : HTTP -> Function -> Function -> HTTP
-with_hash_and_client http hash_method make_client =
-    HTTP.Value http.timeout http.follow_redirects http.proxy http.version http.custom_ssl_context hash_method make_client
+with_hash_and_client : HTTP -> Function -> Function -> Any -> HTTP
+with_hash_and_client http hash_method make_client enso_secret_helper=EnsoSecretHelper =
+    HTTP.Value http.timeout http.follow_redirects http.proxy http.version http.custom_ssl_context hash_method make_client enso_secret_helper
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -157,6 +157,10 @@ type HTTP
         Error.return_if_error headers
 
         ## Can throw a File Not Found
+        Error.return_if_error req.body
+        Error.return_if_error req.body.text_value
+        Error.return_if_error req.body.charset
+        Error.return_if_error req.body.bytes_value
         resolved_body = case req.body of
             Request_Body.Form_Data form_data url_encoded ->
                 _resolve_form_body form_data url_encoded self.hash_method
@@ -221,6 +225,9 @@ type HTTP
    Not explicitly private as allows direct testing.
 _resolve_headers : Request -> Vector Header
 _resolve_headers req =
+    header_err = req.headers.find if_missing=Nothing h-> h.is_error
+    if header_err != Nothing then Error.throw header_err
+
     is_content_type_header h = h.name . equals_ignore_case Header.content_type_header_name
 
     # Check for content type and encoding in the Request_Body.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
@@ -14,7 +14,6 @@ import project.Metadata.Display
 import project.Metadata.Widget
 from project.Data.Ordering import all
 from project.Data.Text.Extensions import all
-from project.Enso_Cloud.Enso_Secret import as_hideable_value
 from project.Metadata import make_single_choice
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Single_Choice, Vector_Editor

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
@@ -20,9 +20,6 @@ from project.Metadata.Choice import Option
 from project.Metadata.Widget import Single_Choice, Vector_Editor
 from project.Nothing import all
 
-polyglot java import java.util.AbstractMap.SimpleEntry as Java_Pair
-polyglot java import org.enso.base.enso_cloud.HideableValue
-
 type Header
     ## ---
        private: true
@@ -47,6 +44,15 @@ type Header
         - `name`: The header name.
         - `value`: The header value.
     Value name:Text value:(Text|Enso_Secret|Derived_Secret_Value)
+
+    ## ---
+       private: true
+       ---
+       The value as a Derived_Secret_Value
+    hideable_value self = case self.value of
+        _ : Text -> Derived_Secret_Value.from self.value
+        _ : Enso_Secret -> Derived_Secret_Value.from self.value
+        _ : Derived_Secret_Value -> self.value
 
     ## ---
        aliases: [build a header]
@@ -285,13 +291,6 @@ type Header
        Gets the name for content_type
     content_type_header_name : Text
     content_type_header_name = "Content-Type"
-
-    ## ---
-       private: true
-       ---
-    to_java_pair : Java_Pair
-    to_java_pair self =
-        Java_Pair.new self.name (as_hideable_value self.value factory=HideableValue)
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
@@ -13,6 +13,7 @@ import project.Nothing.Nothing
 import project.System.File.File
 from project.Data.Boolean import Boolean, False
 from project.Data.Json import key_value_widget
+from project.Data.Json.Extensions import all
 from project.Data.Text.Extensions import all
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Single_Choice, Text_Input, Vector_Editor

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
@@ -1,8 +1,10 @@
 import project.Any.Any
 import project.Data.Dictionary.Dictionary
+import project.Data.Numbers.Integer
 import project.Data.Pair.Pair
 import project.Data.Text.Encoding.Encoding
 import project.Data.Text.Text
+import project.Data.Vector.Vector
 import project.Errors.Common.Missing_Argument
 import project.Meta
 import project.Metadata.Widget
@@ -19,7 +21,6 @@ from project.Widget_Helpers import make_all_selector
 
 ## The HTTP POST request body.
 type Request_Body
-
     ## Request body with text.
 
        ## Arguments
@@ -78,6 +79,46 @@ type Request_Body
             Request_Body.Form_Data _ url_encoded ->
                 if url_encoded then Header.application_x_www_form_urlencoded else Nothing
             Request_Body.Empty -> Nothing
+
+    ## ---
+       private: true
+       ---
+       Returns the type of the request body as text.
+    type_name self -> Text = case self of
+        Request_Body.Text _ _ _ -> "Text"
+        Request_Body.Json _ -> "Json"
+        Request_Body.Binary _ -> "Binary"
+        Request_Body.Byte_Array _ -> "ByteArray"
+        Request_Body.Form_Data _ _ -> "FormData"
+        Request_Body.Empty -> "Empty"
+
+    ## ---
+       private: true
+       ---
+       Converts a Request_Body to a text argument.
+    text_value self -> Text | Nothing = case self of
+        Request_Body.Text text _ _ -> text
+        Request_Body.Json x -> x.to_json
+        Request_Body.Binary file -> file.path
+        _ -> Nothing
+
+    ## ---
+       private: true
+       ---
+       Returns the CharSet to use for the request body, if applicable.
+    charset self = case self of
+        Request_Body.Text _ Nothing _ ->  Nothing
+        Request_Body.Text _ encoding _ -> encoding.to_java_charset.name
+        _ -> Nothing
+
+    ## ---
+       private: true
+       ---
+       Gets the backing byte array.
+    bytes_value self -> Vector Integer | Nothing = case self of
+        Request_Body.Byte_Array bytes -> bytes
+        _ -> Nothing
+
 
 ## ---
    private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -22,6 +22,7 @@ from project.Nothing import all
 polyglot java import java.net.URI as Java_URI
 polyglot java import java.net.URISyntaxException
 polyglot java import org.enso.base.enso_cloud.EnsoSecretAccessDenied
+polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoHeader
 polyglot java import org.enso.base.net.URITransformer
 polyglot java import org.enso.base.net.URIWithSecrets
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -21,8 +21,8 @@ from project.Nothing import all
 
 polyglot java import java.net.URI as Java_URI
 polyglot java import java.net.URISyntaxException
+polyglot java import org.enso.base.enso_cloud.EnsoHeader
 polyglot java import org.enso.base.enso_cloud.EnsoSecretAccessDenied
-polyglot java import org.enso.base.enso_cloud.EnsoSecretHelper.EnsoHeader
 polyglot java import org.enso.base.net.URITransformer
 polyglot java import org.enso.base.net.URIWithSecrets
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -12,19 +12,17 @@ import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Errors.Illegal_State.Illegal_State
 import project.Errors.Problem_Behavior.Problem_Behavior
 import project.Meta
+import project.Network.HTTP.Header.Header
 import project.Panic.Panic
 import project.Warning.Warning
 from project.Data.Boolean.Boolean import False, True
 from project.Data.Text.Extensions import all
-from project.Enso_Cloud.Enso_Secret import as_hideable_value
 from project.Error import all
 from project.Nothing import all
 
 polyglot java import java.net.URI as Java_URI
 polyglot java import java.net.URISyntaxException
-polyglot java import java.util.AbstractMap.SimpleEntry as Java_Pair
 polyglot java import org.enso.base.enso_cloud.EnsoSecretAccessDenied
-polyglot java import org.enso.base.enso_cloud.HideableValue
 polyglot java import org.enso.base.net.URITransformer
 polyglot java import org.enso.base.net.URIWithSecrets
 
@@ -245,7 +243,7 @@ type URI
         - `value`: The value of the query parameter.
     add_query_argument : Text -> Text | Enso_Secret -> URI
     add_query_argument self key:Text value:(Text | Enso_Secret) =
-        URI.Value self.internal_uri self.additional_query_parameters+[Pair.new key value]
+        URI.Value self.internal_uri self.additional_query_parameters+[Header.Value key value]
 
     ## ---
        group: Calculations
@@ -348,7 +346,7 @@ type URI
         - `internal_builder`: A Java URI that contains parsed URI data.
         - `additional_query_parameters`: A list of query parameters to add to the
           URI.
-    Value (internal_uri : Java_URI) (additional_query_parameters : Vector (Pair Text (Text | Enso_Secret)))
+    Value (internal_uri : Java_URI) (additional_query_parameters : Vector Header)
 
     ## ---
        private: true
@@ -377,9 +375,7 @@ type URI
        secrets hidden or processed by trusted operations.
     to_java_representation : URIWithSecrets
     to_java_representation self =
-        parameters = self.additional_query_parameters.map p->
-            Java_Pair.new p.first (as_hideable_value p.second factory=HideableValue)
-        URIWithSecrets.new self.internal_uri parameters
+        URIWithSecrets.new self.internal_uri self.additional_query_parameters
 
     ## ---
        private: true

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/URI.enso
@@ -2,7 +2,6 @@ import project.Data.Json.JS_Object
 import project.Data.Numbers.Integer
 import project.Data.Ordering.Comparable
 import project.Data.Ordering.Ordering
-import project.Data.Pair.Pair
 import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Enso_Cloud.Enso_Secret.Enso_Secret
@@ -101,7 +100,7 @@ type URI
        ```
     scheme : Text | Nothing
     scheme self = handle_resolve_errors <|
-        self.to_java_representation.getScheme
+        self.internal_uri.getScheme
 
     ## ---
        group: Metadata
@@ -119,7 +118,7 @@ type URI
        ```
     user_info : Text | Nothing ! Enso_Secret_Error
     user_info self = handle_resolve_errors <|
-        self.to_java_representation.getUserInfo
+        self.internal_uri.getUserInfo
 
     ## ---
        group: Metadata
@@ -137,7 +136,7 @@ type URI
        ```
     host : Text | Nothing
     host self = handle_resolve_errors <|
-        self.to_java_representation.getHost
+        self.internal_uri.getHost
 
     ## ---
        icon: metadata
@@ -154,7 +153,7 @@ type URI
        ```
     authority : Text | Nothing ! Enso_Secret_Error
     authority self = handle_resolve_errors <|
-        self.to_java_representation.getAuthority
+        self.internal_uri.getAuthority
 
     ## ---
        icon: metadata
@@ -171,7 +170,7 @@ type URI
        ```
     port : Integer | Nothing
     port self = handle_resolve_errors <|
-        port_number = self.to_java_representation.getPort
+        port_number = self.internal_uri.getPort
         if port_number == -1 then Nothing else port_number
 
     ## ---
@@ -190,7 +189,7 @@ type URI
        ```
     path : Text | Nothing
     path self = handle_resolve_errors <|
-        self.to_java_representation.getPath
+        self.internal_uri.getPath
 
     ## ---
        group: Operators
@@ -229,7 +228,8 @@ type URI
        ```
     query : Text | Nothing ! Enso_Secret_Error
     query self = handle_resolve_errors <|
-        self.to_java_representation.getQuery
+        java_rep = URIWithSecrets.new self.to_uri_string self.additional_query_parameters
+        java_rep.getQuery
 
     ## ---
        group: Calculations
@@ -269,7 +269,7 @@ type URI
        ```
     fragment : Text | Nothing
     fragment self = handle_resolve_errors <|
-        self.to_java_representation.getFragment
+        self.internal_uri.getFragment
 
     ## ---
        private: true
@@ -278,7 +278,7 @@ type URI
        Get the unescaped user info part of this URI.
     raw_user_info : Text | Nothing ! Enso_Secret_Error
     raw_user_info self = handle_resolve_errors <|
-        self.to_java_representation.getRawUserInfo
+        self.internal_uri.getRawUserInfo
 
     ## ---
        private: true
@@ -287,7 +287,7 @@ type URI
        Get the unescaped authority part of this URI.
     raw_authority : Text | Nothing ! Enso_Secret_Error
     raw_authority self = handle_resolve_errors <|
-        self.to_java_representation.getRawAuthority
+        self.internal_uri.getRawAuthority
 
     ## ---
        private: true
@@ -296,7 +296,7 @@ type URI
        Get the unescaped path part of this URI.
     raw_path : Text | Nothing
     raw_path self = handle_resolve_errors <|
-        self.to_java_representation.getRawPath
+        self.internal_uri.getRawPath
 
     ## ---
        private: true
@@ -305,7 +305,8 @@ type URI
        Get the unescaped query part of this URI.
     raw_query : Text | Nothing ! Enso_Secret_Error
     raw_query self = handle_resolve_errors <|
-        self.to_java_representation.getRawQuery
+        java_rep = URIWithSecrets.new self.to_uri_string self.additional_query_parameters
+        java_rep.getRawQuery
 
     ## ---
        private: true
@@ -314,7 +315,7 @@ type URI
        Get the unescaped fragment part of this URI.
     raw_fragment : Text | Nothing
     raw_fragment self = handle_resolve_errors <|
-        self.to_java_representation.getRawFragment
+        self.internal_uri.getRawFragment
 
     ## ---
        private: true
@@ -322,7 +323,8 @@ type URI
        Convert this URI to text.
     to_text : Text
     to_text self = handle_resolve_errors <|
-        self.to_java_representation.render.toString
+        java_rep = URIWithSecrets.new self.to_uri_string self.additional_query_parameters
+        java_rep.render.toString
 
     ## ---
        private: true
@@ -371,11 +373,9 @@ type URI
     ## ---
        private: true
        ---
-       Creates a Java representation that can be used to render this URL with
-       secrets hidden or processed by trusted operations.
-    to_java_representation : URIWithSecrets
-    to_java_representation self =
-        URIWithSecrets.new self.internal_uri self.additional_query_parameters
+       Gets the internal_uri as a String allowing it to be passed across JVMs.
+    to_uri_string self -> Text =
+        self.internal_uri.toString
 
     ## ---
        private: true
@@ -383,7 +383,8 @@ type URI
        Convert this to a raw Java URI.
     to_java_uri : Java_URI ! Enso_Secret_Error
     to_java_uri self = handle_resolve_errors <|
-        self.to_java_representation.safeResolve
+        java_rep = URIWithSecrets.new self.to_uri_string self.additional_query_parameters
+        java_rep.safeResolve
 
 ## ---
    private: true

--- a/std-bits/aws/src/main/java/org/enso/aws/ClientBuilder.java
+++ b/std-bits/aws/src/main/java/org/enso/aws/ClientBuilder.java
@@ -80,14 +80,14 @@ public class ClientBuilder {
   /**
    * Builds an HttpClient that will sign requests and payloads using the AWSv4 Signature algorithm.
    */
-  public HttpClient createSignedClient(
-      String regionName, String serviceName, String bodySHA256) {
-    var baseClient = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(30))
-        .followRedirects(HttpClient.Redirect.ALWAYS)
-        .proxy(ProxySelector.getDefault())
-        .version(HttpClient.Version.HTTP_2)
-        .build();
+  public HttpClient createSignedClient(String regionName, String serviceName, String bodySHA256) {
+    var baseClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .proxy(ProxySelector.getDefault())
+            .version(HttpClient.Version.HTTP_2)
+            .build();
 
     return new SignedHttpClient(
         regionName, serviceName, unsafeBuildCredentialProvider(), baseClient, bodySHA256);

--- a/std-bits/aws/src/main/java/org/enso/aws/ClientBuilder.java
+++ b/std-bits/aws/src/main/java/org/enso/aws/ClientBuilder.java
@@ -1,6 +1,8 @@
 package org.enso.aws;
 
+import java.net.ProxySelector;
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.function.Supplier;
 import org.enso.aws.regions.AWSRegion;
 import org.enso.base.enso_cloud.ExternalLibrarySecretHelper;
@@ -79,7 +81,14 @@ public class ClientBuilder {
    * Builds an HttpClient that will sign requests and payloads using the AWSv4 Signature algorithm.
    */
   public HttpClient createSignedClient(
-      String regionName, String serviceName, HttpClient baseClient, String bodySHA256) {
+      String regionName, String serviceName, String bodySHA256) {
+    var baseClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(30))
+        .followRedirects(HttpClient.Redirect.ALWAYS)
+        .proxy(ProxySelector.getDefault())
+        .version(HttpClient.Version.HTTP_2)
+        .build();
+
     return new SignedHttpClient(
         regionName, serviceName, unsafeBuildCredentialProvider(), baseClient, bodySHA256);
   }

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoHeader.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoHeader.java
@@ -1,0 +1,12 @@
+package org.enso.base.enso_cloud;
+
+/** An interface for Standard.Base.Network.HTTP.Header.Header can match */
+public interface EnsoHeader {
+  String name();
+
+  EnsoHideableValue hideable_value();
+
+  default HideableValue getValue() {
+    return HideableValue.from(hideable_value());
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoHeader.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoHeader.java
@@ -5,8 +5,4 @@ public interface EnsoHeader {
   String name();
 
   EnsoHideableValue hideable_value();
-
-  default HideableValue getValue() {
-    return HideableValue.from(hideable_value());
-  }
 }

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoRequestBody.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoRequestBody.java
@@ -1,0 +1,54 @@
+package org.enso.base.enso_cloud;
+
+import java.io.FileNotFoundException;
+import java.net.http.HttpRequest;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/** An interface for Standard.Base.Network.HTTP.Request_Body.Request_Body can match */
+public interface EnsoRequestBody {
+  String type_name();
+
+  String text_value();
+
+  String charset();
+
+  byte[] bytes_value();
+
+  static HttpRequest.BodyPublisher build(EnsoRequestBody body)
+      throws FileNotFoundException, UnsupportedOperationException {
+    return switch (body.type_name()) {
+      case "Empty" -> HttpRequest.BodyPublishers.noBody();
+      case "Text" -> {
+        var charsetToUse = body.charset();
+        yield charsetToUse == null
+            ? HttpRequest.BodyPublishers.ofString(body.text_value())
+            : HttpRequest.BodyPublishers.ofString(body.text_value(), Charset.forName(charsetToUse));
+      }
+      case "Json" -> HttpRequest.BodyPublishers.ofString(body.text_value());
+      case "Binary" -> HttpRequest.BodyPublishers.ofFile(Path.of(body.text_value()));
+      case "ByteArray" -> HttpRequest.BodyPublishers.ofByteArray(body.bytes_value());
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot build request body for " + body.type_name());
+    };
+  }
+
+  static byte[] hashInput(EnsoRequestBody body) throws UnsupportedOperationException {
+    return switch (body.type_name()) {
+      case "Empty" -> new byte[0];
+      case "Text" -> {
+        var charsetToUse = body.charset();
+        yield charsetToUse == null
+            ? body.text_value().getBytes(StandardCharsets.UTF_8)
+            : body.text_value().getBytes(Charset.forName(charsetToUse));
+      }
+      case "Json" -> body.text_value().getBytes(StandardCharsets.UTF_8);
+      case "ByteArray" -> body.bytes_value();
+      default ->
+          throw new UnsupportedOperationException(
+              "Hashing a " + body.type_name() + " body is not yet supported.");
+    };
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -59,7 +59,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
                   "Standard.Base.Errors",
                   "Response_Too_Large",
                   "Error",
-                  tl.getActualSize(),
+                  tl.getActualSize() == null ? EnsoMeta.getNothing() : tl.getActualSize(),
                   tl.getLimit());
           default -> null;
         };

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -1,6 +1,5 @@
 package org.enso.base.enso_cloud;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -10,9 +9,6 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -73,54 +69,6 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     return EnsoMeta.asDataflowError(wrappedException);
   }
 
-  /** An interface for Standard.Base.Network.HTTP.Request_Body.Request_Body can match */
-  public interface EnsoRequestBody {
-    String type_name();
-
-    String text_value();
-
-    String charset();
-
-    byte[] bytes_value();
-
-    static HttpRequest.BodyPublisher build(EnsoRequestBody body)
-        throws FileNotFoundException, UnsupportedOperationException {
-      return switch (body.type_name()) {
-        case "Empty" -> HttpRequest.BodyPublishers.noBody();
-        case "Text" -> {
-          var charsetToUse = body.charset();
-          yield charsetToUse == null
-              ? HttpRequest.BodyPublishers.ofString(body.text_value())
-              : HttpRequest.BodyPublishers.ofString(
-                  body.text_value(), Charset.forName(charsetToUse));
-        }
-        case "Json" -> HttpRequest.BodyPublishers.ofString(body.text_value());
-        case "Binary" -> HttpRequest.BodyPublishers.ofFile(Path.of(body.text_value()));
-        case "ByteArray" -> HttpRequest.BodyPublishers.ofByteArray(body.bytes_value());
-        default ->
-            throw new UnsupportedOperationException(
-                "Cannot build request body for " + body.type_name());
-      };
-    }
-
-    static byte[] hashInput(EnsoRequestBody body) throws UnsupportedOperationException {
-      return switch (body.type_name()) {
-        case "Empty" -> new byte[0];
-        case "Text" -> {
-          var charsetToUse = body.charset();
-          yield charsetToUse == null
-              ? body.text_value().getBytes(StandardCharsets.UTF_8)
-              : body.text_value().getBytes(Charset.forName(charsetToUse));
-        }
-        case "Json" -> body.text_value().getBytes(StandardCharsets.UTF_8);
-        case "ByteArray" -> body.bytes_value();
-        default ->
-            throw new UnsupportedOperationException(
-                "Hashing a " + body.type_name() + " body is not yet supported.");
-      };
-    }
-  }
-
   public static Value resolveBody(EnsoRequestBody body, Function<byte[], String> hashFunction) {
     try {
       var publisher = EnsoRequestBody.build(body);
@@ -134,17 +82,6 @@ public final class EnsoSecretHelper extends SecretValueResolver {
           hash);
     } catch (Exception e) {
       return handleRequestException(e);
-    }
-  }
-
-  /** An interface for Standard.Base.Network.HTTP.Header.Header can match */
-  public interface EnsoHeader {
-    String name();
-
-    EnsoHideableValue hideable_value();
-
-    default HideableValue getValue() {
-      return HideableValue.from(hideable_value());
     }
   }
 

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -118,7 +118,10 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     try {
       var resolvedQueryParameters =
           queryParameters.stream()
-              .map(p -> new AbstractMap.SimpleEntry<>(p.name(), resolveValue(HideableValue.from(p.hideable_value()))))
+              .map(
+                  p ->
+                      new AbstractMap.SimpleEntry<>(
+                          p.name(), resolveValue(HideableValue.from(p.hideable_value()))))
               .toList();
       var resolvedSchematic = new URISchematic(URI.create(baseUri), resolvedQueryParameters);
       return resolvedSchematic.build();
@@ -225,7 +228,9 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     @Override
     public EnsoHttpResponse makeRequest() throws IOException, InterruptedException {
       boolean hasSecrets =
-          uri.containsSecrets() || headers.stream().anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
+          uri.containsSecrets()
+              || headers.stream()
+                  .anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
       if (hasSecrets) {
         if (resolvedURI.getScheme() == null) {
           throw new IllegalArgumentException("The URI must have a scheme.");

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -91,13 +91,15 @@ public final class EnsoSecretHelper extends SecretValueResolver {
           var charsetToUse = body.charset();
           yield charsetToUse == null
               ? HttpRequest.BodyPublishers.ofString(body.text_value())
-              : HttpRequest.BodyPublishers.ofString(body.text_value(), Charset.forName(charsetToUse));
+              : HttpRequest.BodyPublishers.ofString(
+                  body.text_value(), Charset.forName(charsetToUse));
         }
         case "Json" -> HttpRequest.BodyPublishers.ofString(body.text_value());
         case "Binary" -> HttpRequest.BodyPublishers.ofFile(Path.of(body.text_value()));
         case "ByteArray" -> HttpRequest.BodyPublishers.ofByteArray(body.bytes_value());
         default ->
-            throw new UnsupportedOperationException("Cannot build request body for " + body.type_name());
+            throw new UnsupportedOperationException(
+                "Cannot build request body for " + body.type_name());
       };
     }
 
@@ -124,7 +126,12 @@ public final class EnsoSecretHelper extends SecretValueResolver {
       var publisher = EnsoRequestBody.build(body);
       var hash = hashFunction == null ? "" : hashFunction.apply(EnsoRequestBody.hashInput(body));
       return EnsoMeta.makeInstance(
-          "Standard.Base.Network.HTTP", "Resolved_Body", "Value", publisher, EnsoMeta.getNothing(), hash);
+          "Standard.Base.Network.HTTP",
+          "Resolved_Body",
+          "Value",
+          publisher,
+          EnsoMeta.getNothing(),
+          hash);
     } catch (Exception e) {
       return handleRequestException(e);
     }
@@ -170,13 +177,13 @@ public final class EnsoSecretHelper extends SecretValueResolver {
    * Gets the actual URI with all secrets resolved, so that it can be used to create a request. This
    * value should never be returned to Enso.
    */
-  private static URI resolveURI(URIWithSecrets uri) {
+  private static URI resolveURI(String baseUri, List<EnsoHeader> queryParameters) {
     try {
       var resolvedQueryParameters =
-          uri.queryParameters().stream()
+          queryParameters.stream()
               .map(p -> new AbstractMap.SimpleEntry<>(p.name(), resolveValue(p.getValue())))
               .toList();
-      var resolvedSchematic = new URISchematic(uri.baseUri(), resolvedQueryParameters);
+      var resolvedSchematic = new URISchematic(URI.create(baseUri), resolvedQueryParameters);
       return resolvedSchematic.build();
     } catch (URISyntaxException e) {
       // Here we don't display the message of the exception to avoid risking it may leak any
@@ -184,7 +191,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
       // This should never happen in practice.
       throw new IllegalStateException(
           "Unexpectedly unable to build a valid URI from the base URI: "
-              + uri
+              + baseUri
               + ": "
               + e.getClass().getCanonicalName());
     }
@@ -195,11 +202,13 @@ public final class EnsoSecretHelper extends SecretValueResolver {
       HttpClient client,
       String method,
       HttpRequest.BodyPublisher body,
-      URIWithSecrets uri,
+      String baseUri,
+      List<EnsoHeader> queryParameters,
       List<EnsoHeader> headers,
       boolean useCache) {
     try {
-      var response = makeRequestInternal(client, method, body, uri, headers, useCache);
+      var response =
+          makeRequestInternal(client, method, body, baseUri, queryParameters, headers, useCache);
       return Value.asValue(response);
     } catch (Exception e) {
       return handleRequestException(e);
@@ -210,7 +219,8 @@ public final class EnsoSecretHelper extends SecretValueResolver {
       HttpClient client,
       String method,
       HttpRequest.BodyPublisher body,
-      URIWithSecrets uri,
+      String baseUri,
+      List<EnsoHeader> queryParameters,
       List<EnsoHeader> headers,
       boolean useCache)
       throws IllegalArgumentException,
@@ -221,7 +231,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     var builder = HttpRequest.newBuilder().method(method, body);
 
     // Build a new URI with the query arguments.
-    URI resolvedURI = resolveURI(uri);
+    URI resolvedURI = resolveURI(baseUri, queryParameters);
 
     var resolvedHeaders =
         headers.stream()
@@ -233,7 +243,13 @@ public final class EnsoSecretHelper extends SecretValueResolver {
             .toList();
 
     var requestMaker =
-        new RequestMaker(client, builder, uri, resolvedURI, headers, resolvedHeaders);
+        new RequestMaker(
+            client,
+            builder,
+            new URIWithSecrets(baseUri, queryParameters),
+            resolvedURI,
+            headers,
+            resolvedHeaders);
 
     if (!useCache) {
       return requestMaker.makeRequest();

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -1,13 +1,18 @@
 package org.enso.base.enso_cloud;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -19,14 +24,123 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import org.enso.base.cache.ReloadDetector;
 import org.enso.base.cache.ResponseTooLargeException;
 import org.enso.base.net.URISchematic;
 import org.enso.base.net.URIWithSecrets;
+import org.enso.base.polyglot.EnsoMeta;
+import org.graalvm.polyglot.Value;
 
 /** Makes HTTP requests with secrets in either header or query string. */
 public final class EnsoSecretHelper extends SecretValueResolver {
+  private static Value handleRequestException(Exception e) {
+    var wrappedException =
+        switch (e) {
+          case UnsupportedOperationException unsupportedOperationException ->
+              EnsoMeta.makeInstance(
+                  "Standard.Base.Errors.Unimplemented",
+                  "Unimplemented",
+                  "Error",
+                  unsupportedOperationException.getMessage());
+          case IllegalArgumentException argException ->
+              EnsoMeta.makeInstance(
+                  "Standard.Base.Errors.Illegal_Argument",
+                  "Illegal_Argument",
+                  "Error",
+                  argException.getMessage(),
+                  argException);
+          case IOException _ ->
+              EnsoMeta.makeInstance(
+                  "Standard.Base.Network.HTTP",
+                  "Request_Error",
+                  "Error",
+                  e.getClass().getCanonicalName(),
+                  e.getMessage());
+          case ResponseTooLargeException tl ->
+              EnsoMeta.makeInstance(
+                  "Standard.Base.Errors",
+                  "Response_Too_Large",
+                  "Error",
+                  tl.getActualSize(),
+                  tl.getLimit());
+          default -> null;
+        };
+    if (wrappedException == null) {
+      throw new RuntimeException(e);
+    }
+    return EnsoMeta.asDataflowError(wrappedException);
+  }
+
+  /** An interface for Standard.Base.Network.HTTP.Request_Body.Request_Body can match */
+  public interface EnsoRequestBody {
+    String type_name();
+
+    String text_value();
+
+    String charset();
+
+    byte[] bytes_value();
+
+    static HttpRequest.BodyPublisher build(EnsoRequestBody body)
+        throws FileNotFoundException, UnsupportedOperationException {
+      return switch (body.type_name()) {
+        case "Empty" -> HttpRequest.BodyPublishers.noBody();
+        case "Text" -> {
+          var charsetToUse = body.charset();
+          yield charsetToUse == null
+              ? HttpRequest.BodyPublishers.ofString(body.text_value())
+              : HttpRequest.BodyPublishers.ofString(body.text_value(), Charset.forName(charsetToUse));
+        }
+        case "Json" -> HttpRequest.BodyPublishers.ofString(body.text_value());
+        case "Binary" -> HttpRequest.BodyPublishers.ofFile(Path.of(body.text_value()));
+        case "ByteArray" -> HttpRequest.BodyPublishers.ofByteArray(body.bytes_value());
+        default ->
+            throw new UnsupportedOperationException("Cannot build request body for " + body.type_name());
+      };
+    }
+
+    static byte[] hashInput(EnsoRequestBody body) throws UnsupportedOperationException {
+      return switch (body.type_name()) {
+        case "Empty" -> new byte[0];
+        case "Text" -> {
+          var charsetToUse = body.charset();
+          yield charsetToUse == null
+              ? body.text_value().getBytes(StandardCharsets.UTF_8)
+              : body.text_value().getBytes(Charset.forName(charsetToUse));
+        }
+        case "Json" -> body.text_value().getBytes(StandardCharsets.UTF_8);
+        case "ByteArray" -> body.bytes_value();
+        default ->
+            throw new UnsupportedOperationException(
+                "Hashing a " + body.type_name() + " body is not yet supported.");
+      };
+    }
+  }
+
+  public static Value resolveBody(EnsoRequestBody body, Function<byte[], String> hashFunction) {
+    try {
+      var publisher = EnsoRequestBody.build(body);
+      var hash = hashFunction == null ? "" : hashFunction.apply(EnsoRequestBody.hashInput(body));
+      return EnsoMeta.makeInstance(
+          "Standard.Base.Network.HTTP", "Resolved_Body", "Value", publisher, EnsoMeta.getNothing(), hash);
+    } catch (Exception e) {
+      return handleRequestException(e);
+    }
+  }
+
+  /** An interface for Standard.Base.Network.HTTP.Header.Header can match */
+  public interface EnsoHeader {
+    String name();
+
+    EnsoHideableValue hideable_value();
+
+    default HideableValue getValue() {
+      return HideableValue.from(hideable_value());
+    }
+  }
+
   private static EnsoHTTPResponseCache cache;
 
   /**
@@ -60,7 +174,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     try {
       var resolvedQueryParameters =
           uri.queryParameters().stream()
-              .map(p -> new AbstractMap.SimpleEntry<>(p.getKey(), resolveValue(p.getValue())))
+              .map(p -> new AbstractMap.SimpleEntry<>(p.name(), resolveValue(p.getValue())))
               .toList();
       var resolvedSchematic = new URISchematic(uri.baseUri(), resolvedQueryParameters);
       return resolvedSchematic.build();
@@ -77,18 +191,34 @@ public final class EnsoSecretHelper extends SecretValueResolver {
   }
 
   /** Makes a request with secrets in the query string or headers. * */
-  public static EnsoHttpResponse makeRequest(
+  public static Value makeRequest(
       HttpClient client,
-      Builder origBuilder,
+      String method,
+      HttpRequest.BodyPublisher body,
       URIWithSecrets uri,
-      List<Map.Entry<String, HideableValue>> headers,
+      List<EnsoHeader> headers,
+      boolean useCache) {
+    try {
+      var response = makeRequestInternal(client, method, body, uri, headers, useCache);
+      return Value.asValue(response);
+    } catch (Exception e) {
+      return handleRequestException(e);
+    }
+  }
+
+  private static EnsoHttpResponse makeRequestInternal(
+      HttpClient client,
+      String method,
+      HttpRequest.BodyPublisher body,
+      URIWithSecrets uri,
+      List<EnsoHeader> headers,
       boolean useCache)
       throws IllegalArgumentException,
           IOException,
           InterruptedException,
           ResponseTooLargeException {
     // Clone incoming builder so we can't leak secrets through it
-    var builder = origBuilder.copy();
+    var builder = HttpRequest.newBuilder().method(method, body);
 
     // Build a new URI with the query arguments.
     URI resolvedURI = resolveURI(uri);
@@ -96,9 +226,9 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     var resolvedHeaders =
         headers.stream()
             .map(
-                pair -> {
+                header -> {
                   return new AbstractMap.SimpleEntry<>(
-                      pair.getKey(), resolveValue(pair.getValue()));
+                      header.name(), resolveValue(header.getValue()));
                 })
             .toList();
 
@@ -121,7 +251,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     private final Builder builder;
     private final URIWithSecrets uri;
     private final URI resolvedURI;
-    private final List<? extends Map.Entry<String, HideableValue>> headers;
+    private final List<EnsoHeader> headers;
     private final List<? extends Map.Entry<String, String>> resolvedHeaders;
 
     RequestMaker(
@@ -129,7 +259,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
         Builder builder,
         URIWithSecrets uri,
         URI resolvedURI,
-        List<? extends Map.Entry<String, HideableValue>> headers,
+        List<EnsoHeader> headers,
         List<? extends Map.Entry<String, String>> resolvedHeaders) {
       this.client = client;
       this.builder = builder;

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -56,10 +56,10 @@ public final class EnsoSecretHelper extends SecretValueResolver {
                   e.getMessage());
           case ResponseTooLargeException tl ->
               EnsoMeta.makeInstance(
-                  "Standard.Base.Errors",
+                  "Standard.Base.Errors.Common",
                   "Response_Too_Large",
                   "Error",
-                  tl.getActualSize() == null ? EnsoMeta.getNothing() : tl.getActualSize(),
+                  tl.getActualSize(),
                   tl.getLimit());
           default -> null;
         };

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -118,7 +118,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     try {
       var resolvedQueryParameters =
           queryParameters.stream()
-              .map(p -> new AbstractMap.SimpleEntry<>(p.name(), resolveValue(p.getValue())))
+              .map(p -> new AbstractMap.SimpleEntry<>(p.name(), resolveValue(HideableValue.from(p.hideable_value()))))
               .toList();
       var resolvedSchematic = new URISchematic(URI.create(baseUri), resolvedQueryParameters);
       return resolvedSchematic.build();
@@ -175,7 +175,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
             .map(
                 header -> {
                   return new AbstractMap.SimpleEntry<>(
-                      header.name(), resolveValue(header.getValue()));
+                      header.name(), resolveValue(HideableValue.from(header.hideable_value())));
                 })
             .toList();
 
@@ -225,7 +225,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
     @Override
     public EnsoHttpResponse makeRequest() throws IOException, InterruptedException {
       boolean hasSecrets =
-          uri.containsSecrets() || headers.stream().anyMatch(p -> p.getValue().containsSecrets());
+          uri.containsSecrets() || headers.stream().anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
       if (hasSecrets) {
         if (resolvedURI.getScheme() == null) {
           throw new IllegalArgumentException("The URI must have a scheme.");

--- a/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
+++ b/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
@@ -27,7 +27,10 @@ public class URIWithSecrets {
   public URISchematic makeSchematicForRender() {
     var renderedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), HideableValue.from(p.hideable_value()).render()))
+            .map(
+                p ->
+                    new AbstractMap.SimpleEntry<>(
+                        p.name(), HideableValue.from(p.hideable_value()).render()))
             .toList();
     return new URISchematic(baseUri, renderedParameters);
   }
@@ -53,13 +56,17 @@ public class URIWithSecrets {
   }
 
   public boolean containsSecrets() {
-    return queryParameters.stream().anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
+    return queryParameters.stream()
+        .anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
   }
 
   private URISchematic makeSchematicForSafeResolve() {
     var resolvedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), HideableValue.from(p.hideable_value()).safeResolve()))
+            .map(
+                p ->
+                    new AbstractMap.SimpleEntry<>(
+                        p.name(), HideableValue.from(p.hideable_value()).safeResolve()))
             .toList();
     return new URISchematic(baseUri, resolvedParameters);
   }

--- a/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
+++ b/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.List;
 import org.enso.base.enso_cloud.EnsoHeader;
+import org.enso.base.enso_cloud.HideableValue;
 
 /**
  * A structure representing a URI that contains parts which may need to be updated once data from
@@ -26,7 +27,7 @@ public class URIWithSecrets {
   public URISchematic makeSchematicForRender() {
     var renderedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), p.getValue().render()))
+            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), HideableValue.from(p.hideable_value()).render()))
             .toList();
     return new URISchematic(baseUri, renderedParameters);
   }
@@ -52,13 +53,13 @@ public class URIWithSecrets {
   }
 
   public boolean containsSecrets() {
-    return queryParameters.stream().anyMatch(p -> p.getValue().containsSecrets());
+    return queryParameters.stream().anyMatch(p -> HideableValue.from(p.hideable_value()).containsSecrets());
   }
 
   private URISchematic makeSchematicForSafeResolve() {
     var resolvedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), p.getValue().safeResolve()))
+            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), HideableValue.from(p.hideable_value()).safeResolve()))
             .toList();
     return new URISchematic(baseUri, resolvedParameters);
   }

--- a/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
+++ b/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.List;
-import org.enso.base.enso_cloud.EnsoSecretHelper;
+import org.enso.base.enso_cloud.EnsoHeader;
 
 /**
  * A structure representing a URI that contains parts which may need to be updated once data from
@@ -15,9 +15,9 @@ import org.enso.base.enso_cloud.EnsoSecretHelper;
  */
 public class URIWithSecrets {
   private final URI baseUri;
-  private final List<EnsoSecretHelper.EnsoHeader> queryParameters;
+  private final List<EnsoHeader> queryParameters;
 
-  public URIWithSecrets(String baseUri, List<EnsoSecretHelper.EnsoHeader> queryParameters) {
+  public URIWithSecrets(String baseUri, List<EnsoHeader> queryParameters) {
     this.baseUri = URI.create(baseUri);
     this.queryParameters = queryParameters;
   }

--- a/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
+++ b/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
@@ -13,7 +13,15 @@ import org.enso.base.enso_cloud.EnsoSecretHelper;
  * <p>The query parameters are stored separately, because they may contain secrets and will only be
  * resolved to plain values within {@link org.enso.base.enso_cloud.EnsoSecretHelper}.
  */
-public record URIWithSecrets(URI baseUri, List<EnsoSecretHelper.EnsoHeader> queryParameters) {
+public class URIWithSecrets {
+  private final URI baseUri;
+  private final List<EnsoSecretHelper.EnsoHeader> queryParameters;
+
+  public URIWithSecrets(String baseUri, List<EnsoSecretHelper.EnsoHeader> queryParameters) {
+    this.baseUri = URI.create(baseUri);
+    this.queryParameters = queryParameters;
+  }
+
   /** Creates a schematic that does not disclose secret values and can be returned to the user. */
   public URISchematic makeSchematicForRender() {
     var renderedParameters =
@@ -62,7 +70,7 @@ public record URIWithSecrets(URI baseUri, List<EnsoSecretHelper.EnsoHeader> quer
   private URI forAuthorityPart() {
     // We can ignore secrets in the query part, because they are not used for resolving the
     // authority.
-    return new URIWithSecrets(baseUri, List.of()).safeResolve();
+    return new URIWithSecrets(baseUri.toString(), List.of()).safeResolve();
   }
 
   public String getUserInfo() {

--- a/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
+++ b/std-bits/base/src/main/java/org/enso/base/net/URIWithSecrets.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.List;
-import java.util.Map;
-import org.enso.base.enso_cloud.HideableValue;
+import org.enso.base.enso_cloud.EnsoSecretHelper;
 
 /**
  * A structure representing a URI that contains parts which may need to be updated once data from
@@ -14,13 +13,12 @@ import org.enso.base.enso_cloud.HideableValue;
  * <p>The query parameters are stored separately, because they may contain secrets and will only be
  * resolved to plain values within {@link org.enso.base.enso_cloud.EnsoSecretHelper}.
  */
-public record URIWithSecrets(URI baseUri, List<Map.Entry<String, HideableValue>> queryParameters) {
-
+public record URIWithSecrets(URI baseUri, List<EnsoSecretHelper.EnsoHeader> queryParameters) {
   /** Creates a schematic that does not disclose secret values and can be returned to the user. */
   public URISchematic makeSchematicForRender() {
     var renderedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.getKey(), p.getValue().render()))
+            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), p.getValue().render()))
             .toList();
     return new URISchematic(baseUri, renderedParameters);
   }
@@ -52,7 +50,7 @@ public record URIWithSecrets(URI baseUri, List<Map.Entry<String, HideableValue>>
   private URISchematic makeSchematicForSafeResolve() {
     var resolvedParameters =
         queryParameters.stream()
-            .map(p -> new AbstractMap.SimpleEntry<>(p.getKey(), p.getValue().safeResolve()))
+            .map(p -> new AbstractMap.SimpleEntry<>(p.name(), p.getValue().safeResolve()))
             .toList();
     return new URISchematic(baseUri, resolvedParameters);
   }

--- a/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/proxy-config.json
+++ b/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/proxy-config.json
@@ -1,9 +1,7 @@
 [
     {
         "interfaces": [
-            "org.enso.base.enso_cloud.AuthenticationProvider$AuthenticationService",
-            "org.enso.base.enso_cloud.EnsoSecretHelper$EnsoHeader",
-            "org.enso.base.enso_cloud.EnsoSecretHelper$EnsoRequestBody"
+            "org.enso.base.enso_cloud.AuthenticationProvider$AuthenticationService"
         ]
     }
 ]

--- a/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/proxy-config.json
+++ b/std-bits/base/src/main/resources/META-INF/native-image/org/enso/base/proxy-config.json
@@ -1,7 +1,9 @@
 [
     {
         "interfaces": [
-            "org.enso.base.enso_cloud.AuthenticationProvider$AuthenticationService"
+            "org.enso.base.enso_cloud.AuthenticationProvider$AuthenticationService",
+            "org.enso.base.enso_cloud.EnsoSecretHelper$EnsoHeader",
+            "org.enso.base.enso_cloud.EnsoSecretHelper$EnsoRequestBody"
         ]
     }
 ]


### PR DESCRIPTION
### Pull Request Description

Resolve issue with AWS signed post and fetch following dual JVM changes.
- Enso `Header` now implements `EnsoHeader` interface allowing it to be proxied.
- Enso `Request_Body` now implement `EnsoRequestBody` interface allowing it to be proxied.
- `URIWithSecrets` is now built from a `String` (of the base URI) and a `List<EnsoHeader>` allowing to come from any where.
- `EnsoSecretHelper` is now the main Java code for executing web requests.
  - Handles resolving a `Request_Body` into a `Resolved_Body` with a `BodyPublisher` (ensures comes from same JVM).
  - Handles and wraps exceptions as Enso errors.
  - `makeRequest` now does all the request building work and keeps more of it internal.
- AWS passes it's reference of `EnsoSecretHelper` to `with_hash_and_client`.
 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
