### PR TITLE
Use different IDs for local and cloud executions

### DIFF
--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -171,8 +171,8 @@ export class ProjectService {
     if (!cloud) {
       const localSessionId = `localprojectsession-${KSUID.randomSync().string}`
       return [
-        ['ENSO_CLOUD_PROJECT_ID', projectId],
-        ['ENSO_CLOUD_PROJECT_SESSION_ID', localSessionId],
+        ['ENSO_LOCAL_PROJECT_ID', projectId],
+        ['ENSO_LOCAL_PROJECT_SESSION_ID', localSessionId],
       ]
     }
     return [

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -575,6 +575,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     ydoc.shutdownNow()
     runtimeEventsMonitor.close()
     log.info("Stopped Language Server")
+    MDC.remove("projectLocalId")
     MDC.remove("projectId")
     MDC.remove("projectSessionId")
   }

--- a/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
+++ b/engine/runner-common/src/main/java/org/enso/runner/common/LanguageServerApi.java
@@ -20,6 +20,9 @@ public abstract class LanguageServerApi {
   public static final String ENSO_CLOUD_PROJECT_ID_ENV_NAME = "ENSO_CLOUD_PROJECT_ID";
   public static final String ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME =
       "ENSO_CLOUD_PROJECT_SESSION_ID";
+  public static final String ENSO_LOCAL_PROJECT_ID_ENV_NAME = "ENSO_LOCAL_PROJECT_ID";
+  public static final String ENSO_LOCAL_PROJECT_SESSION_ID_ENV_NAME =
+      "ENSO_LOCAL_PROJECT_SESSION_ID";
 
   public static void launchLanguageServer(CommandLine line, ProfilingConfig config, Level logLevel)
       throws WrongOption {

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -1662,21 +1661,20 @@ public class Main {
   }
 
   private void setupLoggingContext(CommandLine line) {
-    String projectId;
-    var projectIdOptional = line.getOptionValue(LanguageServerApi.PROJECT_ID_OPTION);
-    try {
-      // sanity check
-      projectId =
-          projectIdOptional != null
-              ? UUID.fromString(projectIdOptional).toString()
-              : "00000000-0000-0000-0000-000000000000";
-    } catch (IllegalArgumentException e) {
-      projectId = "00000000-0000-0000-0000-000000000000";
-    }
     if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_ID_OPTION)) {
       MDC.put("projectId", line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_ID_OPTION));
     } else if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME) != null) {
       MDC.put("projectId", System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME));
+    }
+    if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME) != null) {
+      // In hybrid projects, the cloud project ID has precedence over the local project ID
+      // because Cloud does not store the local project ID, and it is generated every time the
+      // project is started.
+      MDC.put("projectLocalId", System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME));
+    } else if (System.getenv(LanguageServerApi.ENSO_LOCAL_PROJECT_ID_ENV_NAME) != null) {
+      MDC.put("projectLocalId", System.getenv(LanguageServerApi.ENSO_LOCAL_PROJECT_ID_ENV_NAME));
+    } else if (line.getOptionValue(LanguageServerApi.PROJECT_ID_OPTION) != null) {
+      MDC.put("projectLocalId", line.getOptionValue(LanguageServerApi.PROJECT_ID_OPTION));
     }
     if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION)) {
       MDC.put(
@@ -1686,9 +1684,11 @@ public class Main {
       MDC.put(
           "projectSessionId",
           System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME));
+    } else if (System.getenv(LanguageServerApi.ENSO_LOCAL_PROJECT_SESSION_ID_ENV_NAME) != null) {
+      MDC.put(
+          "projectSessionId",
+          System.getenv(LanguageServerApi.ENSO_LOCAL_PROJECT_SESSION_ID_ENV_NAME));
     }
-    MDC.put("projectLocalId", projectId);
-    System.setProperty("enso.project.local.id", projectId);
   }
 
   private Level setupLogging(CommandLine line, Level logLevel, boolean[] logMasking) {

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -1661,10 +1662,21 @@ public class Main {
   }
 
   private void setupLoggingContext(CommandLine line) {
-    if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME) != null) {
+    String projectId;
+    var projectIdOptional = line.getOptionValue(LanguageServerApi.PROJECT_ID_OPTION);
+    try {
+      // sanity check
+      projectId =
+          projectIdOptional != null
+              ? UUID.fromString(projectIdOptional).toString()
+              : "00000000-0000-0000-0000-000000000000";
+    } catch (IllegalArgumentException e) {
+      projectId = "00000000-0000-0000-0000-000000000000";
+    }
+    if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_ID_OPTION)) {
+      MDC.put("projectId", line.getOptionValue(LanguageServerApi.CLOUD_PROJECT_ID_OPTION));
+    } else if (System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME) != null) {
       MDC.put("projectId", System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_ID_ENV_NAME));
