### PR TITLE
Collect ObservedMessages and dump them on test failure

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -31,7 +31,8 @@ class RuntimeAsyncCommandsTest
     with Matchers
     with BeforeAndAfterEach
     with DebugSpec
-    with FlakySpec {
+    with FlakySpec
+    with org.enso.testkit.ReportLogsOnFailure {
 
   // === Test Utilities =======================================================
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -23,7 +23,8 @@ import java.util.logging.ConsoleHandler
 class RuntimeErrorsTest
     extends AnyFlatSpec
     with Matchers
-    with BeforeAndAfterEach {
+    with BeforeAndAfterEach
+    with org.enso.testkit.ReportLogsOnFailure {
 
   // === Test Utilities =======================================================
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -26,7 +26,8 @@ import java.util.UUID
 class RuntimeServerTest
     extends AnyFlatSpec
     with Matchers
-    with BeforeAndAfterEach {
+    with BeforeAndAfterEach
+    with org.enso.testkit.ReportLogsOnFailure {
 
   // === Test Utilities =======================================================
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -19,7 +19,10 @@ import java.util.UUID
 import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
-class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
+class RuntimeVisualizationsTest
+    extends AnyFlatSpec
+    with Matchers
+    with org.enso.testkit.ReportLogsOnFailure {
 
   // === Test Utilities =======================================================
 

--- a/lib/scala/logging-utils/src/main/java/org/enso/logger/ObservedMessage.java
+++ b/lib/scala/logging-utils/src/main/java/org/enso/logger/ObservedMessage.java
@@ -115,6 +115,11 @@ public final class ObservedMessage {
     return formattedMsg.get();
   }
 
+  @Override
+  public String toString() {
+    return "[" + level + "] [" + instant + "] " + getFormattedMessage();
+  }
+
   /**
    * Provides <em>observing capabilities</em> to used logging infrastructure. Different
    * implementations of {@link Logger} have different ways of being <em>observed</em>. If one is

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/ReportLogsOnFailure.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/ReportLogsOnFailure.scala
@@ -1,42 +1,21 @@
 package org.enso.testkit
 
-import org.scalatest.{Args, Failed, Outcome, Status, TestSuite}
+import org.scalatest.{Failed, Outcome, TestSuite}
 import org.enso.logger.ObservedMessage
+import org.slf4j.LoggerFactory
+import org.slf4j.Logger
 
 trait ReportLogsOnFailure extends TestSuite {
 
-  abstract override protected def runTest(
-    testName: String,
-    args: Args
-  ): Status = {
-    val log    = org.slf4j.LoggerFactory.getLogger("org")
-    val ps     = System.out
-    val arr    = new java.util.ArrayList[ObservedMessage]()
-    val handle = ObservedMessage.observe(log, arr.add(_))
-    try {
-      super.runTest(testName, args)
-    } catch {
-      case e: Throwable =>
-        arr.forEach {
-          ps.println(_)
-        }
-        throw e
-    } finally {
-      arr.clear()
-      handle.close()
-    }
-  }
-
   abstract override def withFixture(test: NoArgTest): Outcome = {
-    val log    = org.slf4j.LoggerFactory.getLogger("org")
-    val ps     = System.out
+    val log    = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
     val arr    = new java.util.ArrayList[ObservedMessage]()
     val handle = ObservedMessage.observe(log, arr.add(_))
     try {
       super.withFixture(test) match {
         case outcome @ Failed(_) =>
           arr.forEach {
-            ps.println(_)
+            System.out.println(_)
           }
           outcome
         case outcome =>

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/ReportLogsOnFailure.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/ReportLogsOnFailure.scala
@@ -1,51 +1,50 @@
 package org.enso.testkit
 
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.Appender
-import org.enso.logging.service.logback.MemoryAppender
 import org.scalatest.{Args, Failed, Outcome, Status, TestSuite}
-import org.slf4j.{Logger, LoggerFactory}
+import org.enso.logger.ObservedMessage
 
 trait ReportLogsOnFailure extends TestSuite {
-
-  private lazy val appender: Appender[ILoggingEvent] = {
-    val ctx = LoggerFactory.getILoggerFactory;
-    val rootLogger = ctx
-      .getLogger(Logger.ROOT_LOGGER_NAME)
-      .asInstanceOf[ch.qos.logback.classic.Logger]
-    rootLogger.getAppender(MemoryAppender.NAME)
-  }
 
   abstract override protected def runTest(
     testName: String,
     args: Args
   ): Status = {
-    appender match {
-      case memoryAppender: MemoryAppender =>
-        memoryAppender.stopForwarding()
-        super.runTest(testName, args)
-      case _ =>
-        super.runTest(testName, args)
+    val log    = org.slf4j.LoggerFactory.getLogger("org")
+    val ps     = System.out
+    val arr    = new java.util.ArrayList[ObservedMessage]()
+    val handle = ObservedMessage.observe(log, arr.add(_))
+    try {
+      super.runTest(testName, args)
+    } catch {
+      case e: Throwable =>
+        arr.forEach {
+          ps.println(_)
+        }
+        throw e
+    } finally {
+      arr.clear()
+      handle.close()
     }
-
   }
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
-    appender match {
-      case memoryAppender: MemoryAppender =>
-        try {
-          super.withFixture(test) match {
-            case outcome @ Failed(_) =>
-              memoryAppender.flush()
-              outcome
-            case outcome =>
-              outcome
+    val log    = org.slf4j.LoggerFactory.getLogger("org")
+    val ps     = System.out
+    val arr    = new java.util.ArrayList[ObservedMessage]()
+    val handle = ObservedMessage.observe(log, arr.add(_))
+    try {
+      super.withFixture(test) match {
+        case outcome @ Failed(_) =>
+          arr.forEach {
+            ps.println(_)
           }
-        } finally {
-          memoryAppender.reset()
-        }
-      case _ =>
-        super.withFixture(test)
+          outcome
+        case outcome =>
+          outcome
+      }
+    } finally {
+      arr.clear()
+      handle.close()
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

- requested by #12725 
- inspired by work in #13721, but ...
- ...using `ObservedMessage` as #13308 suggests
- one has to **opt-in** by adding `with org.enso.testkit.ReportLogsOnFailure` like:
```scala
package org.enso.polyglot.test

class Slf4jTest extends org.scalatest.flatspec.AnyFlatSpec with org.enso.testkit.ReportLogsOnFailure {

  private val logger = org.slf4j.LoggerFactory.getLogger(this.getClass)

  it should "boo" in {
    val l = logger;
    l.error("Boo!")
   if (false) throw new IllegalStateException("OK");
  }
}
```
- such a test doesn't log anything when it succeeds
- but when it fails it [dumps all messages logged](https://github.com/enso-org/enso/pull/14932#discussion_r3023369593) during its execution
- most prominent Scala tests were modified to **opt-in**, other tests can be added on an incremental basis when needed

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
