### PR TITLE
Avoid regenerating tsconfig files in CI runs

### DIFF
--- a/.github/workflows/gui-checks.yml
+++ b/.github/workflows/gui-checks.yml
@@ -48,6 +48,9 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: 🧾 Check generated tsconfigs
+        run: pnpm run check:tsconfigs
+
       - uses: actions/cache/restore@v4
         if: "${{ !(contains(github.event.pull_request.labels.*.name, 'CI: Clean build required')) }}"
         name: Download cache

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,14 +39,19 @@ ts_config(
 )
 
 write_source_files(
-    name = "write_all",
+    name = "write_generated",
     additional_update_targets = [
         "//app/rust-ffi:write_wasm_dist",
         "//app/ydoc-shared:write_ast_codegen",
         "//app/gui:write_icon_metadata",
-        "//app/gui:write_tsconfigs",
         "//app/table-expression:write_parser_codegen",
-        # Generated tsconfig files
+    ],
+)
+
+write_source_files(
+    name = "write_tsconfigs",
+    additional_update_targets = [
+        "//app/gui:write_tsconfigs",
         "//app/common:write_tsconfigs",
         "//app/electron-client:write_tsconfigs",
         "//app/lang-markdown:write_tsconfigs",
@@ -56,6 +61,14 @@ write_source_files(
         "//app/ydoc-channel:write_tsconfigs",
         "//app/ydoc-server:write_tsconfigs",
         "//app/ydoc-shared:write_tsconfigs",
+    ],
+)
+
+write_source_files(
+    name = "write_all",
+    additional_update_targets = [
+        ":write_generated",
+        ":write_tsconfigs",
     ],
 )
 

--- a/internal/checkTsconfigs.mjs
+++ b/internal/checkTsconfigs.mjs
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: options.captureOutput ? 'pipe' : 'inherit',
+    encoding: options.captureOutput ? 'utf8' : undefined,
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+  return result.stdout ?? ''
+}
+
+run('bazel', ['run', '//:write_all', '--verbose_failures'])
+
+// There is an issue on Windows that causes changes in MODULE.bazel.lock.
+const exclude = [':(exclude)MODULE.bazel.lock', ':(exclude)app/gui/.dev-env']
+
+const diff = run('git', ['diff', '--stat', '--', '.', ...exclude], { captureOutput: true })
+
+if (diff.trim() !== '') {
+  console.error('Dirty files after running //:write_all :')
+  console.error(diff.trimEnd())
+  process.exit(1)
+}

--- a/internal/postinstall.mjs
+++ b/internal/postinstall.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+const isCi = process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true'
+
+function run(args) {
+  const result = spawnSync('bazel', args, { stdio: 'inherit' })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+if (isCi) {
+  // [#14956] Windows CI has issues with stale tsconfig files, so we only generated untracked files on CI runners.
+  // Additional check on Linux CI verifies that the state of committed tsconfigs matches the codebase,
+  // see "check:tsconfigs" pnpm script.
+  run(['run', '//:write_generated', '--verbose_failures'])
+} else {
+  run(['run', '//:write_all', '--verbose_failures'])
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "name": "root",
   "scripts": {
     "dev:gui": "corepack pnpm run --parallel -r --filter enso-gui --aggregate-output /^^^^dev:/",
+    "check:tsconfigs": "node internal/checkTsconfigs.mjs",
     "compile": "corepack pnpm run -r compile",
     "build:gui": "corepack pnpm run -r compile && corepack pnpm run -r --filter enso-gui build",
     "build:ide": "corepack pnpm run -r compile && corepack pnpm run -r --filter enso build",
@@ -43,7 +44,7 @@
     "ci:typecheck": "corepack pnpm run -r --parallel typecheck",
     "git-clean": "node git-clean.mjs",
     "bazel-clean": "bazel clean --expunge_async",
-    "postinstall": "bazel run //:write_all --verbose_failures"
+    "postinstall": "node internal/postinstall.mjs"
   },
   "//": "To completely ignore deep dependencies, see .pnpmfile.cjs",
   "pnpm": {


### PR DESCRIPTION
### Pull Request Description

Trying to fix #14956 

No changes for developers, but we no longer regenerate `*.tsconfig` files on CI. Additional step in GUI checks on Linux makes sure that we don't have dirty tree after `pnpm install` (e.g. if somebody forgot to run `pnpm install` before commit).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
