### PR TITLE
Record every aiChallenge run with model / status columns

### DIFF
--- a/app/common/src/ai.ts
+++ b/app/common/src/ai.ts
@@ -97,8 +97,8 @@ export interface RequestUsage {
    * `false` when it fell back to the cost-side sum (because the CLI didn't surface
    * `message.usage` on the final envelope). On a multi-hop turn, `false` means
    * `contextTokens` overstates actual context occupancy and the value should not be trusted
-   * for context-window analysis — see `aiMetrics.appendMetricsRow`, which refuses to write a
-   * CSV row when any sample with `hopCount > 0` was a fallback.
+   * for context-window analysis — see `aiMetrics.appendMetricsRow`, which flags such samples
+   * by suffixing the metrics-row `status` column with ` (broken)`.
    */
   readonly contextFromLastHop: boolean
   /**

--- a/app/electron-client/CLAUDE.md
+++ b/app/electron-client/CLAUDE.md
@@ -433,6 +433,16 @@ If `hard < soft` after env-var resolution, both fall back to defaults with a
 warning. If env-var values aren't valid positive integers, that var alone falls
 back to its default.
 
+### Pass-through CLI flags (`ENSO_AI_CLAUDE_EXTRA_ARGS`)
+
+`ENSO_AI_CLAUDE_EXTRA_ARGS` is split on whitespace and appended verbatim to the
+spawned `claude -p …` flag list, after the built-in flags. Used by the
+AI-effectiveness suite (`tests/aiChallengePrep.spec.ts`) to compare models and
+reasoning levels — e.g. `ENSO_AI_CLAUDE_EXTRA_ARGS="--model claude-sonnet-4-6"`.
+No shell-style quoting: values containing whitespace aren't expressible. Args
+are forwarded to both the primary and any warming child so a context rotation
+preserves the user-selected model.
+
 **Failure handling.** Warming priming can fail (transient CLI bug, ENOENT,
 crash-loop guard tripped). The session reacts:
 

--- a/app/electron-client/CLAUDE.md
+++ b/app/electron-client/CLAUDE.md
@@ -386,12 +386,12 @@ Findings from the probe at the time the long-lived design landed:
     overwrites `lastHopUsage` with `null` rather than coalescing, so a stale
     earlier value never leaks through), this falls back to the result-envelope
     sum. The renderer's `logUsage` flips `ctxSrc=fallback` and emits a
-    `console.warn`; `aiMetrics.appendMetricsRow` refuses to write the CSV row
-    when any sample has `hopCount > 0` and `contextFromLastHop=false`, failing
-    the Playwright run so the developer notices broken telemetry instead of
-    silently archiving misleading data.
+    `console.warn`; `aiMetrics.appendMetricsRow` flags such rows by suffixing
+    the `status` column with ` (broken)` (yielding `pass (broken)` or
+    `fail (broken)`) so downstream analysis can filter them out without losing
+    the rest of the run's signal.
   - `contextFromLastHop` exposes the source of `contextTokens` so consumers can
-    validate; see above for the metrics writer's enforcement.
+    validate; see above for how the metrics writer surfaces it.
   - `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`,
     `hopCount` are turn totals from `result.usage` (and the count of assistant
     envelopes seen). They are the right inputs for billing and for explaining

--- a/app/electron-client/src/ai/claudeAgent.ts
+++ b/app/electron-client/src/ai/claudeAgent.ts
@@ -90,7 +90,7 @@ function resolveThresholds(config: ClaudeSessionConfig): ResolvedThresholds {
 
 /**
  * Read `ENSO_AI_CLAUDE_EXTRA_ARGS` and split on whitespace; empty/unset → `undefined`.
- * No  shell-style quoting — values containing whitespace aren't expressible.
+ * No shell-style quoting — values containing whitespace aren't expressible.
  */
 function readExtraArgsEnv(): readonly string[] | undefined {
   const raw = process.env.ENSO_AI_CLAUDE_EXTRA_ARGS

--- a/app/electron-client/src/ai/claudeAgent.ts
+++ b/app/electron-client/src/ai/claudeAgent.ts
@@ -89,10 +89,8 @@ function resolveThresholds(config: ClaudeSessionConfig): ResolvedThresholds {
 }
 
 /**
- * Read `ENSO_AI_CLAUDE_EXTRA_ARGS` and split on whitespace; empty/unset → `undefined`. Used by
- * the AI-effectiveness suite to compare models or reasoning levels (see
- * `tests/aiChallengePrep.spec.ts`). No shell-style quoting — values containing whitespace
- * aren't expressible, but no flag we'd plausibly pass needs that.
+ * Read `ENSO_AI_CLAUDE_EXTRA_ARGS` and split on whitespace; empty/unset → `undefined`.
+ * No  shell-style quoting — values containing whitespace aren't expressible.
  */
 function readExtraArgsEnv(): readonly string[] | undefined {
   const raw = process.env.ENSO_AI_CLAUDE_EXTRA_ARGS

--- a/app/electron-client/src/ai/claudeAgent.ts
+++ b/app/electron-client/src/ai/claudeAgent.ts
@@ -88,6 +88,19 @@ function resolveThresholds(config: ClaudeSessionConfig): ResolvedThresholds {
   return { soft, hard }
 }
 
+/**
+ * Read `ENSO_AI_CLAUDE_EXTRA_ARGS` and split on whitespace; empty/unset → `undefined`. Used by
+ * the AI-effectiveness suite to compare models or reasoning levels (see
+ * `tests/aiChallengePrep.spec.ts`). No shell-style quoting — values containing whitespace
+ * aren't expressible, but no flag we'd plausibly pass needs that.
+ */
+function readExtraArgsEnv(): readonly string[] | undefined {
+  const raw = process.env.ENSO_AI_CLAUDE_EXTRA_ARGS
+  if (raw == null) return undefined
+  const tokens = raw.split(/\s+/).filter((t) => t.length > 0)
+  return tokens.length > 0 ? tokens : undefined
+}
+
 function parseJsonSafe(text: string): unknown {
   try {
     return JSON.parse(text)
@@ -190,6 +203,7 @@ type SwapMode = 'none' | 'soft' | 'hard'
 export class ClaudeAgentSession {
   private readonly config: ClaudeSessionConfig
   private readonly thresholds: ResolvedThresholds
+  private readonly extraArgs: readonly string[] | undefined
   private primary: ChildAgent
   private warming: ChildAgent | null = null
   private swapMode: SwapMode = 'none'
@@ -216,6 +230,7 @@ export class ClaudeAgentSession {
   constructor(config: ClaudeSessionConfig) {
     this.config = config
     this.thresholds = resolveThresholds(config)
+    this.extraArgs = config.extraArgs ?? readExtraArgsEnv()
     this.primary = new ChildAgent({ ...this.childConfig(), logLabel: 'primary' })
   }
 
@@ -363,6 +378,7 @@ export class ClaudeAgentSession {
     return {
       stdlibRoot: this.config.stdlibRoot,
       mcpConfigPath: this.config.mcpConfigPath,
+      extraArgs: this.extraArgs,
     }
   }
 

--- a/app/electron-client/src/ai/claudeAgentChild.ts
+++ b/app/electron-client/src/ai/claudeAgentChild.ts
@@ -58,9 +58,7 @@ export interface ChildAgentConfig {
   readonly logLabel?: string
   /**
    * Extra CLI tokens appended verbatim to the built-in `claude -p …` flag list (e.g.
-   * `['--model', 'claude-sonnet-4-6']`). Sourced from `ENSO_AI_CLAUDE_EXTRA_ARGS` and used
-   * by the AI-effectiveness suite to compare models / effort levels — see
-   * `tests/aiChallengePrep.spec.ts`. Appended last so that, for last-wins flag parsers, a
+   * `['--model', 'claude-sonnet-4-6']`). Appended last so that, for last-wins flag parsers, a
    * user-supplied value overrides the built-in one.
    */
   readonly extraArgs?: readonly string[] | undefined

--- a/app/electron-client/src/ai/claudeAgentChild.ts
+++ b/app/electron-client/src/ai/claudeAgentChild.ts
@@ -56,6 +56,14 @@ export interface ChildAgentConfig {
    * session running two children stay disambiguated. Empty string means no label.
    */
   readonly logLabel?: string
+  /**
+   * Extra CLI tokens appended verbatim to the built-in `claude -p …` flag list (e.g.
+   * `['--model', 'claude-sonnet-4-6']`). Sourced from `ENSO_AI_CLAUDE_EXTRA_ARGS` and used
+   * by the AI-effectiveness suite to compare models / effort levels — see
+   * `tests/aiChallengePrep.spec.ts`. Appended last so that, for last-wins flag parsers, a
+   * user-supplied value overrides the built-in one.
+   */
+  readonly extraArgs?: readonly string[] | undefined
 }
 
 /** Renderer + request id driving a turn. */
@@ -102,6 +110,7 @@ function streamJsonArgs(config: ChildAgentConfig): string[] {
     '--setting-sources',
     '',
     '--no-session-persistence',
+    ...(config.extraArgs ?? []),
   ]
 }
 

--- a/app/electron-client/src/globals.d.ts
+++ b/app/electron-client/src/globals.d.ts
@@ -66,17 +66,14 @@ declare global {
       // @ts-expect-error The index signature is intentional to disallow unknown env vars.
       readonly NODE_ENV?: string
 
-      // === AI agent context-rotation thresholds (see `claudeAgent.ts`) ===
+      // === AI agent properties ===
 
+      // @ts-expect-error The index signature is intentional to disallow unknown env vars.
+      readonly ENSO_AI_CLAUDE_EXTRA_ARGS?: string
       // @ts-expect-error The index signature is intentional to disallow unknown env vars.
       readonly ENSO_AI_SOFT_CONTEXT_THRESHOLD?: string
       // @ts-expect-error The index signature is intentional to disallow unknown env vars.
       readonly ENSO_AI_HARD_CONTEXT_THRESHOLD?: string
-
-      // === Extra CLI args appended to the spawned `claude` invocation (see `claudeAgent.ts`) ===
-
-      // @ts-expect-error The index signature is intentional to disallow unknown env vars.
-      readonly ENSO_AI_CLAUDE_EXTRA_ARGS?: string
     }
   }
 }

--- a/app/electron-client/src/globals.d.ts
+++ b/app/electron-client/src/globals.d.ts
@@ -72,6 +72,11 @@ declare global {
       readonly ENSO_AI_SOFT_CONTEXT_THRESHOLD?: string
       // @ts-expect-error The index signature is intentional to disallow unknown env vars.
       readonly ENSO_AI_HARD_CONTEXT_THRESHOLD?: string
+
+      // === Extra CLI args appended to the spawned `claude` invocation (see `claudeAgent.ts`) ===
+
+      // @ts-expect-error The index signature is intentional to disallow unknown env vars.
+      readonly ENSO_AI_CLAUDE_EXTRA_ARGS?: string
     }
   }
 }

--- a/app/electron-client/tests/README.md
+++ b/app/electron-client/tests/README.md
@@ -105,10 +105,35 @@ publishes the inputs under different filenames, edit the `WEEK_32_FILES` /
 #### Effectiveness metrics (optional)
 
 Set `ENSO_AI_CHALLENGES_METRICS_DIR=/abs/path` alongside the dataset env var to
-collect per-run AI-effectiveness telemetry. On a **successful** test the spec
-appends one CSV row per run to `<dir>/<sanitized-test-name>.csv`, with totals
-plus semicolon-separated per-AI-node breakdowns of duration, input/output
-tokens, and running context size. The row's `commit` column carries the current
-HEAD SHA when the working tree is clean and the literal `WIP` otherwise, so runs
-from in-progress branches are still recorded but won't be confused with
-clean-tree benchmarks. Failed tests append nothing.
+collect per-run AI-effectiveness telemetry. **Every** run (pass OR fail) appends
+one CSV row to `<dir>/<sanitized-test-name>.csv`, with totals plus
+semicolon-separated per-AI-node breakdowns of duration, input/output tokens, and
+running context size. The row's `commit` column carries the current HEAD SHA
+when the working tree is clean and the literal `WIP` otherwise, so runs from
+in-progress branches are still recorded but won't be confused with clean-tree
+benchmarks. Skipped tests (missing inputs) append nothing.
+
+The `status` column reports one of `pass`, `pass (broken)`, `fail`, or
+`fail (broken)`. The `(broken)` suffix flags rows where at least one AI-node
+sample had its `contextTokens` value derived from the cost-side fallback rather
+than the final assistant envelope — the number then overstates real
+context-window occupancy. The pass/fail half of the status reflects the
+Playwright assertions independently, so a failed run with broken telemetry still
+surfaces as a failure for downstream analysis.
+
+#### Comparing models or effort levels
+
+Set `ENSO_AI_CLAUDE_EXTRA_ARGS` to extra flags forwarded verbatim to the spawned
+`claude` CLI (whitespace-split, no shell quoting):
+
+```bash
+ENSO_TEST_AI_CHALLENGES_DIR=/abs/path/to/preppin-data \
+ENSO_AI_CHALLENGES_METRICS_DIR=/abs/path/to/metrics \
+ENSO_AI_CLAUDE_EXTRA_ARGS="--model claude-sonnet-4-6" \
+  corepack pnpm -r --filter enso ide-integration-test \
+    tests/aiChallengePrep.spec.ts
+```
+
+The verbatim env-var value is captured in each row's `ai_parameters` column, so
+multiple runs with different flag combinations can be grouped and compared in
+the same CSV. An empty `ai_parameters` cell means the default model was used.

--- a/app/electron-client/tests/aiChallengePrep.spec.ts
+++ b/app/electron-client/tests/aiChallengePrep.spec.ts
@@ -20,11 +20,14 @@
  * inputs in the layout below. The spec skips silently when the env var is unset; per-test skips
  * fire when that test's specific files are missing under the path.
  *
- * Optional: `ENSO_AI_CHALLENGES_METRICS_DIR=/abs/path` enables effectiveness telemetry. On a
- * successful run the test appends one CSV row to `<dir>/<sanitized-test-name>.csv` summarizing
- * the run (timestamp, current commit SHA or `WIP` if dirty, per-AI-node durations, hop count,
- * the full `usage` breakdown — input / cache_read / cache_creation / output tokens — and the
- * last-hop `contextTokens`). See `./aiMetrics.ts` for the schema.
+ * Optional: `ENSO_AI_CHALLENGES_METRICS_DIR=/abs/path` enables effectiveness telemetry. Each
+ * run (pass OR fail) appends one CSV row to `<dir>/<sanitized-test-name>.csv` summarizing the
+ * run: timestamp, current commit SHA or `WIP` if dirty, the verbatim value of
+ * `ENSO_AI_CLAUDE_EXTRA_ARGS` in the `ai_parameters` column (for grouping by model / effort),
+ * the `status` (`pass` / `pass (broken)` / `fail` / `fail (broken)`), per-AI-node durations,
+ * hop count, the full `usage` breakdown — input / cache_read / cache_creation / output tokens
+ * — and the last-hop `contextTokens`. Skipped runs (missing input files) write nothing. See
+ * `./aiMetrics.ts` for the schema and the `(broken)` suffix semantics.
  *
  * Expected layout under $ENSO_TEST_AI_CHALLENGES_DIR (flat — files at the top level):
  *   Gym Leader Set Cards.xlsx          # week 32; 3 sheets: Trainer Cards, Pokemon Cards, Leader Order
@@ -60,7 +63,11 @@ const MANUAL_NODE_TIMEOUT_MS = 30_000
 // commit-tag resolution works regardless of where the test runner is invoked from.
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../..')
 
-async function recordSuccess(testInfo: TestInfo, samples: readonly RequestUsage[]) {
+async function recordResult(
+  testInfo: TestInfo,
+  samples: readonly RequestUsage[],
+  outcome: 'pass' | 'fail',
+) {
   if (!METRICS_DIR) return
   await appendMetricsRow({
     dir: METRICS_DIR,
@@ -68,6 +75,8 @@ async function recordSuccess(testInfo: TestInfo, samples: readonly RequestUsage[
     samples,
     commit: await gitCommitTag(REPO_ROOT),
     timestamp: new Date().toISOString(),
+    aiParameters: process.env.ENSO_AI_CLAUDE_EXTRA_ARGS ?? '',
+    outcome,
   })
 }
 
@@ -213,80 +222,88 @@ test("Preppin' Data week 32 — Pokemon Card Organising (stdlib-read isolation)"
   test.setTimeout(45 * 60_000)
   const files = await resolveDataFiles(WEEK_32_FILES)
   const usage = collectAiUsage(page)
-  await loginAsTestUser(page)
-  await closeWelcome(page)
-  await createNewProject(page)
-  await closeRightPanel(page)
-  await clearWelcomeNode(page)
+  // Track the outcome explicitly so the `finally` records pass/fail regardless of which
+  // assertion threw. `testInfo.status` is not reliable inside a test body (it's set after the
+  // test resolves), so a manual flag is the only honest signal here.
+  let passed = false
+  try {
+    await loginAsTestUser(page)
+    await closeWelcome(page)
+    await createNewProject(page)
+    await closeRightPanel(page)
+    await clearWelcomeNode(page)
 
-  const graphNodes = page.locator('.GraphNode')
+    const graphNodes = page.locator('.GraphNode')
 
-  // Manual: 4 Data.read source nodes — three sheets out of `Gym Leader Set Cards.xlsx` and the
-  // Pokemon sheet of `Pokemon Input.xlsx`. The agent identifies which source is which by reading
-  // the sheet name out of the method source it receives in its context.
-  //
-  // Order matters: Pokemon Cards is added last so it ends up auto-selected, and the first AI
-  // prompt's chained Component Browser opens off it (the prompt operates on the Card column,
-  // which only Pokemon Cards has).
-  const sources = [
-    `Data.read "${files.pokemonInput}" (..Sheet "Pokemon")`,
-    `Data.read "${files.cardsWorkbook}" (..Sheet "Leader Order")`,
-    `Data.read "${files.cardsWorkbook}" (..Sheet "Trainer Cards")`,
-    `Data.read "${files.cardsWorkbook}" (..Sheet "Pokemon Cards")`,
-  ]
-  let nodeCount = 0
-  for (const expr of sources) {
-    nodeCount += 1
-    await addFreestandingNode(page, expr, nodeCount)
+    // Manual: 4 Data.read source nodes — three sheets out of `Gym Leader Set Cards.xlsx` and the
+    // Pokemon sheet of `Pokemon Input.xlsx`. The agent identifies which source is which by reading
+    // the sheet name out of the method source it receives in its context.
+    //
+    // Order matters: Pokemon Cards is added last so it ends up auto-selected, and the first AI
+    // prompt's chained Component Browser opens off it (the prompt operates on the Card column,
+    // which only Pokemon Cards has).
+    const sources = [
+      `Data.read "${files.pokemonInput}" (..Sheet "Pokemon")`,
+      `Data.read "${files.cardsWorkbook}" (..Sheet "Leader Order")`,
+      `Data.read "${files.cardsWorkbook}" (..Sheet "Trainer Cards")`,
+      `Data.read "${files.cardsWorkbook}" (..Sheet "Pokemon Cards")`,
+    ]
+    let nodeCount = 0
+    for (const expr of sources) {
+      nodeCount += 1
+      await addFreestandingNode(page, expr, nodeCount)
+    }
+
+    // Each prompt spells out any value-dependent context (column names, gym set tiebreaker, …) so
+    // this test isolates the "agent knows stdlib" capability — see the file-level note before
+    // weakening any prompt. The schemas below mirror the actual sheets:
+    //   Pokemon Cards: level, name, number, set_name (where `name` holds e.g. "Brock's Rhydon")
+    //   Pokemon Input: Pokédex #, Name, Type, ...
+    //   Trainer Cards: Leader, Gym Set, Number, Card
+    //   Leader Order:  Order, Leader
+    const prompts = [
+      'In the Pokemon Cards table (columns: level, name, number, set_name), the `name` column holds' +
+        ' apostrophe-s combinations like "Brock\'s Rhydon". Split `name` into two new columns:' +
+        ' `Leader` (the part before the apostrophe-s, e.g. "Brock") and `Card` (the part after,' +
+        ' e.g. "Rhydon"). Drop the original `name` column; keep level, number, set_name.',
+      'Join the result with the Pokemon Input table (columns: Pokédex #, Name, Type, ...) on the' +
+        " result's `Card` column matching Pokemon Input's `Name` column, bringing in just the" +
+        ' `Pokédex #` column.',
+      'Deduplicate the rows by the combination of (Leader, Card, number, set_name).',
+      'Rename columns: `set_name` to `Gym Set`, `number` to `Number`, `level` to `Level`. Add a new' +
+        ' column `Card Type` with the constant value "Pokémon".',
+      'Union with the Trainer Cards table (columns: Leader, Gym Set, Number, Card). For rows coming' +
+        ' from Trainer Cards, set `Card Type` to "Trainer".',
+      'For rows where `Leader` is null or empty, set `Leader` to "Leftover Trainers".',
+      'Join with the Leader Order table (columns: Order, Leader) on the `Leader` column, bringing in' +
+        ' `Order` and renaming it to `Sort Order`. For "Leftover Trainers" rows where `Sort Order`' +
+        ' is null, set `Sort Order` to 100 so they sort last.',
+      'Sort the rows by: Sort Order ascending, then Card Type ascending, then for Trainer rows' +
+        " Gym Set with 'Gym Heroes' before 'Gym Challenge', then Number ascending, then" +
+        ' `Pokédex #` ascending, then Level ascending.',
+      'Project the table to only these columns, in this order: Sort Order, Leader, Gym Set, Number,' +
+        ' Card, Card Type.',
+    ]
+    for (const prompt of prompts) {
+      nodeCount += 1
+      await runAIPromptOnLastNode(page, prompt, nodeCount)
+    }
+
+    await graphNodes.last().click()
+    await visualizeData(page)
+    for (const col of ['Sort Order', 'Leader', 'Gym Set', 'Number', 'Card', 'Card Type']) {
+      // Pick the first `.TableVisualization` — multiple may be rendered at once (inline preview
+      // for the selected node plus a focused/fullscreen overlay), and the bare class selector
+      // would trip Playwright's strict-mode check.
+      await expect(page.locator('.TableVisualization').first()).toContainText(col)
+    }
+    await expect(page.getByText('Total Row Count: 252')).toBeVisible({
+      timeout: MANUAL_NODE_TIMEOUT_MS,
+    })
+    passed = true
+  } finally {
+    await recordResult(testInfo, usage.samples, passed ? 'pass' : 'fail')
   }
-
-  // Each prompt spells out any value-dependent context (column names, gym set tiebreaker, …) so
-  // this test isolates the "agent knows stdlib" capability — see the file-level note before
-  // weakening any prompt. The schemas below mirror the actual sheets:
-  //   Pokemon Cards: level, name, number, set_name (where `name` holds e.g. "Brock's Rhydon")
-  //   Pokemon Input: Pokédex #, Name, Type, ...
-  //   Trainer Cards: Leader, Gym Set, Number, Card
-  //   Leader Order:  Order, Leader
-  const prompts = [
-    'In the Pokemon Cards table (columns: level, name, number, set_name), the `name` column holds' +
-      ' apostrophe-s combinations like "Brock\'s Rhydon". Split `name` into two new columns:' +
-      ' `Leader` (the part before the apostrophe-s, e.g. "Brock") and `Card` (the part after,' +
-      ' e.g. "Rhydon"). Drop the original `name` column; keep level, number, set_name.',
-    'Join the result with the Pokemon Input table (columns: Pokédex #, Name, Type, ...) on the' +
-      " result's `Card` column matching Pokemon Input's `Name` column, bringing in just the" +
-      ' `Pokédex #` column.',
-    'Deduplicate the rows by the combination of (Leader, Card, number, set_name).',
-    'Rename columns: `set_name` to `Gym Set`, `number` to `Number`, `level` to `Level`. Add a new' +
-      ' column `Card Type` with the constant value "Pokémon".',
-    'Union with the Trainer Cards table (columns: Leader, Gym Set, Number, Card). For rows coming' +
-      ' from Trainer Cards, set `Card Type` to "Trainer".',
-    'For rows where `Leader` is null or empty, set `Leader` to "Leftover Trainers".',
-    'Join with the Leader Order table (columns: Order, Leader) on the `Leader` column, bringing in' +
-      ' `Order` and renaming it to `Sort Order`. For "Leftover Trainers" rows where `Sort Order`' +
-      ' is null, set `Sort Order` to 100 so they sort last.',
-    'Sort the rows by: Sort Order ascending, then Card Type ascending, then for Trainer rows' +
-      " Gym Set with 'Gym Heroes' before 'Gym Challenge', then Number ascending, then" +
-      ' `Pokédex #` ascending, then Level ascending.',
-    'Project the table to only these columns, in this order: Sort Order, Leader, Gym Set, Number,' +
-      ' Card, Card Type.',
-  ]
-  for (const prompt of prompts) {
-    nodeCount += 1
-    await runAIPromptOnLastNode(page, prompt, nodeCount)
-  }
-
-  await graphNodes.last().click()
-  await visualizeData(page)
-  for (const col of ['Sort Order', 'Leader', 'Gym Set', 'Number', 'Card', 'Card Type']) {
-    // Pick the first `.TableVisualization` — multiple may be rendered at once (inline preview
-    // for the selected node plus a focused/fullscreen overlay), and the bare class selector
-    // would trip Playwright's strict-mode check.
-    await expect(page.locator('.TableVisualization').first()).toContainText(col)
-  }
-  await expect(page.getByText('Total Row Count: 252')).toBeVisible({
-    timeout: MANUAL_NODE_TIMEOUT_MS,
-  })
-  await recordSuccess(testInfo, usage.samples)
 })
 
 test("Preppin' Data week 51 — Strictly Positive Improvements (value-probe isolation)", async ({
@@ -296,49 +313,54 @@ test("Preppin' Data week 51 — Strictly Positive Improvements (value-probe isol
   test.setTimeout(30 * 60_000)
   const files = await resolveDataFiles(WEEK_51_FILES)
   const usage = collectAiUsage(page)
-  await loginAsTestUser(page)
-  await closeWelcome(page)
-  await createNewProject(page)
-  await closeRightPanel(page)
-  await clearWelcomeNode(page)
+  let passed = false
+  try {
+    await loginAsTestUser(page)
+    await closeWelcome(page)
+    await createNewProject(page)
+    await closeRightPanel(page)
+    await clearWelcomeNode(page)
 
-  const graphNodes = page.locator('.GraphNode')
+    const graphNodes = page.locator('.GraphNode')
 
-  await addFreestandingNode(page, `Data.read "${files.scores}"`, 1)
+    await addFreestandingNode(page, `Data.read "${files.scores}"`, 1)
 
-  // Input columns: Series, Week, Couple, Scores, Dance, Music, Result, Film, Broadway musical,
-  // Musical, Country, CelebratingBBC. Step 3 deliberately does NOT spell out the `Scores` field's
-  // wire format — the agent has to look at a sample value to figure out the parser. See the
-  // file-level note.
-  const prompts = [
-    'drop rows that look like leaked header rows (the data was scraped, so the column-header row' +
-      ' repeats throughout the body)',
-    'convert the `Week` column to a numeric type and drop rows that fail to parse',
-    'parse the `Scores` column into a `total_score` (number) column and a `judges_count` (number)' +
-      ' column, then add an `avg_judges_score` column equal to `total_score / judges_count`',
-    "keep only each Couple's first dance (their lowest Week) and any of their dances in the" +
-      ' final round; restrict to couples who reached the final',
-    'aggregate the final-round rows per Couple by averaging `avg_judges_score`',
-    "compute the percentage change between each Couple's first-dance `avg_judges_score` and" +
-      ' their final-round average; project to the columns Series, Couple, Finalist Positions,' +
-      " Avg Judge's Score, % Change",
-  ]
-  let nodeCount = 1
-  for (const prompt of prompts) {
-    nodeCount += 1
-    await runAIPromptOnLastNode(page, prompt, nodeCount)
+    // Input columns: Series, Week, Couple, Scores, Dance, Music, Result, Film, Broadway musical,
+    // Musical, Country, CelebratingBBC. Step 3 deliberately does NOT spell out the `Scores` field's
+    // wire format — the agent has to look at a sample value to figure out the parser. See the
+    // file-level note.
+    const prompts = [
+      'drop rows that look like leaked header rows (the data was scraped, so the column-header row' +
+        ' repeats throughout the body)',
+      'convert the `Week` column to a numeric type and drop rows that fail to parse',
+      'parse the `Scores` column into a `total_score` (number) column and a `judges_count` (number)' +
+        ' column, then add an `avg_judges_score` column equal to `total_score / judges_count`',
+      "keep only each Couple's first dance (their lowest Week) and any of their dances in the" +
+        ' final round; restrict to couples who reached the final',
+      'aggregate the final-round rows per Couple by averaging `avg_judges_score`',
+      "compute the percentage change between each Couple's first-dance `avg_judges_score` and" +
+        ' their final-round average; project to the columns Series, Couple, Finalist Positions,' +
+        " Avg Judge's Score, % Change",
+    ]
+    let nodeCount = 1
+    for (const prompt of prompts) {
+      nodeCount += 1
+      await runAIPromptOnLastNode(page, prompt, nodeCount)
+    }
+
+    await graphNodes.last().click()
+    await visualizeData(page)
+    for (const col of ['Series', 'Couple', 'Finalist Positions', "Avg Judge's Score", '% Change']) {
+      // Pick the first `.TableVisualization` — multiple may be rendered at once (inline preview
+      // for the selected node plus a focused/fullscreen overlay), and the bare class selector
+      // would trip Playwright's strict-mode check.
+      await expect(page.locator('.TableVisualization').first()).toContainText(col)
+    }
+    await expect(page.getByText('Total Row Count: 62')).toBeVisible({
+      timeout: MANUAL_NODE_TIMEOUT_MS,
+    })
+    passed = true
+  } finally {
+    await recordResult(testInfo, usage.samples, passed ? 'pass' : 'fail')
   }
-
-  await graphNodes.last().click()
-  await visualizeData(page)
-  for (const col of ['Series', 'Couple', 'Finalist Positions', "Avg Judge's Score", '% Change']) {
-    // Pick the first `.TableVisualization` — multiple may be rendered at once (inline preview
-    // for the selected node plus a focused/fullscreen overlay), and the bare class selector
-    // would trip Playwright's strict-mode check.
-    await expect(page.locator('.TableVisualization').first()).toContainText(col)
-  }
-  await expect(page.getByText('Total Row Count: 62')).toBeVisible({
-    timeout: MANUAL_NODE_TIMEOUT_MS,
-  })
-  await recordSuccess(testInfo, usage.samples)
 })

--- a/app/electron-client/tests/aiMetrics.ts
+++ b/app/electron-client/tests/aiMetrics.ts
@@ -98,6 +98,8 @@ export function sanitizeForFilename(testName: string): string {
 const CSV_COLUMNS = [
   'timestamp',
   'commit',
+  'ai_parameters',
+  'status',
   'test_name',
   'node_count',
   'total_duration_ms',
@@ -136,29 +138,31 @@ interface AppendMetricsRowArgs {
   readonly commit: string
   /** ISO 8601 timestamp for the `timestamp` column. */
   readonly timestamp: string
+  /**
+   * Verbatim value of `ENSO_AI_CLAUDE_EXTRA_ARGS` (or empty string when unset). Recorded as
+   * the `ai_parameters` column so later analysis can group rows by model / effort settings.
+   */
+  readonly aiParameters: string
+  /** Test result: `pass` if the Playwright assertions all succeeded, `fail` otherwise. */
+  readonly outcome: 'pass' | 'fail'
 }
 
 /**
- * Append a single CSV row summarizing one successful test run. Writes the header line first
+ * Append a single CSV row summarizing one test run (pass OR fail). Writes the header line first
  * if the target file does not yet exist. Per-node arrays are joined with `;` so the cell
  * never contains a comma; CSV-escaping still runs in case a future column ever does.
  *
- * Throws (and writes nothing) when any sample with `hopCount > 0` had `contextFromLastHop`
- * false — i.e. the CLI omitted `message.usage` on the final assistant envelope and the
- * context value fell back to the cost-side sum. Such rows would obscure context-window
- * analysis, and an exception here propagates through the test's `recordSuccess` to fail the
- * Playwright run so the developer notices broken telemetry instead of silently archiving it.
+ * The `status` cell is composed from {@link AppendMetricsRowArgs.outcome} plus a
+ * telemetry-health check: if any sample had `hopCount > 0` and `contextFromLastHop === false`
+ * (the CLI omitted `message.usage` on the final assistant envelope, so `contextTokens` fell
+ * back to the cost-side sum and overstates actual context-window occupancy), a
+ * ` (broken)` suffix is appended — yielding `pass`, `pass (broken)`, `fail`, or
+ * `fail (broken)`. Never throws; broken telemetry is surfaced in-band so a failed run is still
+ * recorded and downstream analysis can filter on the `(broken)` rows.
  */
 export async function appendMetricsRow(args: AppendMetricsRowArgs): Promise<void> {
-  const broken = args.samples.filter((s) => !s.contextFromLastHop && s.hopCount > 0)
-  if (broken.length > 0) {
-    throw new Error(
-      `[aiMetrics] refusing to write CSV: ${broken.length}/${args.samples.length} sample(s) had ` +
-        `\`contextFromLastHop=false\` with \`hopCount > 0\`. The CLI omitted \`message.usage\` on ` +
-        `the final assistant envelope, so \`contextTokens\` is the cost-side sum and overstates ` +
-        `actual context-window occupancy. Investigate before resuming metrics collection.`,
-    )
-  }
+  const telemetryBroken = args.samples.some((s) => !s.contextFromLastHop && s.hopCount > 0)
+  const status = telemetryBroken ? `${args.outcome} (broken)` : args.outcome
   await fs.mkdir(args.dir, { recursive: true })
   const csvPath = path.join(args.dir, sanitizeForFilename(args.testName))
   const exists = await fs
@@ -178,6 +182,8 @@ export async function appendMetricsRow(args: AppendMetricsRowArgs): Promise<void
   const row = buildRow([
     args.timestamp,
     args.commit,
+    args.aiParameters,
+    status,
     args.testName,
     String(args.samples.length),
     String(totalDurationMs),

--- a/app/electron-client/tests/aiMetrics.ts
+++ b/app/electron-client/tests/aiMetrics.ts
@@ -1,6 +1,6 @@
 /**
  * @file Helpers for collecting AI-effectiveness telemetry from Playwright e2e tests and
- * appending one CSV row per successful test run to a configurable directory.
+ * appending one CSV row per test run (pass or fail) to a configurable directory.
  */
 import type { RequestUsage } from 'enso-common/src/ai'
 import { execFile } from 'node:child_process'
@@ -18,11 +18,11 @@ const execFileAsync = promisify(execFile)
  * stores integer tokens (the rounding loss is at most a few hundred tokens per sample,
  * acceptable noise on hundred-thousand-token contexts). Cost-side fields (`prompt`, `out`,
  * `cacheRead`, `cacheCreate`) parse as lossless integers. `ctxSrc` carries the
- * `contextFromLastHop` flag so {@link appendMetricsRow} can reject rows where the CLI
- * omitted per-hop usage on the final assistant envelope and the context value is unreliable.
- * The bare ` fresh` keyword (no value) marks the first turn after a context-rotation (a fresh
- * `ChildAgent`); it's omitted entirely otherwise. The capture group is optional so logs
- * without the marker still parse.
+ * `contextFromLastHop` flag so {@link appendMetricsRow} can suffix the `status` column with
+ * ` (broken)` on rows where the CLI omitted per-hop usage on the final assistant envelope and
+ * the context value is unreliable. The bare ` fresh` keyword (no value) marks the first turn
+ * after a context-rotation (a fresh `ChildAgent`); it's omitted entirely otherwise. The capture
+ * group is optional so logs without the marker still parse.
  */
 const AI_USAGE_LINE_REGEX =
   /\[AI\] usage: prompt=(\d+)t out=(\d+)t context=([\d.]+)k hops=(\d+) ctxSrc=(lastHop|fallback)( fresh)? \(cacheRead=(\d+)t cacheCreate=(\d+)t\) time=(\d+)ms/
@@ -157,8 +157,9 @@ interface AppendMetricsRowArgs {
  * (the CLI omitted `message.usage` on the final assistant envelope, so `contextTokens` fell
  * back to the cost-side sum and overstates actual context-window occupancy), a
  * ` (broken)` suffix is appended — yielding `pass`, `pass (broken)`, `fail`, or
- * `fail (broken)`. Never throws; broken telemetry is surfaced in-band so a failed run is still
- * recorded and downstream analysis can filter on the `(broken)` rows.
+ * `fail (broken)`. Broken telemetry is surfaced in-band rather than rejected so a failed run
+ * is still recorded and downstream analysis can filter on the `(broken)` rows. Filesystem
+ * errors from `mkdir` / `appendFile` still propagate to the caller.
  */
 export async function appendMetricsRow(args: AppendMetricsRowArgs): Promise<void> {
   const telemetryBroken = args.samples.some((s) => !s.contextFromLastHop && s.hopCount > 0)

--- a/app/electron-client/tests/headless/aiMetrics.test.ts
+++ b/app/electron-client/tests/headless/aiMetrics.test.ts
@@ -1,0 +1,227 @@
+/** @file Unit tests for the AI-effectiveness telemetry helpers. */
+import type { RequestUsage } from 'enso-common/src/ai'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { appendMetricsRow, parseAiUsageLine, sanitizeForFilename } from '../aiMetrics'
+
+function makeSample(overrides: Partial<RequestUsage> = {}): RequestUsage {
+  return {
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 10_000,
+    cacheCreationTokens: 200,
+    contextTokens: 25_000,
+    contextFromLastHop: true,
+    hopCount: 1,
+    durationMs: 1_500,
+    ...overrides,
+  }
+}
+
+describe('parseAiUsageLine', () => {
+  test('parses a clean line with ctxSrc=lastHop and no fresh marker', () => {
+    const line =
+      '[AI] usage: prompt=1000t out=500t context=25.0k hops=1 ctxSrc=lastHop (cacheRead=10000t cacheCreate=200t) time=1500ms'
+    expect(parseAiUsageLine(line)).toEqual({
+      inputTokens: 1000,
+      outputTokens: 500,
+      contextTokens: 25_000,
+      hopCount: 1,
+      contextFromLastHop: true,
+      freshAgent: false,
+      cacheReadTokens: 10_000,
+      cacheCreationTokens: 200,
+      durationMs: 1500,
+    })
+  })
+
+  test('flips contextFromLastHop to false on ctxSrc=fallback', () => {
+    const line =
+      '[AI] usage: prompt=10t out=20t context=0.1k hops=2 ctxSrc=fallback (cacheRead=0t cacheCreate=0t) time=10ms'
+    expect(parseAiUsageLine(line)?.contextFromLastHop).toBe(false)
+  })
+
+  test('flips freshAgent to true when the bare `fresh` marker is present', () => {
+    const line =
+      '[AI] usage: prompt=10t out=20t context=0.1k hops=1 ctxSrc=lastHop fresh (cacheRead=0t cacheCreate=0t) time=10ms'
+    expect(parseAiUsageLine(line)?.freshAgent).toBe(true)
+  })
+
+  test('returns null for an unrelated console line', () => {
+    expect(parseAiUsageLine('Loading Enso…')).toBeNull()
+  })
+})
+
+describe('sanitizeForFilename', () => {
+  test('lowercases and collapses non-alphanumeric runs into single dashes', () => {
+    expect(sanitizeForFilename('Week 32 — Pokemon Card Organising')).toBe(
+      'week-32-pokemon-card-organising.csv',
+    )
+  })
+
+  test('trims leading/trailing dashes', () => {
+    expect(sanitizeForFilename('—abc—')).toBe('abc.csv')
+  })
+
+  test('falls back to _.csv for all-non-alphanumeric titles', () => {
+    expect(sanitizeForFilename('!!!')).toBe('_.csv')
+  })
+})
+
+describe('appendMetricsRow', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aimetrics-test-'))
+  })
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  async function readCsv(testName: string): Promise<string[]> {
+    const csvPath = path.join(tmpDir, sanitizeForFilename(testName))
+    const content = await fs.readFile(csvPath, 'utf8')
+    // Trailing newline yields an empty last element; drop it for cleaner assertions.
+    return content.replace(/\n$/, '').split('\n')
+  }
+
+  test('writes the header on first invocation, plain row on subsequent ones', async () => {
+    const args = {
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample()],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'pass' as const,
+    }
+    await appendMetricsRow(args)
+    let lines = await readCsv('t')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatch(/^timestamp,commit,ai_parameters,status,test_name,/)
+
+    await appendMetricsRow(args)
+    lines = await readCsv('t')
+    expect(lines).toHaveLength(3)
+    // Second invocation does NOT re-emit the header.
+    expect(lines.filter((l) => l.startsWith('timestamp,'))).toHaveLength(1)
+  })
+
+  test('status is the bare outcome when all samples have lastHop context', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample(), makeSample({ hopCount: 3 })],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'pass',
+    })
+    const [, row] = await readCsv('t')
+    expect(row!.split(',')[3]).toBe('pass')
+  })
+
+  test('status gets the `(broken)` suffix when a multi-hop sample fell back to cost-side context', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample(), makeSample({ contextFromLastHop: false, hopCount: 2 })],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'pass',
+    })
+    const [, row] = await readCsv('t')
+    expect(row!.split(',')[3]).toBe('pass (broken)')
+  })
+
+  test('a fallback sample with hopCount=0 does NOT trigger the (broken) suffix', async () => {
+    // hopCount=0 is the degenerate "no assistant envelope observed" case — there's no last
+    // hop to be missing, so the fallback isn't a sign of broken telemetry.
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample({ contextFromLastHop: false, hopCount: 0 })],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'fail',
+    })
+    const [, row] = await readCsv('t')
+    expect(row!.split(',')[3]).toBe('fail')
+  })
+
+  test('outcome=fail with broken telemetry composes to `fail (broken)`', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample({ contextFromLastHop: false, hopCount: 2 })],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'fail',
+    })
+    const [, row] = await readCsv('t')
+    expect(row!.split(',')[3]).toBe('fail (broken)')
+  })
+
+  test('ai_parameters is recorded verbatim, including embedded commas (CSV-escaped)', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [makeSample()],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '--model claude-sonnet-4-6, --foo bar',
+      outcome: 'pass',
+    })
+    const [, row] = await readCsv('t')
+    // CSV-escape wraps any value containing `,` in quotes — column index 2 is `ai_parameters`.
+    expect(row).toContain('"--model claude-sonnet-4-6, --foo bar"')
+  })
+
+  test('totals and per-node columns aggregate across samples', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [
+        makeSample({ durationMs: 100, hopCount: 1, inputTokens: 10 }),
+        makeSample({ durationMs: 200, hopCount: 2, inputTokens: 20 }),
+      ],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'pass',
+    })
+    const [, row] = await readCsv('t')
+    const cells = row!.split(',')
+    // Columns: timestamp, commit, ai_parameters, status, test_name, node_count,
+    //   total_duration_ms, total_hops, total_input_tokens, …
+    expect(cells[5]).toBe('2') // node_count
+    expect(cells[6]).toBe('300') // total_duration_ms
+    expect(cells[7]).toBe('3') // total_hops
+    expect(cells[8]).toBe('30') // total_input_tokens
+    // per_node arrays are semicolon-joined; per_node_durations_ms is index 13.
+    expect(cells[13]).toBe('100;200')
+  })
+
+  test('empty samples produces a zero-count row, no per-node values', async () => {
+    await appendMetricsRow({
+      dir: tmpDir,
+      testName: 't',
+      samples: [],
+      commit: 'abc',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      aiParameters: '',
+      outcome: 'fail',
+    })
+    const [, row] = await readCsv('t')
+    const cells = row!.split(',')
+    expect(cells[3]).toBe('fail') // status — no samples means no broken signal
+    expect(cells[5]).toBe('0') // node_count
+    expect(cells[12]).toBe('0') // final_context_tokens defaults to 0 for empty samples
+    expect(cells[13]).toBe('') // per_node_durations_ms is empty when there are no samples
+  })
+})

