### PR TITLE
Fix clashing project ids in ProjectManager

### DIFF
--- a/app/common/src/services/Backend.ts
+++ b/app/common/src/services/Backend.ts
@@ -293,6 +293,8 @@ export interface Project extends CreatedProject {
   readonly url?: HttpsUrl
   /** On Local Backend, this is the internal UUID of the project read from `.enso/project.json` */
   readonly internalId?: UUID
+  /** On Local Backend, this is opaque key derived from parent directory and internal UUID. */
+  readonly localProjectKey?: string
 }
 
 /** A user/organization's project containing and/or currently executing code. */

--- a/app/common/src/services/LocalBackend.ts
+++ b/app/common/src/services/LocalBackend.ts
@@ -348,7 +348,7 @@ export class LocalBackend extends backend.Backend {
   ): Promise<backend.Project> {
     const { path } = backend.extractTypeAndPath(projectId)
     const { directoryPath } = getDirectoryAndName(path)
-    const localProjectKey = await this.projectManager.getLocalProjectKey(path)
+    const localProjectKey = await this.projectManager.getTelemetryKey(path)
     if (localProjectKey == null) {
       throw new Error(`Could not get local project key for project '${path}'`)
     }
@@ -967,7 +967,7 @@ export class LocalBackend extends backend.Backend {
     projectId: backend.ProjectId,
   ): Promise<backend.ProjectSession[]> {
     const { path } = backend.extractTypeAndPath(projectId)
-    const localProjectKey = await this.projectManager.getLocalProjectKey(path)
+    const localProjectKey = await this.projectManager.getTelemetryKey(path)
     if (localProjectKey == null) return []
     const { sessions } = await this.projectManager.listProjectSessions(localProjectKey)
     return sessions.map((s) => ({

--- a/app/common/src/services/LocalBackend.ts
+++ b/app/common/src/services/LocalBackend.ts
@@ -348,6 +348,10 @@ export class LocalBackend extends backend.Backend {
   ): Promise<backend.Project> {
     const { path } = backend.extractTypeAndPath(projectId)
     const { directoryPath } = getDirectoryAndName(path)
+    const localProjectKey = await this.projectManager.getLocalProjectKey(path)
+    if (localProjectKey == null) {
+      throw new Error(`Could not get local project key for project '${path}'`)
+    }
     const state = await this.projectManager.getProject(path)
     if (state == null) {
       const entries = await this.projectManager.listDirectory(directoryPath)
@@ -369,6 +373,8 @@ export class LocalBackend extends backend.Backend {
           state: { type: backend.ProjectState.closed, volumeId: '' },
           url: backend.HttpsUrl(this.resolvePath(downloadProjectPath(projectId))),
           ensoPath,
+          internalId: project.id,
+          localProjectKey,
         }
       }
     } else {
@@ -390,6 +396,7 @@ export class LocalBackend extends backend.Backend {
         url: backend.HttpsUrl(this.resolvePath(downloadProjectPath(projectId))),
         ensoPath: backend.EnsoPath(`${directoryPath}/${cachedProject.projectNormalizedName}`),
         internalId: cachedProject.projectId,
+        localProjectKey,
       }
     }
   }
@@ -960,9 +967,9 @@ export class LocalBackend extends backend.Backend {
     projectId: backend.ProjectId,
   ): Promise<backend.ProjectSession[]> {
     const { path } = backend.extractTypeAndPath(projectId)
-    const uuid = await this.projectManager.getProjectId(path)
-    if (uuid == null) return []
-    const { sessions } = await this.projectManager.listProjectSessions(uuid)
+    const localProjectKey = await this.projectManager.getLocalProjectKey(path)
+    if (localProjectKey == null) return []
+    const { sessions } = await this.projectManager.listProjectSessions(localProjectKey)
     return sessions.map((s) => ({
       projectId,
       projectSessionId: backend.ProjectSessionId(s.projectSessionId),

--- a/app/common/src/services/ProjectManager/ProjectManager.ts
+++ b/app/common/src/services/ProjectManager/ProjectManager.ts
@@ -13,7 +13,7 @@ import {
 } from '../../utilities/file.js'
 import { normalizeName } from '../../utilities/nameValidation.js'
 import * as backend from '../Backend.js'
-import { makeLocalProjectKey, makeProjectCacheKey } from './projectIdentity.js'
+import { makeProjectCacheKey, makeProjectTelemetryKey } from './projectIdentity.js'
 import {
   MissingComponentAction,
   Path,
@@ -379,13 +379,13 @@ export class ProjectManager {
     }
   }
 
-  /** Return opaque local key used for local logs and telemetry. */
-  async getLocalProjectKey(projectPath: Path) {
+  /** Return opaque cache key used for local logs and telemetry. */
+  async getTelemetryKey(projectPath: Path) {
     const projectId = await this.getProjectId(projectPath)
     if (projectId == null) {
       return undefined
     }
-    return makeLocalProjectKey(getDirectoryAndName(projectPath).directoryPath, projectId)
+    return makeProjectTelemetryKey(getDirectoryAndName(projectPath).directoryPath, projectId)
   }
 
   /** List project sessions by scanning engine log files for the given local project key. */

--- a/app/common/src/services/ProjectManager/ProjectManager.ts
+++ b/app/common/src/services/ProjectManager/ProjectManager.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utilities/file.js'
 import { normalizeName } from '../../utilities/nameValidation.js'
 import * as backend from '../Backend.js'
+import { makeLocalProjectKey, makeProjectCacheKey } from './projectIdentity.js'
 import {
   MissingComponentAction,
   Path,
@@ -42,7 +43,7 @@ type WithProjectPath<T> = Omit<T, 'projectId' | 'projectsDirectory'> & {
 export class ProjectManager {
   // This is required so that projects get recursively updated (deleted, renamed or moved).
   private readonly directories = new Map<Path, readonly FileSystemEntry[]>()
-  private readonly projects = new Map<UUID, ProjectState>()
+  private readonly projects = new Map<string, ProjectState>()
   private readonly projectIds = new Map<Path, UUID>()
 
   /** Create a {@link ProjectManager} */
@@ -58,22 +59,21 @@ export class ProjectManager {
 
   /** Get the state of a project given its path. */
   async getProject(projectPath: Path) {
-    const existingProjectId = this.projectIds.get(projectPath)
-    if (existingProjectId) {
-      return this.projects.get(existingProjectId)
+    const cacheKey = await this.getProjectCacheKey(projectPath)
+    if (cacheKey != null) {
+      return this.projects.get(cacheKey)
     }
-    await this.listDirectory(Path(getFolderPath(projectPath)))
-    const projectId = this.projectIds.get(projectPath)
-    if (!projectId) {
+    if (!this.projectIds.has(projectPath)) {
       throw new Error(`Unknown project id for project '${projectPath}'.`)
     }
-    return this.projects.get(projectId)
+    return this.projects.get(await this.requireProjectCacheKey(projectPath))
   }
 
   /** Open an existing project. */
   async openProject(params: WithProjectPath<OpenProjectParams>): Promise<OpenProject> {
     const fullParams: OpenProjectParams = await this.paramsWithPathToWithId(params)
-    const cached = this.projects.get(fullParams.projectId)
+    const cacheKey = makeProjectCacheKey(fullParams)
+    const cached = this.projects.get(cacheKey)
     if (cached) {
       return cached.data
     } else {
@@ -81,19 +81,19 @@ export class ProjectManager {
         'project/open',
         fullParams,
       )
-      this.projects.set(fullParams.projectId, {
+      this.projects.set(cacheKey, {
         state: backend.ProjectState.openInProgress,
         data: promise,
       })
       try {
         const result = await promise
-        this.projects.set(fullParams.projectId, {
+        this.projects.set(cacheKey, {
           state: backend.ProjectState.opened,
           data: result,
         })
         return result
       } catch (error) {
-        this.projects.delete(fullParams.projectId)
+        this.projects.delete(cacheKey)
         throw error
       }
     }
@@ -101,8 +101,9 @@ export class ProjectManager {
 
   /** Close an open project. */
   async closeProject(params: WithProjectPath<CloseProjectParams>): Promise<void> {
-    const id = this.projectIds.get(params.projectPath)
-    const state = id != null ? this.projects.get(id) : null
+    const fullParams: CloseProjectParams = await this.paramsWithPathToWithId(params)
+    const cacheKey = makeProjectCacheKey(fullParams)
+    const state = this.projects.get(cacheKey)
     if (state?.state === backend.ProjectState.openInProgress) {
       // Projects that are not opened cannot be closed.
       // This is the only way to wait until the project is open.
@@ -111,8 +112,7 @@ export class ProjectManager {
         missingComponentAction: MissingComponentAction.install,
       })
     }
-    const fullParams: CloseProjectParams = await this.paramsWithPathToWithId(params)
-    this.projects.delete(fullParams.projectId)
+    this.projects.delete(cacheKey)
     return this.runProjectServiceCommand('project/close', fullParams)
   }
 
@@ -148,10 +148,11 @@ export class ProjectManager {
   /** Rename a project. */
   async renameProject(params: WithProjectPath<RenameProjectParams>): Promise<void> {
     const fullParams: RenameProjectParams = await this.paramsWithPathToWithId(params)
+    const cacheKey = makeProjectCacheKey(fullParams)
     await this.runProjectServiceCommand('project/rename', fullParams)
-    const state = this.projects.get(fullParams.projectId)
+    const state = this.projects.get(cacheKey)
     if (state?.state === backend.ProjectState.opened) {
-      this.projects.set(fullParams.projectId, {
+      this.projects.set(cacheKey, {
         state: state.state,
         data: {
           ...state.data,
@@ -191,20 +192,19 @@ export class ProjectManager {
   /** Delete a project. */
   async deleteProject(params: WithProjectPath<DeleteProjectParams>): Promise<void> {
     const fullParams: DeleteProjectParams = await this.paramsWithPathToWithId(params)
-    const cached = this.projects.get(fullParams.projectId)
+    const cacheKey = makeProjectCacheKey(fullParams)
+    const cached = this.projects.get(cacheKey)
     if (cached && backend.IS_OPENING_OR_OPENED[cached.state]) {
       await this.closeProject({ projectPath: params.projectPath })
     }
     await this.runProjectServiceCommand('project/delete', fullParams)
     this.projectIds.delete(params.projectPath)
-    this.projects.delete(fullParams.projectId)
+    this.projects.delete(cacheKey)
     const siblings = this.directories.get(fullParams.projectsDirectory)
     if (siblings != null) {
       this.directories.set(
         fullParams.projectsDirectory,
-        siblings.filter(
-          (entry) => entry.type !== 'ProjectEntry' || entry.metadata.id !== fullParams.projectId,
-        ),
+        siblings.filter((entry) => entry.path !== params.projectPath),
       )
     }
   }
@@ -332,7 +332,12 @@ export class ProjectManager {
               break
             }
             case 'ProjectEntry': {
-              this.projects.delete(child.metadata.id)
+              this.projects.delete(
+                makeProjectCacheKey({
+                  projectId: child.metadata.id,
+                  projectsDirectory: getDirectoryAndName(child.path).directoryPath,
+                }),
+              )
               this.projectIds.delete(child.path)
               break
             }
@@ -374,11 +379,20 @@ export class ProjectManager {
     }
   }
 
-  /** List project sessions by scanning engine log files for the given project UUID. */
-  async listProjectSessions(projectId: string) {
+  /** Return opaque local key used for local logs and telemetry. */
+  async getLocalProjectKey(projectPath: Path) {
+    const projectId = await this.getProjectId(projectPath)
+    if (projectId == null) {
+      return undefined
+    }
+    return makeLocalProjectKey(getDirectoryAndName(projectPath).directoryPath, projectId)
+  }
+
+  /** List project sessions by scanning engine log files for the given local project key. */
+  async listProjectSessions(localProjectKey: string) {
     return this.runStandaloneCommandJson<{
       sessions: readonly { projectSessionId: string; createdAt: string }[]
-    }>(null, 'list-project-sessions', projectId)
+    }>(null, 'list-project-sessions', localProjectKey)
   }
 
   /** Get log content for a local project session. */
@@ -435,5 +449,24 @@ export class ProjectManager {
     } else {
       throw new Error(json.error.message)
     }
+  }
+
+  private async getProjectCacheKey(projectPath: Path) {
+    const projectId = await this.getProjectId(projectPath)
+    if (projectId == null) {
+      return undefined
+    }
+    return makeProjectCacheKey({
+      projectId,
+      projectsDirectory: getDirectoryAndName(projectPath).directoryPath,
+    })
+  }
+
+  private async requireProjectCacheKey(projectPath: Path) {
+    const cacheKey = await this.getProjectCacheKey(projectPath)
+    if (cacheKey == null) {
+      throw new Error(`Unknown project id for project '${projectPath}'.`)
+    }
+    return cacheKey
   }
 }

--- a/app/common/src/services/ProjectManager/__tests__/ProjectManager.test.ts
+++ b/app/common/src/services/ProjectManager/__tests__/ProjectManager.test.ts
@@ -177,11 +177,11 @@ describe('ProjectManager', () => {
     ])
   })
 
-  it('derives different local project keys for same embedded id in different parent directories', async () => {
+  it('derives different project telemtry keys for same embedded id in different parent directories', async () => {
     const projectManager = new ProjectManager(ROOT)
 
-    const firstKey = await projectManager.getLocalProjectKey(FIRST_PROJECT_PATH)
-    const secondKey = await projectManager.getLocalProjectKey(SECOND_PROJECT_PATH)
+    const firstKey = await projectManager.getTelemetryKey(FIRST_PROJECT_PATH)
+    const secondKey = await projectManager.getTelemetryKey(SECOND_PROJECT_PATH)
 
     expect(firstKey).toMatch(/^local-[0-9a-f]{64}$/)
     expect(secondKey).toMatch(/^local-[0-9a-f]{64}$/)

--- a/app/common/src/services/ProjectManager/__tests__/ProjectManager.test.ts
+++ b/app/common/src/services/ProjectManager/__tests__/ProjectManager.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectState as BackendProjectState } from '../../Backend'
+import { ProjectManager } from '../ProjectManager'
+import {
+  MissingComponentAction,
+  Path,
+  UTCDateTime,
+  UUID,
+  type FileSystemEntry,
+  type OpenProjectParams,
+} from '../types'
+
+const ROOT = Path('/root')
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111'
+const FIRST_PARENT = '/root/cloud-first'
+const SECOND_PARENT = '/root/cloud-second'
+const FIRST_PROJECT_PATH = Path(`${FIRST_PARENT}/project_root`)
+const SECOND_PROJECT_PATH = Path(`${SECOND_PARENT}/project_root`)
+
+function jsonRpcResult<T>(result: T) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: 1,
+    result,
+  }
+}
+
+function projectEntry(path: Path): FileSystemEntry {
+  const mockCreationTime = UTCDateTime('2026-01-01T00:00:00.000Z')
+  return {
+    type: 'ProjectEntry',
+    path,
+    attributes: {
+      creationTime: mockCreationTime,
+      lastAccessTime: mockCreationTime,
+      lastModifiedTime: mockCreationTime,
+      byteSize: 0,
+    },
+    metadata: {
+      name: 'Project',
+      namespace: 'local',
+      id: UUID(PROJECT_ID),
+      created: mockCreationTime,
+    },
+  }
+}
+
+describe('ProjectManager', () => {
+  const openCalls: OpenProjectParams[] = []
+  const closeCalls: { projectId: string; projectsDirectory: string }[] = []
+
+  beforeEach(() => {
+    openCalls.length = 0
+    closeCalls.length = 0
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input
+          : input instanceof URL ? input.toString()
+          : input.url
+        if (url.startsWith('/api/run-project-manager-command?')) {
+          const parsed = new URL(url, 'https://example.test')
+          const cliArguments = JSON.parse(
+            parsed.searchParams.get('cli-arguments') ?? '[]',
+          ) as string[]
+          const command = cliArguments[0]
+          const targetPath = cliArguments[1]?.replace(/\/$/, '')
+          if (command !== '--filesystem-list') {
+            throw new Error(`Unexpected standalone command: ${String(command)}`)
+          }
+          const entries =
+            targetPath === FIRST_PARENT ? [projectEntry(FIRST_PROJECT_PATH)]
+            : targetPath === SECOND_PARENT ? [projectEntry(SECOND_PROJECT_PATH)]
+            : []
+          return {
+            json: async () => jsonRpcResult({ entries }),
+          } as Response
+        }
+
+        if (url === '/api/project-service/project/open') {
+          const body = JSON.parse(String(init?.body)) as OpenProjectParams
+          openCalls.push(body)
+          const port = body.projectsDirectory === Path(FIRST_PARENT) ? 4101 : 4102
+          return {
+            json: async () =>
+              jsonRpcResult({
+                projectId: body.projectId,
+                languageServerJsonAddress: { host: '127.0.0.1', port },
+                languageServerYdocAddress: { host: '127.0.0.1', port: port + 1000 },
+                projectName: body.projectsDirectory === Path(FIRST_PARENT) ? 'First' : 'Second',
+                projectNormalizedName:
+                  body.projectsDirectory === Path(FIRST_PARENT) ? 'First' : 'Second',
+                projectNamespace: 'local',
+              }),
+          } as Response
+        }
+
+        if (url === '/api/project-service/project/close') {
+          const body = JSON.parse(String(init?.body)) as {
+            projectId: string
+            projectsDirectory: string
+          }
+          closeCalls.push(body)
+          return {
+            json: async () => jsonRpcResult(null),
+          } as Response
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('opens projects with the same embedded id independently when their paths differ', async () => {
+    const projectManager = new ProjectManager(ROOT)
+
+    const first = await projectManager.openProject({
+      projectPath: FIRST_PROJECT_PATH,
+      missingComponentAction: MissingComponentAction.install,
+    })
+    const second = await projectManager.openProject({
+      projectPath: SECOND_PROJECT_PATH,
+      missingComponentAction: MissingComponentAction.install,
+    })
+
+    expect(first.languageServerJsonAddress.port).toBe(4101)
+    expect(second.languageServerJsonAddress.port).toBe(4102)
+    expect(openCalls).toEqual([
+      {
+        projectId: PROJECT_ID,
+        projectsDirectory: FIRST_PARENT,
+        missingComponentAction: MissingComponentAction.install,
+      },
+      {
+        projectId: PROJECT_ID,
+        projectsDirectory: SECOND_PARENT,
+        missingComponentAction: MissingComponentAction.install,
+      },
+    ])
+
+    const firstState = await projectManager.getProject(FIRST_PROJECT_PATH)
+    const secondState = await projectManager.getProject(SECOND_PROJECT_PATH)
+
+    expect(firstState?.state).toBe(BackendProjectState.opened)
+    expect(secondState?.state).toBe(BackendProjectState.opened)
+    expect((await firstState?.data)?.languageServerJsonAddress.port).toBe(4101)
+    expect((await secondState?.data)?.languageServerJsonAddress.port).toBe(4102)
+  })
+
+  it('closing one path does not clear another open project with the same embedded id', async () => {
+    const projectManager = new ProjectManager(ROOT)
+
+    await projectManager.openProject({
+      projectPath: FIRST_PROJECT_PATH,
+      missingComponentAction: MissingComponentAction.install,
+    })
+    await projectManager.openProject({
+      projectPath: SECOND_PROJECT_PATH,
+      missingComponentAction: MissingComponentAction.install,
+    })
+
+    await projectManager.closeProject({ projectPath: SECOND_PROJECT_PATH })
+
+    const firstProject = await projectManager.getProject(FIRST_PROJECT_PATH)
+    expect(firstProject?.state).toBe(BackendProjectState.opened)
+    expect(closeCalls).toEqual([
+      {
+        projectId: PROJECT_ID,
+        projectsDirectory: SECOND_PARENT,
+      },
+    ])
+  })
+
+  it('derives different local project keys for same embedded id in different parent directories', async () => {
+    const projectManager = new ProjectManager(ROOT)
+
+    const firstKey = await projectManager.getLocalProjectKey(FIRST_PROJECT_PATH)
+    const secondKey = await projectManager.getLocalProjectKey(SECOND_PROJECT_PATH)
+
+    expect(firstKey).toMatch(/^local-[0-9a-f]{64}$/)
+    expect(secondKey).toMatch(/^local-[0-9a-f]{64}$/)
+    expect(firstKey).not.toBe(secondKey)
+  })
+})

--- a/app/common/src/services/ProjectManager/projectIdentity.ts
+++ b/app/common/src/services/ProjectManager/projectIdentity.ts
@@ -15,8 +15,8 @@ export function makeProjectCacheKey(params: {
   return `${params.projectsDirectory}${PROJECT_IDENTITY_SEPARATOR}${params.projectId}`
 }
 
-/** Create opaque local key used for logs and telemetry. */
-export async function makeLocalProjectKey(
+/** Create opaque cache key used for logs and telemetry. */
+export async function makeProjectTelemetryKey(
   projectsDirectory: Path | string,
   projectId: UUID | string,
 ) {

--- a/app/common/src/services/ProjectManager/projectIdentity.ts
+++ b/app/common/src/services/ProjectManager/projectIdentity.ts
@@ -1,0 +1,31 @@
+import type { Path, UUID } from './types.js'
+
+const PROJECT_IDENTITY_SEPARATOR = '\0'
+const LOCAL_PROJECT_KEY_PREFIX = 'local-'
+
+function byteToHex(byte: number) {
+  return byte.toString(16).padStart(2, '0')
+}
+
+/** Create cache key for project-service local identity. */
+export function makeProjectCacheKey(params: {
+  readonly projectId: UUID | string
+  readonly projectsDirectory: Path | string
+}) {
+  return `${params.projectsDirectory}${PROJECT_IDENTITY_SEPARATOR}${params.projectId}`
+}
+
+/** Create opaque local key used for logs and telemetry. */
+export async function makeLocalProjectKey(
+  projectsDirectory: Path | string,
+  projectId: UUID | string,
+) {
+  const crypto = globalThis.crypto
+  if (crypto == null || crypto.subtle == null) {
+    throw new Error('Web Crypto API unavailable.')
+  }
+  const input = new TextEncoder().encode(makeProjectCacheKey({ projectsDirectory, projectId }))
+  const digest = await crypto.subtle.digest('SHA-256', input)
+  const hex = Array.from(new Uint8Array(digest), byteToHex).join('')
+  return `${LOCAL_PROJECT_KEY_PREFIX}${hex}`
+}

--- a/app/common/tsconfig.json
+++ b/app/common/tsconfig.json
@@ -25,6 +25,8 @@
     "./src/services/HttpClient.ts",
     "./src/services/LocalBackend.ts",
     "./src/services/ProjectManager/ProjectManager.ts",
+    "./src/services/ProjectManager/__tests__/ProjectManager.test.ts",
+    "./src/services/ProjectManager/projectIdentity.ts",
     "./src/services/ProjectManager/types.ts",
     "./src/services/RemoteBackend.ts",
     "./src/services/RemoteBackend/ids.ts",

--- a/app/gui/src/providers/openedProjects/projectStates.ts
+++ b/app/gui/src/providers/openedProjects/projectStates.ts
@@ -507,9 +507,8 @@ export function useProjectStates() {
   /** Create an event logger for given project. */
   function eventLogger(project: Opened, runDetails: ProjectDetails) {
     const logProjectId =
-      project.info.mode === 'local' ?
-        `project-${runDetails.internalId?.replaceAll('-', '')}`
-      : project.info.id
+      project.info.mode === 'local' ? runDetails.localProjectKey : project.info.id
+    assertDefined(logProjectId)
     return {
       async send(message: string) {
         backends.remoteBackend.logEvent(message, logProjectId)

--- a/app/project-manager-shim/src/handler/__tests__/filesystem.test.ts
+++ b/app/project-manager-shim/src/handler/__tests__/filesystem.test.ts
@@ -8,8 +8,107 @@ import {
   downloadProjectSessionLogs,
   encodeSessionId,
   getProjectSessionLogs,
+  handleFilesystemCommand,
   listProjectSessions,
 } from '../filesystem'
+
+async function createProject(directory: string, id: string, name = path.basename(directory)) {
+  await fsPromises.mkdir(path.join(directory, '.enso'), { recursive: true })
+  await fsPromises.writeFile(
+    path.join(directory, 'package.yaml'),
+    `name: ${name}\nnamespace: local\n`,
+  )
+  await fsPromises.writeFile(
+    path.join(directory, '.enso/project.json'),
+    JSON.stringify({ id, kind: 'UserProject', created: '2026-01-01T00:00:00.000Z' }, null, 2),
+  )
+}
+
+async function listEntries(directory: string, recursive = false) {
+  const response = await handleFilesystemCommand(
+    [recursive ? '--filesystem-list-recursive' : '--filesystem-list', directory],
+    {} as any,
+  )
+  if (typeof response !== 'string') {
+    throw new Error('Expected JSON-RPC string response.')
+  }
+  return (JSON.parse(response) as { result: { entries: unknown[] } }).result.entries
+}
+
+describe('filesystem listing duplicate resolution', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'filesystem-list-test-'))
+  })
+
+  afterEach(async () => {
+    await fsPromises.rm(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 1000 })
+  })
+
+  test('dedupes sibling project IDs during listing and rewrites younger metadata on disk', async () => {
+    const duplicateId = '11111111-1111-1111-1111-111111111111'
+    const olderProject = path.join(tmpDir, 'older')
+    const youngerProject = path.join(tmpDir, 'younger')
+
+    await createProject(olderProject, duplicateId, 'Older')
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await createProject(youngerProject, duplicateId, 'Younger')
+
+    const entries = (await listEntries(tmpDir)).filter(
+      (
+        entry,
+      ): entry is {
+        type: 'ProjectEntry'
+        path: string
+        metadata: { id: string; name: string }
+      } =>
+        typeof entry === 'object' &&
+        entry != null &&
+        'type' in entry &&
+        entry.type === 'ProjectEntry' &&
+        'metadata' in entry,
+    )
+    const olderEntry = entries.find((entry) => entry.path === olderProject)
+    const youngerEntry = entries.find((entry) => entry.path === youngerProject)
+    const youngerMetadata = JSON.parse(
+      await fsPromises.readFile(path.join(youngerProject, '.enso/project.json'), 'utf-8'),
+    )
+
+    expect(entries).toHaveLength(2)
+    expect(olderEntry?.metadata.id).toBe(duplicateId)
+    expect(youngerEntry?.metadata.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    )
+    expect(youngerEntry?.metadata.id).not.toBe(duplicateId)
+    expect(youngerMetadata.id).toBe(youngerEntry?.metadata.id)
+  })
+
+  test('recursive listing does not dedupe same IDs across different parent directories', async () => {
+    const duplicateId = '22222222-2222-2222-2222-222222222222'
+    const firstParent = path.join(tmpDir, 'first-parent')
+    const secondParent = path.join(tmpDir, 'second-parent')
+    const firstProject = path.join(firstParent, 'project')
+    const secondProject = path.join(secondParent, 'project')
+
+    await fsPromises.mkdir(firstParent, { recursive: true })
+    await fsPromises.mkdir(secondParent, { recursive: true })
+    await createProject(firstProject, duplicateId, 'First')
+    await createProject(secondProject, duplicateId, 'Second')
+
+    const projects = (await listEntries(tmpDir, true)).filter(
+      (entry): entry is { type: 'ProjectEntry'; path: string; metadata: { id: string } } =>
+        typeof entry === 'object' &&
+        entry != null &&
+        'type' in entry &&
+        entry.type === 'ProjectEntry' &&
+        'metadata' in entry,
+    )
+
+    expect(projects.find((entry) => entry.path === firstProject)?.metadata.id).toBe(duplicateId)
+    expect(projects.find((entry) => entry.path === secondProject)?.metadata.id).toBe(duplicateId)
+  })
+})
 
 describe('listProjectSessions', () => {
   let tmpDir: string

--- a/app/project-manager-shim/src/handler/filesystem.ts
+++ b/app/project-manager-shim/src/handler/filesystem.ts
@@ -10,6 +10,7 @@ import { Rfc3339DateTime } from 'enso-common/src/utilities/data/dateTime'
 import * as yaml from 'yaml'
 import { getEngineLogDirectory } from '../distributionManager.js'
 import * as projectManagement from '../projectManagement.js'
+import { resolveClashingProjectIds } from '../projectService/resolveClashingProjectIds.js'
 import { toJSONRPCError, toJSONRPCResult } from './jsonrpc.js'
 
 // =======================
@@ -180,7 +181,7 @@ export async function handleFilesystemCommand(
       case '--filesystem-list':
       case '--filesystem-list-recursive': {
         const directoryPath = cliArguments[1]
-        const isRecursive = cliArguments[1] === '--filesystem-list-recursive'
+        const isRecursive = cliArguments[0] === '--filesystem-list-recursive'
         if (directoryPath == null) break
         const directoryPathQueue = [directoryPath]
         const entries: FileSystemEntry[] = []
@@ -188,13 +189,18 @@ export async function handleFilesystemCommand(
           const currentDirectoryPath = directoryPathQueue.shift()
           if (currentDirectoryPath == null) break
           const entryNames = await fs.readdir(currentDirectoryPath)
-          for (const entryName of entryNames) {
-            const entryPath = path.join(currentDirectoryPath, entryName)
-            if (isFileHidden(entryPath)) continue
-            const entry = await getFileSystemEntry(entryPath)
-            entries.push(entry)
+          const fileEntries = await Promise.all(
+            entryNames.map(async (entryName) => {
+              const entryPath = path.join(currentDirectoryPath, entryName)
+              if (isFileHidden(entryPath)) return []
+              return [await getFileSystemEntry(entryPath)]
+            }),
+          )
+          const resolvedEntries = await resolveClashingProjectEntryIds(fileEntries.flat())
+          entries.push(...resolvedEntries)
+          for (const entry of resolvedEntries) {
             if (isRecursive && entry.type === FileSystemEntryType.DirectoryEntry) {
-              directoryPathQueue.push(entryPath)
+              directoryPathQueue.push(entry.path)
             }
           }
         }
@@ -249,9 +255,9 @@ export async function handleFilesystemCommand(
         break
       }
       case '--list-project-sessions': {
-        const projectId = cliArguments[1]
-        if (projectId == null) break
-        result = toJSONRPCResult(await listProjectSessions(projectId))
+        const localProjectKey = cliArguments[1]
+        if (localProjectKey == null) break
+        result = toJSONRPCResult(await listProjectSessions(localProjectKey))
         break
       }
       case '--get-project-session-logs': {
@@ -281,12 +287,56 @@ export async function handleFilesystemCommand(
   return result
 }
 
+/** Update metadata ids of projects to avoid duplicates. */
+async function resolveClashingProjectEntryIds(entries: readonly FileSystemEntry[]) {
+  const rewrittenProjects = new Map<string, ProjectEntry>()
+  const projects = entries.flatMap((entry) =>
+    entry.type === FileSystemEntryType.ProjectEntry ?
+      [
+        {
+          entry,
+          id: entry.metadata.id,
+          directoryCreationTime: entry.attributes.creationTime,
+        },
+      ]
+    : [],
+  )
+  const resolvedProjects = await resolveClashingProjectIds(projects, async (project, newId) => {
+    const projectMetadataPath = path.join(
+      project.entry.path,
+      projectManagement.PROJECT_METADATA_RELATIVE_PATH,
+    )
+    const projectMetadata = JSON.parse(await fs.readFile(projectMetadataPath, 'utf-8'))
+    projectMetadata.id = newId
+    await fs.writeFile(projectMetadataPath, JSON.stringify(projectMetadata, null, 2))
+    return {
+      ...project,
+      id: newId,
+      entry: {
+        ...project.entry,
+        metadata: {
+          ...project.entry.metadata,
+          id: newId,
+        },
+      },
+    }
+  })
+  for (const project of resolvedProjects) {
+    rewrittenProjects.set(project.entry.path, project.entry)
+  }
+  return entries.map((entry) =>
+    entry.type === FileSystemEntryType.ProjectEntry ?
+      (rewrittenProjects.get(entry.path) ?? entry)
+    : entry,
+  )
+}
+
 /** Get a file system entry for a given path. */
 export async function getFileSystemEntry(entryPath: string): Promise<FileSystemEntry> {
   const stat = await fs.stat(entryPath)
   const attributes: Attributes = {
     byteSize: stat.size,
-    creationTime: new Date(stat.ctimeMs).toISOString(),
+    creationTime: new Date(stat.birthtime).toISOString(),
     lastAccessTime: new Date(stat.atimeMs).toISOString(),
     lastModifiedTime: new Date(stat.mtimeMs).toISOString(),
   }
@@ -383,15 +433,15 @@ function extractSessionBaseName(filename: string): string | null {
 }
 
 /**
- * Encode a session ID from projectId and file base name.
- * Format: `localprojectsession-{projectId}/{baseName}`
+ * Encode a session ID from local project key and file base name.
+ * Format: `localprojectsession-{localProjectKey}/{baseName}`
  */
-export function encodeSessionId(projectId: string, baseName: string): string {
-  return `${SESSION_ID_PREFIX}${projectId}/${baseName}`
+export function encodeSessionId(localProjectKey: string, baseName: string): string {
+  return `${SESSION_ID_PREFIX}${localProjectKey}/${baseName}`
 }
 
 /**
- * Decode a session ID into projectId and file base name.
+ * Decode a session ID into local project key and file base name.
  * Returns the project log directory and the file base name.
  * Throws if the session ID contains path traversal attempts.
  */
@@ -406,25 +456,25 @@ function decodeSessionId(sessionId: string): { projectLogDir: string; baseName: 
     }
     return { projectLogDir: logDir, baseName: raw }
   }
-  const projectId = raw.slice(0, slashIdx)
+  const localProjectKey = raw.slice(0, slashIdx)
   const baseName = raw.slice(slashIdx + 1)
-  if (!isSafePathSegment(projectId) || !isSafePathSegment(baseName)) {
+  if (!isSafePathSegment(localProjectKey) || !isSafePathSegment(baseName)) {
     throw new Error(`Invalid session ID: unsafe path segments in '${sessionId}'`)
   }
-  return { projectLogDir: path.join(logDir, projectId), baseName }
+  return { projectLogDir: path.join(logDir, localProjectKey), baseName }
 }
 
 /**
- * List project sessions by scanning `{logDir}/{projectId}/` for log files.
+ * List project sessions by scanning `{logDir}/{localProjectKey}/` for log files.
  * Each unique base name (active log + its rolled archives) is one session.
  */
 export async function listProjectSessions(
-  projectId: string,
+  localProjectKey: string,
 ): Promise<{ sessions: readonly { projectSessionId: string; createdAt: Rfc3339DateTime }[] }> {
-  if (!isSafePathSegment(projectId)) {
-    throw new Error(`Invalid project ID: unsafe segment '${projectId}'`)
+  if (!isSafePathSegment(localProjectKey)) {
+    throw new Error(`Invalid project key: unsafe segment '${localProjectKey}'`)
   }
-  const projectLogDir = path.join(getEngineLogDirectory(), projectId)
+  const projectLogDir = path.join(getEngineLogDirectory(), localProjectKey)
   let entries: string[]
   try {
     entries = await fs.readdir(projectLogDir)
@@ -445,7 +495,7 @@ export async function listProjectSessions(
     const createdAt = parseDateTimeFromFilename(baseName)
     if (!createdAt) continue
     sessions.push({
-      projectSessionId: encodeSessionId(projectId, baseName),
+      projectSessionId: encodeSessionId(localProjectKey, baseName),
       createdAt,
     })
   }

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -4,6 +4,7 @@
  * renaming, opening, closing, and duplicating projects.
  */
 import { PRODUCT_NAME } from 'enso-common/src/constants'
+import { makeLocalProjectKey } from 'enso-common/src/services/ProjectManager/projectIdentity'
 import { toRfc3339 } from 'enso-common/src/utilities/data/dateTime'
 import KSUID from 'ksuid'
 import * as crypto from 'node:crypto'
@@ -164,14 +165,16 @@ export class ProjectService {
     return project
   }
 
-  private projectEnvVars(
+  private async projectEnvVars(
     projectId: UUID,
+    projectsDirectory: Path,
     cloud?: CloudParams,
-  ): readonly (readonly [string, string])[] {
+  ): Promise<readonly (readonly [string, string])[]> {
     if (!cloud) {
       const localSessionId = `localprojectsession-${KSUID.randomSync().string}`
+      const localProjectKey = await makeLocalProjectKey(projectsDirectory, projectId)
       return [
-        ['ENSO_LOCAL_PROJECT_ID', projectId],
+        ['ENSO_LOCAL_PROJECT_ID', localProjectKey],
         ['ENSO_LOCAL_PROJECT_SESSION_ID', localSessionId],
       ]
     }
@@ -189,7 +192,7 @@ export class ProjectService {
     this.logger.debug(`Running project '${project.path}'`)
     const exitCode = await this.runner.runProject(
       project.path,
-      this.projectEnvVars(projectId, cloud),
+      await this.projectEnvVars(projectId, projectsDirectory, cloud),
     )
     this.logger.debug(`Project '${project.path}' finished running`)
     return exitCode
@@ -215,7 +218,7 @@ export class ProjectService {
       project.path,
       projectId,
       this.extraArgs.length > 0 ? this.extraArgs : undefined,
-      this.projectEnvVars(projectId, cloud),
+      await this.projectEnvVars(projectId, projectsDirectory, cloud),
     )
 
     // Return the OpenProject response

--- a/app/project-manager-shim/src/projectService/index.ts
+++ b/app/project-manager-shim/src/projectService/index.ts
@@ -4,7 +4,7 @@
  * renaming, opening, closing, and duplicating projects.
  */
 import { PRODUCT_NAME } from 'enso-common/src/constants'
-import { makeLocalProjectKey } from 'enso-common/src/services/ProjectManager/projectIdentity'
+import { makeProjectTelemetryKey } from 'enso-common/src/services/ProjectManager/projectIdentity'
 import { toRfc3339 } from 'enso-common/src/utilities/data/dateTime'
 import KSUID from 'ksuid'
 import * as crypto from 'node:crypto'
@@ -172,7 +172,7 @@ export class ProjectService {
   ): Promise<readonly (readonly [string, string])[]> {
     if (!cloud) {
       const localSessionId = `localprojectsession-${KSUID.randomSync().string}`
-      const localProjectKey = await makeLocalProjectKey(projectsDirectory, projectId)
+      const localProjectKey = await makeProjectTelemetryKey(projectsDirectory, projectId)
       return [
         ['ENSO_LOCAL_PROJECT_ID', localProjectKey],
         ['ENSO_LOCAL_PROJECT_SESSION_ID', localSessionId],

--- a/app/project-manager-shim/src/projectService/projectRepository.ts
+++ b/app/project-manager-shim/src/projectService/projectRepository.ts
@@ -5,7 +5,8 @@ import * as path from 'node:path'
 import trash from 'trash'
 import * as yaml from 'yaml'
 import * as nameValidation from './nameValidation.js'
-import { Path, type UUID } from './types.js'
+import { resolveClashingProjectIds } from './resolveClashingProjectIds.js'
+import { Path, UUID } from './types.js'
 
 export interface Project {
   readonly id: UUID
@@ -143,7 +144,11 @@ export class ProjectFileRepository implements ProjectRepository {
       )
 
       const validProjects = projects.filter((p) => p !== null)
-      return this.resolveClashingIds(validProjects)
+      return resolveClashingProjectIds(validProjects, async (project, newId) => {
+        const updatedProject = { ...project, id: UUID(newId) }
+        await this.update(updatedProject)
+        return updatedProject
+      })
     } catch (error) {
       if ((error as any).code === 'ENOENT') {
         return []
@@ -297,43 +302,5 @@ export class ProjectFileRepository implements ProjectRepository {
         return Path(candidatePath)
       }
     }
-  }
-
-  private async resolveClashingIds(projects: Project[]): Promise<Project[]> {
-    const idGroups = new Map<string, Project[]>()
-
-    for (const project of projects) {
-      const group = idGroups.get(project.id) ?? []
-      group.push(project)
-      idGroups.set(project.id, group)
-    }
-
-    const result: Project[] = []
-
-    for (const group of idGroups.values()) {
-      if (group.length === 1) {
-        result.push(group[0]!)
-      } else {
-        // Sort by directory creation time, keep oldest
-        group.sort((a, b) => {
-          const timeA = a.directoryCreationTime ? new Date(a.directoryCreationTime).getTime() : 0
-          const timeB = b.directoryCreationTime ? new Date(b.directoryCreationTime).getTime() : 0
-          return timeA - timeB
-        })
-
-        result.push(group[0]!)
-
-        // Assign new IDs to clashing projects
-        for (let i = 1; i < group.length; i++) {
-          const project = group[i]!
-          const newId = crypto.randomUUID() as UUID
-          const updatedProject = { ...project, id: newId }
-          await this.update(updatedProject)
-          result.push(updatedProject)
-        }
-      }
-    }
-
-    return result
   }
 }

--- a/app/project-manager-shim/src/projectService/resolveClashingProjectIds.ts
+++ b/app/project-manager-shim/src/projectService/resolveClashingProjectIds.ts
@@ -1,0 +1,43 @@
+import * as crypto from 'node:crypto'
+
+export interface ProjectWithClashingId {
+  readonly id: string
+  readonly directoryCreationTime?: string
+}
+
+/** Rewrite duplicate project IDs, keeping oldest project unchanged. */
+export async function resolveClashingProjectIds<T extends ProjectWithClashingId>(
+  projects: readonly T[],
+  rewriteProjectId: (project: T, newId: string) => Promise<T>,
+): Promise<T[]> {
+  const idGroups = new Map<string, T[]>()
+
+  for (const project of projects) {
+    const group = idGroups.get(project.id) ?? []
+    group.push(project)
+    idGroups.set(project.id, group)
+  }
+
+  const result: T[] = []
+
+  for (const group of idGroups.values()) {
+    if (group.length === 1) {
+      result.push(group[0]!)
+      continue
+    }
+
+    group.sort((a, b) => {
+      const timeA = a.directoryCreationTime ? new Date(a.directoryCreationTime).getTime() : 0
+      const timeB = b.directoryCreationTime ? new Date(b.directoryCreationTime).getTime() : 0
+      return timeA - timeB
+    })
+
+    result.push(group[0]!)
+
+    for (let index = 1; index < group.length; index++) {
+      result.push(await rewriteProjectId(group[index]!, crypto.randomUUID()))
+    }
+  }
+
+  return result
+}

--- a/app/project-manager-shim/tsconfig.json
+++ b/app/project-manager-shim/tsconfig.json
@@ -28,6 +28,7 @@
     "./src/projectService/index.ts",
     "./src/projectService/nameValidation.ts",
     "./src/projectService/projectRepository.ts",
+    "./src/projectService/resolveClashingProjectIds.ts",
     "./src/projectService/types.ts",
     "./src/runProjects.ts",
     "./src/upload.ts"


### PR DESCRIPTION
### Pull Request Description

Fixes #14803

- Fix local project identity collisions by keying project state with `projectsDirectory` + `projectId`, not project ID alone.
- Switch local telemetry and session-log lookup from raw internal project ID to hashed local project key derived from parent directory + project ID. **Breaking change**, local project session logs won’t be available.
- Apply duplicate-ID resolution both in project repository loading and filesystem listing used by local project discovery.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
