### PR TITLE
Fix more flaky integration tests.

### DIFF
--- a/app/gui/integration-test/actions/DrivePageActions.ts
+++ b/app/gui/integration-test/actions/DrivePageActions.ts
@@ -102,6 +102,11 @@ export default class DrivePageActions<Context = object> extends PageActions<Cont
   goToCategoryNamed(this: DrivePageActions<Context>, category: string) {
     return this.step(`Go to "${category}" category`, async (page) => {
       await locateCategoryButton(page, category).click()
+      // Move the cursor off the leftBar so its `mouseenter`-triggered auto-expand
+      // timer is cleared and any in-flight expansion collapses. The expanded leftBar
+      // (~150px wide, `position: absolute; z-index: 2`) otherwise covers the leftmost
+      // toolbar/table buttons and intercepts subsequent clicks.
+      await page.mouse.move(0, 0)
       await this.expectCategory(category)
     })
   }
@@ -248,6 +253,9 @@ export default class DrivePageActions<Context = object> extends PageActions<Cont
             await getRow(page, row).dragTo(categoryElement, {
               sourcePosition: ASSET_ROW_SAFE_POSITION,
             })
+            // Drop ends with the cursor on the leftBar; move it off so the
+            // hover-to-expand timer doesn't fire and intercept later clicks.
+            await page.mouse.move(0, 0)
           },
         )
       },

--- a/app/gui/integration-test/actions/contextMenuActions.ts
+++ b/app/gui/integration-test/actions/contextMenuActions.ts
@@ -1,4 +1,5 @@
 /** @file Actions for the context menu. */
+import { expect } from 'integration-test/base'
 import type BaseActions from './BaseActions'
 import type { PageCallback } from './BaseActions'
 import EditorPageActions from './EditorPageActions'