--- a/app/electron-client/tests/headless/claudeAgentChild.test.ts
+++ b/app/electron-client/tests/headless/claudeAgentChild.test.ts
@@ -26,12 +26,17 @@ interface ChildHarness {
 }
 
 function buildChild(
-  config: { stdlibRoot?: string | undefined; mcpConfigPath?: string | undefined } = {},
+  config: {
+    stdlibRoot?: string | undefined
+    mcpConfigPath?: string | undefined
+    extraArgs?: readonly string[]
+  } = {},
 ): ChildHarness {
   const { children } = attachSpawnMock(spawnMock)
   const child = new ChildAgent({
     stdlibRoot: 'stdlibRoot' in config ? config.stdlibRoot : FAKE_STDLIB_ROOT,
     mcpConfigPath: 'mcpConfigPath' in config ? config.mcpConfigPath : undefined,
+    extraArgs: config.extraArgs,
   })
   return { child, children }
 }
@@ -266,6 +271,21 @@ describe('ChildAgent', () => {
     expect(allowedToolsIdx).toBeGreaterThan(-1)
     // With both stdlib + MCP enabled, all three filesystem tools plus the MCP tool show up.
     expect(args[allowedToolsIdx + 1]).toBe('Read,Glob,Grep,mcp__enso__evaluateExpression')
+    child.shutdown()
+  })
+
+  test('extraArgs are appended verbatim after the built-in flags', () => {
+    const { child } = buildChild({ extraArgs: ['--model', 'claude-sonnet-4-6'] })
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [, args] = spawnMock.mock.calls[0]!
+    const modelIdx = args.indexOf('--model')
+    expect(modelIdx).toBeGreaterThan(-1)
+    expect(args[modelIdx + 1]).toBe('claude-sonnet-4-6')
+    // Extra args land after the built-in `--no-session-persistence` so a last-wins flag parser
+    // would let user-supplied values override the built-in ones.
+    const sessionIdx = args.indexOf('--no-session-persistence')
+    expect(sessionIdx).toBeGreaterThan(-1)
+    expect(modelIdx).toBeGreaterThan(sessionIdx)
     child.shutdown()
   })
 

--- a/app/electron-client/tsconfig.json
+++ b/app/electron-client/tsconfig.json
@@ -58,6 +58,7 @@
     "./tests/electronTest.ts",
     "./tests/gettingStarted.spec.ts",
     "./tests/headless/aiMcpServer.test.ts",
+    "./tests/headless/aiMetrics.test.ts",
     "./tests/headless/claudeAgent.test.ts",
     "./tests/headless/claudeAgentChild.test.ts",
     "./tests/headless/claudeAgentTestHarness.ts",


### PR DESCRIPTION
Adds `ENSO_AI_CLAUDE_EXTRA_ARGS` (whitespace-split) to append flags to the spawned `claude` invocation so the suite can compare models / effort levels. Extends the metrics CSV with `ai_parameters` and `status` (`pass` / `pass (broken)` / `fail` / `fail (broken)`) and records every run, not just passes. The previous broken-telemetry throw is replaced by the `(broken)` suffix so the row is preserved either way.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- ~~[ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.~~
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
