### PR TITLE
Avoid `injectSyntheticModuleExports`  to lower transitive closure of `Text`, `Data` & co.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -42,6 +42,8 @@ from project.Metadata.Widget import File_Browse, Folder_Browse, Numeric_Input, T
 from project.Nothing import all
 from project.System.File_Format import Auto_Detect, File_Format
 
+export project.Data.Numbers
+
 ## ---
    aliases: [load, open]
    macros:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -34,6 +34,7 @@ import project.Runtime.Context
 import project.System.File.File
 import project.System.File.Generic.Writable_File.Writable_File
 from project.Data.Boolean import Boolean, False, True
+from project.Data.Text.Extensions import all
 from project.Error import all
 from project.Meta.Enso_Project import enso_project
 from project.Metadata.Choice import Option

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Internal/Helpers.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Internal/Helpers.enso
@@ -2,7 +2,7 @@ private
 
 from Standard.Base import all
 from Standard.Base.Runtime import assert
-from Standard.Base.Runtime import State
+import Standard.Base.Runtime.State
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import project.Group.Group

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsEmitSignatures.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/docs/DocsEmitSignatures.java
@@ -21,11 +21,11 @@ final class DocsEmitSignatures implements DocsVisit {
 
   @Override
   public boolean visitModule(QualifiedName name, Module module, PrintWriter w) throws IOException {
+    w.println("## Enso Signatures 1.0");
+    w.println("## module " + name);
     if (isEmpty(module)) {
       return false;
     } else {
-      w.println("## Enso Signatures 1.0");
-      w.println("## module " + name);
       return true;
     }
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -725,11 +725,12 @@ class Compiler(
       if (module.isSynthetic())
         expr
       else
-        injectSyntheticModuleExports(
-          module.getName().toString(),
-          expr,
-          module.getDirectModulesRefs
-        )
+        //injectSyntheticModuleExports(
+        //  module.getName().toString(),
+        //  expr,
+        //  module.getDirectModulesRefs
+        //)
+        expr
     context.updateModule(module, _.ir(exprWithModuleExports))
     val discoveredModule =
       recognizeBindings(exprWithModuleExports, moduleContext, irDumper)
@@ -858,7 +859,7 @@ class Compiler(
     * @param modules fully qualified names of modules
     * @return enhanced
     */
-  private def injectSyntheticModuleExports(
+  def injectSyntheticModuleExports(
     n: String,
     ir: IRModule,
     modules: java.util.List[QualifiedName]

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -13,13 +13,11 @@ import org.enso.compiler.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{
   Diagnostic,
   Expression,
-  Name,
   Warning,
   Module => IRModule
 }
 import org.enso.compiler.core.ir.MetadataStorage.MetadataPair
 import org.enso.compiler.core.ir.expression.Error
-import org.enso.compiler.core.ir.module.scope.Export
 import org.enso.compiler.core.ir.module.scope.Import
 import org.enso.compiler.core.ir.module.scope.imports
 import org.enso.compiler.core.EnsoParser
@@ -28,7 +26,6 @@ import org.enso.compiler.pass.PassManager
 import org.enso.compiler.pass.analyse._
 import org.enso.compiler.phase.{ImportResolver, ImportResolverAlgorithm}
 import org.enso.editions.LibraryName
-import org.enso.pkg.QualifiedName
 import org.enso.common.CompilationStage
 import org.enso.compiler.docs.{DocsGenerate, DocsVisit}
 import org.enso.compiler.dump.service.IRDumper
@@ -721,16 +718,7 @@ class Compiler(
     val idMap = Option(context.getIdMap(module))
     val expr  = EnsoParser.compile(src, idMap.map(_.values).orNull)
 
-    val exprWithModuleExports =
-      if (module.isSynthetic())
-        expr
-      else
-        //injectSyntheticModuleExports(
-        //  module.getName().toString(),
-        //  expr,
-        //  module.getDirectModulesRefs
-        //)
-        expr
+    val exprWithModuleExports = expr
     context.updateModule(module, _.ir(exprWithModuleExports))
     val discoveredModule =
       recognizeBindings(exprWithModuleExports, moduleContext, irDumper)
@@ -827,74 +815,6 @@ class Compiler(
     */
   def parseInline(source: CharSequence): Tree =
     Parser.parseBlock(source)
-
-  /** Enhances the provided IR with import/export statements for the provided list
-    * of fully qualified names of modules. The statements are considered to be "synthetic" i.e. compiler-generated.
-    * That way one can access modules using fully qualified names.
-    * E.g.,
-    * Given module A/B/C.enso
-    * ````
-    *   type C
-    *       C a
-    * ````
-    * it is possible to
-    * ```
-    * import A
-    * ...
-    *   x = A.B.C 0
-    * ```
-    * because the compiler will inject synthetic modules A and A.B such that
-    * A.enso:
-    * ````
-    *   import project.A.B
-    *   export project.A.B
-    * ````
-    * and A/B.enso:
-    * ````
-    *   import project.A.B.C
-    *   export project.A.B.C
-    * ````
-    * @param n name of module providing the IR
-    * @param ir IR to be enhanced
-    * @param modules fully qualified names of modules
-    * @return enhanced
-    */
-  def injectSyntheticModuleExports(
-    n: String,
-    ir: IRModule,
-    modules: java.util.List[QualifiedName]
-  ): IRModule = {
-    import scala.jdk.CollectionConverters._
-    n.getClass
-    val moduleNames = modules.asScala.map { q =>
-      val name = q.path.foldRight(
-        List(
-          Name.Literal
-            .builder()
-            .name(q.item)
-            .isMethod(false)
-            .build()
-        )
-      ) { case (part, acc) =>
-        Name.Literal
-          .builder()
-          .name(part)
-          .isMethod(false)
-          .build() :: acc
-      }
-      Name.Qualified.builder().parts(name).build()
-    }.toList
-    ir.copyWithImportsAndExports(
-      ir.imports ::: moduleNames.map(m => Import.Module.createSynthetic(m)),
-      ir.exports ::: moduleNames.map(m =>
-        Export.Module
-          .builder()
-          .name(m)
-          .isSynthetic(true)
-          .build()
-      )
-    )
-  }
 
   private def recognizeBindings(
     module: IRModule,

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecStrictCompilerTest.java
@@ -1,6 +1,5 @@
 package org.enso.compiler.test;
 
-import static org.enso.compiler.test.ExecCompilerTest.ctxRule;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -133,7 +133,7 @@ class ImportsTest extends PackageTest {
       fail("Should throw CompilerError")
     } catch {
       case e: InterpreterException =>
-        e.getMessage.contains("Conflicting resolutions") shouldBe true
+        e.getMessage.trim shouldEqual "Method `c_mod_method` of type C.type could not be found."
     }
   }
 

--- a/test/Base_Tests/src/Data/Regression_Spec.enso
+++ b/test/Base_Tests/src/Data/Regression_Spec.enso
@@ -1,4 +1,5 @@
-from Standard.Base import Nothing, Float, Regression
+from Standard.Base import Nothing, Float
+import Standard.Base.Data.Regression
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Test import all


### PR DESCRIPTION

### Pull Request Description

- Avoid `injectSyntheticModuleExports` as that needlessly increases transitive closure of imports
- needed by #14980
   - in fact needed by #12819  
   - and any task that builds on top of #12819
- the [failures are moderate](https://github.com/enso-org/enso/pull/14984#issuecomment-4311358657) and can be mitigated
- what do you think guys about these changes?

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
