### PR TITLE
`from Xyz import to_text` can import extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - [Require opt-in to prefer local libraries][14885]
 - [One log file per execution][14893]
 - [Opt-in to get more detailed logs][14895]
+- [`from Xyz import to_text` can import extension methods][14949]
 
 [14480]: https://github.com/enso-org/enso/pull/14480
 [14490]: https://github.com/enso-org/enso/pull/14490
@@ -96,6 +97,7 @@
 [14885]: https://github.com/enso-org/enso/pull/14885
 [14893]: https://github.com/enso-org/enso/pull/14893
 [14895]: https://github.com/enso-org/enso/pull/14895
+[14949]: https://github.com/enso-org/enso/pull/14949
 
 # Enso 2025.3
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
@@ -304,6 +304,39 @@ public class ExportedSymbolsTest {
   }
 
   @Test
+  public void exportExtensionMethodByAllWithHiding() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            import project.Raw_Module.Raw_Type
+
+            Raw_Type.enhanced_method = 42
+            Raw_Type.wrong_method = 33
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      var mainValue =
+          ctx.evalModule(
+              """
+              import local.Enhancing.Raw_Module.Raw_Type
+              from local.Enhancing.Ext_Module import all hiding wrong_method
+
+              main = Raw_Type.enhanced_method
+              """);
+      assertEquals(42, mainValue.asInt());
+    }
+  }
+
+  @Test
   public void exportExtensionWrongMethod() throws IOException {
     var rawMod =
         new SourceModule(

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
@@ -414,6 +414,43 @@ public class ExportedSymbolsTest {
     }
   }
 
+  @Test
+  public void exportConversionWhileHidingSomething() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            from Standard.Base import Integer
+            import project.Raw_Module.Raw_Type
+
+            something = 33
+            Integer.from (_:Raw_Type) = 42
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      var mainValue =
+          ctx.evalModule(
+              """
+              from Standard.Base import Integer
+              import local.Enhancing.Raw_Module.Raw_Type
+              from local.Enhancing.Ext_Module import all hiding something
+
+              main =
+                  fourtyTwo = Raw_Type:Integer
+                  fourtyTwo
+              """);
+      assertEquals("Conversion from Raw_Type to Integer found", 42, mainValue.asInt());
+    }
+  }
+
   private static ContextUtils createCtx(Path projDir) {
     return ContextUtils.newBuilder().withProjectRoot(projDir).build();
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,6 +22,7 @@ import org.enso.polyglot.PolyglotContext;
 import org.enso.test.utils.ContextUtils;
 import org.enso.test.utils.ProjectUtils;
 import org.enso.test.utils.SourceModule;
+import org.graalvm.polyglot.PolyglotException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -298,6 +300,45 @@ public class ExportedSymbolsTest {
               main = Raw_Type.enhanced_method
               """);
       assertEquals(42, mainValue.asInt());
+    }
+  }
+
+  @Test
+  public void exportExtensionWrongMethod() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            import project.Raw_Module.Raw_Type
+
+            Raw_Type.enhanced_method = 42
+            Raw_Type.wrong_method = 33
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      try {
+
+        var mainValue =
+            ctx.evalModule(
+                """
+                import local.Enhancing.Raw_Module.Raw_Type
+                from local.Enhancing.Ext_Module import wrong_method
+
+                main = Raw_Type.enhanced_method
+                """);
+        fail("Expecting exception, not a value: " + mainValue);
+      } catch (PolyglotException ex) {
+        assertEquals(
+            "Method `enhanced_method` of type Raw_Type could not be found.", ex.getMessage());
+      }
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
@@ -375,6 +375,45 @@ public class ExportedSymbolsTest {
     }
   }
 
+  @Test
+  public void exportExtensionHidingTheRightMethod() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            import project.Raw_Module.Raw_Type
+
+            Raw_Type.enhanced_method = 42
+            Raw_Type.wrong_method = 33
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      try {
+
+        var mainValue =
+            ctx.evalModule(
+                """
+                import local.Enhancing.Raw_Module.Raw_Type
+                from local.Enhancing.Ext_Module import all hiding enhanced_method
+
+                main = Raw_Type.enhanced_method
+                """);
+        fail("Expecting exception, not a value: " + mainValue);
+      } catch (PolyglotException ex) {
+        assertEquals(
+            "Method `enhanced_method` of type Raw_Type could not be found.", ex.getMessage());
+      }
+    }
+  }
+
   private static ContextUtils createCtx(Path projDir) {
     return ContextUtils.newBuilder().withProjectRoot(projDir).build();
   }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExportedSymbolsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -233,6 +234,70 @@ public class ExportedSymbolsTest {
       assertThat(
           mainExportedSymbols.get("Synthetic_Module").get(0),
           is(instanceOf(BindingsMap.ResolvedModule.class)));
+    }
+  }
+
+  @Test
+  public void exportExtensionMethodViaAll() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            import project.Raw_Module.Raw_Type
+
+            Raw_Type.enhanced_method = 42
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      var mainValue =
+          ctx.evalModule(
+              """
+              import local.Enhancing.Raw_Module.Raw_Type
+              from local.Enhancing.Ext_Module import all
+
+              main = Raw_Type.enhanced_method
+              """);
+      assertEquals(42, mainValue.asInt());
+    }
+  }
+
+  @Test
+  public void exportExtensionMethodByName() throws IOException {
+    var rawMod =
+        new SourceModule(
+            QualifiedName.fromString("Raw_Module"),
+            """
+            type Raw_Type
+            """);
+    var extMod =
+        new SourceModule(
+            QualifiedName.fromString("Ext_Module"),
+            """
+            import project.Raw_Module.Raw_Type
+
+            Raw_Type.enhanced_method = 42
+            """);
+    ProjectUtils.createProject("Enhancing", Set.of(rawMod, extMod), projDir);
+    try (var ctx = createCtx(projDir)) {
+      compile(ctx);
+
+      var mainValue =
+          ctx.evalModule(
+              """
+              import local.Enhancing.Raw_Module.Raw_Type
+              from local.Enhancing.Ext_Module import enhanced_method
+
+              main = Raw_Type.enhanced_method
+              """);
+      assertEquals(42, mainValue.asInt());
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ImportExportScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ImportExportScope.java
@@ -12,29 +12,36 @@ import org.enso.interpreter.runtime.data.Type;
  * A proxy scope delegating to the underlying module's scope. Additionally, `ImportExportScope` may
  * limit the number of types that are imported/exported.
  */
-public class ImportExportScope extends EnsoObject {
+public final class ImportExportScope extends EnsoObject {
 
   private final Module module;
   private final List<String> onlyNames;
+  private final List<String> hiddenNames;
 
-  public ImportExportScope(CompilerContext.Module module, List<String> typesOnlyNames) {
+  public ImportExportScope(
+      CompilerContext.Module module, List<String> onlyNames, List<String> hiddenNames) {
     this.module = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
-    this.onlyNames = typesOnlyNames != null && !typesOnlyNames.isEmpty() ? typesOnlyNames : null;
-  }
-
-  public ImportExportScope(CompilerContext.Module module) {
-    this.module = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
-    this.onlyNames = null;
+    this.onlyNames = onlyNames != null && !onlyNames.isEmpty() ? onlyNames : null;
+    this.hiddenNames = hiddenNames != null && !hiddenNames.isEmpty() ? hiddenNames : null;
   }
 
   private boolean isValidTypeOrSymbol(Type type, String symbol) {
     if (onlyNames == null) {
+      if (hiddenNames != null) {
+        if (symbol != null && hiddenNames.contains(symbol)) {
+          return false;
+        }
+        if (hiddenNames.contains(type.getName())) {
+          return false;
+        }
+      }
       return true;
+    } else {
+      if (onlyNames.contains(type.getName()) && module.getScope().hasType(type)) {
+        return true;
+      }
+      return symbol != null && onlyNames.contains(symbol);
     }
-    if (onlyNames.contains(type.getName()) && module.getScope().hasType(type)) {
-      return true;
-    }
-    return symbol != null && onlyNames.contains(symbol);
   }
 
   private boolean isValidType(Type type) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ImportExportScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ImportExportScope.java
@@ -15,26 +15,34 @@ import org.enso.interpreter.runtime.data.Type;
 public class ImportExportScope extends EnsoObject {
 
   private final Module module;
-  private final List<String> typesOnlyNames;
+  private final List<String> onlyNames;
 
   public ImportExportScope(CompilerContext.Module module, List<String> typesOnlyNames) {
     this.module = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
-    this.typesOnlyNames =
-        typesOnlyNames != null && !typesOnlyNames.isEmpty() ? typesOnlyNames : null;
+    this.onlyNames = typesOnlyNames != null && !typesOnlyNames.isEmpty() ? typesOnlyNames : null;
   }
 
   public ImportExportScope(CompilerContext.Module module) {
     this.module = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
-    this.typesOnlyNames = null;
+    this.onlyNames = null;
+  }
+
+  private boolean isValidTypeOrSymbol(Type type, String symbol) {
+    if (onlyNames == null) {
+      return true;
+    }
+    if (onlyNames.contains(type.getName()) && module.getScope().hasType(type)) {
+      return true;
+    }
+    return symbol != null && onlyNames.contains(symbol);
   }
 
   private boolean isValidType(Type type) {
-    if (typesOnlyNames == null) return true;
-    return typesOnlyNames.contains(type.getName()) && module.getScope().hasType(type);
+    return isValidTypeOrSymbol(type, null);
   }
 
   public Function getExportedMethod(Type type, String name) {
-    if (isValidType(type)) {
+    if (isValidTypeOrSymbol(type, name)) {
       return module.getScope().getExportedMethod(type, name);
     } else {
       return null;
@@ -50,7 +58,7 @@ public class ImportExportScope extends EnsoObject {
   }
 
   public Function getMethodForType(Type type, String methodName) {
-    if (isValidType(type)) {
+    if (isValidTypeOrSymbol(type, methodName)) {
       return module.getScope().getMethodForType(type, methodName);
     } else {
       return null;

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -412,7 +412,7 @@ private[runtime] class IrToTruffle(
       exportedModule: BindingsMap.ExportedModule
     ): ImportExportScope = {
       val exportedRuntimeMod = exportedModule.module.module.unsafeAsModule()
-      new ImportExportScope(exportedRuntimeMod)
+      new ImportExportScope(exportedRuntimeMod, null, null)
     }
 
     override protected def buildImportScope(
@@ -420,9 +420,10 @@ private[runtime] class IrToTruffle(
       resolvedModule: ResolvedModule
     ): ImportExportScope = {
       val mod = resolvedModule.module.unsafeAsModule()
-      resolvedImport.importDef.onlyNames
-        .map(only => new ImportExportScope(mod, only.map(_.name).asJava))
-        .getOrElse(new ImportExportScope(mod))
+      val d = resolvedImport.importDef
+      val onlyNamesOrNull = d.onlyNames.map(only => only.map(_.name).asJava).getOrElse(null)
+      val hiddenNamesOrNull = d.hiddenNames.map(hide => hide.map(_.name).asJava).getOrElse(null)
+      new ImportExportScope(mod, onlyNamesOrNull, hiddenNamesOrNull)
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -420,9 +420,11 @@ private[runtime] class IrToTruffle(
       resolvedModule: ResolvedModule
     ): ImportExportScope = {
       val mod = resolvedModule.module.unsafeAsModule()
-      val d = resolvedImport.importDef
-      val onlyNamesOrNull = d.onlyNames.map(only => only.map(_.name).asJava).getOrElse(null)
-      val hiddenNamesOrNull = d.hiddenNames.map(hide => hide.map(_.name).asJava).getOrElse(null)
+      val d   = resolvedImport.importDef
+      val onlyNamesOrNull =
+        d.onlyNames.map(only => only.map(_.name).asJava).getOrElse(null)
+      val hiddenNamesOrNull =
+        d.hiddenNames.map(hide => hide.map(_.name).asJava).getOrElse(null)
       new ImportExportScope(mod, onlyNamesOrNull, hiddenNamesOrNull)
     }
   }


### PR DESCRIPTION
### Pull Request Description

- fixes #10796
- by adding extensive list of new tests
- by checking the name of method to import in `onlyNames` list


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
