### PR TITLE
Fix `check_syntax` holding `to_read` mutex across file reads

### DIFF
--- a/lib/rust/parser/debug/src/bin/check_syntax.rs
+++ b/lib/rust/parser/debug/src/bin/check_syntax.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             while let Some(path) = {
                 let mut to_read = to_read.lock().unwrap();
                 to_read.pop()
-             } {
+            } {
                 let data = std::fs::read_to_string(&path).unwrap();
                 to_parse.lock().unwrap().0.push(WithSourcePath { path, value: data });
                 condvar.notify_one();

--- a/lib/rust/parser/debug/src/bin/check_syntax.rs
+++ b/lib/rust/parser/debug/src/bin/check_syntax.rs
@@ -60,7 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let to_parse = std::sync::Arc::clone(&to_parse);
         std::thread::spawn(move || {
             let (to_parse, condvar) = &*to_parse;
-            while let Some(path) = to_read.lock().unwrap().pop() {
+            while let Some(path) = {
+                let mut to_read = to_read.lock().unwrap();
+                to_read.pop()
+             } {
                 let data = std::fs::read_to_string(&path).unwrap();
                 to_parse.lock().unwrap().0.push(WithSourcePath { path, value: data });
                 condvar.notify_one();


### PR DESCRIPTION
### Pull Request Description

See #14967

TL;DR

  - what is wrong: while let keeps the lock guard alive for the loop body
  - impact: the I/O worker threads serialize access to to_read instead of briefly locking only to pop the next path. This defeats the intended parallel file-reading stage.
  - fix: scope the lock to the pop() only
  - closes: Closes #14967


Suggested fix:

```diff
diff --git a/lib/rust/parser/debug/src/bin/check_syntax.rs b/lib/rust/parser/debug/src/bin/check_syntax.rs
--- a/lib/rust/parser/debug/src/bin/check_syntax.rs
+++ b/lib/rust/parser/debug/src/bin/check_syntax.rs
@@
-            while let Some(path) = to_read.lock().unwrap().pop() {
+            while let Some(path) = {
+                let mut to_read = to_read.lock().unwrap();
+                to_read.pop()
+            } {
                 let data = std::fs::read_to_string(&path).unwrap();
                 to_parse.lock().unwrap().0.push(WithSourcePath { path, value: data });
                 condvar.notify_one();
```

### Important Notes

Passed the cargo check (`cargo check -p enso-parser-debug --bin check_syntax`) against current `develop` branch.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
