### PR TITLE
Avoid unnecessary recalculation when editing autoscope constructors

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/ChangesetBuilder.scala
@@ -437,8 +437,13 @@ object ChangesetBuilder {
     * @return the tree representation of the IR
     */
   private def buildTree(ir: IR): Tree = {
+    // `Name.MethodReference` is the IR representation of autoscope construtors
+    // and its children has no DataflowAnalysis dependents and threfore should
+    // not be analyzed. Otherwise the algorithm will fallback to dynamic search
+    // in `toDataflowDependencyTypes` invalidating all expressions with this symbol
+    def isAtomicName(ir: IR): Boolean = ir.isInstanceOf[Name.MethodReference]
     def depthFirstSearch(currentIr: IR, acc: Tree, isBinding: Boolean): Unit = {
-      if (currentIr.children.isEmpty) {
+      if (currentIr.children.isEmpty || isAtomicName(currentIr)) {
         Node.fromIr(currentIr, isBinding).foreach(acc.add)
       } else {
         val hasImportantId = currentIr.getExternalId.nonEmpty

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.enso.compiler.Passes;
@@ -117,6 +118,41 @@ public class ChangesetBuilderComputeTest {
   private String rawCode(String code) {
     int idx = code.indexOf("\n\n\n#### METADATA ####\n");
     return idx >= 0 ? code.substring(0, idx) : code;
+  }
+
+  /**
+   * Finds the {@link Range} of all occurrences of {@code expression} in {@code code}. Fails the
+   * test if the expression is not found.
+   */
+  private List<Range> findPositions(String code, String expression) {
+    var positions = new ArrayList<Range>();
+    int idx = code.indexOf(expression);
+    while (idx != -1) {
+      int line = 0;
+      int col = 0;
+      for (int i = 0; i < idx; i++) {
+        if (code.charAt(i) == '\n') {
+          line++;
+          col = 0;
+        } else {
+          col++;
+        }
+      }
+      int endLine = line;
+      int endCol = col;
+      for (int i = 0; i < expression.length(); i++) {
+        if (expression.charAt(i) == '\n') {
+          endLine++;
+          endCol = 0;
+        } else {
+          endCol++;
+        }
+      }
+      positions.add(new Range(new Position(line, col), new Position(endLine, endCol)));
+      idx = code.indexOf(expression, idx + 1);
+    }
+    assertFalse("Expression '" + expression + "' not found in code", positions.isEmpty());
+    return positions;
   }
 
   /**
@@ -550,7 +586,7 @@ public class ChangesetBuilderComputeTest {
     var code = addMetadata(rawCode);
     var ir = preprocessModule(code);
 
-    var edit = new TextEdit(new Range(new Position(11, 34), new Position(11, 37)), "..B");
+    var edit = new TextEdit(findPositions(rawCode, "..A").get(1), "..B");
     var result = computeInvalidated(ir, code, edit);
 
     assertNotInvalidated(result, ir, "file1");

--- a/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
+++ b/engine/runtime-instrument-common/src/test/java/org/enso/interpreter/instrument/ChangesetBuilderComputeTest.java
@@ -529,6 +529,36 @@ public class ChangesetBuilderComputeTest {
   }
 
   @Test
+  public void editAutoscopeConstructorDoesNotInvalidateOtherAutoscopeConstructors() {
+    var rawCode =
+        """
+        type T
+            A
+            B
+
+        type Table
+            Impl data
+            filter self a b = Table.Impl (self.data + a.to_text + b.to_text)
+
+        main =
+            file1 = Table.Impl ''
+            any1 = file1.filter 'Column 1' ..A
+            any2 = any1.filter 'Column 1' ..A
+            any2
+        """;
+
+    var code = addMetadata(rawCode);
+    var ir = preprocessModule(code);
+
+    var edit = new TextEdit(new Range(new Position(11, 34), new Position(11, 37)), "..B");
+    var result = computeInvalidated(ir, code, edit);
+
+    assertNotInvalidated(result, ir, "file1");
+    assertNotInvalidated(result, ir, "any1");
+    assertInvalidated(result, ir, "any2");
+  }
+
+  @Test
   public void addApplicationArgumentInvalidatesSingleCall() {
     var rawCode =
         """


### PR DESCRIPTION
### Pull Request Description

- followup #14924 
- close #14863 

`Name.MethodReference` (the IR representation of autoscope constructor `..A`) has a child `Name.Literal("A")`. `buildTree` decomposesd the MethodReference into its child, putting only the child literal in the changeset tree. The child literal has no DataflowAnalysis dependents, so the algorithm falls back to `Dynamic("A")` which matched all occurrences of `..A`, incorrectly invalidating other expressions.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
