### PR TITLE
"Retry AI prompt" button

### DIFF
--- a/app/gui/integration-test/project-view/aiPlaceholder.spec.ts
+++ b/app/gui/integration-test/project-view/aiPlaceholder.spec.ts
@@ -7,6 +7,8 @@ test.use({ aiAvailable: true })
 const aiPendingNode = (page: Page) => page.locator('.AiPendingNode')
 const aiPendingStatus = (node: ReturnType<typeof aiPendingNode>) =>
   node.locator('[data-testid="ai-pending-status"]')
+const aiPendingRefresh = (node: ReturnType<typeof aiPendingNode>) =>
+  node.locator('[data-testid="ai-pending-refresh"]')
 
 /** Switch the AI mock into deferred mode so each `generateComponent` waits for the test to drive it. */
 async function enableDeferredAiMock(page: Page): Promise<void> {
@@ -313,6 +315,110 @@ test('after a cancel, a freshly submitted prompt is dispatched and completes', a
   const secondProbe = await probeAiMock(page)
   expect(secondProbe.cancels).toEqual([firstId])
   const secondId = secondProbe.ids.find((id) => id !== firstId)!
+
+  await emitProgress(page, { requestId: secondId, kind: 'started' })
+  await resolveAi(page, secondId)
+  await expect(placeholders).toHaveCount(0)
+  await expect(locate.graphNodeByBinding(page, 'ai_component1')).toBeVisible()
+})
+
+test('refresh button is hidden while queued and visible once running or failed', async ({
+  editorPage,
+  page,
+}) => {
+  await editorPage
+  await enableDeferredAiMock(page)
+
+  // Two prompts: first runs, second sits queued behind it.
+  await openAiPrompt(page, 'first')
+  await openAiPrompt(page, 'second')
+  const placeholders = aiPendingNode(page)
+  await expect(placeholders).toHaveCount(2)
+
+  // Queued placeholder must not offer refresh.
+  await expect(aiPendingRefresh(placeholders.nth(1))).toHaveCount(0)
+  // The first placeholder is still queued (no `started` event yet) — also hidden.
+  await expect(aiPendingRefresh(placeholders.nth(0))).toHaveCount(0)
+
+  // Drive `started` on the first; refresh appears for the now-running entry only.
+  const probe = await probeAiMock(page)
+  await emitProgress(page, { requestId: probe.ids[0]!, kind: 'started' })
+  await expect(aiPendingRefresh(placeholders.nth(0))).toHaveCount(1)
+  await expect(aiPendingRefresh(placeholders.nth(1))).toHaveCount(0)
+
+  // Fail the first; refresh stays visible on the failed entry.
+  await failAi(page, probe.ids[0]!, 'Mock failure')
+  const failed = page.locator('.AiPendingNode.failed')
+  await expect(failed).toHaveCount(1)
+  await expect(aiPendingRefresh(failed)).toHaveCount(1)
+})
+
+test('refresh on a failed placeholder re-queues the same prompt', async ({ editorPage, page }) => {
+  await editorPage
+  await enableDeferredAiMock(page)
+
+  await openAiPrompt(page, 'first')
+  const placeholders = aiPendingNode(page)
+  await expect(placeholders).toHaveCount(1)
+  const { ids } = await probeAiMock(page)
+  const failedId = ids[0]!
+  await failAi(page, failedId, 'Mock failure for testing')
+
+  const failed = page.locator('.AiPendingNode.failed')
+  await expect(failed).toHaveCount(1)
+
+  // Click refresh: the failed placeholder is dismissed and a fresh request is enqueued.
+  await aiPendingRefresh(failed).click()
+  await expect(failed).toHaveCount(0)
+  await expect(placeholders).toHaveCount(1)
+
+  // A new request id appears in the mock — proves a fresh IPC went out.
+  await expect
+    .poll(
+      async () => {
+        const p = await probeAiMock(page)
+        return p.ids.find((id) => id !== failedId)
+      },
+      { timeout: 10_000 },
+    )
+    .not.toBeUndefined()
+  const probe = await probeAiMock(page)
+  const newId = probe.ids.find((id) => id !== failedId)!
+
+  await emitProgress(page, { requestId: newId, kind: 'started' })
+  await resolveAi(page, newId)
+  await expect(placeholders).toHaveCount(0)
+  await expect(locate.graphNodeByBinding(page, 'ai_component1')).toBeVisible()
+})
+
+test('refresh on a running placeholder cancels the in-flight prompt and re-queues it', async ({
+  editorPage,
+  page,
+}) => {
+  await editorPage
+  await enableDeferredAiMock(page)
+
+  await openAiPrompt(page, 'first')
+  const placeholders = aiPendingNode(page)
+  await expect(placeholders).toHaveCount(1)
+  const firstProbe = await probeAiMock(page)
+  const firstId = firstProbe.ids[0]!
+  await emitProgress(page, { requestId: firstId, kind: 'started' })
+
+  await aiPendingRefresh(placeholders.nth(0)).click()
+  // Original request is cancelled and a new one is dispatched.
+  await expect
+    .poll(
+      async () => {
+        const p = await probeAiMock(page)
+        return p.ids.find((id) => id !== firstId)
+      },
+      { timeout: 10_000 },
+    )
+    .not.toBeUndefined()
+  const afterRefresh = await probeAiMock(page)
+  expect(afterRefresh.cancels).toEqual([firstId])
+  const secondId = afterRefresh.ids.find((id) => id !== firstId)!
 
   await emitProgress(page, { requestId: secondId, kind: 'started' })
   await resolveAi(page, secondId)

--- a/app/gui/src/project-view/components/GraphEditor/AiPendingNode.vue
+++ b/app/gui/src/project-view/components/GraphEditor/AiPendingNode.vue
@@ -5,7 +5,7 @@ import type { AiPending } from '@/stores/ongoingAiPrompts'
 import { computed } from 'vue'
 
 const { pending } = defineProps<{ pending: AiPending }>()
-const emit = defineEmits<{ cancel: [] }>()
+const emit = defineEmits<{ cancel: []; refresh: [] }>()
 
 const transform = computed(() => {
   const { x, y } = pending.position
@@ -32,6 +32,14 @@ const transform = computed(() => {
         phase="loading-medium"
       />
       <span class="prompt">{{ pending.prompt }}</span>
+      <SvgButton
+        v-if="pending.status === 'running' || pending.status === 'failed'"
+        class="refresh"
+        data-testid="ai-pending-refresh"
+        name="refresh"
+        title="Retry AI prompt"
+        @activate="emit('refresh')"
+      />
       <SvgButton class="cancel" name="close" title="Cancel AI prompt" @activate="emit('cancel')" />
     </div>
   </div>
@@ -70,6 +78,8 @@ const transform = computed(() => {
   align-items: center;
   gap: 8px;
   min-height: var(--node-base-height, 32px);
+  /* Roughly match a default node's footprint so the placeholder reads as node-shaped, not pill-shaped. */
+  min-width: 300px;
   padding: 6px 12px;
   border-radius: var(--node-border-radius, 16px);
   background-color: var(--color-node-background-pending, #d8d8d8);
@@ -87,12 +97,14 @@ const transform = computed(() => {
 }
 
 .prompt {
+  /* Absorb skeleton slack so trailing buttons stay flush right when content is shorter than min-width. */
+  flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 320px;
 }
 
+.refresh,
 .cancel {
   flex: 0 0 auto;
 }

--- a/app/gui/src/project-view/components/GraphEditor/GraphNodes.vue
+++ b/app/gui/src/project-view/components/GraphEditor/GraphNodes.vue
@@ -96,6 +96,7 @@ const layerStyle = computed(() => ({
       :key="entry.id"
       :pending="entry"
       @cancel="aiPrompts.cancel(entry.id)"
+      @refresh="aiPrompts.refresh(entry.id)"
     />
   </div>
 </template>

--- a/app/gui/src/project-view/stores/__tests__/ongoingAiPrompts.test.ts
+++ b/app/gui/src/project-view/stores/__tests__/ongoingAiPrompts.test.ts
@@ -1,0 +1,282 @@
+/** @file Unit tests for the renderer-side AI prompt queue. Focused on enqueue, cancel, and refresh. */
+
+import { ongoingAiPromptsStoreFactory, type OngoingAiPromptsDeps } from '@/stores/ongoingAiPrompts'
+import { Vec2 } from '@/util/data/vec2'
+import { withSetup } from '@/util/testing'
+import type { AiComponentResponse, AiProgressEvent } from 'enso-common/src/ai'
+import { Err, Ok, type Result } from 'enso-common/src/utilities/data/result'
+import { describe, expect, test, vi, type Mock } from 'vitest'
+import { computed, nextTick } from 'vue'
+import type { ExternalId } from 'ydoc-shared/yjsModel'
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+interface Harness {
+  store: ReturnType<typeof ongoingAiPromptsStoreFactory>
+  dispatch: Mock
+  dispatchCalls: Deferred<Result<AiComponentResponse>>[]
+  toastShow: Mock
+  cancelIpc: Mock
+  emitProgress: (event: AiProgressEvent) => void
+}
+
+function setupHarness(): Harness {
+  const dispatchCalls: Deferred<Result<AiComponentResponse>>[] = []
+  const dispatch = vi.fn(() => {
+    const d = deferred<Result<AiComponentResponse>>()
+    dispatchCalls.push(d)
+    return d.promise
+  })
+  const toastShow = vi.fn()
+  const cancelIpc = vi.fn()
+  const progressHandlers: Array<(event: AiProgressEvent) => void> = []
+
+  const electronApi = {
+    ai: {
+      onProgress: vi.fn((handler: (event: AiProgressEvent) => void) => {
+        progressHandlers.push(handler)
+        return () => {
+          const i = progressHandlers.indexOf(handler)
+          if (i !== -1) progressHandlers.splice(i, 1)
+        }
+      }),
+      cancel: cancelIpc,
+    },
+  } as unknown as typeof window.api
+
+  const methodId = 'method-1' as ExternalId
+  const bodyId = 'body-1' as ExternalId
+  const graphStore = {
+    db: { nodeIdToNode: new Map() },
+    currentMethod: {
+      ast: Ok({ externalId: methodId, body: { externalId: bodyId } }),
+      pointer: Ok({ name: 'method_one' }),
+    },
+    registerExtraOccupiedAreas: vi.fn(() => () => {}),
+    generateLocallyUniqueIdent: (s: string) => s,
+  } as unknown as OngoingAiPromptsDeps['graphStore']
+
+  const module = computed(
+    () =>
+      ({
+        root: undefined,
+        edit: vi.fn(),
+      }) as unknown as OngoingAiPromptsDeps['module']['value'],
+  )
+
+  const store = withSetup(() =>
+    ongoingAiPromptsStoreFactory({
+      graphStore,
+      module,
+      ai: { dispatch },
+      toastError: { show: toastShow },
+      electronApi,
+    }),
+  )
+
+  return {
+    store,
+    dispatch,
+    dispatchCalls,
+    toastShow,
+    cancelIpc,
+    emitProgress: (event: AiProgressEvent) => progressHandlers.forEach((h) => h(event)),
+  }
+}
+
+function enqueueOne(harness: Harness, prompt: string): string {
+  return harness.store.enqueue({
+    prompt,
+    sourceIdentifier: undefined,
+    methodId: 'method-1' as ExternalId,
+    methodBodyId: 'body-1' as ExternalId,
+    methodName: 'method_one',
+    position: new Vec2(10, 20),
+  })
+}
+
+describe('enqueue + dispatcher', () => {
+  test('first enqueue dispatches synchronously', () => {
+    const h = setupHarness()
+    enqueueOne(h, 'hello')
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+    const entry = h.store.entriesForCurrentMethod[0]!
+    expect(entry.prompt).toBe('hello')
+    expect(entry.dispatched).toBe(true)
+    expect(h.dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  test('second enqueue waits behind the first', () => {
+    const h = setupHarness()
+    enqueueOne(h, 'first')
+    enqueueOne(h, 'second')
+    expect(h.store.entriesForCurrentMethod).toHaveLength(2)
+    expect(h.store.entriesForCurrentMethod[0]!.dispatched).toBe(true)
+    expect(h.store.entriesForCurrentMethod[1]!.dispatched).toBe(false)
+    expect(h.dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  test('started progress event flips the entry from queued to running', () => {
+    const h = setupHarness()
+    enqueueOne(h, 'hello')
+    const entry = h.store.entriesForCurrentMethod[0]!
+    expect(entry.status).toBe('queued')
+    expect(entry.statusText).toBe('Waiting…')
+
+    h.emitProgress({ kind: 'started', requestId: entry.requestId })
+
+    expect(entry.status).toBe('running')
+    expect(entry.statusText).toBe('Thinking…')
+  })
+
+  test('after a successful completion, the next enqueue dispatches the new entry', async () => {
+    const h = setupHarness()
+    enqueueOne(h, 'first')
+    const firstEntry = h.store.entriesForCurrentMethod[0]!
+    h.dispatchCalls[0]!.resolve(
+      Ok({
+        functionName: 'helper',
+        argumentNames: [],
+        body: 'x = 1\nx',
+        callArguments: [],
+      }) as Result<AiComponentResponse>,
+    )
+    // Let runEntry resume, hit commit(), and remove the entry from the map.
+    await nextTick()
+    await nextTick()
+    // commit will toast-fail because our stub module has no root; the dispatcher must still
+    // release `dispatching` and proceed to the next entry.
+    enqueueOne(h, 'second')
+    const secondEntry = h.store.entriesForCurrentMethod.find((e) => e.prompt === 'second')!
+    expect(secondEntry.dispatched).toBe(true)
+    expect(h.dispatch).toHaveBeenCalledTimes(2)
+    expect(h.dispatch.mock.calls[1]![0]).toBe('second')
+    expect(h.dispatch.mock.calls[1]![2]).toBe(secondEntry.requestId)
+    void firstEntry
+  })
+})
+
+describe('cancel', () => {
+  test('cancel on a not-yet-dispatched entry deletes locally without IPC', () => {
+    const h = setupHarness()
+    enqueueOne(h, 'first')
+    const secondId = enqueueOne(h, 'second')
+    h.store.cancel(secondId)
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+    expect(h.store.entriesForCurrentMethod[0]!.prompt).toBe('first')
+    expect(h.cancelIpc).not.toHaveBeenCalled()
+  })
+
+  test('cancel on a dispatched entry sends IPC and keeps the entry until the reply', () => {
+    const h = setupHarness()
+    const id = enqueueOne(h, 'first')
+    const entry = h.store.entriesForCurrentMethod[0]!
+    h.store.cancel(id)
+    expect(h.cancelIpc).toHaveBeenCalledTimes(1)
+    expect(h.cancelIpc).toHaveBeenCalledWith(entry.requestId)
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+  })
+
+  test('cancel on a failed entry deletes locally without IPC', async () => {
+    const h = setupHarness()
+    enqueueOne(h, 'first')
+    h.dispatchCalls[0]!.resolve(Err('boom'))
+    await nextTick()
+    await nextTick()
+    expect(h.store.entriesForCurrentMethod[0]!.status).toBe('failed')
+    const id = h.store.entriesForCurrentMethod[0]!.id
+    h.store.cancel(id)
+    expect(h.store.entriesForCurrentMethod).toHaveLength(0)
+    expect(h.cancelIpc).not.toHaveBeenCalled()
+  })
+})
+
+describe('refresh', () => {
+  test('refresh on a failed entry replaces it with a fresh queued entry', async () => {
+    const h = setupHarness()
+    enqueueOne(h, 'first')
+    const originalEntry = h.store.entriesForCurrentMethod[0]!
+    const originalId = originalEntry.id
+    const originalRequestId = originalEntry.requestId
+    const originalPosition = originalEntry.position
+
+    h.dispatchCalls[0]!.resolve(Err('boom'))
+    await nextTick()
+    await nextTick()
+    expect(h.store.entriesForCurrentMethod[0]!.status).toBe('failed')
+
+    h.store.refresh(originalId)
+    expect(h.cancelIpc).not.toHaveBeenCalled()
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+
+    const newEntry = h.store.entriesForCurrentMethod[0]!
+    expect(newEntry.id).not.toBe(originalId)
+    expect(newEntry.requestId).not.toBe(originalRequestId)
+    expect(newEntry.prompt).toBe('first')
+    expect(newEntry.position).toEqual(originalPosition)
+    expect(newEntry.status).toBe('queued')
+    expect(newEntry.dispatched).toBe(true)
+    expect(h.dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  test('refresh on a running entry sends cancel IPC and enqueues a fresh entry', () => {
+    const h = setupHarness()
+    const id = enqueueOne(h, 'first')
+    const originalEntry = h.store.entriesForCurrentMethod[0]!
+    const originalRequestId = originalEntry.requestId
+
+    h.store.refresh(id)
+    expect(h.cancelIpc).toHaveBeenCalledTimes(1)
+    expect(h.cancelIpc).toHaveBeenCalledWith(originalRequestId)
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+
+    const newEntry = h.store.entriesForCurrentMethod[0]!
+    expect(newEntry.id).not.toBe(id)
+    expect(newEntry.requestId).not.toBe(originalRequestId)
+    expect(newEntry.prompt).toBe('first')
+    // Dispatcher is still awaiting the original dispatch promise, so the new entry stays queued.
+    expect(newEntry.status).toBe('queued')
+    expect(newEntry.dispatched).toBe(false)
+    expect(h.dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  test('after refresh-on-running, the cancellation reply unblocks the new dispatch', async () => {
+    const h = setupHarness()
+    const id = enqueueOne(h, 'first')
+    h.store.refresh(id)
+    const newEntry = h.store.entriesForCurrentMethod[0]!
+
+    // Resolve the original dispatch with the cancellation reply the main process would send.
+    h.dispatchCalls[0]!.resolve(Err('Request cancelled by user.'))
+    await nextTick()
+    await nextTick()
+
+    expect(h.dispatch).toHaveBeenCalledTimes(2)
+    const secondCallRequestId = h.dispatch.mock.calls[1]![2]
+    expect(secondCallRequestId).toBe(newEntry.requestId)
+    expect(h.store.entriesForCurrentMethod).toHaveLength(1)
+    expect(h.store.entriesForCurrentMethod[0]!.dispatched).toBe(true)
+  })
+
+  test('refresh on a missing id is a no-op', () => {
+    const h = setupHarness()
+    h.store.refresh('does-not-exist')
+    expect(h.store.entriesForCurrentMethod).toHaveLength(0)
+    expect(h.dispatch).not.toHaveBeenCalled()
+    expect(h.cancelIpc).not.toHaveBeenCalled()
+  })
+})

--- a/app/gui/src/project-view/stores/ongoingAiPrompts.ts
+++ b/app/gui/src/project-view/stores/ongoingAiPrompts.ts
@@ -1,11 +1,12 @@
 /** @file Renderer-side queue and placeholder nodes for in-flight AI component prompts. */
 
 import {
+  type CurrentProjectStore,
   useCurrentProject,
   useGraphStore,
   useProjectNames,
 } from '$/components/WithCurrentProject.vue'
-import type { NodeId } from '$/providers/openedProjects/graph'
+import type { GraphStore, NodeId } from '$/providers/openedProjects/graph'
 import { proxyRefs } from '$/utils/reactivity'
 import { DEFAULT_NODE_SIZE } from '@/components/ComponentBrowser/placement'
 import {
@@ -90,6 +91,23 @@ export interface EnqueueEditArgs {
 
 export type OngoingAiPromptsStore = ReturnType<typeof ongoingAiPromptsStoreFactory>
 
+/**
+ * Dependencies the {@link ongoingAiPromptsStoreFactory} reaches for. Surfaced as a parameter
+ * so unit tests can wire in fakes; the production `createContextStore` lambda below resolves the
+ * real stores. Each entry is `Pick<>`-ed to just the methods actually called so test fakes need
+ * not re-implement the full upstream surface.
+ */
+export interface OngoingAiPromptsDeps {
+  readonly graphStore: Pick<
+    GraphStore,
+    'db' | 'currentMethod' | 'registerExtraOccupiedAreas' | 'generateLocallyUniqueIdent'
+  >
+  readonly module: CurrentProjectStore['module']
+  readonly ai: Pick<ReturnType<typeof useAI>, 'dispatch'>
+  readonly toastError: Pick<ReturnType<typeof useToast.error>, 'show'>
+  readonly electronApi: typeof window.api | undefined
+}
+
 const STATUS_TEXT_MAX_CHARS = 120
 const QUEUED_LABEL = 'Waiting…'
 const STARTED_LABEL = 'Thinking…'
@@ -105,17 +123,12 @@ function queuedPositionLabel(position: number): string {
  * cancelling either drops a still-queued/failed entry or sends a cancel IPC for a running one.
  * The store is local-only (not broadcast over Yjs awareness).
  */
-function ongoingAiPromptsStoreFactory() {
-  const graphStore = useGraphStore()
-  const projectNames = useProjectNames()
-  const { module } = useCurrentProject()
-  const ai = useAI(graphStore, projectNames)
-  const toastError = useToast.error()
+export function ongoingAiPromptsStoreFactory(deps: OngoingAiPromptsDeps) {
+  const { graphStore, module, ai, toastError, electronApi } = deps
 
   const entries = reactive(new Map<string, AiPending>())
   let dispatching = false
 
-  const electronApi = typeof window === 'undefined' ? undefined : window.api
   if (electronApi != null) {
     const dispose = electronApi.ai.onProgress(handleProgress)
     onScopeDispose(dispose)
@@ -281,6 +294,51 @@ function ongoingAiPromptsStoreFactory() {
     entries.delete(id)
   }
 
+  /**
+   * Re-queue the same prompt: cancel any in-flight dispatch for this entry and enqueue a fresh
+   * placeholder with the same args at the same position. The caller hides the refresh button on
+   * `queued` entries, so this is only invoked from `running` or `failed`.
+   *
+   * For edit entries, this recaptures `previousPrompt`/`previousDefinition` from the live AST — a
+   * deliberate "fresh start" so any manual edits the user made while the placeholder was failed
+   * feed into the retry.
+   *
+   * Unlike {@link cancel}, which lets {@link runEntry}'s cancellation reply delete the entry,
+   * this deletes the old entry synchronously. The `entries.has(entry.id)` guard inside
+   * {@link runEntry} keeps the late-arriving cancellation reply silent.
+   */
+  function refresh(id: string): void {
+    const entry = entries.get(id)
+    if (entry == null) return
+    if (entry.editTarget != null) {
+      const result = enqueueEdit({
+        prompt: entry.prompt,
+        sourceIdentifier: entry.sourceIdentifier,
+        methodId: entry.methodId,
+        methodBodyId: entry.methodBodyId,
+        methodName: entry.methodName,
+        editNodeId: entry.editTarget.nodeId,
+      })
+      if (!result.ok) {
+        toastError.show(result.error.message('Cannot retry AI prompt'))
+        return
+      }
+    } else {
+      enqueue({
+        prompt: entry.prompt,
+        sourceIdentifier: entry.sourceIdentifier,
+        methodId: entry.methodId,
+        methodBodyId: entry.methodBodyId,
+        methodName: entry.methodName,
+        position: entry.position,
+      })
+    }
+    if (entry.dispatched && entry.status !== 'failed') {
+      electronApi?.ai.cancel(entry.requestId)
+    }
+    entries.delete(id)
+  }
+
   async function kickDispatcher(): Promise<void> {
     if (dispatching) return
     dispatching = true
@@ -429,6 +487,7 @@ function ongoingAiPromptsStoreFactory() {
     enqueue,
     enqueueEdit,
     cancel,
+    refresh,
     findByRequestId,
     entriesForCurrentMethod,
     hiddenNodeIds,
@@ -437,7 +496,18 @@ function ongoingAiPromptsStoreFactory() {
 
 export const [provideOngoingAiPrompts, useOngoingAiPrompts] = createContextStore(
   'ongoingAiPrompts',
-  ongoingAiPromptsStoreFactory,
+  () => {
+    const graphStore = useGraphStore()
+    const projectNames = useProjectNames()
+    const { module } = useCurrentProject()
+    return ongoingAiPromptsStoreFactory({
+      graphStore,
+      module,
+      ai: useAI(graphStore, projectNames),
+      toastError: useToast.error(),
+      electronApi: typeof window === 'undefined' ? undefined : window.api,
+    })
+  },
 )
 
 function truncate(value: string, max: number): string {

--- a/app/gui/tsconfig.app.vitest.json
+++ b/app/gui/tsconfig.app.vitest.json
@@ -58,6 +58,7 @@
     "./src/project-view/providers/__tests__/asyncResources.test.ts",
     "./src/project-view/providers/__tests__/interactionHandler.test.ts",
     "./src/project-view/providers/asyncResources/__tests__/parse.test.ts",
+    "./src/project-view/stores/__tests__/ongoingAiPrompts.test.ts",
     "./src/project-view/stores/visualization/__tests__/metadata.test.ts",
     "./src/project-view/util/__tests__/array.test.ts",
     "./src/project-view/util/__tests__/callTree.test.ts",


### PR DESCRIPTION
### Pull Request Description

In ongoing and failed prompts, there is a new "refresh" button, which cancels prompt (if ongoing) and re-schedules it.

<img width="841" height="343" alt="image" src="https://github.com/user-attachments/assets/77fecd84-3ebd-484d-8abd-ca9aa949602a" />


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