-    } else if (line.hasOption(LanguageServerApi.PROJECT_ID_OPTION)) {
-      MDC.put("projectId", line.getOptionValue(LanguageServerApi.PROJECT_ID_OPTION));
     }
     if (line.hasOption(LanguageServerApi.CLOUD_PROJECT_SESSION_ID_OPTION)) {
       MDC.put(
@@ -1675,6 +1687,8 @@ public class Main {
           "projectSessionId",
           System.getenv(LanguageServerApi.ENSO_CLOUD_PROJECT_SESSION_ID_ENV_NAME));
     }
+    MDC.put("projectLocalId", projectId);
+    System.setProperty("enso.project.local.id", projectId);
   }
 
   private Level setupLogging(CommandLine line, Level logLevel, boolean[] logMasking) {

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.enso.logging.config.*;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
 public final class LogbackSetup extends LoggerSetup {
@@ -186,7 +185,7 @@ public final class LogbackSetup extends LoggerSetup {
         if (logPrefix == null) {
           logPrefix = "enso";
         }
-        var projectId = MDC.get("projectId");
+        var projectId = resolveProjectId();
         var now = LocalDateTime.now();
         var dateStr = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         var timeStr = now.format(DateTimeFormatter.ofPattern("HH-mm-ss"));
@@ -234,7 +233,7 @@ public final class LogbackSetup extends LoggerSetup {
       } else {
         fileAppender = new FileAppender<>();
         fileAppender.setName("enso-file");
-        var projectId = MDC.get("projectId");
+        var projectId = resolveProjectId();
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         String currentDate = LocalDate.now().format(dtf);
         String fullFilePath;
@@ -464,4 +463,16 @@ public final class LogbackSetup extends LoggerSetup {
   }
 
   private static final String LANG_PREFIX = "enso";
+  private static final String NULL_UUID = "00000000-0000-0000-0000-000000000000";
+
+  private static String resolveProjectId() {
+    String id = System.getenv("ENSO_CLOUD_PROJECT_ID");
+    if (id == null || id.isEmpty()) {
+      id = System.getProperty("enso.project.local.id");
+    }
+    if (id == null || id.isEmpty() || id.equals(NULL_UUID)) {
+      return null;
+    }
+    return id;
+  }
 }

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/LogbackSetup.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.enso.logging.config.*;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
 public final class LogbackSetup extends LoggerSetup {
@@ -185,7 +186,7 @@ public final class LogbackSetup extends LoggerSetup {
         if (logPrefix == null) {
           logPrefix = "enso";
         }
-        var projectId = resolveProjectId();
+        var projectId = MDC.get("projectLocalId");
         var now = LocalDateTime.now();
         var dateStr = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         var timeStr = now.format(DateTimeFormatter.ofPattern("HH-mm-ss"));
@@ -233,7 +234,7 @@ public final class LogbackSetup extends LoggerSetup {
       } else {
         fileAppender = new FileAppender<>();
         fileAppender.setName("enso-file");
-        var projectId = resolveProjectId();
+        var projectId = MDC.get("projectLocalId");
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         String currentDate = LocalDate.now().format(dtf);
         String fullFilePath;
@@ -463,16 +464,4 @@ public final class LogbackSetup extends LoggerSetup {
   }
 
   private static final String LANG_PREFIX = "enso";
-  private static final String NULL_UUID = "00000000-0000-0000-0000-000000000000";
-
-  private static String resolveProjectId() {
-    String id = System.getenv("ENSO_CLOUD_PROJECT_ID");
-    if (id == null || id.isEmpty()) {
-      id = System.getProperty("enso.project.local.id");
-    }
-    if (id == null || id.isEmpty() || id.equals(NULL_UUID)) {
-      return null;
-    }
-    return id;
-  }
 }

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
@@ -13,7 +13,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.time.Instant;
 import java.util.Map;
-import java.util.UUID;
 
 // Contributors: Moses Hohman <mmhohman@rainbow.uchicago.edu>
 
@@ -51,7 +50,7 @@ public class SocketLoggingNode implements Runnable {
 
   volatile State state = State.NOT_STARTED;
   SocketServer socketServer;
-  UUID projectId;
+  String projectId;
   Map<String, String> localMdc;
 
   public SocketLoggingNode(SocketServer socketServer, Socket socket, LoggerContext context) {
@@ -82,14 +81,10 @@ public class SocketLoggingNode implements Runnable {
         try {
           event = (ILoggingEvent) hardenedLoggingEventInputStream.readObject();
           if (projectId == null) {
-            try {
-              var property = event.getMDCPropertyMap().get("projectLocalId");
-              if (property != null) {
-                projectId = UUID.fromString(property);
-                localMdc = event.getMDCPropertyMap();
-              }
-            } catch (IllegalArgumentException e) {
-              // ignore
+            var property = event.getMDCPropertyMap().get("projectLocalId");
+            if (property != null) {
+              projectId = property;
+              localMdc = event.getMDCPropertyMap();
             }
           }
           // get a logger from the hierarchy. The name of the logger is taken to

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logging/service/logback/SocketLoggingNode.java
@@ -13,6 +13,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.time.Instant;
 import java.util.Map;
+import java.util.UUID;
 
 // Contributors: Moses Hohman <mmhohman@rainbow.uchicago.edu>
 
@@ -50,7 +51,7 @@ public class SocketLoggingNode implements Runnable {
 
   volatile State state = State.NOT_STARTED;
   SocketServer socketServer;
-  String projectId;
+  UUID projectId;
   Map<String, String> localMdc;
 
   public SocketLoggingNode(SocketServer socketServer, Socket socket, LoggerContext context) {
@@ -81,10 +82,14 @@ public class SocketLoggingNode implements Runnable {
         try {
           event = (ILoggingEvent) hardenedLoggingEventInputStream.readObject();
           if (projectId == null) {
-            var property = event.getMDCPropertyMap().get("projectId");
-            if (property != null) {
-              projectId = property;
-              localMdc = event.getMDCPropertyMap();
+            try {
+              var property = event.getMDCPropertyMap().get("projectLocalId");
+              if (property != null) {
+                projectId = UUID.fromString(property);
+                localMdc = event.getMDCPropertyMap();
+              }
+            } catch (IllegalArgumentException e) {
+              // ignore
             }
           }
           // get a logger from the hierarchy. The name of the logger is taken to

--- a/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingServiceManager.java
+++ b/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingServiceManager.java
@@ -3,6 +3,7 @@ package org.enso.logging.service;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.enso.logging.config.LoggingServer;
+import org.slf4j.MDC;
 import org.slf4j.event.Level;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -37,12 +38,20 @@ public class LoggingServiceManager {
         } else {
           currentLevel = logLevel;
         }
+        var mdcContext = MDC.getCopyOfContextMap();
         return Future.apply(
             () -> {
-              var server = LoggingServiceFactory.get().localServerFor(port);
-              loggingService = server;
-              return new LoggingServerConfig(
-                  currentLevel, server.start(logLevel, logPath, logFileSuffix, config));
+              if (mdcContext != null) {
+                MDC.setContextMap(mdcContext);
+              }
+              try {
+                var server = LoggingServiceFactory.get().localServerFor(port);
+                loggingService = server;
+                return new LoggingServerConfig(
+                    currentLevel, server.start(logLevel, logPath, logFileSuffix, config));
+              } finally {
+                MDC.clear();
+              }
             },
             ec);
       } else {

--- a/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingServiceManager.java
+++ b/lib/scala/logging-service/src/main/java/org/enso/logging/service/LoggingServiceManager.java
@@ -3,7 +3,6 @@ package org.enso.logging.service;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.enso.logging.config.LoggingServer;
-import org.slf4j.MDC;
 import org.slf4j.event.Level;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -38,20 +37,12 @@ public class LoggingServiceManager {
         } else {
           currentLevel = logLevel;
         }
-        var mdcContext = MDC.getCopyOfContextMap();
         return Future.apply(
             () -> {
-              if (mdcContext != null) {
-                MDC.setContextMap(mdcContext);
-              }
-              try {
-                var server = LoggingServiceFactory.get().localServerFor(port);
-                loggingService = server;
-                return new LoggingServerConfig(
-                    currentLevel, server.start(logLevel, logPath, logFileSuffix, config));
-              } finally {
-                MDC.clear();
-              }
+              var server = LoggingServiceFactory.get().localServerFor(port);
+              loggingService = server;
+              return new LoggingServerConfig(
+                  currentLevel, server.start(logLevel, logPath, logFileSuffix, config));
             },
             ec);
       } else {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

- followup #14935 

Revert the unification of `projectId` and `localProjectId` identifiers introduced in eeae6c1b5566d0e15729cd6f1490fbcce22ca1d4. Fixes Cloud issues:
```
"eb76bee1-ad6d-487d-8bfd-3629fcf81d08" is not an Id.
```
when the Cloud expects a different type of ID in the telemetry messages.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