@@ -68,7 +69,12 @@ export function contextMenuActions<T extends BaseActions<Context>, Context>(
           .click()
 
         // Confirm the deletion in the dialog
-        await page.getByRole('button', { name: TEXT.delete }).getByText(TEXT.delete).click()
+        const dialog = page.getByTestId('modal-dialog')
+        await dialog.getByRole('button', { name: TEXT.delete }).getByText(TEXT.delete).click()
+        // Wait for the dialog to be detached. While the react-aria exit animation
+        // runs (~200ms `slide-out-to-top-1`), the modal still has `fixed inset-0`
+        // and intercepts subsequent clicks.
+        await expect(dialog).toBeHidden()
       }),
     moveToTrash: () =>
       step('Move to trash (context menu)', async (page) => {
@@ -78,7 +84,12 @@ export function contextMenuActions<T extends BaseActions<Context>, Context>(
           .click()
 
         // Confirm the deletion in the dialog
-        await page.getByRole('button', { name: TEXT.delete }).getByText(TEXT.delete).click()
+        const dialog = page.getByTestId('modal-dialog')
+        await dialog.getByRole('button', { name: TEXT.delete }).getByText(TEXT.delete).click()
+        // Wait for the dialog to be detached. While the react-aria exit animation
+        // runs (~200ms `slide-out-to-top-1`), the modal still has `fixed inset-0`
+        // and intercepts subsequent clicks.
+        await expect(dialog).toBeHidden()
       }),
     restoreFromTrash: () =>
       step('Restore from trash (context menu)', (page) =>

--- a/app/gui/integration-test/project-view/edgeRendering.spec.ts
+++ b/app/gui/integration-test/project-view/edgeRendering.spec.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import type EditorPageActions from 'integration-test/actions/EditorPageActions'
 import { expect, test } from 'integration-test/base'
 import { connectedEdgesFromNodeWithBinding } from './locate'
@@ -47,18 +46,29 @@ test('Hover behaviour of edges', async ({ editorPage, page }) => {
   const targetEdge = edgeElements.locator('.io')
   await expect(targetEdge).toExist()
 
-  // Hover over edge to the left of node with binding `ten`.
-  // GraphEdge.vue tracks hover via `pointerenter`, which requires the pointer to
-  // traverse from outside into the element. A single `locator.hover({ force: true })`
-  // dispatches one `mousemove` at the target and can leave the pointer already
-  // "inside" — no enter event fires and the `hovered` class stays off. Explicit
-  // two-step move guarantees the enter transition.
-  const edgeBox = await targetEdge.boundingBox()
-  assert(edgeBox)
-  const hoverX = edgeBox.x + 30
-  const hoverY = edgeBox.y + 75
-  await page.mouse.move(edgeBox.x - 20, hoverY)
-  await page.mouse.move(hoverX, hoverY, { steps: 5 })
+  // Hover near the target end of the edge so `clickWillDisconnect` is true and the
+  // edge renders with a `dimmed hovered` lower part plus a non-dimmed upper part
+  // (see `activePath` in `GraphEdge.vue`). The bounding box is unsuitable for
+  // picking a point — for an L-shaped path it's mostly empty space, and `.io` has
+  // `pointer-events: stroke`, so the pointer must actually land on the path.
+  // Query the path geometry to get a point 5 units (in path-length) from the end,
+  // well within `TARGET_DISCONNECT_THRESHOLD = 10`. Convert SVG-local coordinates
+  // to viewport via `getScreenCTM` so `page.mouse.move` lands on the stroke.
+  // The two-step move ensures `pointerenter` fires (a single `mousemove` at the
+  // target may leave the pointer already "inside" without firing enter).
+  const hoverPoint = await targetEdge.evaluate((el) => {
+    const path = el as SVGPathElement
+    const length = path.getTotalLength()
+    const local = path.getPointAtLength(Math.max(0, length - 5))
+    const ctm = path.getScreenCTM()
+    if (ctm == null) throw new Error('Edge path has no screen CTM')
+    return {
+      x: ctm.a * local.x + ctm.c * local.y + ctm.e,
+      y: ctm.b * local.x + ctm.d * local.y + ctm.f,
+    }
+  })
+  await page.mouse.move(hoverPoint.x - 30, hoverPoint.y)
+  await page.mouse.move(hoverPoint.x, hoverPoint.y, { steps: 5 })
 
   // Expect an extra edge for the split rendering.
   const hoveredEdgeElements = await connectedEdgesFromNodeWithBinding(page, 'twenty')

--- a/app/gui/integration-test/project-view/widgets.spec.ts
+++ b/app/gui/integration-test/project-view/widgets.spec.ts
@@ -1038,7 +1038,9 @@ test('Table widget', async ({ editorPage, page }) => {
   await expect(widget.locator('.ag-cell')).toHaveText(['0', '', ''])
 
   // Putting first value
-  await widget.locator('.ag-cell', { hasNotText: '0' }).first().click()
+  const firstValueCell = widget.locator('.ag-cell', { hasNotText: '0' }).first()
+  await firstValueCell.click()
+  await expect(firstValueCell).toBeFocused()
   await page.keyboard.type('Value')
   await page.keyboard.press('Enter')
   // There will be new blank row allowing adding new rows.
@@ -1046,8 +1048,10 @@ test('Table widget', async ({ editorPage, page }) => {
 
   // Renaming column
   await widget.locator('.ag-header-cell-text', { hasText: 'Column 1' }).first().click()
-  await page.keyboard.type('Header')
-  await page.keyboard.press('Enter')
+  const headerInput = widget.locator('.ag-text-field-input')
+  await expect(headerInput).toBeFocused()
+  await headerInput.fill('Header')
+  await headerInput.press('Enter')
   await expect(widget.locator('.ag-header-cell-text')).toHaveText(['#', 'Header'])
 
   // Adding next column


### PR DESCRIPTION
- Hover behaviour of edges: derive hover position from path geometry (getPointAtLength + getScreenCTM) so the pointer lands on the stroke near the target end. The previous bbox-relative (30, 75) was off the L-shaped path entirely; .io has pointer-events: stroke, so pointerenter never fired and the `hovered` class was never set.
- moveToTrash / delete: wait for the confirmation modal to be hidden after clicking confirm. While the react-aria slide-out animation runs (~200ms), the modal still has fixed inset-0 and intercepts subsequent clicks.
- goToCategoryNamed / dragRowToCategory: move mouse to (0, 0) after interacting with the leftBar, so its 550ms hover-to-expand timer is cleared. An expanded leftBar (~150px wide, position: absolute, z-index: 2) otherwise covers the leftmost toolbar/table buttons and intercepts later clicks; once the cursor is inside the expanded bbox it stays there because mouseleave doesn't fire on subsequent moves within the new bounds.
- Table widget: wait for the inline editor to be focused before typing (cherry-picked from 89f06632b6).

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
