### PR TITLE
Bump tar from 0.4.41 to 0.4.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_yaml = { version = "0.9.16" }
 sha2 = { version = "0.10.8" }
 sysinfo = { version = "0.30.7" }
-tar = { version = "0.4.40" }
+tar = { version = "0.4.45" }
 tokio = { version = "1.37.0", features = ["full", "tracing"] }
 tokio-stream = { version = "0.1.15", features = ["fs"] }
 tokio-util = { version = "0.7.10", features = ["full"] }


### PR DESCRIPTION
To run CI on https://github.com/enso-org/enso/pull/14897