### PR TITLE
Introducing `InvokeToTextNode`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
@@ -44,8 +44,26 @@ public abstract class InteropMethodCallNode extends Node {
    * @param arguments the arguments for the function.
    * @return the result of calling the function.
    */
-  public abstract Object execute(UnresolvedSymbol method, Object state, Object[] arguments)
+  public abstract Object execute(UnresolvedSymbol method, State state, Object[] arguments)
       throws ArityException;
+
+  /**
+   * Helper method that handles {@link State} and {@link ArityException} automatically. Any arity
+   * exception is converted to {@code PanicException}.
+   *
+   * @param method method to invoke
+   * @param args provided arguments
+   * @return the result of invoking {@link #execute}
+   */
+  public final Object executeOrPanic(UnresolvedSymbol method, Object... args) {
+    var ctx = EnsoContext.get(this);
+    try {
+      var state = ctx.currentState();
+      return execute(method, state, args);
+    } catch (ArityException e) {
+      throw ctx.raiseAssertionPanic(this, null, e);
+    }
+  }
 
   @CompilerDirectives.TruffleBoundary
   CallArgumentInfo[] buildSchema(int length) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.node.expression.builtin.io;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
-import com.oracle.truffle.api.dsl.NeverDefault;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -11,16 +10,11 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
-import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.node.callable.InvokeCallableNode;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.builtin.Builtins;
-import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
-import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
-import org.enso.interpreter.runtime.type.TypesGen;
 
 @BuiltinMethod(
     type = "IO",
@@ -53,12 +47,10 @@ public abstract class PrintErrNode extends Node {
       VirtualFrame frame,
       Object message,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings,
-      @Cached("buildToTextSymbol($node)") UnresolvedSymbol symbol,
-      @Cached("buildInvokeCallableNode()") InvokeCallableNode invokeCallableNode,
+      @Cached InvokeToTextNode invokeToText,
       @Cached ExpectStringNode expectStringNode) {
     var ctx = EnsoContext.get(this);
-    var state = ctx.currentState();
-    var str = invokeCallableNode.execute(symbol, frame, state, new Object[] {message});
+    var str = invokeToText.executeToText(frame, message);
     print(ctx.getErr(), expectStringNode.execute(str));
     return ctx.getNothing();
   }
@@ -66,24 +58,5 @@ public abstract class PrintErrNode extends Node {
   @CompilerDirectives.TruffleBoundary
   private void print(PrintStream err, Object str) {
     err.println(str);
-  }
-
-  boolean isText(Object o) {
-    return TypesGen.isText(o);
-  }
-
-  @NeverDefault
-  InvokeCallableNode buildInvokeCallableNode() {
-    return InvokeCallableNode.build(
-        new CallArgumentInfo[] {new CallArgumentInfo()},
-        InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
-        InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
-  }
-
-  @NeverDefault
-  static UnresolvedSymbol buildToTextSymbol(Node where) {
-    var mod = Builtins.get(where).getModule();
-    var scope = mod.getScope();
-    return UnresolvedSymbol.build(Constants.Names.TO_TEXT, scope);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -11,14 +11,10 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
-import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.node.callable.InvokeCallableNode;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.builtin.Builtins;
-import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
-import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.warning.WarningsLibrary;
 
 @BuiltinMethod(
@@ -27,11 +23,6 @@ import org.enso.interpreter.runtime.warning.WarningsLibrary;
     description = "Prints its argument to standard out.",
     autoRegister = false)
 public abstract class PrintlnNode extends Node {
-  private @Child InvokeCallableNode invokeCallableNode =
-      InvokeCallableNode.build(
-          new CallArgumentInfo[] {new CallArgumentInfo()},
-          InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
-          InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
 
   abstract Object execute(VirtualFrame frame, @AcceptsError Object message, Object nl);
 
@@ -58,11 +49,9 @@ public abstract class PrintlnNode extends Node {
       Object nl,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings,
       @CachedLibrary(limit = "10") WarningsLibrary warnings,
-      @Cached("buildToTextSymbol($node)") UnresolvedSymbol symbol,
-      @Cached("buildInvokeCallableNode()") InvokeCallableNode invokeCallableNode) {
+      @Cached InvokeToTextNode invokeToText) {
     var ctx = EnsoContext.get(this);
-    var state = ctx.currentState();
-    var probablyStr = invokeCallableNode.execute(symbol, frame, state, new Object[] {message});
+    var probablyStr = invokeToText.executeToText(frame, new Object[] {message});
     if (warnings.hasWarnings(probablyStr)) {
       try {
         probablyStr = warnings.removeWarnings(probablyStr);
@@ -97,21 +86,6 @@ public abstract class PrintlnNode extends Node {
       case "" -> out.print(str);
       default -> out.print(str + nl);
     }
-  }
-
-  @NeverDefault
-  static UnresolvedSymbol buildToTextSymbol(Node where) {
-    var mod = Builtins.get(where).getModule();
-    var scope = mod.getScope();
-    return UnresolvedSymbol.build(Constants.Names.TO_TEXT, scope);
-  }
-
-  @NeverDefault
-  InvokeCallableNode buildInvokeCallableNode() {
-    return InvokeCallableNode.build(
-        new CallArgumentInfo[] {new CallArgumentInfo()},
-        InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
-        InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
   }
 
   @NeverDefault

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -51,7 +51,7 @@ public abstract class PrintlnNode extends Node {
       @CachedLibrary(limit = "10") WarningsLibrary warnings,
       @Cached InvokeToTextNode invokeToText) {
     var ctx = EnsoContext.get(this);
-    var probablyStr = invokeToText.executeToText(frame, new Object[] {message});
+    var probablyStr = invokeToText.executeToText(frame, message);
     if (warnings.hasWarnings(probablyStr)) {
       try {
         probablyStr = warnings.removeWarnings(probablyStr);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -28,7 +28,7 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
-import org.enso.interpreter.node.expression.builtin.text.AnyToTextNode;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -118,7 +118,7 @@ public abstract class SortVectorNode extends Node {
       @Shared("lengthNode") @Cached ArrayLikeLengthNode lengthNode,
       @Shared("atNode") @Cached ArrayLikeAtNode atNode,
       @Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
-      @Shared("anyToTextNode") @Cached AnyToTextNode toTextNode,
+      @Shared("anyToTextNode") @Cached InvokeToTextNode toTextNode,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary interop) {
     EnsoContext ctx = EnsoContext.get(this);
     Object[] elems;
@@ -157,7 +157,7 @@ public abstract class SortVectorNode extends Node {
       LessThanNode lessThanNode,
       EqualsNode equalsNode,
       TypeOfNode typeOfNode,
-      AnyToTextNode toTextNode,
+      InvokeToTextNode toTextNode,
       long ascending,
       long problemBehaviorNum,
       InteropLibrary interop) {
@@ -194,7 +194,7 @@ public abstract class SortVectorNode extends Node {
       @Shared("typeOfNode") @Cached TypeOfNode typeOfNode,
       @Shared("lengthNode") @Cached ArrayLikeLengthNode lengthNode,
       @Shared("atNode") @Cached ArrayLikeAtNode atNode,
-      @Shared("anyToTextNode") @Cached AnyToTextNode toTextNode,
+      @Shared("anyToTextNode") @Cached InvokeToTextNode toTextNode,
       @Cached MethodResolverNode methodResolverNode,
       @Cached(value = "build()", uncached = "build()") CallOptimiserNode callNode) {
     var problemBehavior = ProblemBehavior.fromInt((int) problemBehaviorNum);
@@ -540,12 +540,12 @@ public abstract class SortVectorNode extends Node {
   private abstract static class SortComparator implements java.util.Comparator<Object> {
 
     private final Set<String> warnings = new HashSet<>();
-    final AnyToTextNode toTextNode;
+    final InvokeToTextNode toTextNode;
     final ProblemBehavior problemBehavior;
     final InteropLibrary interop;
 
     protected SortComparator(
-        AnyToTextNode toTextNode, ProblemBehavior problemBehavior, InteropLibrary interop) {
+        InvokeToTextNode toTextNode, ProblemBehavior problemBehavior, InteropLibrary interop) {
       this.toTextNode = toTextNode;
       this.problemBehavior = problemBehavior;
       this.interop = interop;
@@ -553,8 +553,8 @@ public abstract class SortVectorNode extends Node {
 
     @TruffleBoundary
     protected void attachIncomparableValuesWarning(Object x, Object y) {
-      var xStr = toTextNode.execute(x).toString();
-      var yStr = toTextNode.execute(y).toString();
+      var xStr = toTextNode.executeToText(null, y).toString();
+      var yStr = toTextNode.executeToText(null, y).toString();
       String warnText = "Values " + xStr + " and " + yStr + " are incomparable";
       warnings.add(warnText);
     }
@@ -592,7 +592,7 @@ public abstract class SortVectorNode extends Node {
         LessThanNode lessThanNode,
         EqualsNode equalsNode,
         TypeOfNode typeOfNode,
-        AnyToTextNode toTextNode,
+        InvokeToTextNode toTextNode,
         boolean ascending,
         ProblemBehavior problemBehavior,
         InteropLibrary interop) {
@@ -675,7 +675,8 @@ public abstract class SortVectorNode extends Node {
 
     private String getQualifiedTypeName(Object object) {
       var typeObj = typeOfNode.findTypeOrError(object);
-      return toTextNode.execute(typeObj).toString();
+      var txt = toTextNode.executeToText(null, typeObj);
+      return txt.toString();
     }
 
     private int getPrimitiveValueCost(Object object) {
@@ -824,7 +825,7 @@ public abstract class SortVectorNode extends Node {
         Type comparator,
         CallOptimiserNode callNode,
         WarningsLibrary warnLib,
-        AnyToTextNode toTextNode,
+        InvokeToTextNode toTextNode,
         State state,
         Atom less,
         Atom equal,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -553,7 +553,7 @@ public abstract class SortVectorNode extends Node {
 
     @TruffleBoundary
     protected void attachIncomparableValuesWarning(Object x, Object y) {
-      var xStr = toTextNode.executeToText(null, y).toString();
+      var xStr = toTextNode.executeToText(null, x).toString();
       var yStr = toTextNode.executeToText(null, y).toString();
       String warnText = "Values " + xStr + " and " + yStr + " are incomparable";
       warnings.add(warnText);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -17,22 +17,26 @@ import org.enso.interpreter.runtime.data.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.atom.StructsLibrary;
 import org.enso.interpreter.runtime.data.text.Text;
 
+/**
+ * This is an implementation of {@code Any.to_text}. This node shouldn't be used directly. To invoke
+ * {@code to_text} use {@link InvokeToTextNode}.
+ */
 @BuiltinMethod(
     type = "Any",
     name = Constants.Names.TO_TEXT,
     description = "Generic text conversion.")
 @GenerateUncached
-public abstract class AnyToTextNode extends Node {
+abstract class AnyToTextNode extends Node {
 
-  public static AnyToTextNode build() {
+  static AnyToTextNode build() {
     return AnyToTextNodeGen.create();
   }
 
-  public static AnyToTextNode getUncached() {
+  static AnyToTextNode getUncached() {
     return AnyToTextNodeGen.getUncached();
   }
 
-  public abstract Text execute(Object self);
+  abstract Text execute(Object self);
 
   @Specialization
   Text doAtom(Atom at) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
@@ -11,6 +11,7 @@ import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
+import org.enso.interpreter.runtime.data.EnsoMultiValue;
 
 /**
  * Converts provided object into Text. This is a generic node to be used to convert any object into
@@ -24,6 +25,7 @@ public final class InvokeToTextNode extends Node {
   @CompilerDirectives.CompilationFinal private UnresolvedSymbol toText;
   @Child private InteropMethodCallNode methodNode;
   @Child private InvokeCallableNode invokeCallableNode;
+  @Child private AnyToTextNode anyToText;
 
   private InvokeToTextNode() {}
 
@@ -48,6 +50,9 @@ public final class InvokeToTextNode extends Node {
    * @return the textual representation of the {@code obj}
    */
   public Object executeToText(VirtualFrame frame, Object obj) {
+    if (obj instanceof EnsoMultiValue emv) {
+      return executeMultiValue(emv);
+    }
     if (frame == null || this == uncached) {
       return executeToTextNoFrame(obj);
     } else {
@@ -92,5 +97,12 @@ public final class InvokeToTextNode extends Node {
         new CallArgumentInfo[] {new CallArgumentInfo()},
         InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
         InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
+  }
+
+  private Object executeMultiValue(EnsoMultiValue emv) {
+    if (anyToText == null) {
+      anyToText = this == uncached ? AnyToTextNode.getUncached() : AnyToTextNode.build();
+    }
+    return anyToText.execute(emv);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
@@ -1,0 +1,96 @@
+package org.enso.interpreter.node.expression.builtin.text;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.compiler.core.ConstantsNames;
+import org.enso.interpreter.node.callable.InteropMethodCallNode;
+import org.enso.interpreter.node.callable.InvokeCallableNode;
+import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.builtin.Builtins;
+import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
+import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
+
+/**
+ * Converts provided object into Text. This is a generic node to be used to convert any object into
+ * Text. It does so by calling {@code to_text} method or by special means for various builtin
+ * objects.
+ *
+ * @author devel
+ */
+public final class InvokeToTextNode extends Node {
+  private static InvokeToTextNode uncached;
+  @CompilerDirectives.CompilationFinal private UnresolvedSymbol toText;
+  @Child private InteropMethodCallNode methodNode;
+  @Child private InvokeCallableNode invokeCallableNode;
+
+  private InvokeToTextNode() {}
+
+  @NeverDefault
+  public static InvokeToTextNode create() {
+    return new InvokeToTextNode();
+  }
+
+  @NeverDefault
+  public static InvokeToTextNode getUncached() {
+    if (uncached == null) {
+      uncached = new InvokeToTextNode();
+    }
+    return uncached;
+  }
+
+  /**
+   * Converts an object to its textual representation.
+   *
+   * @param frame frame to invoke {@code to_text} at - it can be {@code null}
+   * @param obj the object to compute textual representation for
+   * @return the textual representation of the {@code obj}
+   */
+  public Object executeToText(VirtualFrame frame, Object obj) {
+    if (frame == null || this == uncached) {
+      return executeToTextNoFrame(obj);
+    } else {
+      return executeWitFrame(frame, obj);
+    }
+  }
+
+  private Object executeToTextNoFrame(Object obj) {
+    if (methodNode == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      methodNode =
+          insert(
+              this == uncached
+                  ? InteropMethodCallNode.getUncached()
+                  : InteropMethodCallNode.build());
+    }
+    return methodNode.executeOrPanic(ensureToTextSymbol(), obj);
+  }
+
+  private UnresolvedSymbol ensureToTextSymbol() {
+    if (toText == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var textScope = Builtins.get(this).textExtensions().getDefinitionScope();
+      toText = UnresolvedSymbol.build(ConstantsNames.TO_TEXT, textScope);
+    }
+    return toText;
+  }
+
+  private Object executeWitFrame(VirtualFrame frame, Object obj) {
+    if (invokeCallableNode == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      invokeCallableNode = insert(buildInvokeCallableNode());
+    }
+    var ctx = EnsoContext.get(this);
+    var state = ctx.currentState();
+    return invokeCallableNode.execute(ensureToTextSymbol(), frame, state, new Object[] {obj});
+  }
+
+  @NeverDefault
+  InvokeCallableNode buildInvokeCallableNode() {
+    return InvokeCallableNode.build(
+        new CallArgumentInfo[] {new CallArgumentInfo()},
+        InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
+        InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
@@ -17,11 +17,9 @@ import org.enso.interpreter.runtime.data.EnsoMultiValue;
  * Converts provided object into Text. This is a generic node to be used to convert any object into
  * Text. It does so by calling {@code to_text} method or by special means for various builtin
  * objects.
- *
- * @author devel
  */
 public final class InvokeToTextNode extends Node {
-  private static InvokeToTextNode uncached;
+  private static final InvokeToTextNode UNCACHED = new InvokeToTextNode();
   @CompilerDirectives.CompilationFinal private UnresolvedSymbol toText;
   @Child private InteropMethodCallNode methodNode;
   @Child private InvokeCallableNode invokeCallableNode;
@@ -36,10 +34,7 @@ public final class InvokeToTextNode extends Node {
 
   @NeverDefault
   public static InvokeToTextNode getUncached() {
-    if (uncached == null) {
-      uncached = new InvokeToTextNode();
-    }
-    return uncached;
+    return UNCACHED;
   }
 
   /**
@@ -53,7 +48,7 @@ public final class InvokeToTextNode extends Node {
     if (obj instanceof EnsoMultiValue emv) {
       return executeMultiValue(emv);
     }
-    if (frame == null || this == uncached) {
+    if (frame == null || isUncached()) {
       return executeToTextNoFrame(obj);
     } else {
       return executeWitFrame(frame, obj);
@@ -65,9 +60,7 @@ public final class InvokeToTextNode extends Node {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       methodNode =
           insert(
-              this == uncached
-                  ? InteropMethodCallNode.getUncached()
-                  : InteropMethodCallNode.build());
+              isUncached() ? InteropMethodCallNode.getUncached() : InteropMethodCallNode.build());
     }
     return methodNode.executeOrPanic(ensureToTextSymbol(), obj);
   }
@@ -102,8 +95,12 @@ public final class InvokeToTextNode extends Node {
   private Object executeMultiValue(EnsoMultiValue emv) {
     if (anyToText == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
-      anyToText = insert(this == uncached ? AnyToTextNode.getUncached() : AnyToTextNode.build());
+      anyToText = insert(isUncached() ? AnyToTextNode.getUncached() : AnyToTextNode.build());
     }
     return anyToText.execute(emv);
+  }
+
+  private boolean isUncached() {
+    return this == UNCACHED;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
@@ -101,7 +101,8 @@ public final class InvokeToTextNode extends Node {
 
   private Object executeMultiValue(EnsoMultiValue emv) {
     if (anyToText == null) {
-      anyToText = this == uncached ? AnyToTextNode.getUncached() : AnyToTextNode.build();
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      anyToText = insert(this == uncached ? AnyToTextNode.getUncached() : AnyToTextNode.build());
     }
     return anyToText.execute(emv);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/InvokeToTextNode.java
@@ -51,7 +51,7 @@ public final class InvokeToTextNode extends Node {
     if (frame == null || isUncached()) {
       return executeToTextNoFrame(obj);
     } else {
-      return executeWitFrame(frame, obj);
+      return executeWithFrame(frame, obj);
     }
   }
 
@@ -74,7 +74,7 @@ public final class InvokeToTextNode extends Node {
     return toText;
   }
 
-  private Object executeWitFrame(VirtualFrame frame, Object obj) {
+  private Object executeWithFrame(VirtualFrame frame, Object obj) {
     if (invokeCallableNode == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       invokeCallableNode = insert(buildInvokeCallableNode());

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -72,6 +72,7 @@ public final class Builtins {
   private final RuntimeContext runtimeContext;
   private final Ordering ordering;
   private final Supplier<Type> comparable;
+  private final Supplier<Type> textExtensions;
   private final Supplier<Type> defaultComparator;
 
   /** Factory method to create the builtins. */
@@ -128,6 +129,7 @@ public final class Builtins {
     ordering = new Ordering(supplyType("Data", "Ordering", "Ordering"));
     comparable = supplyType("Data", "Ordering", "Comparable");
     defaultComparator = supplyType("Internal", "Ordering_Helpers", "Default_Comparator");
+    textExtensions = supplyType("Data", "Text", "Extensions", null);
   }
 
   /**
@@ -232,6 +234,11 @@ public final class Builtins {
    */
   public Type text() {
     return text.getType();
+  }
+
+  /** Extensions with Text methods. Especially {@code to_text} method. */
+  public Type textExtensions() {
+    return textExtensions.get();
   }
 
   /**
@@ -470,9 +477,13 @@ public final class Builtins {
     var moduleName = toFqn(1, shortFqn);
     var typeName = shortFqn[last];
     var scope = loadModule(context, moduleName);
-    var type = scope.getType(typeName, true);
-    assert type != null : typeName + " in " + moduleName;
-    return type;
+    if (typeName != null) {
+      var type = scope.getType(typeName, true);
+      assert type != null : typeName + " in " + moduleName;
+      return type;
+    } else {
+      return scope.getAssociatedType();
+    }
   }
 
   private static String toFqn(int skip, String... elems) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoMultiValue.java
@@ -31,7 +31,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.enso.interpreter.node.callable.resolver.MethodResolverNode;
-import org.enso.interpreter.node.expression.builtin.text.AnyToTextNode;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.FunctionAndType;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -286,12 +286,12 @@ public final class EnsoMultiValue extends EnsoObject {
   @TruffleBoundary
   @Override
   public final String toDisplayString(boolean ignore) {
-    return toDisplayString(ignore, AnyToTextNode.getUncached()).toString();
+    return toDisplayString(ignore, InvokeToTextNode.getUncached()).toString();
   }
 
   @ExportMessage
-  final Object toDisplayString(boolean ignore, @Cached AnyToTextNode toTextNode) {
-    return toTextNode.execute(this);
+  final Object toDisplayString(boolean ignore, @Cached InvokeToTextNode toTextNode) {
+    return toTextNode.executeToText(null, this);
   }
 
   private enum InteropType {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/Atom.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
@@ -385,7 +385,7 @@ public abstract class Atom extends EnsoObject {
   public Object toDisplayString(boolean allowSideEffects) {
     return toDisplayString(
         allowSideEffects,
-        InteropLibrary.getUncached(),
+        InvokeToTextNode.getUncached(),
         WarningsLibrary.getUncached(),
         InteropLibrary.getUncached(),
         BranchProfile.getUncached());
@@ -394,14 +394,13 @@ public abstract class Atom extends EnsoObject {
   @ExportMessage
   Text toDisplayString(
       boolean allowSideEffects,
-      @CachedLibrary("this") InteropLibrary atoms,
+      @Cached InvokeToTextNode toTextNode,
       @CachedLibrary(limit = "3") WarningsLibrary warnings,
       @CachedLibrary(limit = "3") InteropLibrary interop,
       @Cached BranchProfile handleError) {
-    Object result = null;
     String msg;
     try {
-      result = atoms.invokeMember(this, Constants.Names.TO_TEXT);
+      var result = toTextNode.executeToText(null, this);
       if (warnings.hasWarnings(result)) {
         result = warnings.removeWarnings(result);
       }
@@ -416,11 +415,8 @@ public abstract class Atom extends EnsoObject {
             this.toString(
                 "Error in method `to_text` of [", 10, "]: Expected Text but got ", result);
       }
-    } catch (AbstractTruffleException
-        | UnsupportedMessageException
-        | ArityException
-        | UnknownIdentifierException
-        | UnsupportedTypeException panic) {
+    } catch (AbstractTruffleException | UnsupportedMessageException panic) {
+
       handleError.enter();
       msg = this.toString("Panic in method `to_text` of [", 10, "]: ", panic);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/BoxingAtom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/atom/BoxingAtom.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import java.util.List;
+import org.enso.interpreter.node.expression.builtin.text.InvokeToTextNode;
 import org.enso.interpreter.runtime.data.atom.UnboxingAtom.FieldGetterNode;
 import org.enso.interpreter.runtime.data.atom.UnboxingAtom.FieldSetterNode;
 import org.enso.interpreter.runtime.warning.WarningsLibrary;
@@ -96,7 +97,7 @@ final class BoxingAtom extends Atom {
   public Object toDisplayString(boolean allowSideEffects) {
     return toDisplayString(
         allowSideEffects,
-        InteropLibrary.getUncached(),
+        InvokeToTextNode.getUncached(),
         WarningsLibrary.getUncached(),
         InteropLibrary.getUncached(),
         BranchProfile.getUncached());

--- a/test/Base_Tests/src/Data/Ordering_Spec.enso
+++ b/test/Base_Tests/src/Data/Ordering_Spec.enso
@@ -62,13 +62,19 @@ type No_Comp_Type
    does not matter. Iterates through all the warnings of result.
 expect_incomparable_warn : Any -> Any -> Any -> Nothing
 expect_incomparable_warn left_val right_val result =
-    # Incomparable values warning wraps Text values in simple quotes
-    left_val_text = left_val.pretty
-    right_val_text = right_val.pretty
+    left_val_text = left_val.to_text
+    right_val_text = right_val.to_text
     expected_warn_msg_left = "Values " + left_val_text + " and " + right_val_text + " are incomparable"
     expected_warn_msg_right = "Values " + right_val_text + " and " + left_val_text + " are incomparable"
     has_expected_warning = Warning.get_all result . map (_.value) . any (it-> it == expected_warn_msg_left || it == expected_warn_msg_right)
-    has_expected_warning . should_be_true
+    if has_expected_warning.not then
+        Test.fail
+            "Expecting "
+                + expected_warn_msg_left
+                + " and "
+                + expected_warn_msg_right
+                + " but got: "
+                + (Warning.get_all result . to_text)
 
 expect_no_warns : Any -> Nothing
 expect_no_warns result =


### PR DESCRIPTION

### Pull Request Description

- spin off #14944 
- turns out that we often want to invoke `.to_text` in the engine
   - there were many ways to do it
   - many of them flawed in some way
- this PR introduces `InvokeToTextNode` that provides unified way
   - the node takes optional `VirtualFrame` parameter
   - based on `frame` being provided or not, it uses slightly different technique of invocation
- however all of that should be encapsulated and hidden for the benefit of those using the node

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue working
