### PR TITLE
Fix duplicate-pair warning for conversion-method overloads

### DIFF
--- a/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -14,7 +14,7 @@ import { Filtering, type MatchResult } from '@/components/ComponentBrowser/filte
 import { stdPath } from '@/util/projectPath'
 import { qnLastSegment } from '@/util/qualifiedName'
 import type { Opt } from 'enso-common/src/utilities/data/opt'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 test.each([
   makeModuleMethod('Standard.Base.Data.read', { group: 'Standard.Base.MockGroup1' }),
@@ -113,6 +113,29 @@ test('`Any` or ancestor type methods may be overshadowed', () => {
   const db = SuggestionDb.createMock([entry1, entry2, entry3])
   expect(filtering.filter(entry1, db)).not.toBeNull()
   expect(filtering.filter(entry2, db)).toBeNull()
+})
+
+test('Conversion-method overloads do not trigger duplicate-index warnings', () => {
+  // Engine reports each `Email_Attachment.from (that:X)` overload as a distinct
+  // `method` entry sharing the same `(name, selfType)` pair. Indexing them must
+  // not emit the "Attempt to repeatedly write the same key-value pair" warning,
+  // and the overshadow lookup must still answer correctly.
+  const fromFile = makeMethod('Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from')
+  const fromUri = makeMethod('Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from')
+  const fromText = makeMethod('Standard.Base.Network.Email.Email_Attachment.Email_Attachment.from')
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    const db = SuggestionDb.createMock([fromFile, fromUri, fromText])
+    expect(
+      db.hasMethodOnType(
+        stdPath('Standard.Base.Network.Email.Email_Attachment.Email_Attachment'),
+        'from',
+      ),
+    ).toBe(true)
+    expect(errorSpy).not.toHaveBeenCalled()
+  } finally {
+    errorSpy.mockRestore()
+  }
 })
 
 test('Hidden self types and ancestors are taken into account when filtering', () => {

--- a/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
+++ b/app/gui/src/project-view/components/ComponentBrowser/filtering.ts
@@ -295,7 +295,7 @@ export class Filtering {
         this.selfArg.ancestors.find((t) => entrySelfType.equals(t))
       )
     if (matchedAncestor == null) return null
-    const ancestorOvershadowed = db.conflictingMethods.lookup(entry.name).has(matchedAncestor.key())
+    const ancestorOvershadowed = db.hasMethodOnType(matchedAncestor, entry.name)
     if (ancestorOvershadowed) return null
     // Matched ancestor are not added to `fromType`, because type casting is not needed.
     return { score: DIFFERENT_TYPE_PENALTY, fromType: undefined }

--- a/app/gui/src/providers/openedProjects/suggestionDatabase/index.ts
+++ b/app/gui/src/providers/openedProjects/suggestionDatabase/index.ts
@@ -50,10 +50,15 @@ export class SuggestionDb extends ReactiveDb<SuggestionId, SuggestionEntry> {
     return []
   })
   readonly conflictingNames = new ReactiveIndex(this, (id, entry) => [[entry.name, id]])
-  readonly conflictingMethods = new ReactiveIndex(this, (_, entry): [string, string][] =>
-    entry.kind === SuggestionKind.Method && entry.selfType != null ?
-      [[entry.name, entry.selfType.key()]]
-    : [],
+  // Keyed by `selfType#name` so multiple LS entries sharing a `(name, selfType)` pair
+  // (in particular: conversion-method overloads like `Email_Attachment.from`) coexist
+  // under unique `(compositeKey, id)` pairs. Use {@link hasMethodOnType} to query.
+  private readonly methodOnTypeIndex = new ReactiveIndex(
+    this,
+    (id, entry): [string, SuggestionId][] =>
+      entry.kind === SuggestionKind.Method && entry.selfType != null ?
+        [[methodOnTypeKey(entry.selfType, entry.name), id]]
+      : [],
   )
   private readonly suggestionsByKind = new ReactiveIndex(this, (id, entry) => [[entry.kind, id]])
   private readonly constructorFields = new ReactiveIndex(this, (id, entry) => {
@@ -183,6 +188,11 @@ export class SuggestionDb extends ReactiveDb<SuggestionId, SuggestionEntry> {
     return this.constructorFields.lookup(constructorFieldKey(type, field))
   }
 
+  /** Whether the suggestion DB contains a method with the given `name` on the given `selfType`. */
+  hasMethodOnType(selfType: ProjectPath, name: string): boolean {
+    return this.methodOnTypeIndex.hasKey(methodOnTypeKey(selfType, name))
+  }
+
   /** Returns the entry's ancestors, starting with its parent. */
   *ancestors(entry: SuggestionEntry): Iterable<ProjectPath> {
     while (entry.kind === SuggestionKind.Type && entry.parentType) {
@@ -197,6 +207,11 @@ export class SuggestionDb extends ReactiveDb<SuggestionId, SuggestionEntry> {
 /** Helper for serializing keys of `constructorFields` index. */
 function constructorFieldKey(type: ProjectPath, field: string): string {
   return `${type.key()}#${field}`
+}
+
+/** Helper for serializing keys of `methodOnTypeIndex`. */
+function methodOnTypeKey(selfType: ProjectPath, name: string): string {
+  return `${selfType.key()}#${name}`
 }
 
 /**


### PR DESCRIPTION
Fix for many error console messages appearing on project start. Turned out to be a regression introduced by overshadow method fix.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
