### PR TITLE
Even less logging in `enso-language-server*.log`

### DIFF
--- a/docs/infrastructure/logging.md
+++ b/docs/infrastructure/logging.md
@@ -31,6 +31,7 @@ problems, but don't overload by too much logging. The system allows to
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 
 - [User config](#user-config)
+  - [IDE Config](#ide-config)
 - [Configuration in Code](#configuration-in-code)
   - [Custom Log Levels](#custom-log-levels)
   - [Appenders](#appenders)
@@ -69,6 +70,17 @@ refer to the _FQN_ of the logger - e.g. usually the package elements and class
 name. The `debug` value (or other) shall represent a valid level name. System
 properties always take priority over any default values defined in embedded
 `application.conf` file (see [custom Log Levels](#custom-log-levels) section).
+
+### IDE Config
+
+When running the IDE one can configure the logging using the same arguments, but
+providing them via `ENSO_ENGINE_ARGS` environment variable:
+
+```bash
+enso$ ENSO_ENGINE_ARGS="--log-level debug" corepack pnpm run dev:gui
+```
+
+Turns the `DEBUG` verbosity on.
 
 ## Configuration in Code
 

--- a/engine/language-server/src/main/resources/application-ls.conf
+++ b/engine/language-server/src/main/resources/application-ls.conf
@@ -42,9 +42,6 @@ logging-service {
     org.eclipse.jgit = error
     # Log levels to limit during very verbose setting
     org.enso.interpreter.epb.HostClassLoader = error
-    org.enso.jsonrpc.JsonRpcServer = debug
-    org.enso.languageserver.protocol.json.JsonConnectionController = debug
-    org.enso.languageserver.runtime.RuntimeConnector = debug
     org.enso.ydoc.polyfill.web = warn
     org.enso.ydoc.polyfill.ParserPolyfill = warn
     org.enso.persist = warn
@@ -72,7 +69,7 @@ logging-service {
     log-to-file {
       enable = true
       enable = ${?ENSO_LOGSERVER_LOG_TO_FILE}
-      log-level = debug
+      log-level = info
       log-level = ${?ENSO_LOGSERVER_LOG_TO_FILE_LOG_LEVEL}
     }
     appenders = [ # file/console/socket/telemetry/opensearch
@@ -91,7 +88,7 @@ logging-service {
           uri = ${?ENSO_CLOUD_API_URL}
           log-connection-failures = false
           log-connection-failures = ${?ENSO_LOGSERVER_LOG_ERRORS}
-          log-level = debug
+          log-level = info
           log-level = ${?ENSO_LOGSERVER_REMOTE_LOG_LEVEL}
           enabled = true
           enabled = ${?ENSO_OPENSEARCH_APPENDER_ENABLED}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -87,7 +87,7 @@ import scala.concurrent.duration.DurationInt
 class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
 
   private val log = LoggerFactory.getLogger(this.getClass)
-  log.debug(
+  log.info(
     "Initializing main module of the Language Server from [{}, {}, {}]",
     BuildVersion.currentEdition,
     serverConfig,


### PR DESCRIPTION
### Pull Request Description

- continuation of #14895 
- avoid `debug` messages in the language server log by default
- use `ENSO_ENGINE_ARGS="--log-level debug" ./enso-linux-*.AppImage` to see more

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Changelog already updated in #14895
